### PR TITLE
Add get_config_parameters websocket command to zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -296,6 +296,7 @@ def websocket_get_config_parameters(
                 "max": metadata.max,
                 "unit": metadata.unit,
                 "writeable": metadata.writeable,
+                "readable": metadata.readable,
             },
             "value": zwave_value.value,
         }

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -31,6 +31,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_stop_inclusion)
     websocket_api.async_register_command(hass, websocket_remove_node)
     websocket_api.async_register_command(hass, websocket_stop_exclusion)
+    websocket_api.async_register_command(hass, websocket_get_configuration_values)
     hass.http.register_view(DumpView)  # type: ignore
 
 
@@ -257,6 +258,40 @@ async def websocket_remove_node(
     ]
 
     result = await controller.async_begin_exclusion()
+    connection.send_result(
+        msg[ID],
+        result,
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/get_configuration_values",
+        vol.Required(ENTRY_ID): str,
+        vol.Required(NODE_ID): int,
+    }
+)
+@callback
+def websocket_get_configuration_values(
+    hass: HomeAssistant, connection: ActiveConnection, msg: dict
+) -> None:
+    """Get a list of configuration values for a Z-Wave node."""
+    entry_id = msg[ENTRY_ID]
+    node_id = msg[NODE_ID]
+    client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
+    node = client.driver.controller.nodes[node_id]
+    values = node.get_configuration_values()
+    result = {}
+    for value in values:
+        result[value] = {
+            "property": values[value].data["property"],
+            "property_name": values[value].data["propertyName"],
+            "metadata": values[value].data["metadata"],
+            "value": values[value].data.get(
+                "value"
+            ),  # Some config properties don't return a value
+        }
     connection.send_result(
         msg[ID],
         result,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -284,13 +284,22 @@ def websocket_get_configuration_values(
     values = node.get_configuration_values()
     result = {}
     for value in values:
+        metadata = values[value].metadata
         result[value] = {
-            "property": values[value].data["property"],
-            "property_name": values[value].data["propertyName"],
-            "metadata": values[value].data["metadata"],
-            "value": values[value].data.get(
-                "value"
-            ),  # Some config properties don't return a value
+            "property": values[value].property_,
+            "property_name": values[value].property_name,
+            "property_key": values[value].property_key,
+            "type": values[value].type.value,
+            "metadata": {
+                "description": metadata.description,
+                "label": metadata.label,
+                "type": metadata.type,
+                "min": metadata.min,
+                "max": metadata.max,
+                "unit": metadata.unit,
+                "writeable": metadata.writeable,
+            },
+            "value": values[value].value,
         }
     connection.send_result(
         msg[ID],

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -31,11 +31,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_stop_inclusion)
     websocket_api.async_register_command(hass, websocket_remove_node)
     websocket_api.async_register_command(hass, websocket_stop_exclusion)
-<<<<<<< HEAD
     websocket_api.async_register_command(hass, websocket_get_config_parameters)
-=======
-    websocket_api.async_register_command(hass, websocket_get_configuration_values)
->>>>>>> 5bb3567170... Add get_configuration_values websocket command to zwave_js
     hass.http.register_view(DumpView)  # type: ignore
 
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -283,13 +283,11 @@ def websocket_get_configuration_values(
     node = client.driver.controller.nodes[node_id]
     values = node.get_configuration_values()
     result = {}
-    for value in values:
-        metadata = values[value].metadata
-        result[value] = {
-            "property": values[value].property_,
-            "property_name": values[value].property_name,
-            "property_key": values[value].property_key,
-            "type": values[value].type.value,
+    for value_id, zwave_value in values.items():
+        metadata = zwave_value.metadata
+        result[value_id] = {
+            "property": zwave_value.property_,
+            "configuration_value_type": zwave_value.configuration_value_type.value,
             "metadata": {
                 "description": metadata.description,
                 "label": metadata.label,
@@ -299,7 +297,7 @@ def websocket_get_configuration_values(
                 "unit": metadata.unit,
                 "writeable": metadata.writeable,
             },
-            "value": values[value].value,
+            "value": zwave_value.value,
         }
     connection.send_result(
         msg[ID],

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -31,7 +31,11 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_stop_inclusion)
     websocket_api.async_register_command(hass, websocket_remove_node)
     websocket_api.async_register_command(hass, websocket_stop_exclusion)
+<<<<<<< HEAD
     websocket_api.async_register_command(hass, websocket_get_config_parameters)
+=======
+    websocket_api.async_register_command(hass, websocket_get_configuration_values)
+>>>>>>> 5bb3567170... Add get_configuration_values websocket command to zwave_js
     hass.http.register_view(DumpView)  # type: ignore
 
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -31,7 +31,7 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_stop_inclusion)
     websocket_api.async_register_command(hass, websocket_remove_node)
     websocket_api.async_register_command(hass, websocket_stop_exclusion)
-    websocket_api.async_register_command(hass, websocket_get_configuration_values)
+    websocket_api.async_register_command(hass, websocket_get_config_parameters)
     hass.http.register_view(DumpView)  # type: ignore
 
 
@@ -267,16 +267,16 @@ async def websocket_remove_node(
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
-        vol.Required(TYPE): "zwave_js/get_configuration_values",
+        vol.Required(TYPE): "zwave_js/get_config_parameters",
         vol.Required(ENTRY_ID): str,
         vol.Required(NODE_ID): int,
     }
 )
 @callback
-def websocket_get_configuration_values(
+def websocket_get_config_parameters(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ) -> None:
-    """Get a list of configuration values for a Z-Wave node."""
+    """Get a list of configuration parameterss for a Z-Wave node."""
     entry_id = msg[ENTRY_ID]
     node_id = msg[NODE_ID]
     client = hass.data[DOMAIN][entry_id][DATA_CLIENT]

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -41,6 +41,24 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     assert not result["is_secure"]
     assert result["status"] == 1
 
+    # Test getting configuration values
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/get_configuration_values",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: node.node_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+
+    assert len(result) == 44
+    key = "52-112-00-2-00"
+    assert result[key]["property"] == 2
+    assert result[key]["property_name"] == "Stay Awake in Battery Mode"
+    assert result[key]["metadata"]["type"] == "number"
+
 
 async def test_add_node(
     hass, integration, client, hass_ws_client, nortek_thermostat_added_event

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -53,8 +53,8 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     msg = await ws_client.receive_json()
     result = msg["result"]
 
-    assert len(result) == 44
-    key = "52-112-00-2-00"
+    assert len(result) == 61
+    key = "52-112-0-2-00-00"
     assert result[key]["property"] == 2
     assert result[key]["metadata"]["type"] == "number"
     assert result[key]["configuration_value_type"] == "enumerated"

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -56,8 +56,8 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     assert len(result) == 44
     key = "52-112-00-2-00"
     assert result[key]["property"] == 2
-    assert result[key]["property_name"] == "Stay Awake in Battery Mode"
     assert result[key]["metadata"]["type"] == "number"
+    assert result[key]["configuration_value_type"] == "enumerated"
 
 
 async def test_add_node(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -41,11 +41,11 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     assert not result["is_secure"]
     assert result["status"] == 1
 
-    # Test getting configuration values
+    # Test getting configuration parameter values
     await ws_client.send_json(
         {
             ID: 4,
-            TYPE: "zwave_js/get_configuration_values",
+            TYPE: "zwave_js/get_config_parameters",
             ENTRY_ID: entry.entry_id,
             NODE_ID: node.node_id,
         }


### PR DESCRIPTION
## Proposed change
Adds a get_config_parameters websocket command to the zwave_js integration. Will be used for the frontend config panel.

~~Will require a new release of the upstream zwave-js-server-python library.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
