### PR TITLE
Use core constants for modbus

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_METHOD,
     CONF_NAME,
+    CONF_OFFSET,
     CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
@@ -46,7 +47,6 @@ from .const import (
     CONF_INPUT_TYPE,
     CONF_MAX_TEMP,
     CONF_MIN_TEMP,
-    CONF_OFFSET,
     CONF_PARITY,
     CONF_PRECISION,
     CONF_REGISTER,
@@ -257,7 +257,6 @@ class ModbusHub:
 
     def __init__(self, client_config):
         """Initialize the Modbus hub."""
-
         # generic configuration
         self._client = None
         self._lock = threading.Lock()

--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -10,13 +10,12 @@ from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_SLAVE
+from homeassistant.const import CONF_ADDRESS, CONF_DEVICE_CLASS, CONF_NAME, CONF_SLAVE
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
-    CONF_ADDRESS,
     CONF_COILS,
     CONF_HUB,
     CONF_INPUT_TYPE,

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -15,6 +15,7 @@ from homeassistant.components.climate.const import (
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_NAME,
+    CONF_OFFSET,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
     CONF_STRUCTURE,
@@ -39,7 +40,6 @@ from .const import (
     CONF_DATA_TYPE,
     CONF_MAX_TEMP,
     CONF_MIN_TEMP,
-    CONF_OFFSET,
     CONF_PRECISION,
     CONF_SCALE,
     CONF_STEP,
@@ -146,7 +146,6 @@ class ModbusThermostat(ClimateEntity):
 
         False if entity pushes its state to HA.
         """
-
         # Handle polling directly in this entity
         return False
 

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -13,7 +13,6 @@ CONF_REVERSE_ORDER = "reverse_order"
 CONF_SCALE = "scale"
 CONF_COUNT = "count"
 CONF_PRECISION = "precision"
-CONF_OFFSET = "offset"
 CONF_COILS = "coils"
 
 # integration names
@@ -51,7 +50,6 @@ DEFAULT_SCAN_INTERVAL = 15  # seconds
 # binary_sensor.py
 CONF_INPUTS = "inputs"
 CONF_INPUT_TYPE = "input_type"
-CONF_ADDRESS = "address"
 
 # sensor.py
 # CONF_DATA_TYPE = "data_type"

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -148,7 +148,6 @@ class ModbusCover(CoverEntity, RestoreEntity):
 
         False if entity pushes its state to HA.
         """
-
         # Handle polling directly in this entity
         return False
 

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -200,7 +200,6 @@ class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
 
     def turn_on(self, **kwargs):
         """Set switch on."""
-
         # Only holding register is writable
         if self._register_type == CALL_TYPE_REGISTER_HOLDING:
             self._write_register(self._command_on)
@@ -209,7 +208,6 @@ class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
 
     def turn_off(self, **kwargs):
         """Set switch off."""
-
         # Only holding register is writable
         if self._register_type == CALL_TYPE_REGISTER_HOLDING:
             self._write_register(self._command_off)

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -46,7 +46,6 @@ async def setup_base_test(
     scan_interval,
 ):
     """Run setup device for given config."""
-
     # Full sensor configuration
     config = {
         entity_domain: {
@@ -79,7 +78,6 @@ async def run_base_read_test(
     now,
 ):
     """Run test for given config."""
-
     # Setup inputs for the sensor
     read_result = ReadResult(register_words)
     if register_type == CALL_TYPE_COIL:

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -7,11 +7,10 @@ from homeassistant.components.binary_sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
-    CONF_ADDRESS,
     CONF_INPUT_TYPE,
     CONF_INPUTS,
 )
-from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON
+from homeassistant.const import CONF_ADDRESS, CONF_NAME, STATE_OFF, STATE_ON
 
 from .conftest import run_base_read_test, setup_base_test
 

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -8,7 +8,6 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_REGISTER_INPUT,
     CONF_COUNT,
     CONF_DATA_TYPE,
-    CONF_OFFSET,
     CONF_PRECISION,
     CONF_REGISTER,
     CONF_REGISTER_TYPE,
@@ -21,7 +20,7 @@ from homeassistant.components.modbus.const import (
     DATA_TYPE_UINT,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, CONF_OFFSET
 
 from .conftest import run_base_read_test, setup_base_test
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use core constants for modbus.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
