### PR TITLE
Use core constants for lovelace

### DIFF
--- a/homeassistant/components/lovelace/__init__.py
+++ b/homeassistant/components/lovelace/__init__.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 
 from homeassistant.components import frontend
 from homeassistant.config import async_hass_config_yaml, async_process_component_config
-from homeassistant.const import CONF_FILENAME
+from homeassistant.const import CONF_FILENAME, CONF_MODE, CONF_RESOURCES
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection, config_validation as cv
@@ -16,9 +16,7 @@ from homeassistant.loader import async_get_integration
 from . import dashboard, resources, websocket
 from .const import (
     CONF_ICON,
-    CONF_MODE,
     CONF_REQUIRE_ADMIN,
-    CONF_RESOURCES,
     CONF_SHOW_IN_SIDEBAR,
     CONF_TITLE,
     CONF_URL_PATH,

--- a/homeassistant/components/lovelace/const.py
+++ b/homeassistant/components/lovelace/const.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_ICON, CONF_TYPE, CONF_URL
+from homeassistant.const import CONF_ICON, CONF_MODE, CONF_TYPE, CONF_URL
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import slugify
@@ -13,13 +13,11 @@ EVENT_LOVELACE_UPDATED = "lovelace_updated"
 
 DEFAULT_ICON = "hass:view-dashboard"
 
-CONF_MODE = "mode"
 MODE_YAML = "yaml"
 MODE_STORAGE = "storage"
 MODE_AUTO = "auto-gen"
 
 LOVELACE_CONFIG_FILE = "ui-lovelace.yaml"
-CONF_RESOURCES = "resources"
 CONF_URL_PATH = "url_path"
 CONF_RESOURCE_TYPE_WS = "res_type"
 

--- a/homeassistant/components/lovelace/resources.py
+++ b/homeassistant/components/lovelace/resources.py
@@ -5,14 +5,13 @@ import uuid
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_TYPE
+from homeassistant.const import CONF_RESOURCES, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection, storage
 
 from .const import (
     CONF_RESOURCE_TYPE_WS,
-    CONF_RESOURCES,
     DOMAIN,
     RESOURCE_CREATE_FIELDS,
     RESOURCE_SCHEMA,

--- a/homeassistant/components/lovelace/system_health.py
+++ b/homeassistant/components/lovelace/system_health.py
@@ -2,9 +2,10 @@
 import asyncio
 
 from homeassistant.components import system_health
+from homeassistant.const import CONF_MODE
 from homeassistant.core import HomeAssistant, callback
 
-from .const import CONF_MODE, DOMAIN, MODE_AUTO, MODE_STORAGE, MODE_YAML
+from .const import DOMAIN, MODE_AUTO, MODE_STORAGE, MODE_YAML
 
 
 @callback


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use core constants for lovelace.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
