### PR TITLE
MQTT cover Bugfixes

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -129,15 +129,15 @@ def validate_options(value):
     ):
         _LOGGER.warning(
             "using 'value_template' for 'position_topic' is deprecated "
-            "and will be removed from Home Assistant in version 2021.6"
-            "please replace it with 'position_template'"
+            "and will be removed from Home Assistant in version 2021.6, "
+            "please replace it with 'position_template'."
         )
 
     if CONF_TILT_INVERT_STATE in value:
         _LOGGER.warning(
             "'tilt_invert_state' is deprecated "
-            "and will be removed from Home Assistant in version 2021.6"
-            "please invert tilt using 'tilt_min' & 'tilt_max'"
+            "and will be removed from Home Assistant in version 2021.6, "
+            "please invert tilt using 'tilt_min' & 'tilt_max'."
         )
 
     return value
@@ -172,9 +172,7 @@ PLATFORM_SCHEMA = vol.All(
                 CONF_TILT_CLOSED_POSITION, default=DEFAULT_TILT_CLOSED_POSITION
             ): int,
             vol.Optional(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
-            vol.Optional(
-                CONF_TILT_INVERT_STATE, default=DEFAULT_TILT_INVERT_STATE
-            ): cv.boolean,
+            vol.Optional(CONF_TILT_INVERT_STATE): cv.boolean,
             vol.Optional(CONF_TILT_MAX, default=DEFAULT_TILT_MAX): int,
             vol.Optional(CONF_TILT_MIN, default=DEFAULT_TILT_MIN): int,
             vol.Optional(
@@ -247,15 +245,22 @@ class MqttCover(MqttEntity, CoverEntity):
         )
         self._tilt_optimistic = config[CONF_TILT_STATE_OPTIMISTIC]
 
-        template = self._config.get(CONF_VALUE_TEMPLATE)
-        if template is not None:
-            template.hass = self.hass
+        value_template = self._config.get(CONF_VALUE_TEMPLATE)
+        if value_template is not None:
+            value_template.hass = self.hass
+
         set_position_template = self._config.get(CONF_SET_POSITION_TEMPLATE)
         if set_position_template is not None:
             set_position_template.hass = self.hass
+
+        get_position_template = self._config.get(CONF_GET_POSITION_TEMPLATE)
+        if get_position_template is not None:
+            get_position_template.hass = self.hass
+
         set_tilt_template = self._config.get(CONF_TILT_COMMAND_TEMPLATE)
         if set_tilt_template is not None:
             set_tilt_template.hass = self.hass
+
         tilt_status_template = self._config.get(CONF_TILT_STATUS_TEMPLATE)
         if tilt_status_template is not None:
             tilt_status_template.hass = self.hass
@@ -290,23 +295,20 @@ class MqttCover(MqttEntity, CoverEntity):
         def state_message_received(msg):
             """Handle new MQTT state messages."""
             payload = msg.payload
-            template = self._config.get(CONF_VALUE_TEMPLATE)
-            if template is not None:
-                payload = template.async_render_with_possible_json_value(payload)
+            value_template = self._config.get(CONF_VALUE_TEMPLATE)
+            if value_template is not None:
+                payload = value_template.async_render_with_possible_json_value(payload)
 
             if payload == self._config[CONF_STATE_STOPPED]:
-                if (
-                    self._optimistic
-                    or self._config.get(CONF_GET_POSITION_TOPIC) is None
-                ):
-                    self._state = (
-                        STATE_CLOSED if self._state == STATE_CLOSING else STATE_OPEN
-                    )
-                else:
+                if self._config.get(CONF_GET_POSITION_TOPIC) is not None:
                     self._state = (
                         STATE_CLOSED
                         if self._position == DEFAULT_POSITION_CLOSED
                         else STATE_OPEN
+                    )
+                else:
+                    self._state = (
+                        STATE_CLOSED if self._state == STATE_CLOSING else STATE_OPEN
                     )
             elif payload == self._config[CONF_STATE_OPENING]:
                 self._state = STATE_OPENING
@@ -616,7 +618,7 @@ class MqttCover(MqttEntity, CoverEntity):
         max_percent = 100
         min_percent = 0
         position_percentage = min(max(position_percentage, min_percent), max_percent)
-        if range_type == TILT_PAYLOAD and self._config[CONF_TILT_INVERT_STATE]:
+        if range_type == TILT_PAYLOAD and self._config.get(CONF_TILT_INVERT_STATE):
             return 100 - position_percentage
         return position_percentage
 
@@ -640,6 +642,6 @@ class MqttCover(MqttEntity, CoverEntity):
         position = round(current_range * (percentage / 100.0))
         position += offset
 
-        if range_type == TILT_PAYLOAD and self._config[CONF_TILT_INVERT_STATE]:
+        if range_type == TILT_PAYLOAD and self._config.get(CONF_TILT_INVERT_STATE):
             position = max_range - position + offset
         return position

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -130,14 +130,14 @@ def validate_options(value):
         _LOGGER.warning(
             "using 'value_template' for 'position_topic' is deprecated "
             "and will be removed from Home Assistant in version 2021.6, "
-            "please replace it with 'position_template'."
+            "please replace it with 'position_template'"
         )
 
     if CONF_TILT_INVERT_STATE in value:
         _LOGGER.warning(
             "'tilt_invert_state' is deprecated "
             "and will be removed from Home Assistant in version 2021.6, "
-            "please invert tilt using 'tilt_min' & 'tilt_max'."
+            "please invert tilt using 'tilt_min' & 'tilt_max'"
         )
 
     return value

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -2032,10 +2032,10 @@ async def test_entity_debug_info_message(hass, mqtt_mock):
     )
 
 
-async def test_deprecated_value_template_for_position_topic_warnning(
+async def test_deprecated_value_template_for_position_topic_warning(
     hass, caplog, mqtt_mock
 ):
-    """Test warnning when value_template is used for position_topic."""
+    """Test warning when value_template is used for position_topic."""
     assert await async_setup_component(
         hass,
         cover.DOMAIN,
@@ -2054,13 +2054,13 @@ async def test_deprecated_value_template_for_position_topic_warnning(
 
     assert (
         "using 'value_template' for 'position_topic' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6"
-        "please replace it with 'position_template'"
+        "and will be removed from Home Assistant in version 2021.6, "
+        "please replace it with 'position_template'."
     ) in caplog.text
 
 
-async def test_deprecated_tilt_invert_state_warnning(hass, caplog, mqtt_mock):
-    """Test warnning when tilt_invert_state is used."""
+async def test_deprecated_tilt_invert_state_warning(hass, caplog, mqtt_mock):
+    """Test warning when tilt_invert_state is used."""
     assert await async_setup_component(
         hass,
         cover.DOMAIN,
@@ -2077,9 +2077,31 @@ async def test_deprecated_tilt_invert_state_warnning(hass, caplog, mqtt_mock):
 
     assert (
         "'tilt_invert_state' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6"
-        "please invert tilt using 'tilt_min' & 'tilt_max'"
+        "and will be removed from Home Assistant in version 2021.6, "
+        "please invert tilt using 'tilt_min' & 'tilt_max'."
     ) in caplog.text
+
+
+async def test_no_deprecated_tilt_invert_state_warning(hass, caplog, mqtt_mock):
+    """Test warning when tilt_invert_state is used."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        "'tilt_invert_state' is deprecated "
+        "and will be removed from Home Assistant in version 2021.6, "
+        "please invert tilt using 'tilt_min' & 'tilt_max'."
+    ) not in caplog.text
 
 
 async def test_no_deprecated_warning_for_position_topic_using_position_template(
@@ -2104,8 +2126,8 @@ async def test_no_deprecated_warning_for_position_topic_using_position_template(
 
     assert (
         "using 'value_template' for 'position_topic' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6"
-        "please replace it with 'position_template'"
+        "and will be removed from Home Assistant in version 2021.6, "
+        "please replace it with 'position_template'."
     ) not in caplog.text
 
 
@@ -2221,8 +2243,8 @@ async def test_set_state_via_position_using_stopped_state(hass, mqtt_mock):
     assert state.state == STATE_OPEN
 
 
-async def test_set_state_via_stopped_state_optimistic(hass, mqtt_mock):
-    """Test the controlling state via stopped state in optimistic mode."""
+async def test_position_via_position_topic_template(hass, mqtt_mock):
+    """Test position by updating status via position template."""
     assert await async_setup_component(
         hass,
         cover.DOMAIN,
@@ -2231,51 +2253,28 @@ async def test_set_state_via_stopped_state_optimistic(hass, mqtt_mock):
                 "platform": "mqtt",
                 "name": "test",
                 "state_topic": "state-topic",
-                "position_topic": "get-position-topic",
-                "position_open": 100,
-                "position_closed": 0,
-                "state_open": "OPEN",
-                "state_closed": "CLOSE",
-                "state_stopped": "STOPPED",
-                "state_opening": "OPENING",
-                "state_closing": "CLOSING",
                 "command_topic": "command-topic",
-                "qos": 0,
-                "optimistic": True,
+                "set_position_topic": "set-position-topic",
+                "position_topic": "get-position-topic",
+                "position_template": "{{ (value | multiply(0.01)) | int }}",
             }
         },
     )
     await hass.async_block_till_done()
 
-    async_fire_mqtt_message(hass, "state-topic", "OPEN")
+    async_fire_mqtt_message(hass, "get-position-topic", "99")
 
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
+    current_cover_position_position = hass.states.get("cover.test").attributes[
+        ATTR_CURRENT_POSITION
+    ]
+    assert current_cover_position_position == 0
 
-    async_fire_mqtt_message(hass, "get-position-topic", "50")
+    async_fire_mqtt_message(hass, "get-position-topic", "5000")
 
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
-
-    async_fire_mqtt_message(hass, "state-topic", "OPENING")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_OPENING
-
-    async_fire_mqtt_message(hass, "state-topic", "STOPPED")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
-
-    async_fire_mqtt_message(hass, "state-topic", "CLOSING")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSING
-
-    async_fire_mqtt_message(hass, "state-topic", "STOPPED")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
+    current_cover_position_position = hass.states.get("cover.test").attributes[
+        ATTR_CURRENT_POSITION
+    ]
+    assert current_cover_position_position == 50
 
 
 async def test_set_state_via_stopped_state_no_position_topic(hass, mqtt_mock):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -2055,7 +2055,7 @@ async def test_deprecated_value_template_for_position_topic_warning(
     assert (
         "using 'value_template' for 'position_topic' is deprecated "
         "and will be removed from Home Assistant in version 2021.6, "
-        "please replace it with 'position_template'."
+        "please replace it with 'position_template'"
     ) in caplog.text
 
 
@@ -2078,7 +2078,7 @@ async def test_deprecated_tilt_invert_state_warning(hass, caplog, mqtt_mock):
     assert (
         "'tilt_invert_state' is deprecated "
         "and will be removed from Home Assistant in version 2021.6, "
-        "please invert tilt using 'tilt_min' & 'tilt_max'."
+        "please invert tilt using 'tilt_min' & 'tilt_max'"
     ) in caplog.text
 
 
@@ -2100,7 +2100,7 @@ async def test_no_deprecated_tilt_invert_state_warning(hass, caplog, mqtt_mock):
     assert (
         "'tilt_invert_state' is deprecated "
         "and will be removed from Home Assistant in version 2021.6, "
-        "please invert tilt using 'tilt_min' & 'tilt_max'."
+        "please invert tilt using 'tilt_min' & 'tilt_max'"
     ) not in caplog.text
 
 
@@ -2127,7 +2127,7 @@ async def test_no_deprecated_warning_for_position_topic_using_position_template(
     assert (
         "using 'value_template' for 'position_topic' is deprecated "
         "and will be removed from Home Assistant in version 2021.6, "
-        "please replace it with 'position_template'."
+        "please replace it with 'position_template'"
     ) not in caplog.text
 
 


### PR DESCRIPTION
Fix bugs introduced by https://github.com/home-assistant/core/pull/46059
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Bugfixes:**
Deprecated warnings missing punctuation.
Assign `hass` to position template (+ add test)
`tilt_invert_state` warning shown even if `tilt_invert_state` is not set (+ add test)
Revise `state_stopped` logic to make it aligned with other states (+ update test)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
