### PR TITLE
Add support for pre-filtering events to the event bus

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1139,17 +1139,13 @@ class EntityRegistryDisabledHandler:
     def async_setup(self) -> None:
         """Set up the disable handler."""
         self.hass.bus.async_listen(
-            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED, self._handle_entry_updated
+            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED,
+            self._handle_entry_updated,
+            event_filter=_handle_entry_updated_filter,
         )
 
     async def _handle_entry_updated(self, event: Event) -> None:
         """Handle entity registry entry update."""
-        if (
-            event.data["action"] != "update"
-            or "disabled_by" not in event.data["changes"]
-        ):
-            return
-
         if self.registry is None:
             self.registry = await entity_registry.async_get_registry(self.hass)
 
@@ -1201,6 +1197,14 @@ class EntityRegistryDisabledHandler:
         await asyncio.gather(
             *[self.hass.config_entries.async_reload(entry_id) for entry_id in to_reload]
         )
+
+
+@callback
+def _handle_entry_updated_filter(event: Event) -> bool:
+    """Handle entity registry entry update filter."""
+    if event.data["action"] != "update" or "disabled_by" not in event.data["changes"]:
+        return False
+    return True
 
 
 async def support_entry_unload(hass: HomeAssistant, domain: str) -> bool:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -28,6 +28,7 @@ from typing import (
     Mapping,
     Optional,
     Set,
+    Tuple,
     TypeVar,
     Union,
     cast,
@@ -661,7 +662,7 @@ class EventBus:
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize a new event bus."""
-        self._listeners: Dict[str, List[HassJob]] = {}
+        self._listeners: Dict[str, List[Tuple[HassJob, Optional[Callable]]]] = {}
         self._hass = hass
 
     @callback
@@ -717,7 +718,14 @@ class EventBus:
         if not listeners:
             return
 
-        for job in listeners:
+        for job, event_filter in listeners:
+            if event_filter is not None:
+                try:
+                    if not event_filter(event):
+                        continue
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Error in event filter")
+                    continue
             self._hass.async_add_hass_job(job, event)
 
     def listen(self, event_type: str, listener: Callable) -> CALLBACK_TYPE:
@@ -737,7 +745,12 @@ class EventBus:
         return remove_listener
 
     @callback
-    def async_listen(self, event_type: str, listener: Callable) -> CALLBACK_TYPE:
+    def async_listen(
+        self,
+        event_type: str,
+        listener: Callable,
+        event_filter: Optional[Callable] = None,
+    ) -> CALLBACK_TYPE:
         """Listen for all events or events of a specific type.
 
         To listen to all events specify the constant ``MATCH_ALL``
@@ -745,15 +758,21 @@ class EventBus:
 
         This method must be run in the event loop.
         """
-        return self._async_listen_job(event_type, HassJob(listener))
+        if event_filter is not None and not is_callback(event_filter):
+            raise HomeAssistantError(f"Event filter {event_filter} is not a callback")
+        return self._async_listen_filterable_job(
+            event_type, (HassJob(listener), event_filter)
+        )
 
     @callback
-    def _async_listen_job(self, event_type: str, hassjob: HassJob) -> CALLBACK_TYPE:
-        self._listeners.setdefault(event_type, []).append(hassjob)
+    def _async_listen_filterable_job(
+        self, event_type: str, filterable_job: Tuple[HassJob, Optional[Callable]]
+    ) -> CALLBACK_TYPE:
+        self._listeners.setdefault(event_type, []).append(filterable_job)
 
         def remove_listener() -> None:
             """Remove the listener."""
-            self._async_remove_listener(event_type, hassjob)
+            self._async_remove_listener(event_type, filterable_job)
 
         return remove_listener
 
@@ -786,12 +805,12 @@ class EventBus:
 
         This method must be run in the event loop.
         """
-        job: Optional[HassJob] = None
+        filterable_job: Optional[Tuple[HassJob, Optional[Callable]]] = None
 
         @callback
         def _onetime_listener(event: Event) -> None:
             """Remove listener from event bus and then fire listener."""
-            nonlocal job
+            nonlocal filterable_job
             if hasattr(_onetime_listener, "run"):
                 return
             # Set variable so that we will never run twice.
@@ -800,22 +819,24 @@ class EventBus:
             # multiple times as well.
             # This will make sure the second time it does nothing.
             setattr(_onetime_listener, "run", True)
-            assert job is not None
-            self._async_remove_listener(event_type, job)
+            assert filterable_job is not None
+            self._async_remove_listener(event_type, filterable_job)
             self._hass.async_run_job(listener, event)
 
-        job = HassJob(_onetime_listener)
+        filterable_job = (HassJob(_onetime_listener), None)
 
-        return self._async_listen_job(event_type, job)
+        return self._async_listen_filterable_job(event_type, filterable_job)
 
     @callback
-    def _async_remove_listener(self, event_type: str, hassjob: HassJob) -> None:
+    def _async_remove_listener(
+        self, event_type: str, filterable_job: Tuple[HassJob, Optional[Callable]]
+    ) -> None:
         """Remove a listener of a specific event_type.
 
         This method must be run in the event loop.
         """
         try:
-            self._listeners[event_type].remove(hassjob)
+            self._listeners[event_type].remove(filterable_job)
 
             # delete event_type list if empty
             if not self._listeners[event_type]:
@@ -823,7 +844,9 @@ class EventBus:
         except (KeyError, ValueError):
             # KeyError is key event_type listener did not exist
             # ValueError if listener did not exist within event_type
-            _LOGGER.exception("Unable to remove unknown job listener %s", hassjob)
+            _LOGGER.exception(
+                "Unable to remove unknown job listener %s", filterable_job
+            )
 
 
 class State:

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -756,6 +756,10 @@ class EventBus:
         To listen to all events specify the constant ``MATCH_ALL``
         as event_type.
 
+        An optional event_filter, which must be a callable decorated with
+        @callback that returns a boolean value, determines if the
+        listener callable should run.
+
         This method must be run in the event loop.
         """
         if event_filter is not None and not is_callback(event_filter):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -686,25 +686,34 @@ def async_setup_cleanup(hass: HomeAssistantType, dev_reg: DeviceRegistry) -> Non
     )
 
     async def entity_registry_changed(event: Event) -> None:
-        """Handle entity updated or removed."""
+        """Handle entity updated or removed dispatch."""
+        await debounced_cleanup.async_call()
+
+    @callback
+    def entity_registry_changed_filter(event: Event) -> bool:
+        """Handle entity updated or removed filter."""
         if (
             event.data["action"] == "update"
             and "device_id" not in event.data["changes"]
         ) or event.data["action"] == "create":
-            return
+            return False
 
-        await debounced_cleanup.async_call()
+        return True
 
     if hass.is_running:
         hass.bus.async_listen(
-            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED, entity_registry_changed
+            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED,
+            entity_registry_changed,
+            event_filter=entity_registry_changed_filter,
         )
         return
 
     async def startup_clean(event: Event) -> None:
         """Clean up on startup."""
         hass.bus.async_listen(
-            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED, entity_registry_changed
+            entity_registry.EVENT_ENTITY_REGISTRY_UPDATED,
+            entity_registry_changed,
+            event_filter=entity_registry_changed_filter,
         )
         await debounced_cleanup.async_call()
 

--- a/homeassistant/scripts/benchmark/__init__.py
+++ b/homeassistant/scripts/benchmark/__init__.py
@@ -62,7 +62,7 @@ async def fire_events(hass):
     """Fire a million events."""
     count = 0
     event_name = "benchmark_event"
-    event = asyncio.Event()
+    events_to_fire = 10 ** 6
 
     @core.callback
     def listener(_):
@@ -70,17 +70,48 @@ async def fire_events(hass):
         nonlocal count
         count += 1
 
-        if count == 10 ** 6:
-            event.set()
-
     hass.bus.async_listen(event_name, listener)
 
-    for _ in range(10 ** 6):
+    for _ in range(events_to_fire):
         hass.bus.async_fire(event_name)
 
     start = timer()
 
-    await event.wait()
+    await hass.async_block_till_done()
+
+    assert count == events_to_fire
+
+    return timer() - start
+
+
+@benchmark
+async def fire_events_with_filter(hass):
+    """Fire a million events with a filter that rejects them."""
+    count = 0
+    event_name = "benchmark_event"
+    events_to_fire = 10 ** 6
+
+    @core.callback
+    def event_filter(event):
+        """Filter event."""
+        return False
+
+    @core.callback
+    def listener(_):
+        """Handle event."""
+        nonlocal count
+        count += 1
+
+    hass.bus.async_listen(event_name, listener, event_filter=event_filter)
+
+    for _ in range(events_to_fire):
+        hass.bus.async_fire(event_name)
+
+    start = timer()
+
+    await hass.async_block_till_done()
+
+    assert count == 0
 
     return timer() - start
 
@@ -154,16 +185,13 @@ async def state_changed_event_helper(hass):
     """Run a million events through state changed event helper with 1000 entities."""
     count = 0
     entity_id = "light.kitchen"
-    event = asyncio.Event()
+    events_to_fire = 10 ** 6
 
     @core.callback
     def listener(*args):
         """Handle event."""
         nonlocal count
         count += 1
-
-        if count == 10 ** 6:
-            event.set()
 
     hass.helpers.event.async_track_state_change_event(
         [f"{entity_id}{idx}" for idx in range(1000)], listener
@@ -175,12 +203,49 @@ async def state_changed_event_helper(hass):
         "new_state": core.State(entity_id, "on"),
     }
 
-    for _ in range(10 ** 6):
+    for _ in range(events_to_fire):
         hass.bus.async_fire(EVENT_STATE_CHANGED, event_data)
 
     start = timer()
 
-    await event.wait()
+    await hass.async_block_till_done()
+
+    assert count == events_to_fire
+
+    return timer() - start
+
+
+@benchmark
+async def state_changed_event_filter_helper(hass):
+    """Run a million events through state changed event helper with 1000 entities that all get filtered."""
+    count = 0
+    entity_id = "light.kitchen"
+    events_to_fire = 10 ** 6
+
+    @core.callback
+    def listener(*args):
+        """Handle event."""
+        nonlocal count
+        count += 1
+
+    hass.helpers.event.async_track_state_change_event(
+        [f"{entity_id}{idx}" for idx in range(1000)], listener
+    )
+
+    event_data = {
+        "entity_id": "switch.no_listeners",
+        "old_state": core.State(entity_id, "off"),
+        "new_state": core.State(entity_id, "on"),
+    }
+
+    for _ in range(events_to_fire):
+        hass.bus.async_fire(EVENT_STATE_CHANGED, event_data)
+
+    start = timer()
+
+    await hass.async_block_till_done()
+
+    assert count == 0
 
     return timer() - start
 

--- a/tests/components/mqtt/test_device_tracker_discovery.py
+++ b/tests/components/mqtt/test_device_tracker_discovery.py
@@ -194,6 +194,7 @@ async def test_cleanup_device_tracker(hass, device_reg, entity_reg, mqtt_mock):
 
     device_reg.async_remove_device(device_entry.id)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
     device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})

--- a/tests/components/mqtt/test_discovery.py
+++ b/tests/components/mqtt/test_discovery.py
@@ -411,6 +411,7 @@ async def test_cleanup_device(hass, device_reg, entity_reg, mqtt_mock):
 
     device_reg.async_remove_device(device_entry.id)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     # Verify device and registry entries are cleared
     device_entry = device_reg.async_get_device({("mqtt", "0AFFD2")})

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -353,6 +353,7 @@ async def test_remove_clients(hass, aioclient_mock):
     }
     controller.api.session_handler(SIGNAL_DATA)
     await hass.async_block_till_done()
+    await hass.async_block_till_done()
 
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -379,6 +379,35 @@ async def test_eventbus_add_remove_listener(hass):
     unsub()
 
 
+async def test_eventbus_filtered_listener(hass):
+    """Test we can prefilter events."""
+    calls = []
+
+    @ha.callback
+    def listener(event):
+        """Mock listener."""
+        calls.append(event)
+
+    @ha.callback
+    def filter(event):
+        """Mock filter."""
+        return not event.data["filtered"]
+
+    unsub = hass.bus.async_listen("test", listener, event_filter=filter)
+
+    hass.bus.async_fire("test", {"filtered": True})
+    await hass.async_block_till_done()
+
+    assert len(calls) == 0
+
+    hass.bus.async_fire("test", {"filtered": False})
+    await hass.async_block_till_done()
+
+    assert len(calls) == 1
+
+    unsub()
+
+
 async def test_eventbus_unsubscribe_listener(hass):
     """Test unsubscribe listener from returned function."""
     calls = []


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The event bus now supports passing a `callback` that will
be used to pre-filter listeners before they are scheduled
in the event loop.

Most events are actually rejected (in testing it 
was around 55% of events on most of my production installs) 
with only the recorder processing most events.  
By pre-filtering them we can avoid the overhead of scheduling
jobs in the event loop that will do nothing.

The below benchmarks show events rejected by the filter
are multiple orders of magnitude faster. 

Using event loop: _UnixSelectorEventLoop
Benchmark fire_events done in 1.4954355582594872s
Benchmark fire_events done in 1.4697927068918943s
Benchmark fire_events done in 1.514022232964635s

Using event loop: _UnixSelectorEventLoop
Benchmark fire_events_with_filter done in 0.00010396912693977356s
Benchmark fire_events_with_filter done in 0.00010444782674312592s
Benchmark fire_events_with_filter done in 0.00010054744780063629s

Using event loop: _UnixSelectorEventLoop
Benchmark state_changed_event_helper done in 3.3746970128268003s
Benchmark state_changed_event_helper done in 3.447709832340479s
Benchmark state_changed_event_helper done in 3.4875717479735613s

Using event loop: _UnixSelectorEventLoop
Benchmark state_changed_event_filter_helper done in 0.00010205432772636414s
Benchmark state_changed_event_filter_helper done in 0.00010164640843868256s
Benchmark state_changed_event_filter_helper done in 0.00010021217167377472s


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40292
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
