### PR TITLE
Implement percentage step sizes for fans

### DIFF
--- a/homeassistant/components/bond/fan.py
+++ b/homeassistant/components/bond/fan.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -84,6 +85,11 @@ class BondFan(BondEntity, FanEntity):
         if not self._speed or not self._power:
             return 0
         return ranged_value_to_percentage(self._speed_range, self._speed)
+
+    @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(self._speed_range)
 
     @property
     def current_direction(self) -> Optional[str]:

--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -13,6 +13,7 @@ from pycomfoconnect import (
 from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -100,6 +101,11 @@ class ComfoConnectFan(FanEntity):
         if speed is None:
             return None
         return ranged_value_to_percentage(SPEED_RANGE, speed)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     def turn_on(
         self, speed: str = None, percentage=None, preset_mode=None, **kwargs

--- a/homeassistant/components/demo/fan.py
+++ b/homeassistant/components/demo/fan.py
@@ -215,6 +215,11 @@ class DemoPercentageFan(BaseDemoFan, FanEntity):
         """Return the current speed."""
         return self._percentage
 
+    @property
+    def speed_count(self) -> Optional[float]:
+        """Return the number of speeds the fan supports."""
+        return 3
+
     def set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         self._percentage = percentage
@@ -269,6 +274,11 @@ class AsyncDemoPercentageFan(BaseDemoFan, FanEntity):
     def percentage(self) -> str:
         """Return the current speed."""
         return self._percentage
+
+    @property
+    def speed_count(self) -> Optional[float]:
+        """Return the number of speeds the fan supports."""
+        return 3
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""

--- a/homeassistant/components/dyson/fan.py
+++ b/homeassistant/components/dyson/fan.py
@@ -13,6 +13,7 @@ import voluptuous as vol
 from homeassistant.components.fan import SUPPORT_OSCILLATE, SUPPORT_SET_SPEED, FanEntity
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -153,6 +154,11 @@ class DysonFanEntity(DysonEntity, FanEntity):
         if self.auto_mode:
             return None
         return ranged_value_to_percentage(SPEED_RANGE, int(self._device.state.speed))
+
+    @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def preset_modes(self):

--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -119,6 +119,11 @@ class EsphomeFan(EsphomeEntity, FanEntity):
             ORDERED_NAMED_FAN_SPEEDS, self._state.speed
         )
 
+    @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        return len(ORDERED_NAMED_FAN_SPEEDS)
+
     @esphome_state_property
     def oscillating(self) -> None:
         """Return the oscillation state."""

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -108,6 +108,7 @@ increase_speed:
       description: Name(s) of the entities to increase speed
       example: "fan.living_room"
     percentage_step:
+      advanced: true
       required: false
       description: Increase speed by a percentage. Should be between 0..100. [optional]
       example: 50

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -100,3 +100,37 @@ set_direction:
           options:
             - "forward"
             - "reverse"
+
+increase_speed:
+  description: Increase the speed of the fan by one speed or a percentage_step.
+  fields:
+    entity_id:
+      description: Name(s) of the entities to increase speed
+      example: "fan.living_room"
+    percentage_step:
+      description: Increase speed by a percentage. Should be between 0..100. [optional]
+      example: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider
+
+decrease_speed:
+  description: Decrease the speed of the fan by one speed or a percentage_step.
+  fields:
+    entity_id:
+      description: Name(s) of the entities to decrease speed
+      example: "fan.living_room"
+    percentage_step:
+      description: Decrease speed by a percentage. Should be between 0..100. [optional]
+      example: 50
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -108,6 +108,7 @@ increase_speed:
       description: Name(s) of the entities to increase speed
       example: "fan.living_room"
     percentage_step:
+      required: false
       description: Increase speed by a percentage. Should be between 0..100. [optional]
       example: 50
       selector:

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -125,6 +125,7 @@ decrease_speed:
       description: Name(s) of the entities to decrease speed
       example: "fan.living_room"
     percentage_step:
+      required: false
       description: Decrease speed by a percentage. Should be between 0..100. [optional]
       example: 50
       selector:

--- a/homeassistant/components/fan/services.yaml
+++ b/homeassistant/components/fan/services.yaml
@@ -127,6 +127,7 @@ decrease_speed:
       description: Name(s) of the entities to decrease speed
       example: "fan.living_room"
     percentage_step:
+      advanced: true
       required: false
       description: Decrease speed by a percentage. Should be between 0..100. [optional]
       example: 50

--- a/homeassistant/components/isy994/fan.py
+++ b/homeassistant/components/isy994/fan.py
@@ -2,12 +2,13 @@
 import math
 from typing import Callable
 
-from pyisy.constants import ISY_VALUE_UNKNOWN
+from pyisy.constants import ISY_VALUE_UNKNOWN, PROTO_INSTEON
 
 from homeassistant.components.fan import DOMAIN as FAN, SUPPORT_SET_SPEED, FanEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -47,6 +48,13 @@ class ISYFanEntity(ISYNodeEntity, FanEntity):
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         return ranged_value_to_percentage(SPEED_RANGE, self._node.status)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        if self._node.protocol == PROTO_INSTEON:
+            return 3
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def is_on(self) -> bool:
@@ -94,6 +102,13 @@ class ISYFanProgramEntity(ISYProgramEntity, FanEntity):
         if self._node.status == ISY_VALUE_UNKNOWN:
             return None
         return ranged_value_to_percentage(SPEED_RANGE, self._node.status)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        if self._node.protocol == PROTO_INSTEON:
+            return 3
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -7,6 +7,7 @@ from xknx.devices.fan import FanSpeedMode
 
 from homeassistant.components.fan import SUPPORT_OSCILLATE, SUPPORT_SET_SPEED, FanEntity
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -67,6 +68,13 @@ class KNXFan(KnxEntity, FanEntity):
                 self._step_range, self._device.current_speed
             )
         return self._device.current_speed
+
+    @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        if self._step_range is None:
+            return super().speed_count
+        return int_states_in_range(self._step_range)
 
     async def async_turn_on(
         self,

--- a/homeassistant/components/lutron_caseta/fan.py
+++ b/homeassistant/components/lutron_caseta/fan.py
@@ -49,6 +49,11 @@ class LutronCasetaFan(LutronCasetaDevice, FanEntity):
         )
 
     @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return len(ORDERED_NAMED_FAN_SPEEDS)
+
+    @property
     def supported_features(self) -> int:
         """Flag supported features. Speed Only."""
         return SUPPORT_SET_SPEED

--- a/homeassistant/components/ozw/fan.py
+++ b/homeassistant/components/ozw/fan.py
@@ -9,6 +9,7 @@ from homeassistant.components.fan import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -71,6 +72,11 @@ class ZwaveFan(ZWaveDeviceEntity, FanEntity):
         The normal range of the speed is 0-99. 0 means off.
         """
         return ranged_value_to_percentage(SPEED_RANGE, self.values.primary.value)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/smartthings/fan.py
+++ b/homeassistant/components/smartthings/fan.py
@@ -6,6 +6,7 @@ from pysmartthings import Capability
 
 from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -78,6 +79,11 @@ class SmartThingsFan(SmartThingsEntity, FanEntity):
     def percentage(self) -> str:
         """Return the current speed percentage."""
         return ranged_value_to_percentage(SPEED_RANGE, self._device.status.fan_speed)
+
+    @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -46,6 +46,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONF_FANS = "fans"
 CONF_SPEED_LIST = "speeds"
+CONF_SPEED_COUNT = "speed_count"
 CONF_PRESET_MODES = "preset_modes"
 CONF_SPEED_TEMPLATE = "speed_template"
 CONF_PERCENTAGE_TEMPLATE = "percentage_template"
@@ -86,6 +87,7 @@ FAN_SCHEMA = vol.All(
             vol.Optional(CONF_SET_PRESET_MODE_ACTION): cv.SCRIPT_SCHEMA,
             vol.Optional(CONF_SET_OSCILLATING_ACTION): cv.SCRIPT_SCHEMA,
             vol.Optional(CONF_SET_DIRECTION_ACTION): cv.SCRIPT_SCHEMA,
+            vol.Optional(CONF_SPEED_COUNT): vol.Coerce(int),
             vol.Optional(
                 CONF_SPEED_LIST,
                 default=[SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH],
@@ -126,6 +128,7 @@ async def _async_create_entities(hass, config):
         set_direction_action = device_config.get(CONF_SET_DIRECTION_ACTION)
 
         speed_list = device_config[CONF_SPEED_LIST]
+        speed_count = device_config.get(CONF_SPEED_COUNT)
         preset_modes = device_config.get(CONF_PRESET_MODES)
         unique_id = device_config.get(CONF_UNIQUE_ID)
 
@@ -148,6 +151,7 @@ async def _async_create_entities(hass, config):
                 set_preset_mode_action,
                 set_oscillating_action,
                 set_direction_action,
+                speed_count,
                 speed_list,
                 preset_modes,
                 unique_id,
@@ -185,6 +189,7 @@ class TemplateFan(TemplateEntity, FanEntity):
         set_preset_mode_action,
         set_oscillating_action,
         set_direction_action,
+        speed_count,
         speed_list,
         preset_modes,
         unique_id,
@@ -260,6 +265,9 @@ class TemplateFan(TemplateEntity, FanEntity):
 
         self._unique_id = unique_id
 
+        # Number of valid speeds
+        self._speed_count = speed_count
+
         # List of valid speeds
         self._speed_list = speed_list
 
@@ -280,6 +288,11 @@ class TemplateFan(TemplateEntity, FanEntity):
     def supported_features(self) -> int:
         """Flag supported features."""
         return self._supported_features
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return self._speed_count or super().speed_count
 
     @property
     def speed_list(self) -> list:

--- a/homeassistant/components/tuya/fan.py
+++ b/homeassistant/components/tuya/fan.py
@@ -103,6 +103,13 @@ class TuyaFanDevice(TuyaDevice, FanEntity):
         self._tuya.oscillate(oscillating)
 
     @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        if self.speeds is None:
+            return super().speed_count
+        return len(self.speeds)
+
+    @property
     def oscillating(self):
         """Return current oscillating status."""
         if self.supported_features & SUPPORT_OSCILLATE == 0:

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -6,6 +6,7 @@ from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -76,6 +77,11 @@ class VeSyncFanHA(VeSyncDevice, FanEntity):
             if current_level is not None:
                 return ranged_value_to_percentage(SPEED_RANGE, current_level)
         return None
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def preset_modes(self):

--- a/homeassistant/components/wemo/fan.py
+++ b/homeassistant/components/wemo/fan.py
@@ -10,6 +10,7 @@ from homeassistant.components.fan import SUPPORT_SET_SPEED, FanEntity
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -129,6 +130,11 @@ class WemoHumidifier(WemoSubscriptionEntity, FanEntity):
     def percentage(self) -> str:
         """Return the current speed percentage."""
         return ranged_value_to_percentage(SPEED_RANGE, self._fan_mode)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/wilight/fan.py
+++ b/homeassistant/components/wilight/fan.py
@@ -88,6 +88,11 @@ class WiLightFan(WiLightDevice, FanEntity):
         return ordered_list_item_to_percentage(ORDERED_NAMED_FAN_SPEEDS, wl_speed)
 
     @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return len(ORDERED_NAMED_FAN_SPEEDS)
+
+    @property
     def current_direction(self) -> str:
         """Return the current direction of the fan."""
         if "direction" in self._status:

--- a/homeassistant/components/zwave/fan.py
+++ b/homeassistant/components/zwave/fan.py
@@ -5,6 +5,7 @@ from homeassistant.components.fan import DOMAIN, SUPPORT_SET_SPEED, FanEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -67,6 +68,11 @@ class ZwaveFan(ZWaveDeviceEntity, FanEntity):
     def percentage(self):
         """Return the current speed percentage."""
         return ranged_value_to_percentage(SPEED_RANGE, self._state)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def supported_features(self):

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util.percentage import (
+    int_states_in_range,
     percentage_to_ranged_value,
     ranged_value_to_percentage,
 )
@@ -95,6 +96,11 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
             # guard missing value
             return None
         return ranged_value_to_percentage(SPEED_RANGE, self.info.primary_value.value)
+
+    @property
+    def speed_count(self) -> Optional[int]:
+        """Return the number of speeds the fan supports."""
+        return int_states_in_range(SPEED_RANGE)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/util/percentage.py
+++ b/homeassistant/util/percentage.py
@@ -67,7 +67,7 @@ def ranged_value_to_percentage(
     (1,255), 127: 50
     (1,255), 10: 4
     """
-    return int((value * 100) // (low_high_range[1] - low_high_range[0] + 1))
+    return int((value * 100) // states_in_range(low_high_range))
 
 
 def percentage_to_ranged_value(
@@ -84,4 +84,14 @@ def percentage_to_ranged_value(
     (1,255), 50: 127.5
     (1,255), 4: 10.2
     """
-    return (low_high_range[1] - low_high_range[0] + 1) * percentage / 100
+    return states_in_range(low_high_range) * percentage / 100
+
+
+def states_in_range(low_high_range: Tuple[float, float]) -> float:
+    """Given a range of low and high values return how many states exist."""
+    return low_high_range[1] - low_high_range[0] + 1
+
+
+def int_states_in_range(low_high_range: Tuple[float, float]) -> int:
+    """Given a range of low and high values return how many integer states exist."""
+    return int(states_in_range(low_high_range))

--- a/tests/components/fan/common.py
+++ b/tests/components/fan/common.py
@@ -7,9 +7,12 @@ from homeassistant.components.fan import (
     ATTR_DIRECTION,
     ATTR_OSCILLATING,
     ATTR_PERCENTAGE,
+    ATTR_PERCENTAGE_STEP,
     ATTR_PRESET_MODE,
     ATTR_SPEED,
     DOMAIN,
+    SERVICE_DECREASE_SPEED,
+    SERVICE_INCREASE_SPEED,
     SERVICE_OSCILLATE,
     SERVICE_SET_DIRECTION,
     SERVICE_SET_PERCENTAGE,
@@ -104,6 +107,38 @@ async def async_set_percentage(
     }
 
     await hass.services.async_call(DOMAIN, SERVICE_SET_PERCENTAGE, data, blocking=True)
+
+
+async def async_increase_speed(
+    hass, entity_id=ENTITY_MATCH_ALL, percentage_step: int = None
+) -> None:
+    """Increase speed for all or specified fan."""
+    data = {
+        key: value
+        for key, value in [
+            (ATTR_ENTITY_ID, entity_id),
+            (ATTR_PERCENTAGE_STEP, percentage_step),
+        ]
+        if value is not None
+    }
+
+    await hass.services.async_call(DOMAIN, SERVICE_INCREASE_SPEED, data, blocking=True)
+
+
+async def async_decrease_speed(
+    hass, entity_id=ENTITY_MATCH_ALL, percentage_step: int = None
+) -> None:
+    """Decrease speed for all or specified fan."""
+    data = {
+        key: value
+        for key, value in [
+            (ATTR_ENTITY_ID, entity_id),
+            (ATTR_PERCENTAGE_STEP, percentage_step),
+        ]
+        if value is not None
+    }
+
+    await hass.services.async_call(DOMAIN, SERVICE_DECREASE_SPEED, data, blocking=True)
 
 
 async def async_set_direction(

--- a/tests/components/fan/test_init.py
+++ b/tests/components/fan/test_init.py
@@ -19,6 +19,8 @@ def test_fanentity():
     assert len(fan.speed_list) == 0
     assert len(fan.preset_modes) == 0
     assert fan.supported_features == 0
+    assert fan.percentage_step == 1
+    assert fan.speed_count == 100
     assert fan.capability_attributes == {}
     # Test set_speed not required
     with pytest.raises(NotImplementedError):
@@ -43,6 +45,8 @@ async def test_async_fanentity(hass):
     assert len(fan.speed_list) == 0
     assert len(fan.preset_modes) == 0
     assert fan.supported_features == 0
+    assert fan.percentage_step == 1
+    assert fan.speed_count == 100
     assert fan.capability_attributes == {}
     # Test set_speed not required
     with pytest.raises(NotImplementedError):
@@ -57,3 +61,7 @@ async def test_async_fanentity(hass):
         await fan.async_turn_on()
     with pytest.raises(NotImplementedError):
         await fan.async_turn_off()
+    with pytest.raises(NotImplementedError):
+        await fan.async_increase_speed()
+    with pytest.raises(NotImplementedError):
+        await fan.async_decrease_speed()

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -203,6 +203,7 @@ async def test_templates_with_entities(hass, calls):
                             "preset_mode_template": "{{ states('input_select.preset_mode') }}",
                             "oscillating_template": "{{ states('input_select.osc') }}",
                             "direction_template": "{{ states('input_select.direction') }}",
+                            "speed_count": "3",
                             "set_percentage": {
                                 "service": "script.fans_set_speed",
                                 "data_template": {"percentage": "{{ percentage }}"},
@@ -646,6 +647,46 @@ async def test_set_percentage(hass, calls):
     assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 50
 
     _verify(hass, STATE_ON, SPEED_MEDIUM, 50, None, None, None)
+
+
+async def test_increase_decrease_speed(hass, calls):
+    """Test set valid increase and derease speed."""
+    await _register_components(hass)
+
+    # Turn on fan
+    await common.async_turn_on(hass, _TEST_FAN)
+
+    # Set fan's percentage speed to 100
+    await common.async_set_percentage(hass, _TEST_FAN, 100)
+
+    # verify
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 100
+
+    _verify(hass, STATE_ON, SPEED_HIGH, 100, None, None, None)
+
+    # Set fan's percentage speed to 66
+    await common.async_decrease_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 66
+
+    _verify(hass, STATE_ON, SPEED_MEDIUM, 66, None, None, None)
+
+    # Set fan's percentage speed to 33
+    await common.async_decrease_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 33
+
+    _verify(hass, STATE_ON, SPEED_LOW, 33, None, None, None)
+
+    # Set fan's percentage speed to 0
+    await common.async_decrease_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 0
+
+    _verify(hass, STATE_OFF, SPEED_OFF, 0, None, None, None)
+
+    # Set fan's percentage speed to 33
+    await common.async_increase_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 33
+
+    _verify(hass, STATE_ON, SPEED_LOW, 33, None, None, None)
 
 
 async def test_set_invalid_speed_from_initial_stage(hass, calls):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This was deferred from the original implementation of https://github.com/home-assistant/architecture/issues/127 to contain scope (https://github.com/home-assistant/frontend/pull/8216#issuecomment-766355828) cc @Jc2k 

This is a followup PR to address the request to include
step sizes that was original made in related frontend #45407 

The step size is automatically calculated by having the integration provide
the `speed_count` property.  This avoids the need for the integration deal
with `float` values since fans with 7 speeds have a percentage step size of
`14.285714285714286`...

Frontend: https://github.com/home-assistant/frontend/pull/8393
Dev docs: https://github.com/home-assistant/developers.home-assistant/pull/804
User docs: https://github.com/home-assistant/home-assistant.io/pull/16558 and https://github.com/home-assistant/home-assistant.io/pull/16562

Adds a `fan.increase_speed` and `fan.decrease_speed` service to handle
the case where remotes have an up/down button where it would
be difficult to pre-select a percentage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16558

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
