### PR TITLE
Do not trigger when numeric_state is true at startup

### DIFF
--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -73,7 +73,7 @@ async def async_attach_trigger(
     template.attach(hass, time_delta)
     value_template = config.get(CONF_VALUE_TEMPLATE)
     unsub_track_same = {}
-    entities_triggered = set()
+    armed_entities = set()
     period: dict = {}
     attribute = config.get(CONF_ATTRIBUTE)
     job = HassJob(action)
@@ -100,20 +100,22 @@ async def async_attach_trigger(
 
     @callback
     def check_numeric_state(entity_id, from_s, to_s):
-        """Return True if criteria are now met."""
+        """Return whether the criteria are met, raise ConditionError if unknown."""
+        return condition.async_numeric_state(
+            hass, to_s, below, above, value_template, variables(entity_id), attribute
+        )
+
+    # If the condition is False at startup, we are already armed.
+    for entity_id in entity_ids:
         try:
-            return condition.async_numeric_state(
-                hass,
-                to_s,
-                below,
-                above,
-                value_template,
-                variables(entity_id),
-                attribute,
+            if not check_numeric_state(entity_id, None, entity_id):
+                armed_entities.add(entity_id)
+        except exceptions.ConditionError as ex:
+            _LOGGER.warning(
+                "Error initializing 'numeric_state' trigger for '%s': %s",
+                automation_info["name"],
+                ex,
             )
-        except exceptions.ConditionError as err:
-            _LOGGER.warning("%s", err)
-            return False
 
     @callback
     def state_automation_listener(event):
@@ -142,12 +144,25 @@ async def async_attach_trigger(
                 to_s.context,
             )
 
-        matching = check_numeric_state(entity_id, from_s, to_s)
+        @callback
+        def check_numeric_state_no_raise(entity_id, from_s, to_s):
+            """Return True if the criteria are now met, False otherwise."""
+            try:
+                return check_numeric_state(entity_id, from_s, to_s)
+            except exceptions.ConditionError:
+                # We can skip logging since the main listener will get and log an identical exception
+                return False
+
+        try:
+            matching = check_numeric_state(entity_id, from_s, to_s)
+        except exceptions.ConditionError as ex:
+            _LOGGER.warning("Error in '%s' trigger: %s", automation_info["name"], ex)
+            return
 
         if not matching:
-            entities_triggered.discard(entity_id)
-        elif entity_id not in entities_triggered:
-            entities_triggered.add(entity_id)
+            armed_entities.add(entity_id)
+        elif entity_id in armed_entities:
+            armed_entities.discard(entity_id)
 
             if time_delta:
                 try:
@@ -160,7 +175,6 @@ async def async_attach_trigger(
                         automation_info["name"],
                         ex,
                     )
-                    entities_triggered.discard(entity_id)
                     return
 
                 unsub_track_same[entity_id] = async_track_same_state(
@@ -168,7 +182,7 @@ async def async_attach_trigger(
                     period[entity_id],
                     call_action,
                     entity_ids=entity_id,
-                    async_check_same_func=check_numeric_state,
+                    async_check_same_func=check_numeric_state_no_raise,
                 )
             else:
                 call_action()

--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -105,7 +105,7 @@ async def async_attach_trigger(
             hass, to_s, below, above, value_template, variables(entity_id), attribute
         )
 
-    # If the condition is False at startup, we are already armed.
+    # Each entity that starts outside the range is already armed (ready to fire).
     for entity_id in entity_ids:
         try:
             if not check_numeric_state(entity_id, None, entity_id):
@@ -150,7 +150,9 @@ async def async_attach_trigger(
             try:
                 return check_numeric_state(entity_id, from_s, to_s)
             except exceptions.ConditionError:
-                # We can skip logging since the main listener will get and log an identical exception
+                # This is an internal same-state listener so we just drop the
+                # error. The same error will be reached and logged by the
+                # primary async_track_state_change_event() listener.
                 return False
 
         try:

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -542,8 +542,12 @@ async def test_if_fires_on_position(hass, calls):
             ]
         },
     )
+    hass.states.async_set(ent.entity_id, STATE_OPEN, attributes={"current_position": 1})
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_position": 50}
+        ent.entity_id, STATE_CLOSED, attributes={"current_position": 95}
+    )
+    hass.states.async_set(
+        ent.entity_id, STATE_OPEN, attributes={"current_position": 50}
     )
     await hass.async_block_till_done()
     assert len(calls) == 3
@@ -551,8 +555,8 @@ async def test_if_fires_on_position(hass, calls):
         [calls[0].data["some"], calls[1].data["some"], calls[2].data["some"]]
     ) == sorted(
         [
-            "is_pos_gt_45_lt_90 - device - cover.set_position_cover - open - closed - None",
-            "is_pos_lt_90 - device - cover.set_position_cover - open - closed - None",
+            "is_pos_gt_45_lt_90 - device - cover.set_position_cover - closed - open - None",
+            "is_pos_lt_90 - device - cover.set_position_cover - closed - open - None",
             "is_pos_gt_45 - device - cover.set_position_cover - open - closed - None",
         ]
     )
@@ -666,7 +670,13 @@ async def test_if_fires_on_tilt_position(hass, calls):
         },
     )
     hass.states.async_set(
-        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 50}
+        ent.entity_id, STATE_OPEN, attributes={"current_tilt_position": 1}
+    )
+    hass.states.async_set(
+        ent.entity_id, STATE_CLOSED, attributes={"current_tilt_position": 95}
+    )
+    hass.states.async_set(
+        ent.entity_id, STATE_OPEN, attributes={"current_tilt_position": 50}
     )
     await hass.async_block_till_done()
     assert len(calls) == 3
@@ -674,8 +684,8 @@ async def test_if_fires_on_tilt_position(hass, calls):
         [calls[0].data["some"], calls[1].data["some"], calls[2].data["some"]]
     ) == sorted(
         [
-            "is_pos_gt_45_lt_90 - device - cover.set_position_cover - open - closed - None",
-            "is_pos_lt_90 - device - cover.set_position_cover - open - closed - None",
+            "is_pos_gt_45_lt_90 - device - cover.set_position_cover - closed - open - None",
+            "is_pos_lt_90 - device - cover.set_position_cover - closed - open - None",
             "is_pos_gt_45 - device - cover.set_position_cover - open - closed - None",
         ]
     )

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -10,7 +10,12 @@ import homeassistant.components.automation as automation
 from homeassistant.components.homeassistant.triggers import (
     numeric_state as numeric_state_trigger,
 )
-from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ENTITY_MATCH_ALL,
+    SERVICE_TURN_OFF,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -241,7 +246,7 @@ async def test_if_not_below_fires_on_entity_change_to_equal(hass, calls, below):
 
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))
-async def test_if_fires_on_initial_entity_below(hass, calls, below):
+async def test_if_not_fires_on_initial_entity_below(hass, calls, below):
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 9)
     await hass.async_block_till_done()
@@ -261,14 +266,14 @@ async def test_if_fires_on_initial_entity_below(hass, calls, below):
         },
     )
 
-    # Fire on first update even if initial state was already below
+    # Do not fire on first update when initial state was already below
     hass.states.async_set("test.entity", 8)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 0
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
-async def test_if_fires_on_initial_entity_above(hass, calls, above):
+async def test_if_not_fires_on_initial_entity_above(hass, calls, above):
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
@@ -288,10 +293,10 @@ async def test_if_fires_on_initial_entity_above(hass, calls, above):
         },
     )
 
-    # Fire on first update even if initial state was already above
+    # Do not fire on first update when initial state was already above
     hass.states.async_set("test.entity", 12)
     await hass.async_block_till_done()
-    assert len(calls) == 1
+    assert len(calls) == 0
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
@@ -318,6 +323,74 @@ async def test_if_fires_on_entity_change_above(hass, calls, above):
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
     assert len(calls) == 1
+
+
+async def test_if_fires_on_entity_unavailable_at_startup(hass, calls):
+    """Test the firing with changed entity at startup."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "numeric_state",
+                    "entity_id": "test.entity",
+                    "above": 10,
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+    # 11 is above 10
+    hass.states.async_set("test.entity", 11)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+
+
+async def test_if_not_fires_on_entity_unavailable(hass, calls):
+    """Test the firing with entity changing to unavailable."""
+    # set initial state
+    hass.states.async_set("test.entity", 9)
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": {
+                    "platform": "numeric_state",
+                    "entity_id": "test.entity",
+                    "above": 10,
+                },
+                "action": {"service": "test.automation"},
+            }
+        },
+    )
+
+    # 11 is above 10
+    hass.states.async_set("test.entity", 11)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Going to unavailable and back should not fire
+    hass.states.async_set("test.entity", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    hass.states.async_set("test.entity", 11)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+
+    # Crossing threshold via unavailable should fire
+    hass.states.async_set("test.entity", 9)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    hass.states.async_set("test.entity", STATE_UNAVAILABLE)
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    hass.states.async_set("test.entity", 11)
+    await hass.async_block_till_done()
+    assert len(calls) == 2
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))

--- a/tests/components/sensor/test_device_trigger.py
+++ b/tests/components/sensor/test_device_trigger.py
@@ -428,6 +428,7 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
     assert hass.states.get(sensor1.entity_id).state == STATE_UNKNOWN
     assert len(calls) == 0
 
+    hass.states.async_set(sensor1.entity_id, 10)
     hass.states.async_set(sensor1.entity_id, 11)
     await hass.async_block_till_done()
     assert len(calls) == 0
@@ -437,5 +438,5 @@ async def test_if_fires_on_state_change_with_for(hass, calls):
     await hass.async_block_till_done()
     assert (
         calls[0].data["some"]
-        == f"turn_off device - {sensor1.entity_id} - unknown - 11 - 0:00:05"
+        == f"turn_off device - {sensor1.entity_id} - 10 - 11 - 0:00:05"
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This PR changes the behaviour but I think we agreed to call it a bug fix.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As agreed in home-assistant/architecture#456, this modifies the `numeric_state` trigger to only fire when it has been false and then turns true. Specifically, it will no longer fire in these two situations:
1. When the condition is initially true during setup (startup/reload).
2. When the condition goes from true through an `ConditionError` and back to true, never being false.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40331
- This PR is related to issue: closes home-assistant/architecture#456
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
