### PR TITLE
Do not trigger when template is true at startup

### DIFF
--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -43,12 +43,14 @@ async def test_if_fires_on_change_bool(hass, calls):
             automation.DOMAIN: {
                 "trigger": {
                     "platform": "template",
-                    "value_template": "{{ states.test.entity.state and true }}",
+                    "value_template": '{{ states.test.entity.state == "world" and true }}',
                 },
                 "action": {"service": "test.automation"},
             }
         },
     )
+
+    assert len(calls) == 0
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -75,12 +77,14 @@ async def test_if_fires_on_change_str(hass, calls):
             automation.DOMAIN: {
                 "trigger": {
                     "platform": "template",
-                    "value_template": '{{ states.test.entity.state and "true" }}',
+                    "value_template": '{{ states.test.entity.state == "world" and "true" }}',
                 },
                 "action": {"service": "test.automation"},
             }
         },
     )
+
+    assert len(calls) == 0
 
     hass.states.async_set("test.entity", "world")
     await hass.async_block_till_done()
@@ -96,7 +100,7 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
             automation.DOMAIN: {
                 "trigger": {
                     "platform": "template",
-                    "value_template": '{{ states.test.entity.state and "TrUE" }}',
+                    "value_template": '{{ states.test.entity.state == "world" and "TrUE" }}',
                 },
                 "action": {"service": "test.automation"},
             }
@@ -104,6 +108,62 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
     )
 
     hass.states.async_set("test.entity", "world")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+
+async def test_if_not_fires_when_true_at_setup(hass, calls):
+    """Test for not firing on boolean change."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "template",
+                    "value_template": '{{ states.test.entity.state == "hello" }}',
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    assert len(calls) == 0
+
+    hass.states.async_set("test.entity", "hello", force_update=True)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+async def test_if_not_fires_because_fail(hass, calls):
+    """Test for not firing on boolean change."""
+    hass.states.async_set("test.number", "1")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "template",
+                    "value_template": "{{ 84 / states.test.number.state|int == 42 }}",
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    assert len(calls) == 0
+
+    hass.states.async_set("test.number", "2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set("test.number", "0")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    hass.states.async_set("test.number", "2")
     await hass.async_block_till_done()
     assert len(calls) == 1
 
@@ -117,7 +177,7 @@ async def test_if_not_fires_on_change_bool(hass, calls):
             automation.DOMAIN: {
                 "trigger": {
                     "platform": "template",
-                    "value_template": "{{ states.test.entity.state and false }}",
+                    "value_template": '{{ states.test.entity.state == "world" and false }}',
                 },
                 "action": {"service": "test.automation"},
             }
@@ -198,7 +258,7 @@ async def test_if_fires_on_two_change(hass, calls):
             automation.DOMAIN: {
                 "trigger": {
                     "platform": "template",
-                    "value_template": "{{ states.test.entity.state and true }}",
+                    "value_template": "{{ states.test.entity.state == 'world' }}",
                 },
                 "action": {"service": "test.automation"},
             }

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -113,7 +113,7 @@ async def test_if_fires_on_change_str_crazy(hass, calls):
 
 
 async def test_if_not_fires_when_true_at_setup(hass, calls):
-    """Test for not firing on boolean change."""
+    """Test for not firing during startup."""
     assert await async_setup_component(
         hass,
         automation.DOMAIN,
@@ -136,7 +136,7 @@ async def test_if_not_fires_when_true_at_setup(hass, calls):
 
 
 async def test_if_not_fires_because_fail(hass, calls):
-    """Test for not firing on boolean change."""
+    """Test for not firing after TemplateError."""
     hass.states.async_set("test.number", "1")
 
     assert await async_setup_component(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This PR changes the behaviour but I think we agreed to call it a bug fix.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As agreed in home-assistant/architecture#456, this modifies the `template` trigger to only fire when it has been false and then turns true. Specifically, it will no longer fire in these three situations:
1. When the template is initially true during setup (startup/reload).
2. When the template goes from true through a `TemplateError` and back to true, never being false.
3. When the template goes from true to true, for example `true` ➡️ `True` or `5` ➡️ `6`.

I'll cc @frenck since he suggested an implementation detail that I didn't 100% understand so please check and elaborate if I got it wrong :-)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/architecture#456, home-assistant/core#40331
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
