### PR TITLE
Increase test coverage of UniFi integration

### DIFF
--- a/homeassistant/components/unifi/config_flow.py
+++ b/homeassistant/components/unifi/config_flow.py
@@ -123,8 +123,9 @@ class UnifiFlowHandler(config_entries.ConfigFlow, domain=UNIFI_DOMAIN):
 
                 return await self.async_step_site()
 
-        host = self.config.get(CONF_HOST)
-        if not host and await async_discover_unifi(self.hass):
+        if not (host := self.config.get(CONF_HOST, "")) and await async_discover_unifi(
+            self.hass
+        ):
             host = "unifi"
 
         data = self.reauth_schema or {

--- a/homeassistant/components/unifi/controller.py
+++ b/homeassistant/components/unifi/controller.py
@@ -415,9 +415,8 @@ class UniFiController:
         If config entry is updated due to reauth flow
         the entry might already have been reset and thus is not available.
         """
-        if config_entry.entry_id not in hass.data[UNIFI_DOMAIN]:
+        if not (controller := hass.data[UNIFI_DOMAIN].get(config_entry.entry_id)):
             return
-        controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
         controller.load_config_entry_options()
         async_dispatcher_send(hass, controller.signal_options_update)
 

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -5,6 +5,13 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
+def mock_unifi_websocket():
+    """No real websocket allowed."""
+    with patch("aiounifi.controller.WSClient") as mock:
+        yield mock
+
+
+@pytest.fixture(autouse=True)
 def mock_discovery():
     """No real network traffic allowed."""
     with patch(

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -1,4 +1,5 @@
 """Fixtures for UniFi methods."""
+from typing import Optional
 from unittest.mock import patch
 
 from aiounifi.websocket import SIGNAL_CONNECTION_STATE, SIGNAL_DATA
@@ -10,7 +11,7 @@ def mock_unifi_websocket():
     """No real websocket allowed."""
     with patch("aiounifi.controller.WSClient") as mock:
 
-        def make_websocket_call(data: str = "", state: str = ""):
+        def make_websocket_call(data: Optional[dict] = None, state: str = ""):
             """Generate a websocket call."""
             if data:
                 mock.return_value.data = data

--- a/tests/components/unifi/conftest.py
+++ b/tests/components/unifi/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for UniFi methods."""
 from unittest.mock import patch
 
+from aiounifi.websocket import SIGNAL_CONNECTION_STATE, SIGNAL_DATA
 import pytest
 
 
@@ -8,7 +9,19 @@ import pytest
 def mock_unifi_websocket():
     """No real websocket allowed."""
     with patch("aiounifi.controller.WSClient") as mock:
-        yield mock
+
+        def make_websocket_call(data: str = "", state: str = ""):
+            """Generate a websocket call."""
+            if data:
+                mock.return_value.data = data
+                mock.call_args[1]["callback"](SIGNAL_DATA)
+            elif state:
+                mock.return_value.state = state
+                mock.call_args[1]["callback"](SIGNAL_CONNECTION_STATE)
+            else:
+                raise NotImplementedError
+
+        yield make_websocket_call
 
 
 @pytest.fixture(autouse=True)

--- a/tests/components/unifi/test_config_flow.py
+++ b/tests/components/unifi/test_config_flow.py
@@ -1,9 +1,12 @@
 """Test UniFi config flow."""
+
+import socket
 from unittest.mock import patch
 
 import aiounifi
 
 from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.unifi.config_flow import async_discover_unifi
 from homeassistant.components.unifi.const import (
     CONF_ALLOW_BANDWIDTH_SENSORS,
     CONF_ALLOW_UPTIME_SENSORS,
@@ -148,6 +151,23 @@ async def test_flow_works(hass, aioclient_mock, mock_discovery):
             CONF_SITE_ID: "site_id",
             CONF_VERIFY_SSL: True,
         },
+    }
+
+
+async def test_flow_works_negative_discovery(hass, aioclient_mock, mock_discovery):
+    """Test config flow with a negative outcome of async_discovery_unifi."""
+    result = await hass.config_entries.flow.async_init(
+        UNIFI_DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["data_schema"]({CONF_USERNAME: "", CONF_PASSWORD: ""}) == {
+        CONF_HOST: "",
+        CONF_USERNAME: "",
+        CONF_PASSWORD: "",
+        CONF_PORT: 443,
+        CONF_VERIFY_SSL: False,
     }
 
 
@@ -617,3 +637,15 @@ async def test_form_ssdp_gets_form_with_ignored_entry(hass):
         "host": "1.2.3.4",
         "site": "default",
     }
+
+
+async def test_discover_unifi_positive(hass):
+    """Verify positive run of UniFi discovery."""
+    with patch("socket.gethostbyname", return_value=True):
+        assert await async_discover_unifi(hass)
+
+
+async def test_discover_unifi_negative(hass):
+    """Verify negative run of UniFi discovery."""
+    with patch("socket.gethostbyname", side_effect=socket.gaierror):
+        assert await async_discover_unifi(hass) is None

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -154,6 +154,7 @@ async def setup_unifi_integration(
     wlans_response=None,
     known_wireless_clients=None,
     controllers=None,
+    unique_id="1",
 ):
     """Create the UniFi controller."""
     assert await async_setup_component(hass, UNIFI_DOMAIN, {})
@@ -162,8 +163,8 @@ async def setup_unifi_integration(
         domain=UNIFI_DOMAIN,
         data=deepcopy(config),
         options=deepcopy(options),
+        unique_id=unique_id,
         entry_id=1,
-        unique_id="1",
         version=1,
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -27,8 +27,8 @@ from homeassistant.components.unifi.const import (
     UNIFI_WIRELESS_CLIENTS,
 )
 from homeassistant.components.unifi.controller import (
-    RETRY_TIMER,
     PLATFORMS,
+    RETRY_TIMER,
     get_controller,
 )
 from homeassistant.components.unifi.errors import AuthenticationRequired, CannotConnect

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -46,6 +46,7 @@ import homeassistant.util.dt as dt_util
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
+DEFAULT_CONFIG_ENTRY_ID = 1
 DEFAULT_HOST = "1.2.3.4"
 DEFAULT_SITE = "site_id"
 
@@ -174,7 +175,7 @@ async def setup_unifi_integration(
         data=deepcopy(config),
         options=deepcopy(options),
         unique_id=unique_id,
-        entry_id=1,
+        entry_id=DEFAULT_CONFIG_ENTRY_ID,
         version=1,
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/unifi/test_controller.py
+++ b/tests/components/unifi/test_controller.py
@@ -299,31 +299,10 @@ async def test_config_entry_updated(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert controller.option_track_clients is False
-    assert controller.option_track_devices is False
+    assert config_entry.options[CONF_TRACK_CLIENTS] is False
+    assert config_entry.options[CONF_TRACK_DEVICES] is False
 
     event_call.assert_called_once()
-
-    unsub()
-
-
-async def test_config_entry_updated_no_matching_entry(hass, aioclient_mock):
-    """Verify options aren't updated if config entry not available."""
-    config_entry = await setup_unifi_integration(hass, aioclient_mock)
-    controller = hass.data[UNIFI_DOMAIN].pop(config_entry.entry_id)
-
-    event_call = Mock()
-    unsub = async_dispatcher_connect(hass, controller.signal_options_update, event_call)
-
-    hass.config_entries.async_update_entry(
-        config_entry, options={CONF_TRACK_CLIENTS: False, CONF_TRACK_DEVICES: False}
-    )
-    await hass.async_block_till_done()
-
-    assert controller.option_track_clients is True
-    assert controller.option_track_devices is True
-
-    assert len(event_call.mock_calls) == 0
 
     unsub()
 

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -8,9 +8,8 @@ from aiounifi.controller import (
     MESSAGE_CLIENT_REMOVED,
     MESSAGE_DEVICE,
     MESSAGE_EVENT,
-    SIGNAL_CONNECTION_STATE,
 )
-from aiounifi.websocket import SIGNAL_DATA, STATE_DISCONNECTED, STATE_RUNNING
+from aiounifi.websocket import STATE_DISCONNECTED, STATE_RUNNING
 
 from homeassistant import config_entries
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
@@ -171,11 +170,12 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
 
     # State change signalling works without events
     client_1_copy = copy(CLIENT_1)
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -187,11 +187,12 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
 
     # State change signalling works with events
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_CLIENT_1_WIRELESS_DISCONNECTED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_CLIENT_1_WIRELESS_DISCONNECTED],
+        }
+    )
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -205,11 +206,12 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "not_home"
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_CLIENT_1_WIRELESS_CONNECTED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_CLIENT_1_WIRELESS_CONNECTED],
+        }
+    )
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -254,11 +256,12 @@ async def test_tracked_clients(hass, aioclient_mock, mock_unifi_websocket):
 
     # State change signalling works
     client_1_copy = copy(CLIENT_1)
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -286,18 +289,20 @@ async def test_tracked_devices(hass, aioclient_mock, mock_unifi_websocket):
     # State change signalling work
     device_1_copy = copy(DEVICE_1)
     device_1_copy["next_interval"] = 20
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_DEVICE},
-        "data": [device_1_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_DEVICE},
+            "data": [device_1_copy],
+        }
+    )
     device_2_copy = copy(DEVICE_2)
     device_2_copy["next_interval"] = 50
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_DEVICE},
-        "data": [device_2_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_DEVICE},
+            "data": [device_2_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
@@ -318,11 +323,12 @@ async def test_tracked_devices(hass, aioclient_mock, mock_unifi_websocket):
     # Disabled device is unavailable
     device_1_copy = copy(DEVICE_1)
     device_1_copy["disabled"] = True
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_DEVICE},
-        "data": [device_1_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_DEVICE},
+            "data": [device_1_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
@@ -331,16 +337,18 @@ async def test_tracked_devices(hass, aioclient_mock, mock_unifi_websocket):
     # Update device registry when device is upgraded
     device_2_copy = copy(DEVICE_2)
     device_2_copy["version"] = EVENT_DEVICE_2_UPGRADED["version_to"]
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_DEVICE},
-        "data": [device_2_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_DEVICE_2_UPGRADED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_DEVICE},
+            "data": [device_2_copy],
+        }
+    )
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_DEVICE_2_UPGRADED],
+        }
+    )
     await hass.async_block_till_done()
 
     # Verify device registry has been updated
@@ -365,11 +373,12 @@ async def test_remove_clients(hass, aioclient_mock, mock_unifi_websocket):
     wired_client = hass.states.get("device_tracker.wired_client")
     assert wired_client is not None
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT_REMOVED},
-        "data": [CLIENT_1],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT_REMOVED},
+            "data": [CLIENT_1],
+        }
+    )
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
@@ -400,8 +409,7 @@ async def test_controller_state_change(hass, aioclient_mock, mock_unifi_websocke
     assert device_1.state == "home"
 
     # Controller unavailable
-    mock_unifi_websocket.return_value.state = STATE_DISCONNECTED
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_CONNECTION_STATE)
+    mock_unifi_websocket(state=STATE_DISCONNECTED)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -411,8 +419,7 @@ async def test_controller_state_change(hass, aioclient_mock, mock_unifi_websocke
     assert device_1.state == STATE_UNAVAILABLE
 
     # Controller available
-    mock_unifi_websocket.return_value.state = STATE_RUNNING
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_CONNECTION_STATE)
+    mock_unifi_websocket(state=STATE_RUNNING)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -611,19 +618,21 @@ async def test_option_ssid_filter(hass, aioclient_mock, mock_unifi_websocket):
     # Roams to SSID outside of filter
     client_1_copy = copy(CLIENT_1)
     client_1_copy["essid"] = "other_ssid"
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_copy],
+        }
+    )
     # Data update while SSID filter is in effect shouldn't create the client
     client_3_copy = copy(CLIENT_3)
     client_3_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_3_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_3_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     # SSID filter marks client as away
@@ -641,16 +650,18 @@ async def test_option_ssid_filter(hass, aioclient_mock, mock_unifi_websocket):
     )
     await hass.async_block_till_done()
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_3_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_copy],
+        }
+    )
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_3_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -667,22 +678,24 @@ async def test_option_ssid_filter(hass, aioclient_mock, mock_unifi_websocket):
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "not_home"
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_3_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_3_copy],
+        }
+    )
     await hass.async_block_till_done()
     # Client won't go away until after next update
     client_3 = hass.states.get("device_tracker.client_3")
     assert client_3.state == "home"
 
     # Trigger update to get client marked as away
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_3_copy],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_3_copy],
+        }
+    )
     await hass.async_block_till_done()
 
     new_time = (
@@ -720,11 +733,12 @@ async def test_wireless_client_go_wired_issue(
 
     # Trigger wired bug
     client_1_client["is_wired"] = True
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_client],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_client],
+        }
+    )
     await hass.async_block_till_done()
 
     # Wired bug fix keeps client marked as wireless
@@ -744,11 +758,12 @@ async def test_wireless_client_go_wired_issue(
     assert client_1.attributes["is_wired"] is False
 
     # Try to mark client as connected
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_client],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_client],
+        }
+    )
     await hass.async_block_till_done()
 
     # Make sure it don't go online again until wired bug disappears
@@ -758,11 +773,12 @@ async def test_wireless_client_go_wired_issue(
 
     # Make client wireless
     client_1_client["is_wired"] = False
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_client],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_client],
+        }
+    )
     await hass.async_block_till_done()
 
     # Client is no longer affected by wired bug and can be marked online
@@ -793,11 +809,12 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock, mock_unifi_websocke
 
     # Trigger wired bug
     client_1_client["is_wired"] = True
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_client],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_client],
+        }
+    )
     await hass.async_block_till_done()
 
     # Wired bug in effect
@@ -817,11 +834,12 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock, mock_unifi_websocke
     assert client_1.attributes["is_wired"] is True
 
     # Mark client as connected again
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_client],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_client],
+        }
+    )
     await hass.async_block_till_done()
 
     # Ignoring wired bug allows client to go home again even while affected
@@ -831,11 +849,12 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock, mock_unifi_websocke
 
     # Make client wireless
     client_1_client["is_wired"] = False
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": [client_1_client],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": [client_1_client],
+        }
+    )
     await hass.async_block_till_done()
 
     # Client is wireless and still connected

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -186,11 +186,12 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
     assert client_1.attributes["host_name"] == "client_1"
 
     # State change signalling works with events
-    controller.api.websocket._data = {
+
+    mock_unifi_websocket.return_value.data = {
         "meta": {"message": MESSAGE_EVENT},
         "data": [EVENT_CLIENT_1_WIRELESS_DISCONNECTED],
     }
-    controller.api.session_handler(SIGNAL_DATA)
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -204,30 +205,29 @@ async def test_tracked_wireless_clients(hass, aioclient_mock, mock_unifi_websock
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "not_home"
 
-    controller.api.websocket._data = {
+    mock_unifi_websocket.return_value.data = {
         "meta": {"message": MESSAGE_EVENT},
         "data": [EVENT_CLIENT_1_WIRELESS_CONNECTED],
     }
-    controller.api.session_handler(SIGNAL_DATA)
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "home"
 
 
-async def test_tracked_clients(hass, aioclient_mock):
+async def test_tracked_clients(hass, aioclient_mock, mock_unifi_websocket):
     """Test the update_items function with some clients."""
     client_4_copy = copy(CLIENT_4)
     client_4_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
 
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         options={CONF_SSID_FILTER: ["ssid"]},
         clients_response=[CLIENT_1, CLIENT_2, CLIENT_3, CLIENT_5, client_4_copy],
         known_wireless_clients=(CLIENT_4["mac"],),
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 4
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -254,22 +254,25 @@ async def test_tracked_clients(hass, aioclient_mock):
 
     # State change signalling works
     client_1_copy = copy(CLIENT_1)
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "home"
 
 
-async def test_tracked_devices(hass, aioclient_mock):
+async def test_tracked_devices(hass, aioclient_mock, mock_unifi_websocket):
     """Test the update_items function with some devices."""
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         devices_response=[DEVICE_1, DEVICE_2],
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
 
     device_1 = hass.states.get("device_tracker.device_1")
@@ -283,12 +286,18 @@ async def test_tracked_devices(hass, aioclient_mock):
     # State change signalling work
     device_1_copy = copy(DEVICE_1)
     device_1_copy["next_interval"] = 20
-    event = {"meta": {"message": MESSAGE_DEVICE}, "data": [device_1_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_DEVICE},
+        "data": [device_1_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     device_2_copy = copy(DEVICE_2)
     device_2_copy["next_interval"] = 50
-    event = {"meta": {"message": MESSAGE_DEVICE}, "data": [device_2_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_DEVICE},
+        "data": [device_2_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
@@ -309,8 +318,11 @@ async def test_tracked_devices(hass, aioclient_mock):
     # Disabled device is unavailable
     device_1_copy = copy(DEVICE_1)
     device_1_copy["disabled"] = True
-    event = {"meta": {"message": MESSAGE_DEVICE}, "data": [device_1_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_DEVICE},
+        "data": [device_1_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     device_1 = hass.states.get("device_tracker.device_1")
@@ -319,10 +331,16 @@ async def test_tracked_devices(hass, aioclient_mock):
     # Update device registry when device is upgraded
     device_2_copy = copy(DEVICE_2)
     device_2_copy["version"] = EVENT_DEVICE_2_UPGRADED["version_to"]
-    message = {"meta": {"message": MESSAGE_DEVICE}, "data": [device_2_copy]}
-    controller.api.message_handler(message)
-    event = {"meta": {"message": MESSAGE_EVENT}, "data": [EVENT_DEVICE_2_UPGRADED]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_DEVICE},
+        "data": [device_2_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_EVENT},
+        "data": [EVENT_DEVICE_2_UPGRADED],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Verify device registry has been updated
@@ -364,15 +382,15 @@ async def test_remove_clients(hass, aioclient_mock, mock_unifi_websocket):
     assert wired_client is not None
 
 
-async def test_controller_state_change(hass, aioclient_mock):
+async def test_controller_state_change(hass, aioclient_mock, mock_unifi_websocket):
     """Verify entities state reflect on controller becoming unavailable."""
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         clients_response=[CLIENT_1],
         devices_response=[DEVICE_1],
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -382,9 +400,8 @@ async def test_controller_state_change(hass, aioclient_mock):
     assert device_1.state == "home"
 
     # Controller unavailable
-    controller.async_unifi_signalling_callback(
-        SIGNAL_CONNECTION_STATE, STATE_DISCONNECTED
-    )
+    mock_unifi_websocket.return_value.state = STATE_DISCONNECTED
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_CONNECTION_STATE)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -394,7 +411,8 @@ async def test_controller_state_change(hass, aioclient_mock):
     assert device_1.state == STATE_UNAVAILABLE
 
     # Controller available
-    controller.async_unifi_signalling_callback(SIGNAL_CONNECTION_STATE, STATE_RUNNING)
+    mock_unifi_websocket.return_value.state = STATE_RUNNING
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_CONNECTION_STATE)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -554,7 +572,7 @@ async def test_option_track_devices(hass, aioclient_mock):
     assert device_1 is not None
 
 
-async def test_option_ssid_filter(hass, aioclient_mock):
+async def test_option_ssid_filter(hass, aioclient_mock, mock_unifi_websocket):
     """Test the SSID filter works.
 
     Client 1 will travel from a supported SSID to an unsupported ssid.
@@ -593,13 +611,19 @@ async def test_option_ssid_filter(hass, aioclient_mock):
     # Roams to SSID outside of filter
     client_1_copy = copy(CLIENT_1)
     client_1_copy["essid"] = "other_ssid"
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     # Data update while SSID filter is in effect shouldn't create the client
     client_3_copy = copy(CLIENT_3)
     client_3_copy["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_3_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_3_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # SSID filter marks client as away
@@ -616,10 +640,17 @@ async def test_option_ssid_filter(hass, aioclient_mock):
         options={CONF_SSID_FILTER: []},
     )
     await hass.async_block_till_done()
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_copy]}
-    controller.api.message_handler(event)
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_3_copy]}
-    controller.api.message_handler(event)
+
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_3_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     client_1 = hass.states.get("device_tracker.client_1")
@@ -636,16 +667,22 @@ async def test_option_ssid_filter(hass, aioclient_mock):
     client_1 = hass.states.get("device_tracker.client_1")
     assert client_1.state == "not_home"
 
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_3_copy]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_3_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
     # Client won't go away until after next update
     client_3 = hass.states.get("device_tracker.client_3")
     assert client_3.state == "home"
 
     # Trigger update to get client marked as away
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [CLIENT_3]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_3_copy],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     new_time = (
@@ -659,7 +696,9 @@ async def test_option_ssid_filter(hass, aioclient_mock):
     assert client_3.state == "not_home"
 
 
-async def test_wireless_client_go_wired_issue(hass, aioclient_mock):
+async def test_wireless_client_go_wired_issue(
+    hass, aioclient_mock, mock_unifi_websocket
+):
     """Test the solution to catch wireless device go wired UniFi issue.
 
     UniFi has a known issue that when a wireless device goes away it sometimes gets marked as wired.
@@ -681,8 +720,11 @@ async def test_wireless_client_go_wired_issue(hass, aioclient_mock):
 
     # Trigger wired bug
     client_1_client["is_wired"] = True
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_client]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_client],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Wired bug fix keeps client marked as wireless
@@ -702,8 +744,11 @@ async def test_wireless_client_go_wired_issue(hass, aioclient_mock):
     assert client_1.attributes["is_wired"] is False
 
     # Try to mark client as connected
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_client]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_client],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Make sure it don't go online again until wired bug disappears
@@ -713,8 +758,11 @@ async def test_wireless_client_go_wired_issue(hass, aioclient_mock):
 
     # Make client wireless
     client_1_client["is_wired"] = False
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_client]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_client],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Client is no longer affected by wired bug and can be marked online
@@ -723,7 +771,7 @@ async def test_wireless_client_go_wired_issue(hass, aioclient_mock):
     assert client_1.attributes["is_wired"] is False
 
 
-async def test_option_ignore_wired_bug(hass, aioclient_mock):
+async def test_option_ignore_wired_bug(hass, aioclient_mock, mock_unifi_websocket):
     """Test option to ignore wired bug."""
     client_1_client = copy(CLIENT_1)
     client_1_client["last_seen"] = dt_util.as_timestamp(dt_util.utcnow())
@@ -745,8 +793,11 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock):
 
     # Trigger wired bug
     client_1_client["is_wired"] = True
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_client]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_client],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Wired bug in effect
@@ -766,8 +817,11 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock):
     assert client_1.attributes["is_wired"] is True
 
     # Mark client as connected again
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_client]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_client],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Ignoring wired bug allows client to go home again even while affected
@@ -777,8 +831,11 @@ async def test_option_ignore_wired_bug(hass, aioclient_mock):
 
     # Make client wireless
     client_1_client["is_wired"] = False
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": [client_1_client]}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": [client_1_client],
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     # Client is wireless and still connected

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -1,14 +1,18 @@
 """Test UniFi setup process."""
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, patch
 
 from homeassistant.components import unifi
-from homeassistant.components.unifi import async_flatten_entry_data
+from homeassistant.components.unifi import (
+    UnifiWirelessClients,
+    async_flatten_entry_data,
+)
 from homeassistant.components.unifi.const import CONF_CONTROLLER, DOMAIN as UNIFI_DOMAIN
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.setup import async_setup_component
 
 from .test_controller import CONTROLLER_DATA, ENTRY_CONFIG, setup_unifi_integration
 
-from tests.common import MockConfigEntry, mock_coro
+from tests.common import MockConfigEntry
 
 
 async def test_setup_with_no_config(hass):
@@ -19,7 +23,7 @@ async def test_setup_with_no_config(hass):
 
 async def test_successful_config_entry(hass, aioclient_mock):
     """Test that configured options for a host are loaded via config entry."""
-    await setup_unifi_integration(hass, aioclient_mock)
+    await setup_unifi_integration(hass, aioclient_mock, unique_id=None)
     assert hass.data[UNIFI_DOMAIN]
 
 
@@ -32,29 +36,28 @@ async def test_controller_fail_setup(hass):
     assert hass.data[UNIFI_DOMAIN] == {}
 
 
-async def test_controller_no_mac(hass):
+async def test_controller_mac(hass):
     """Test that configured options for a host are loaded via config entry."""
     entry = MockConfigEntry(
-        domain=UNIFI_DOMAIN,
-        data=ENTRY_CONFIG,
-        unique_id="1",
-        version=1,
+        domain=UNIFI_DOMAIN, data=ENTRY_CONFIG, unique_id="1", entry_id=1
     )
     entry.add_to_hass(hass)
-    mock_registry = Mock()
-    with patch(
-        "homeassistant.components.unifi.UniFiController"
-    ) as mock_controller, patch(
-        "homeassistant.helpers.device_registry.async_get_registry",
-        return_value=mock_coro(mock_registry),
-    ):
+
+    with patch("homeassistant.components.unifi.UniFiController") as mock_controller:
         mock_controller.return_value.async_setup = AsyncMock(return_value=True)
-        mock_controller.return_value.mac = None
+        mock_controller.return_value.mac = "mac1"
         assert await unifi.async_setup_entry(hass, entry) is True
 
     assert len(mock_controller.mock_calls) == 2
 
-    assert len(mock_registry.mock_calls) == 0
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id, connections={(CONNECTION_NETWORK_MAC, "mac1")}
+    )
+    assert device.manufacturer == "Ubiquiti Networks"
+    assert device.model == "UniFi Controller"
+    assert device.name == "UniFi Controller"
+    assert device.sw_version is None
 
 
 async def test_flatten_entry_data(hass):
@@ -75,3 +78,30 @@ async def test_unload_entry(hass, aioclient_mock):
 
     assert await unifi.async_unload_entry(hass, config_entry)
     assert not hass.data[UNIFI_DOMAIN]
+
+
+async def test_wireless_clients(hass, hass_storage):
+    """Verify wireless clients class."""
+    entry = MockConfigEntry(domain=UNIFI_DOMAIN, data=ENTRY_CONFIG, entry_id=1)
+    hass_storage[unifi.STORAGE_KEY] = {
+        "version": unifi.STORAGE_VERSION,
+        "data": {entry.entry_id: {"wireless_devices": ["mac1", "mac2", "mac3"]}},
+    }
+
+    wireless_clients = UnifiWirelessClients(hass)
+
+    await wireless_clients.async_load()
+
+    assert wireless_clients.get_data(entry) == {"mac1", "mac2", "mac3"}
+
+    wireless_clients.update_data({"mac4"}, entry)
+
+    assert wireless_clients._data_to_save() == {
+        entry.entry_id: {"wireless_devices": ["mac4"]}
+    }
+
+    await hass.async_block_till_done()
+    assert hass_storage[unifi.STORAGE_KEY] == {
+        "version": unifi.STORAGE_VERSION,
+        "data": {entry.entry_id: {"wireless_devices": ["mac4"]}},
+    }

--- a/tests/components/unifi/test_init.py
+++ b/tests/components/unifi/test_init.py
@@ -76,7 +76,7 @@ async def test_unload_entry(hass, aioclient_mock):
     config_entry = await setup_unifi_integration(hass, aioclient_mock)
     assert hass.data[UNIFI_DOMAIN]
 
-    assert await unifi.async_unload_entry(hass, config_entry)
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
     assert not hass.data[UNIFI_DOMAIN]
 
 

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -2,7 +2,6 @@
 from copy import deepcopy
 
 from aiounifi.controller import MESSAGE_CLIENT, MESSAGE_CLIENT_REMOVED
-from aiounifi.websocket import SIGNAL_DATA
 
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -104,11 +103,12 @@ async def test_sensors(hass, aioclient_mock, mock_unifi_websocket):
     clients[1]["tx_bytes"] = 6789000000
     clients[1]["uptime"] = 1600180860
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT},
-        "data": clients,
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT},
+            "data": clients,
+        }
+    )
     await hass.async_block_till_done()
 
     wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
@@ -212,11 +212,12 @@ async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
     wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
     assert wireless_client_uptime is not None
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT_REMOVED},
-        "data": [CLIENTS[0]],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT_REMOVED},
+            "data": [CLIENTS[0]],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -178,9 +178,9 @@ async def test_sensors(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
 
 
-async def test_remove_sensors(hass, aioclient_mock):
+async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
     """Test the remove_items function with some clients."""
-    config_entry = await setup_unifi_integration(
+    await setup_unifi_integration(
         hass,
         aioclient_mock,
         options={
@@ -189,7 +189,7 @@ async def test_remove_sensors(hass, aioclient_mock):
         },
         clients_response=CLIENTS,
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
+
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
 
@@ -209,11 +209,11 @@ async def test_remove_sensors(hass, aioclient_mock):
     wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
     assert wireless_client_uptime is not None
 
-    controller.api.websocket._data = {
+    mock_unifi_websocket.return_value.data = {
         "meta": {"message": MESSAGE_CLIENT_REMOVED},
         "data": [CLIENTS[0]],
     }
-    controller.api.session_handler(SIGNAL_DATA)
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -63,7 +63,7 @@ async def test_no_clients(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
 
 
-async def test_sensors(hass, aioclient_mock):
+async def test_sensors(hass, aioclient_mock, mock_unifi_websocket):
     """Test the update_items function with some clients."""
     config_entry = await setup_unifi_integration(
         hass,
@@ -104,8 +104,11 @@ async def test_sensors(hass, aioclient_mock):
     clients[1]["tx_bytes"] = 6789000000
     clients[1]["uptime"] = 1600180860
 
-    event = {"meta": {"message": MESSAGE_CLIENT}, "data": clients}
-    controller.api.message_handler(event)
+    mock_unifi_websocket.return_value.data = {
+        "meta": {"message": MESSAGE_CLIENT},
+        "data": clients,
+    }
+    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
     await hass.async_block_till_done()
 
     wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -2,7 +2,6 @@
 from copy import deepcopy
 
 from aiounifi.controller import MESSAGE_CLIENT_REMOVED, MESSAGE_EVENT
-from aiounifi.websocket import SIGNAL_DATA
 
 from homeassistant import config_entries
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
@@ -445,11 +444,12 @@ async def test_remove_switches(hass, aioclient_mock, mock_unifi_websocket):
     block_switch = hass.states.get("switch.block_client_2")
     assert block_switch is not None
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_CLIENT_REMOVED},
-        "data": [CLIENT_1, UNBLOCKED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_CLIENT_REMOVED},
+            "data": [CLIENT_1, UNBLOCKED],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
@@ -486,11 +486,12 @@ async def test_block_switches(hass, aioclient_mock, mock_unifi_websocket):
     assert unblocked is not None
     assert unblocked.state == "on"
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_BLOCKED_CLIENT_UNBLOCKED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_BLOCKED_CLIENT_UNBLOCKED],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2
@@ -498,11 +499,12 @@ async def test_block_switches(hass, aioclient_mock, mock_unifi_websocket):
     assert blocked is not None
     assert blocked.state == "on"
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_BLOCKED_CLIENT_BLOCKED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_BLOCKED_CLIENT_BLOCKED],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2
@@ -553,20 +555,22 @@ async def test_new_client_discovered_on_block_control(
     blocked = hass.states.get("switch.block_client_1")
     assert blocked is None
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": "sta:sync"},
-        "data": [BLOCKED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": "sta:sync"},
+            "data": [BLOCKED],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 0
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_BLOCKED_CLIENT_CONNECTED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_BLOCKED_CLIENT_CONNECTED],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
@@ -657,20 +661,22 @@ async def test_new_client_discovered_on_poe_control(
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": "sta:sync"},
-        "data": [CLIENT_2],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": "sta:sync"},
+            "data": [CLIENT_2],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 1
 
-    mock_unifi_websocket.return_value.data = {
-        "meta": {"message": MESSAGE_EVENT},
-        "data": [EVENT_CLIENT_2_CONNECTED],
-    }
-    mock_unifi_websocket.call_args[1]["callback"](SIGNAL_DATA)
+    mock_unifi_websocket(
+        data={
+            "meta": {"message": MESSAGE_EVENT},
+            "data": [EVENT_CLIENT_2_CONNECTED],
+        }
+    )
     await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 2

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -17,6 +17,7 @@ from homeassistant.components.unifi.const import (
 )
 from homeassistant.components.unifi.switch import POE_SWITCH
 from homeassistant.helpers import entity_registry
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .test_controller import (
     CONTROLLER_HOST,
@@ -370,6 +371,7 @@ async def test_switches(hass, aioclient_mock):
     dpi_switch = hass.states.get("switch.block_media_streaming")
     assert dpi_switch is not None
     assert dpi_switch.state == "on"
+    assert dpi_switch.attributes["icon"] == "mdi:network"
 
     # Block and unblock client
 
@@ -418,6 +420,11 @@ async def test_switches(hass, aioclient_mock):
     )
     assert aioclient_mock.call_count == 14
     assert aioclient_mock.mock_calls[13][2] == {"enabled": True}
+
+    # Make sure no duplicates arise on generic signal update
+    async_dispatcher_send(hass, controller.signal_update)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(SWITCH_DOMAIN)) == 4
 
 
 async def test_remove_switches(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve test coverage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
