### PR TITLE
Enhance platform discovery for zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -102,7 +102,7 @@ DISCOVERY_SCHEMAS = [
     # GE fan controllers using switch multilevel CC
     ZWaveDiscoverySchema(
         platform="fan",
-        manufacturer_id={1584},
+        manufacturer_id={99},
         product_id={12340, 12593},
         product_type={18756},
         primary_value=ZWaveValueDiscoverySchema(

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -123,7 +123,7 @@ DISCOVERY_SCHEMAS = [
             type={"number"},
         ),
     ),
-    # Fibaro FGS222
+    # Fibaro Shutter Fibaro FGS222
     ZWaveDiscoverySchema(
         platform="cover",
         hint="fibaro_fgs222",

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -14,12 +14,14 @@ from homeassistant.core import callback
 class ZwaveDiscoveryInfo:
     """Info discovered from (primary) ZWave Value to create entity."""
 
-    node: ZwaveNode  # node to which the value(s) belongs
-    primary_value: ZwaveValue  # the value object itself for primary value
-    platform: str  # the home assistant platform for which an entity should be created
-    platform_hint: Optional[
-        str
-    ] = ""  # hint for the platform about this discovered entity
+    # node to which the value(s) belongs
+    node: ZwaveNode
+    # the value object itself for primary value
+    primary_value: ZwaveValue
+    # the home assistant platform for which an entity should be created
+    platform: str
+    # hint for the platform about this discovered entity
+    platform_hint: Optional[str] = ""
 
     @property
     def value_id(self) -> str:
@@ -28,24 +30,14 @@ class ZwaveDiscoveryInfo:
 
 
 @dataclass
-class ZWaveDiscoverySchema:
-    """Z-Wave discovery schema.
+class ZWaveValueDiscoverySchema:
+    """Z-Wave Value discovery schema.
 
-    The (primary) value for an entity must match these conditions.
+    The Z-Wave Value must match these conditions.
     Use the Z-Wave specifications to find out the values for these parameters:
     https://github.com/zwave-js/node-zwave-js/tree/master/specs
     """
 
-    # specify the hass platform for which this scheme applies (e.g. light, sensor)
-    platform: str
-    # [optional] hint for platform
-    hint: Optional[str] = None
-    # [optional] the node's basic device class must match ANY of these values
-    device_class_basic: Optional[Set[str]] = None
-    # [optional] the node's generic device class must match ANY of these values
-    device_class_generic: Optional[Set[str]] = None
-    # [optional] the node's specific device class must match ANY of these values
-    device_class_specific: Optional[Set[str]] = None
     # [optional] the value's command class must match ANY of these values
     command_class: Optional[Set[int]] = None
     # [optional] the value's endpoint must match ANY of these values
@@ -56,9 +48,109 @@ class ZWaveDiscoverySchema:
     type: Optional[Set[str]] = None
 
 
+@dataclass
+class ZWaveDiscoverySchema:
+    """Z-Wave discovery schema.
+
+    The Z-Wave node and it's (primary) value for an entity must match these conditions.
+    Use the Z-Wave specifications to find out the values for these parameters:
+    https://github.com/zwave-js/node-zwave-js/tree/master/specs
+    """
+
+    # specify the hass platform for which this scheme applies (e.g. light, sensor)
+    platform: str
+    # primary value belonging to this discovery scheme
+    primary_value: ZWaveValueDiscoverySchema
+    # [optional] hint for platform
+    hint: Optional[str] = None
+    # [optional] the node's manufacturer_id must match ANY of these values
+    manufacturer_id: Optional[Set[int]] = None
+    # [optional] the node's model_id must match ANY of these values
+    model_id: Optional[Set[int]] = None
+    # [optional] the node's product_type must match ANY of these values
+    product_type: Optional[Set[int]] = None
+    # [optional] the node's firmware_version must match ANY of these values
+    firmware_version: Optional[Set[str]] = None
+    # [optional] the node's basic device class must match ANY of these values
+    device_class_basic: Optional[Set[str]] = None
+    # [optional] the node's generic device class must match ANY of these values
+    device_class_generic: Optional[Set[str]] = None
+    # [optional] the node's specific device class must match ANY of these values
+    device_class_specific: Optional[Set[str]] = None
+    # [optional] additional values that need to be present on the node for this scheme to pass
+    required_values: Optional[Set[ZWaveValueDiscoverySchema]] = None
+    # [optional] bool to specify if this primary value may be discovered by multiple platforms
+    allow_multi: bool = False
+
+
 # For device class mapping see:
 # https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/deviceClasses.json
 DISCOVERY_SCHEMAS = [
+    # ====== START OF DEVICE SPECIFIC MAPPING SCHEMAS =======
+    # Honeywell/Jasco 39358 In-Wall Fan Control using switch multilevel CC
+    ZWaveDiscoverySchema(
+        platform="fan",
+        manufacturer_id={57},
+        model_id={12593},
+        product_type={18756},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
+    ),
+    # GE fan controllers using switch multilevel CC
+    ZWaveDiscoverySchema(
+        platform="fan",
+        manufacturer_id={1584},
+        model_id={12340, 12593},
+        product_type={18756},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
+    ),
+    # Fibaro FGS222
+    ZWaveDiscoverySchema(
+        platform="cover",
+        hint="fibaro_fgs222",
+        manufacturer_id={271},
+        model_id={4096},
+        product_type={770},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
+    ),
+    # Qubino flush shutter
+    ZWaveDiscoverySchema(
+        platform="cover",
+        hint="fibaro_fgs222",
+        manufacturer_id={345},
+        model_id={82},
+        product_type={3},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
+    ),
+    # Graber/Bali/Spring Fashion Covers
+    ZWaveDiscoverySchema(
+        platform="cover",
+        hint="fibaro_fgs222",
+        manufacturer_id={622},
+        model_id={23089},
+        product_type={17235},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
+    ),
+    # ====== START OF GENERIC MAPPING SCHEMAS =======
     # locks
     ZWaveDiscoverySchema(
         platform="lock",
@@ -69,12 +161,14 @@ DISCOVERY_SCHEMAS = [
             "Secure Keypad Door Lock",
             "Secure Lockbox",
         },
-        command_class={
-            CommandClass.LOCK,
-            CommandClass.DOOR_LOCK,
-        },
-        property={"currentMode", "locked"},
-        type={"number", "boolean"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.LOCK,
+                CommandClass.DOOR_LOCK,
+            },
+            property={"currentMode", "locked"},
+            type={"number", "boolean"},
+        ),
     ),
     # door lock door status
     ZWaveDiscoverySchema(
@@ -87,12 +181,14 @@ DISCOVERY_SCHEMAS = [
             "Secure Keypad Door Lock",
             "Secure Lockbox",
         },
-        command_class={
-            CommandClass.LOCK,
-            CommandClass.DOOR_LOCK,
-        },
-        property={"doorStatus"},
-        type={"any"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.LOCK,
+                CommandClass.DOOR_LOCK,
+            },
+            property={"doorStatus"},
+            type={"any"},
+        ),
     ),
     # climate
     ZWaveDiscoverySchema(
@@ -102,10 +198,14 @@ DISCOVERY_SCHEMAS = [
             "Setback Thermostat",
             "Thermostat General",
             "Thermostat General V2",
+            "General Thermostat",
+            "General Thermostat V2",
         },
-        command_class={CommandClass.THERMOSTAT_MODE},
-        property={"mode"},
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.THERMOSTAT_MODE},
+            property={"mode"},
+            type={"number"},
+        ),
     ),
     # climate
     # setpoint thermostats
@@ -115,9 +215,11 @@ DISCOVERY_SCHEMAS = [
         device_class_specific={
             "Setpoint Thermostat",
         },
-        command_class={CommandClass.THERMOSTAT_SETPOINT},
-        property={"setpoint"},
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.THERMOSTAT_SETPOINT},
+            property={"setpoint"},
+            type={"number"},
+        ),
     ),
     # lights
     # primary value is the currentValue (brightness)
@@ -132,85 +234,104 @@ DISCOVERY_SCHEMAS = [
             "Multilevel Scene Switch",
             "Unused",
         },
-        command_class={CommandClass.SWITCH_MULTILEVEL},
-        property={"currentValue"},
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
     ),
     # binary sensors
     ZWaveDiscoverySchema(
         platform="binary_sensor",
         hint="boolean",
-        command_class={
-            CommandClass.SENSOR_BINARY,
-            CommandClass.BATTERY,
-            CommandClass.SENSOR_ALARM,
-        },
-        type={"boolean"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.SENSOR_BINARY,
+                CommandClass.BATTERY,
+                CommandClass.SENSOR_ALARM,
+            },
+            type={"boolean"},
+        ),
     ),
     ZWaveDiscoverySchema(
         platform="binary_sensor",
         hint="notification",
-        command_class={
-            CommandClass.NOTIFICATION,
-        },
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.NOTIFICATION,
+            },
+            type={"number"},
+        ),
+        allow_multi=True,
     ),
     # generic text sensors
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="string_sensor",
-        command_class={
-            CommandClass.SENSOR_ALARM,
-            CommandClass.INDICATOR,
-        },
-        type={"string"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.SENSOR_ALARM,
+                CommandClass.INDICATOR,
+            },
+            type={"string"},
+        ),
     ),
     # generic numeric sensors
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="numeric_sensor",
-        command_class={
-            CommandClass.SENSOR_MULTILEVEL,
-            CommandClass.SENSOR_ALARM,
-            CommandClass.INDICATOR,
-            CommandClass.BATTERY,
-        },
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.SENSOR_MULTILEVEL,
+                CommandClass.SENSOR_ALARM,
+                CommandClass.INDICATOR,
+                CommandClass.BATTERY,
+            },
+            type={"number"},
+        ),
     ),
     # numeric sensors for Meter CC
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="numeric_sensor",
-        command_class={
-            CommandClass.METER,
-        },
-        type={"number"},
-        property={"value"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.METER,
+            },
+            type={"number"},
+            property={"value"},
+        ),
     ),
     # special list sensors (Notification CC)
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="list_sensor",
-        command_class={
-            CommandClass.NOTIFICATION,
-        },
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.NOTIFICATION,
+            },
+            type={"number"},
+        ),
+        allow_multi=True,
     ),
     # sensor for basic CC
     ZWaveDiscoverySchema(
         platform="sensor",
         hint="numeric_sensor",
-        command_class={
-            CommandClass.BASIC,
-        },
-        type={"number"},
-        property={"currentValue"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={
+                CommandClass.BASIC,
+            },
+            type={"number"},
+            property={"currentValue"},
+        ),
     ),
     # binary switches
     ZWaveDiscoverySchema(
         platform="switch",
-        command_class={CommandClass.SWITCH_BINARY},
-        property={"currentValue"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_BINARY}, property={"currentValue"}
+        ),
     ),
     # cover
     ZWaveDiscoverySchema(
@@ -223,9 +344,11 @@ DISCOVERY_SCHEMAS = [
             "Motor Control Class C",
             "Multiposition Motor",
         },
-        command_class={CommandClass.SWITCH_MULTILEVEL},
-        property={"currentValue"},
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
     ),
     # fan
     ZWaveDiscoverySchema(
@@ -233,9 +356,11 @@ DISCOVERY_SCHEMAS = [
         hint="fan",
         device_class_generic={"Multilevel Switch"},
         device_class_specific={"Fan Switch"},
-        command_class={CommandClass.SWITCH_MULTILEVEL},
-        property={"currentValue"},
-        type={"number"},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
     ),
 ]
 
@@ -263,21 +388,13 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
                 and value.node.device_class.specific not in schema.device_class_specific
             ):
                 continue
-            # check command_class
-            if (
-                schema.command_class is not None
-                and value.command_class not in schema.command_class
-            ):
+            # check primary value
+            if not check_value(value, schema.primary_value):
                 continue
-            # check endpoint
-            if schema.endpoint is not None and value.endpoint not in schema.endpoint:
-                continue
-            # check property
-            if schema.property is not None and value.property_ not in schema.property:
-                continue
-            # check metadata_type
-            if schema.type is not None and value.metadata.type not in schema.type:
-                continue
+            # check additional required values
+            if schema.required_values is not None:
+                pass
+
             # all checks passed, this value belongs to an entity
             yield ZwaveDiscoveryInfo(
                 node=value.node,
@@ -285,3 +402,29 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
                 platform=schema.platform,
                 platform_hint=schema.hint,
             )
+            if not schema.allow_multi:
+                # break out of loop, this value may not be discovered by other schemas/platforms
+                break
+
+
+@callback
+def check_value(value: ZwaveValue, schema: ZWaveValueDiscoverySchema) -> bool:
+    """Check if value matches scheme."""
+    if value is None or schema is None:
+        return False
+    # check command_class
+    if (
+        schema.command_class is not None
+        and value.command_class not in schema.command_class
+    ):
+        return False
+    # check endpoint
+    if schema.endpoint is not None and value.endpoint not in schema.endpoint:
+        return False
+    # check property
+    if schema.property is not None and value.property_ not in schema.property:
+        return False
+    # check metadata_type
+    if schema.type is not None and value.metadata.type not in schema.type:
+        return False
+    return True

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -90,9 +90,9 @@ DISCOVERY_SCHEMAS = [
     # Honeywell/Jasco 39358 In-Wall Fan Control using switch multilevel CC
     ZWaveDiscoverySchema(
         platform="fan",
-        manufacturer_id={57},
-        product_id={12593},
-        product_type={18756},
+        manufacturer_id={0x0039},
+        product_id={0x3131, 0x3138},
+        product_type={0x4944},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
             property={"currentValue"},
@@ -102,9 +102,21 @@ DISCOVERY_SCHEMAS = [
     # GE fan controllers using switch multilevel CC
     ZWaveDiscoverySchema(
         platform="fan",
-        manufacturer_id={99},
-        product_id={12340, 12593},
-        product_type={18756},
+        manufacturer_id={0x0063},
+        product_id={0x3034, 0x3131},
+        product_type={0x4944},
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.SWITCH_MULTILEVEL},
+            property={"currentValue"},
+            type={"number"},
+        ),
+    ),
+    # Leviton ZW4SF fan controllers using switch multilevel CC
+    ZWaveDiscoverySchema(
+        platform="fan",
+        manufacturer_id={0x001D},
+        product_id={0x0002},
+        product_type={0x0038},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
             property={"currentValue"},
@@ -115,9 +127,9 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform="cover",
         hint="fibaro_fgs222",
-        manufacturer_id={271},
-        product_id={4096},
-        product_type={770},
+        manufacturer_id={0x010F},
+        product_id={0x1000},
+        product_type={0x0302},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
             property={"currentValue"},
@@ -128,9 +140,9 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform="cover",
         hint="fibaro_fgs222",
-        manufacturer_id={345},
-        product_id={82},
-        product_type={3},
+        manufacturer_id={0x0159},
+        product_id={0x0052},
+        product_type={0x0003},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
             property={"currentValue"},
@@ -141,9 +153,9 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform="cover",
         hint="fibaro_fgs222",
-        manufacturer_id={622},
-        product_id={23089},
-        product_type={17235},
+        manufacturer_id={0x026E},
+        product_id={0x5A31},
+        product_type={0x4353},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
             property={"currentValue"},

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -87,11 +87,11 @@ class ZWaveDiscoverySchema:
 # https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/deviceClasses.json
 DISCOVERY_SCHEMAS = [
     # ====== START OF DEVICE SPECIFIC MAPPING SCHEMAS =======
-    # Honeywell/Jasco 39358 In-Wall Fan Control using switch multilevel CC
+    # Honeywell 39358 In-Wall Fan Control using switch multilevel CC
     ZWaveDiscoverySchema(
         platform="fan",
         manufacturer_id={0x0039},
-        product_id={0x3131, 0x3138},
+        product_id={0x3131},
         product_type={0x4944},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
@@ -99,11 +99,11 @@ DISCOVERY_SCHEMAS = [
             type={"number"},
         ),
     ),
-    # GE fan controllers using switch multilevel CC
+    # GE/Jasco fan controllers using switch multilevel CC
     ZWaveDiscoverySchema(
         platform="fan",
         manufacturer_id={0x0063},
-        product_id={0x3034, 0x3131},
+        product_id={0x3034, 0x3131, 0x3138},
         product_type={0x4944},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -380,6 +380,7 @@ DISCOVERY_SCHEMAS = [
 @callback
 def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None, None]:
     """Run discovery on ZWave node and return matching (primary) values."""
+    # pylint: disable=too-many-nested-blocks
     for value in node.values.values():
         for schema in DISCOVERY_SCHEMAS:
             # check manufacturer_id

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -65,8 +65,8 @@ class ZWaveDiscoverySchema:
     hint: Optional[str] = None
     # [optional] the node's manufacturer_id must match ANY of these values
     manufacturer_id: Optional[Set[int]] = None
-    # [optional] the node's model_id must match ANY of these values
-    model_id: Optional[Set[int]] = None
+    # [optional] the node's product_id must match ANY of these values
+    product_id: Optional[Set[int]] = None
     # [optional] the node's product_type must match ANY of these values
     product_type: Optional[Set[int]] = None
     # [optional] the node's firmware_version must match ANY of these values
@@ -91,7 +91,7 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform="fan",
         manufacturer_id={57},
-        model_id={12593},
+        product_id={12593},
         product_type={18756},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
@@ -103,7 +103,7 @@ DISCOVERY_SCHEMAS = [
     ZWaveDiscoverySchema(
         platform="fan",
         manufacturer_id={1584},
-        model_id={12340, 12593},
+        product_id={12340, 12593},
         product_type={18756},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
@@ -116,7 +116,7 @@ DISCOVERY_SCHEMAS = [
         platform="cover",
         hint="fibaro_fgs222",
         manufacturer_id={271},
-        model_id={4096},
+        product_id={4096},
         product_type={770},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
@@ -129,7 +129,7 @@ DISCOVERY_SCHEMAS = [
         platform="cover",
         hint="fibaro_fgs222",
         manufacturer_id={345},
-        model_id={82},
+        product_id={82},
         product_type={3},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
@@ -142,7 +142,7 @@ DISCOVERY_SCHEMAS = [
         platform="cover",
         hint="fibaro_fgs222",
         manufacturer_id={622},
-        model_id={23089},
+        product_id={23089},
         product_type={17235},
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SWITCH_MULTILEVEL},
@@ -370,6 +370,30 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
     """Run discovery on ZWave node and return matching (primary) values."""
     for value in node.values.values():
         for schema in DISCOVERY_SCHEMAS:
+            # check manufacturer_id
+            if (
+                schema.manufacturer_id is not None
+                and value.node.manufacturer_id not in schema.manufacturer_id
+            ):
+                continue
+            # check product_id
+            if (
+                schema.product_id is not None
+                and value.node.product_id not in schema.product_id
+            ):
+                continue
+            # check product_type
+            if (
+                schema.product_type is not None
+                and value.node.product_type not in schema.product_type
+            ):
+                continue
+            # check firmware_version
+            if (
+                schema.firmware_version is not None
+                and value.node.firmware_version not in schema.firmware_version
+            ):
+                continue
             # check device_class_basic
             if (
                 schema.device_class_basic is not None


### PR DESCRIPTION
## Breaking change

## Proposed change
This adds a bit more flexibility to the discovery schema:
- Require some device specific values to be present
- Require additional values to be present
- Do not rediscovery a primary value by default for multiple platforms

This change allows us to solve several outstanding issues regarding device specific support where a device does not follow the Z-Wave specs 100% where our current discovery schema requires this.

For example some Fan and cover controllers being detected as light.
I've implemented the 2 low hanging fruit device specific schemas: those for the fans and covers but once this PR is merged this can be the foundation of more device specific fixes.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information

- This PR fixes or closes issue: fixes #46285 fixes #45934 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
