### PR TITLE
Use core constants for switcher_kis

### DIFF
--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -8,7 +8,7 @@ from aioswitcher.bridge import SwitcherV2Bridge
 import voluptuous as vol
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import CONF_DEVICE_ID, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
@@ -20,7 +20,6 @@ _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "switcher_kis"
 
-CONF_DEVICE_ID = "device_id"
 CONF_DEVICE_PASSWORD = "device_password"
 CONF_PHONE_ID = "phone_id"
 
@@ -48,7 +47,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistantType, config: Dict) -> bool:
     """Set up the switcher component."""
-
     phone_id = config[DOMAIN][CONF_PHONE_ID]
     device_id = config[DOMAIN][CONF_DEVICE_ID]
     device_password = config[DOMAIN][CONF_DEVICE_PASSWORD]

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -62,7 +62,6 @@ async def async_setup_platform(
 
     async def async_set_auto_off_service(entity, service_call: ServiceCallType) -> None:
         """Use for handling setting device auto-off service calls."""
-
         async with SwitcherV2Api(
             hass.loop,
             device_data.ip_addr,
@@ -76,7 +75,6 @@ async def async_setup_platform(
         entity, service_call: ServiceCallType
     ) -> None:
         """Use for handling turning device on with a timer service calls."""
-
         async with SwitcherV2Api(
             hass.loop,
             device_data.ip_addr,
@@ -133,7 +131,6 @@ class SwitcherControl(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
-
         return self._state == SWITCHER_STATE_ON
 
     @property
@@ -144,7 +141,6 @@ class SwitcherControl(SwitchEntity):
     @property
     def device_state_attributes(self) -> Dict:
         """Return the optional state attributes."""
-
         attribs = {}
 
         for prop, attr in DEVICE_PROPERTIES_TO_HA_ATTRIBUTES.items():
@@ -157,7 +153,6 @@ class SwitcherControl(SwitchEntity):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
-
         return self._state in [SWITCHER_STATE_ON, SWITCHER_STATE_OFF]
 
     async def async_added_to_hass(self) -> None:
@@ -188,7 +183,6 @@ class SwitcherControl(SwitchEntity):
 
     async def _control_device(self, send_on: bool) -> None:
         """Turn the entity on or off."""
-
         response: SwitcherV2ControlResponseMSG = None
         async with SwitcherV2Api(
             self.hass.loop,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use core constants for switcher_kis.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
