### PR TITLE
Revert "Implement support for additional ecobee hold modes (#40520)"

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -617,7 +617,6 @@ class Thermostat(ClimateEntity):
             cool_temp_setpoint,
             heat_temp_setpoint,
             self.hold_preference(),
-            self.hold_hours(),
         )
         _LOGGER.debug(
             "Setting ecobee hold_temp to: heat=%s, is=%s, cool=%s, is=%s",
@@ -718,32 +717,15 @@ class Thermostat(ClimateEntity):
 
     def hold_preference(self):
         """Return user preference setting for hold time."""
-        # Values returned from thermostat are:
-        #   "useEndTime2hour", "useEndTime4hour"
-        #   "nextPeriod", "askMe"
-        #   "indefinite"
-        device_preference = self.thermostat["settings"]["holdAction"]
-        # Currently supported pyecobee holdTypes:
-        #   dateTime, nextTransition, indefinite, holdHours
-        hold_pref_map = {
-            "useEndTime2hour": "holdHours",
-            "useEndTime4hour": "holdHours",
-            "indefinite": "indefinite",
-        }
-        return hold_pref_map.get(device_preference, "nextTransition")
-
-    def hold_hours(self):
-        """Return user preference setting for hold duration in hours."""
-        # Values returned from thermostat are:
-        #   "useEndTime2hour", "useEndTime4hour"
-        #   "nextPeriod", "askMe"
-        #   "indefinite"
-        device_preference = self.thermostat["settings"]["holdAction"]
-        hold_hours_map = {
-            "useEndTime2hour": 2,
-            "useEndTime4hour": 4,
-        }
-        return hold_hours_map.get(device_preference, 0)
+        # Values returned from thermostat are 'useEndTime4hour',
+        # 'useEndTime2hour', 'nextTransition', 'indefinite', 'askMe'
+        default = self.thermostat["settings"]["holdAction"]
+        if default == "nextTransition":
+            return default
+        # add further conditions if other hold durations should be
+        # supported; note that this should not include 'indefinite'
+        # as an indefinite away hold is interpreted as away_mode
+        return "nextTransition"
 
     def create_vacation(self, service_data):
         """Create a vacation with user-specified parameters."""

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -208,32 +208,26 @@ async def test_set_temperature(ecobee_fixture, thermostat, data):
     # Auto -> Auto
     data.reset_mock()
     thermostat.set_temperature(target_temp_low=20, target_temp_high=30)
-    data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 30, 20, "nextTransition", 0)]
-    )
+    data.ecobee.set_hold_temp.assert_has_calls([mock.call(1, 30, 20, "nextTransition")])
 
     # Auto -> Hold
     data.reset_mock()
     thermostat.set_temperature(temperature=20)
-    data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 25, 15, "nextTransition", 0)]
-    )
+    data.ecobee.set_hold_temp.assert_has_calls([mock.call(1, 25, 15, "nextTransition")])
 
     # Cool -> Hold
     data.reset_mock()
     ecobee_fixture["settings"]["hvacMode"] = "cool"
     thermostat.set_temperature(temperature=20.5)
     data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 20.5, 20.5, "nextTransition", 0)]
+        [mock.call(1, 20.5, 20.5, "nextTransition")]
     )
 
     # Heat -> Hold
     data.reset_mock()
     ecobee_fixture["settings"]["hvacMode"] = "heat"
     thermostat.set_temperature(temperature=20)
-    data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 20, 20, "nextTransition", 0)]
-    )
+    data.ecobee.set_hold_temp.assert_has_calls([mock.call(1, 20, 20, "nextTransition")])
 
     # Heat -> Auto
     data.reset_mock()
@@ -286,32 +280,16 @@ async def test_resume_program(thermostat, data):
 
 async def test_hold_preference(ecobee_fixture, thermostat):
     """Test hold preference."""
-    ecobee_fixture["settings"]["holdAction"] = "indefinite"
-    assert thermostat.hold_preference() == "indefinite"
-    for action in ["useEndTime2hour", "useEndTime4hour"]:
-        ecobee_fixture["settings"]["holdAction"] = action
-        assert thermostat.hold_preference() == "holdHours"
+    assert thermostat.hold_preference() == "nextTransition"
     for action in [
-        "nextPeriod",
-        "askMe",
-    ]:
-        ecobee_fixture["settings"]["holdAction"] = action
-        assert thermostat.hold_preference() == "nextTransition"
-
-
-def test_hold_hours(ecobee_fixture, thermostat):
-    """Test hold hours preference."""
-    ecobee_fixture["settings"]["holdAction"] = "useEndTime2hour"
-    assert thermostat.hold_hours() == 2
-    ecobee_fixture["settings"]["holdAction"] = "useEndTime4hour"
-    assert thermostat.hold_hours() == 4
-    for action in [
+        "useEndTime4hour",
+        "useEndTime2hour",
         "nextPeriod",
         "indefinite",
         "askMe",
     ]:
         ecobee_fixture["settings"]["holdAction"] = action
-        assert thermostat.hold_hours() == 0
+        assert thermostat.hold_preference() == "nextTransition"
 
 
 async def test_set_fan_mode_on(thermostat, data):


### PR DESCRIPTION
This reverts commit 3b184ad11c2916a61add781e88c1c17055f4053a.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This reverts a prior breaking change, and thus it is itself a breaking change? But the prior breaking change broke the basic functionality, so.... I'm not sure.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a un-edited `git revert 3b184ad11c2916a61add781e88c1c17055f4053a`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45936
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
