### PR TITLE
Make Rflink handle set_level command for dimmable devices

### DIFF
--- a/homeassistant/components/rflink/__init__.py
+++ b/homeassistant/components/rflink/__init__.py
@@ -28,6 +28,8 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.restore_state import RestoreEntity
 
+from .utils import brightness_to_rflink
+
 _LOGGER = logging.getLogger(__name__)
 
 ATTR_EVENT = "event"
@@ -498,7 +500,7 @@ class RflinkCommand(RflinkDevice):
 
         elif command == "dim":
             # convert brightness to rflink dim level
-            cmd = str(int(args[0] / 17))
+            cmd = str(brightness_to_rflink(args[0]))
             self._state = True
 
         elif command == "toggle":

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -242,7 +242,7 @@ class HybridRflinkLight(DimmableRflinkLight, LightEntity):
         # if the receiving device does not support dimlevel this
         # will ensure it is turned on when full brightness is set
         if self.brightness == 255:
-            await super()._async_handle_command("turn_on")
+            await self._async_handle_command("turn_on")
 
 
 class ToggleRflinkLight(SwitchableRflinkDevice, LightEntity):

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -221,7 +221,6 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
         return SUPPORT_BRIGHTNESS
 
 
-# class HybridRflinkLight(SwitchableRflinkDevice, LightEntity):
 class HybridRflinkLight(DimmableRflinkLight, LightEntity):
     """Rflink light device that sends out both dim and on/off commands.
 
@@ -244,65 +243,6 @@ class HybridRflinkLight(DimmableRflinkLight, LightEntity):
         # will ensure it is turned on when full brightness is set
         if self.brightness == 255:
             await super()._async_handle_command("turn_on")
-
-    # _brightness = 255
-
-    # async def async_added_to_hass(self):
-    #     """Restore RFLink light brightness attribute."""
-    #     await super().async_added_to_hass()
-
-    #     old_state = await self.async_get_last_state()
-    #     if (
-    #         old_state is not None
-    #         and old_state.attributes.get(ATTR_BRIGHTNESS) is not None
-    #     ):
-    #         # restore also brightness in dimmables devices
-    #         self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
-
-    # async def async_turn_on(self, **kwargs):
-    #     """Turn the device on and set dim level."""
-    #     if ATTR_BRIGHTNESS in kwargs:
-    #         # rflink only support 16 brightness levels
-    #         self._brightness = int(kwargs[ATTR_BRIGHTNESS] / 17) * 17
-
-    #     # if receiver supports dimming this will turn on the light
-    #     # at the requested dim level
-    #     await self._async_handle_command("dim", self._brightness)
-
-    #     # if the receiving device does not support dimlevel this
-    #     # will ensure it is turned on when full brightness is set
-    #     if self._brightness == 255:
-    #         await self._async_handle_command("turn_on")
-
-    # def _handle_event(self, event):
-    #     """Adjust state if Rflink picks up a remote command for this device."""
-    #     self.cancel_queued_send_commands()
-
-    #     command = event["command"]
-    #     if command in ["on", "allon"]:
-    #         self._state = True
-    #     elif command in ["off", "alloff"]:
-    #         self._state = False
-    #     elif re.search('^set_level=(0?[0-9]|1[0-5])$', command, re.IGNORECASE):
-    #         self._brightness = int(command.split('=')[1]) * 17
-    #         self._state = True
-
-    # @property
-    # def brightness(self):
-    #     """Return the brightness of this light between 0..255."""
-    #     return self._brightness
-
-    # @property
-    # def device_state_attributes(self):
-    #     """Return the device state attributes."""
-    #     if self._brightness is None:
-    #         return {}
-    #     return {ATTR_BRIGHTNESS: self._brightness}
-
-    # @property
-    # def supported_features(self):
-    #     """Flag supported features."""
-    #     return SUPPORT_BRIGHTNESS
 
 
 class ToggleRflinkLight(SwitchableRflinkDevice, LightEntity):

--- a/homeassistant/components/rflink/light.py
+++ b/homeassistant/components/rflink/light.py
@@ -1,5 +1,6 @@
 """Support for Rflink lights."""
 import logging
+import re
 
 import voluptuous as vol
 
@@ -188,6 +189,20 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
         # Turn on light at the requested dim level
         await self._async_handle_command("dim", self._brightness)
 
+    def _handle_event(self, event):
+        """Adjust state if Rflink picks up a remote command for this device."""
+        self.cancel_queued_send_commands()
+
+        command = event["command"]
+        if command in ["on", "allon"]:
+            self._state = True
+        elif command in ["off", "alloff"]:
+            self._state = False
+        # dimmable device accept 'set_level=(0-15)' commands
+        elif re.search("^set_level=(0?[0-9]|1[0-5])$", command, re.IGNORECASE):
+            self._brightness = int(command.split("=")[1]) * 17
+            self._state = True
+
     @property
     def brightness(self):
         """Return the brightness of this light between 0..255."""
@@ -206,7 +221,8 @@ class DimmableRflinkLight(SwitchableRflinkDevice, LightEntity):
         return SUPPORT_BRIGHTNESS
 
 
-class HybridRflinkLight(SwitchableRflinkDevice, LightEntity):
+# class HybridRflinkLight(SwitchableRflinkDevice, LightEntity):
+class HybridRflinkLight(DimmableRflinkLight, LightEntity):
     """Rflink light device that sends out both dim and on/off commands.
 
     Used for protocols which support lights that are not exclusively on/off
@@ -221,51 +237,72 @@ class HybridRflinkLight(SwitchableRflinkDevice, LightEntity):
     Which results in a nice house disco :)
     """
 
-    _brightness = 255
-
-    async def async_added_to_hass(self):
-        """Restore RFLink light brightness attribute."""
-        await super().async_added_to_hass()
-
-        old_state = await self.async_get_last_state()
-        if (
-            old_state is not None
-            and old_state.attributes.get(ATTR_BRIGHTNESS) is not None
-        ):
-            # restore also brightness in dimmables devices
-            self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
-
     async def async_turn_on(self, **kwargs):
         """Turn the device on and set dim level."""
-        if ATTR_BRIGHTNESS in kwargs:
-            # rflink only support 16 brightness levels
-            self._brightness = int(kwargs[ATTR_BRIGHTNESS] / 17) * 17
-
-        # if receiver supports dimming this will turn on the light
-        # at the requested dim level
-        await self._async_handle_command("dim", self._brightness)
-
+        await super().async_turn_on(**kwargs)
         # if the receiving device does not support dimlevel this
         # will ensure it is turned on when full brightness is set
-        if self._brightness == 255:
-            await self._async_handle_command("turn_on")
+        if self.brightness == 255:
+            await super()._async_handle_command("turn_on")
 
-    @property
-    def brightness(self):
-        """Return the brightness of this light between 0..255."""
-        return self._brightness
+    # _brightness = 255
 
-    @property
-    def extra_state_attributes(self):
-        """Return the device state attributes."""
-        if self._brightness is None:
-            return {}
-        return {ATTR_BRIGHTNESS: self._brightness}
+    # async def async_added_to_hass(self):
+    #     """Restore RFLink light brightness attribute."""
+    #     await super().async_added_to_hass()
 
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_BRIGHTNESS
+    #     old_state = await self.async_get_last_state()
+    #     if (
+    #         old_state is not None
+    #         and old_state.attributes.get(ATTR_BRIGHTNESS) is not None
+    #     ):
+    #         # restore also brightness in dimmables devices
+    #         self._brightness = int(old_state.attributes[ATTR_BRIGHTNESS])
+
+    # async def async_turn_on(self, **kwargs):
+    #     """Turn the device on and set dim level."""
+    #     if ATTR_BRIGHTNESS in kwargs:
+    #         # rflink only support 16 brightness levels
+    #         self._brightness = int(kwargs[ATTR_BRIGHTNESS] / 17) * 17
+
+    #     # if receiver supports dimming this will turn on the light
+    #     # at the requested dim level
+    #     await self._async_handle_command("dim", self._brightness)
+
+    #     # if the receiving device does not support dimlevel this
+    #     # will ensure it is turned on when full brightness is set
+    #     if self._brightness == 255:
+    #         await self._async_handle_command("turn_on")
+
+    # def _handle_event(self, event):
+    #     """Adjust state if Rflink picks up a remote command for this device."""
+    #     self.cancel_queued_send_commands()
+
+    #     command = event["command"]
+    #     if command in ["on", "allon"]:
+    #         self._state = True
+    #     elif command in ["off", "alloff"]:
+    #         self._state = False
+    #     elif re.search('^set_level=(0?[0-9]|1[0-5])$', command, re.IGNORECASE):
+    #         self._brightness = int(command.split('=')[1]) * 17
+    #         self._state = True
+
+    # @property
+    # def brightness(self):
+    #     """Return the brightness of this light between 0..255."""
+    #     return self._brightness
+
+    # @property
+    # def device_state_attributes(self):
+    #     """Return the device state attributes."""
+    #     if self._brightness is None:
+    #         return {}
+    #     return {ATTR_BRIGHTNESS: self._brightness}
+
+    # @property
+    # def supported_features(self):
+    #     """Flag supported features."""
+    #     return SUPPORT_BRIGHTNESS
 
 
 class ToggleRflinkLight(SwitchableRflinkDevice, LightEntity):

--- a/homeassistant/components/rflink/utils.py
+++ b/homeassistant/components/rflink/utils.py
@@ -1,0 +1,11 @@
+"""RFLink integration utils."""
+
+
+def brightness_to_rflink(brightness: int) -> int:
+    """Convert 0-255 brightness to RFLink dim level (0-15)."""
+    return int(brightness / 17)
+
+
+def rflink_to_brightness(dim_level: int) -> int:
+    """Convert RFLink dim level (0-15) to 0-255 brightness."""
+    return int(dim_level * 17)

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -494,7 +494,7 @@ async def test_nogroup_alias(hass, monkeypatch):
     # should not affect state
     assert hass.states.get(f"{DOMAIN}.test").state == "off"
 
-    # test sending group command to nogroup alias
+    # test sending group commands to nogroup alias
     event_callback({"id": "test_nogroup_0_0", "command": "on"})
     await hass.async_block_till_done()
     # should affect state

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -386,6 +386,21 @@ async def test_set_level_command(hass, monkeypatch):
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_BRIGHTNESS] == 170
+    # turn off
+    event_callback({"id": "newkaku_12345678_0", "command": "off"})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"{DOMAIN}.l1")
+    assert state
+    assert state.state == STATE_OFF
+    # off light shouldn't have brightness
+    assert not state.attributes.get(ATTR_BRIGHTNESS)
+    # turn on
+    event_callback({"id": "newkaku_12345678_0", "command": "on"})
+    await hass.async_block_till_done()
+    state = hass.states.get(f"{DOMAIN}.l1")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 170
 
     # test sending command to a no dimmable device
     event_callback({"id": "test_no_dimmable", "command": "set_level=10"})
@@ -420,7 +435,8 @@ async def test_set_level_command(hass, monkeypatch):
     state = hass.states.get(f"{DOMAIN}.l4")
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes[ATTR_BRIGHTNESS] == 255
+    # off light shouldn't have brightness
+    assert not state.attributes.get(ATTR_BRIGHTNESS)
 
     event_callback({"id": "test_hybrid", "command": "set_level=0"})
     await hass.async_block_till_done()
@@ -599,7 +615,8 @@ async def test_restore_state(hass, monkeypatch):
     state = hass.states.get(f"{DOMAIN}.l4")
     assert state
     assert state.state == STATE_OFF
-    assert state.attributes[ATTR_BRIGHTNESS] == 255
+    # off light shouldn't have brightness
+    assert not state.attributes.get(ATTR_BRIGHTNESS)
     assert state.attributes["assumed_state"]
 
     # test coverage for dimmable light

--- a/tests/components/rflink/test_light.py
+++ b/tests/components/rflink/test_light.py
@@ -360,6 +360,77 @@ async def test_type_toggle(hass, monkeypatch):
     assert hass.states.get(f"{DOMAIN}.toggle_test").state == "off"
 
 
+async def test_set_level_command(hass, monkeypatch):
+    """Test 'set_level=XX' events."""
+    config = {
+        "rflink": {"port": "/dev/ttyABC0"},
+        DOMAIN: {
+            "platform": "rflink",
+            "devices": {
+                "newkaku_12345678_0": {"name": "l1"},
+                "test_no_dimmable": {"name": "l2"},
+                "test_dimmable": {"name": "l3", "type": "dimmable"},
+                "test_hybrid": {"name": "l4", "type": "hybrid"},
+            },
+        },
+    }
+
+    # setup mocking rflink module
+    event_callback, _, _, _ = await mock_rflink(hass, config, DOMAIN, monkeypatch)
+
+    # test sending command to a newkaku device
+    event_callback({"id": "newkaku_12345678_0", "command": "set_level=10"})
+    await hass.async_block_till_done()
+    # should affect state
+    state = hass.states.get(f"{DOMAIN}.l1")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 170
+
+    # test sending command to a no dimmable device
+    event_callback({"id": "test_no_dimmable", "command": "set_level=10"})
+    await hass.async_block_till_done()
+    # should NOT affect state
+    state = hass.states.get(f"{DOMAIN}.l2")
+    assert state
+    assert state.state == STATE_OFF
+    assert not state.attributes.get(ATTR_BRIGHTNESS)
+
+    # test sending command to a dimmable device
+    event_callback({"id": "test_dimmable", "command": "set_level=5"})
+    await hass.async_block_till_done()
+    # should affect state
+    state = hass.states.get(f"{DOMAIN}.l3")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 85
+
+    # test sending command to a hybrid device
+    event_callback({"id": "test_hybrid", "command": "set_level=15"})
+    await hass.async_block_till_done()
+    # should affect state
+    state = hass.states.get(f"{DOMAIN}.l4")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
+
+    event_callback({"id": "test_hybrid", "command": "off"})
+    await hass.async_block_till_done()
+    # should affect state
+    state = hass.states.get(f"{DOMAIN}.l4")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
+
+    event_callback({"id": "test_hybrid", "command": "set_level=0"})
+    await hass.async_block_till_done()
+    # should affect state
+    state = hass.states.get(f"{DOMAIN}.l4")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 0
+
+
 async def test_group_alias(hass, monkeypatch):
     """Group aliases should only respond to group commands (allon/alloff)."""
     config = {
@@ -367,7 +438,12 @@ async def test_group_alias(hass, monkeypatch):
         DOMAIN: {
             "platform": "rflink",
             "devices": {
-                "protocol_0_0": {"name": "test", "group_aliases": ["test_group_0_0"]}
+                "protocol_0_0": {"name": "test", "group_aliases": ["test_group_0_0"]},
+                "protocol_0_1": {
+                    "name": "test2",
+                    "type": "dimmable",
+                    "group_aliases": ["test_group_0_0"],
+                },
             },
         },
     }
@@ -382,12 +458,14 @@ async def test_group_alias(hass, monkeypatch):
     await hass.async_block_till_done()
 
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
+    assert hass.states.get(f"{DOMAIN}.test2").state == "on"
 
     # test sending group command to group alias
     event_callback({"id": "test_group_0_0", "command": "off"})
     await hass.async_block_till_done()
 
     assert hass.states.get(f"{DOMAIN}.test").state == "on"
+    assert hass.states.get(f"{DOMAIN}.test2").state == "on"
 
 
 async def test_nogroup_alias(hass, monkeypatch):

--- a/tests/components/rflink/test_utils.py
+++ b/tests/components/rflink/test_utils.py
@@ -1,0 +1,33 @@
+"""Test for RFLink utils methods."""
+from homeassistant.components.rflink.utils import (
+    brightness_to_rflink,
+    rflink_to_brightness,
+)
+
+
+async def test_utils(hass, monkeypatch):
+    """Test all utils methods."""
+    # test brightness_to_rflink
+    assert brightness_to_rflink(0) == 0
+    assert brightness_to_rflink(17) == 1
+    assert brightness_to_rflink(34) == 2
+    assert brightness_to_rflink(85) == 5
+    assert brightness_to_rflink(170) == 10
+    assert brightness_to_rflink(255) == 15
+
+    assert brightness_to_rflink(10) == 0
+    assert brightness_to_rflink(20) == 1
+    assert brightness_to_rflink(30) == 1
+    assert brightness_to_rflink(40) == 2
+    assert brightness_to_rflink(50) == 2
+    assert brightness_to_rflink(60) == 3
+    assert brightness_to_rflink(70) == 4
+    assert brightness_to_rflink(80) == 4
+
+    # test rflink_to_brightness
+    assert rflink_to_brightness(0) == 0
+    assert rflink_to_brightness(1) == 17
+    assert rflink_to_brightness(5) == 85
+    assert rflink_to_brightness(10) == 170
+    assert rflink_to_brightness(12) == 204
+    assert rflink_to_brightness(15) == 255


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements the `handle_event` for SET_LEVEL commands.

Dimmable remotes send a SET_LEVEL=XX command to dim devices but the RFLink integration did not react to events of this type, so the devices did not update their status accordly.
The RFLink library implements the parse part from [v0.0.51](https://github.com/aequitas/python-rflink/releases/tag/0.0.51)
In RFLink SET_LEVEL values come from 0-15

Also, common code existing in classes `DimmableRflinkLight` and `HybridRflinkLight` has been refactored. I had planned to do it in a separate PR, but it implied duplicating the new method and I have chosen to do everything in the same PR.

The changes I have not been able to test locally as I do not have devices of that type. I would appreciate if someone can test the changes locally before merging the code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
  - https://community.home-assistant.io/t/implement-cmd-set-level-x-command-in-rflink-module-closed-issue-10814/279576
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- N/A Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- N/A The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- N/A New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- N/A Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
