### PR TITLE
Add switch platform to goalzero

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -340,6 +340,7 @@ omit =
     homeassistant/components/goalfeed/*
     homeassistant/components/goalzero/__init__.py
     homeassistant/components/goalzero/binary_sensor.py
+    homeassistant/components/goalzero/switch.py
     homeassistant/components/google/*
     homeassistant/components/google_cloud/tts.py
     homeassistant/components/google_maps/device_tracker.py

--- a/homeassistant/components/goalzero/__init__.py
+++ b/homeassistant/components/goalzero/__init__.py
@@ -20,12 +20,11 @@ from .const import DATA_KEY_API, DATA_KEY_COORDINATOR, DOMAIN, MIN_TIME_BETWEEN_
 _LOGGER = logging.getLogger(__name__)
 
 
-PLATFORMS = ["binary_sensor"]
+PLATFORMS = ["binary_sensor", "switch"]
 
 
 async def async_setup(hass: HomeAssistant, config):
     """Set up the Goal Zero Yeti component."""
-
     hass.data[DOMAIN] = {}
 
     return True

--- a/homeassistant/components/goalzero/binary_sensor.py
+++ b/homeassistant/components/goalzero/binary_sensor.py
@@ -5,8 +5,6 @@ from homeassistant.const import CONF_NAME
 from . import YetiEntity
 from .const import BINARY_SENSOR_DICT, DATA_KEY_API, DATA_KEY_COORDINATOR, DOMAIN
 
-PARALLEL_UPDATES = 0
-
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up the Goal Zero Yeti sensor."""

--- a/homeassistant/components/goalzero/const.py
+++ b/homeassistant/components/goalzero/const.py
@@ -15,9 +15,6 @@ DATA_KEY_API = "api"
 MIN_TIME_BETWEEN_UPDATES = timedelta(seconds=30)
 
 BINARY_SENSOR_DICT = {
-    "v12PortStatus": ["12V Port Status", DEVICE_CLASS_POWER, None],
-    "usbPortStatus": ["USB Port Status", DEVICE_CLASS_POWER, None],
-    "acPortStatus": ["AC Port Status", DEVICE_CLASS_POWER, None],
     "backlight": ["Backlight", None, "mdi:clock-digital"],
     "app_online": [
         "App Online",
@@ -25,4 +22,10 @@ BINARY_SENSOR_DICT = {
         None,
     ],
     "isCharging": ["Charging", DEVICE_CLASS_BATTERY_CHARGING, None],
+}
+
+SWITCH_DICT = {
+    "v12PortStatus": ["12V Port Status", DEVICE_CLASS_POWER, None],
+    "usbPortStatus": ["USB Port Status", DEVICE_CLASS_POWER, None],
+    "acPortStatus": ["AC Port Status", DEVICE_CLASS_POWER, None],
 }

--- a/homeassistant/components/goalzero/manifest.json
+++ b/homeassistant/components/goalzero/manifest.json
@@ -3,6 +3,6 @@
   "name": "Goal Zero Yeti",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/goalzero",
-  "requirements": ["goalzero==0.1.4"],
+  "requirements": ["goalzero==0.1.5"],
   "codeowners": ["@tkdrob"]
 }

--- a/homeassistant/components/goalzero/switch.py
+++ b/homeassistant/components/goalzero/switch.py
@@ -52,15 +52,14 @@ class YetiSwitch(YetiEntity, SwitchEntity):
         """Return state of the switch."""
         return self.api.data[self._condition]
 
-    @property
-    def icon(self):
-        """Icon to use in the frontend, if any."""
-        return self._icon
-
     async def async_turn_off(self, **kwargs):
         """Turn off the switch."""
-        await self.api.post_state(payload={self._condition: 0})
+        _payload = {self._condition: 0}
+        await self.api.post_state(payload=_payload)
+        self.coordinator.async_set_updated_data(data=_payload)
 
     async def async_turn_on(self, **kwargs):
         """Turn on the switch."""
-        await self.api.post_state(payload={self._condition: 1})
+        _payload = {self._condition: 1}
+        await self.api.post_state(payload=_payload)
+        self.coordinator.async_set_updated_data(data=_payload)

--- a/homeassistant/components/goalzero/switch.py
+++ b/homeassistant/components/goalzero/switch.py
@@ -1,0 +1,66 @@
+"""Support for Goal Zero Yeti Switches."""
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME
+
+from . import YetiEntity
+from .const import DATA_KEY_API, DATA_KEY_COORDINATOR, DOMAIN, SWITCH_DICT
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the Goal Zero Yeti switch."""
+    name = entry.data[CONF_NAME]
+    goalzero_data = hass.data[DOMAIN][entry.entry_id]
+    switches = [
+        YetiSwitch(
+            goalzero_data[DATA_KEY_API],
+            goalzero_data[DATA_KEY_COORDINATOR],
+            name,
+            switch_name,
+            entry.entry_id,
+        )
+        for switch_name in SWITCH_DICT
+    ]
+    async_add_entities(switches, True)
+
+
+class YetiSwitch(YetiEntity, SwitchEntity):
+    """Representation of a Goal Zero Yeti switch."""
+
+    def __init__(self, api, coordinator, name, switch_name, server_unique_id):
+        """Initialize a Goal Zero Yeti switch."""
+        super().__init__(api, coordinator, name, server_unique_id)
+
+        self._condition = switch_name
+
+        variable_info = SWITCH_DICT[switch_name]
+        self._condition_name = variable_info[0]
+        self._icon = variable_info[2]
+        self._device_class = variable_info[1]
+
+    @property
+    def name(self):
+        """Return the name of the switch."""
+        return f"{self._name} {self._condition_name}"
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the switch."""
+        return f"{self._server_unique_id}/{self._condition_name}"
+
+    @property
+    def is_on(self):
+        """Return state of the switch."""
+        return self.api.data[self._condition]
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend, if any."""
+        return self._icon
+
+    async def async_turn_off(self, **kwargs):
+        """Turn off the switch."""
+        await self.api.post_state(payload={self._condition: 0})
+
+    async def async_turn_on(self, **kwargs):
+        """Turn on the switch."""
+        await self.api.post_state(payload={self._condition: 1})

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -669,7 +669,7 @@ glances_api==0.2.0
 gntp==1.0.3
 
 # homeassistant.components.goalzero
-goalzero==0.1.4
+goalzero==0.1.5
 
 # homeassistant.components.gogogate2
 gogogate2-api==3.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -354,7 +354,7 @@ gios==0.1.5
 glances_api==0.2.0
 
 # homeassistant.components.goalzero
-goalzero==0.1.4
+goalzero==0.1.5
 
 # homeassistant.components.gogogate2
 gogogate2-api==3.0.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Potential breaking change moving three switches from binary_sensor to switch. 

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add switch support for the 12V, USB, and AC switches on Goal Zero Yeti wifi enabled devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16515

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
