### PR TITLE
Make FAN_ON use the max duration rather than 15 min default

### DIFF
--- a/homeassistant/components/nest/climate_sdm.py
+++ b/homeassistant/components/nest/climate_sdm.py
@@ -75,6 +75,8 @@ FAN_MODE_MAP = {
 }
 FAN_INV_MODE_MAP = {v: k for k, v in FAN_MODE_MAP.items()}
 
+MAX_FAN_DURATION = 43200  # 15 hours is the max in the SDM API
+
 
 async def async_setup_sdm_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
@@ -322,4 +324,7 @@ class ThermostatEntity(ClimateEntity):
         if fan_mode not in self.fan_modes:
             raise ValueError(f"Unsupported fan_mode '{fan_mode}'")
         trait = self._device.traits[FanTrait.NAME]
-        await trait.set_timer(FAN_INV_MODE_MAP[fan_mode])
+        duration = None
+        if fan_mode != FAN_OFF:
+            duration = MAX_FAN_DURATION
+        await trait.set_timer(FAN_INV_MODE_MAP[fan_mode], duration=duration)

--- a/tests/components/nest/climate_sdm_test.py
+++ b/tests/components/nest/climate_sdm_test.py
@@ -819,6 +819,20 @@ async def test_thermostat_set_fan(hass, auth):
         "params": {"timerMode": "OFF"},
     }
 
+    # Turn on fan mode
+    await common.async_set_fan_mode(hass, FAN_ON)
+    await hass.async_block_till_done()
+
+    assert auth.method == "post"
+    assert auth.url == "some-device-id:executeCommand"
+    assert auth.json == {
+        "command": "sdm.devices.commands.Fan.SetTimer",
+        "params": {
+            "duration": "43200s",
+            "timerMode": "ON",
+        },
+    }
+
 
 async def test_thermostat_fan_empty(hass):
     """Test a fan trait with an empty response."""
@@ -938,7 +952,7 @@ async def test_thermostat_set_hvac_fan_only(hass, auth):
     assert url == "some-device-id:executeCommand"
     assert json == {
         "command": "sdm.devices.commands.Fan.SetTimer",
-        "params": {"timerMode": "ON"},
+        "params": {"duration": "43200s", "timerMode": "ON"},
     }
     (method, url, json, headers) = auth.captured_requests.pop(0)
     assert method == "post"


### PR DESCRIPTION
## Breaking change

The nest `FAN_ON` mode now sets the device timer to use the max duration of 12 hours, rather than the default of 15 minutes.  Users that would like the fan to turn off sooner may use an automation with `timer` to set `FAN_OFF` sooner.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Make the Nest thermostat `FAN_ON` mode have a more reasonable duration of 12 hours, increased from the default of 15 minutes, making it act more like a switch.   The `climate` entity currently does not pass a duration to the API, causing it to shut off after the default timeout of 15 minutes.

See [API docs](https://developers.google.com/nest/device-access/traits/device/fan#commands) for `SetTimer` which has an optional `duration` for more details.

Alternatives considered, and rejected, where to provide more flexibility such as allowing a user specified timeout, however that does not seem worth extending the existing `climate` APIs or creating new services `nest` specific services to support.  The most straight forward option, and likely most expected behavior, is to simply stay on as long as possible when turned on.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46364
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
