### PR TITLE
Clean up xbee

### DIFF
--- a/homeassistant/components/xbee/__init__.py
+++ b/homeassistant/components/xbee/__init__.py
@@ -29,6 +29,11 @@ SIGNAL_XBEE_FRAME_RECEIVED = "xbee_frame_received"
 
 CONF_BAUD = "baud"
 
+CONF_ON_STATE = "on_state"
+
+DEFAULT_ON_STATE = "high"
+STATES = ["high", "low"]
+
 DEFAULT_DEVICE = "/dev/ttyUSB0"
 DEFAULT_BAUD = 9600
 DEFAULT_ADC_MAX_VOLTS = 1.2
@@ -59,7 +64,6 @@ PLATFORM_SCHEMA = vol.Schema(
 
 def setup(hass, config):
     """Set up the connection to the XBee Zigbee device."""
-
     usb_device = config[DOMAIN].get(CONF_DEVICE, DEFAULT_DEVICE)
     baud = int(config[DOMAIN].get(CONF_BAUD, DEFAULT_BAUD))
     try:

--- a/homeassistant/components/xbee/__init__.py
+++ b/homeassistant/components/xbee/__init__.py
@@ -21,18 +21,13 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
 from homeassistant.helpers.entity import Entity
 
-_LOGGER = logging.getLogger(__name__)
+from .const import DOMAIN
 
-DOMAIN = "xbee"
+_LOGGER = logging.getLogger(__name__)
 
 SIGNAL_XBEE_FRAME_RECEIVED = "xbee_frame_received"
 
 CONF_BAUD = "baud"
-
-CONF_ON_STATE = "on_state"
-
-DEFAULT_ON_STATE = "high"
-STATES = ["high", "low"]
 
 DEFAULT_DEVICE = "/dev/ttyUSB0"
 DEFAULT_BAUD = 9600

--- a/homeassistant/components/xbee/binary_sensor.py
+++ b/homeassistant/components/xbee/binary_sensor.py
@@ -3,14 +3,8 @@ import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from . import (
-    CONF_ON_STATE,
-    DOMAIN,
-    PLATFORM_SCHEMA,
-    STATES,
-    XBeeDigitalIn,
-    XBeeDigitalInConfig,
-)
+from . import PLATFORM_SCHEMA, XBeeDigitalIn, XBeeDigitalInConfig
+from .const import CONF_ON_STATE, DOMAIN, STATES
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_ON_STATE): vol.In(STATES)})
 

--- a/homeassistant/components/xbee/binary_sensor.py
+++ b/homeassistant/components/xbee/binary_sensor.py
@@ -3,12 +3,14 @@ import voluptuous as vol
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
 
-from . import DOMAIN, PLATFORM_SCHEMA, XBeeDigitalIn, XBeeDigitalInConfig
-
-CONF_ON_STATE = "on_state"
-
-DEFAULT_ON_STATE = "high"
-STATES = ["high", "low"]
+from . import (
+    CONF_ON_STATE,
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    STATES,
+    XBeeDigitalIn,
+    XBeeDigitalInConfig,
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_ON_STATE): vol.In(STATES)})
 

--- a/homeassistant/components/xbee/const.py
+++ b/homeassistant/components/xbee/const.py
@@ -1,0 +1,5 @@
+"""Constants for the xbee integration."""
+CONF_ON_STATE = "on_state"
+DEFAULT_ON_STATE = "high"
+DOMAIN = "xbee"
+STATES = ["high", "low"]

--- a/homeassistant/components/xbee/light.py
+++ b/homeassistant/components/xbee/light.py
@@ -3,12 +3,15 @@ import voluptuous as vol
 
 from homeassistant.components.light import LightEntity
 
-from . import DOMAIN, PLATFORM_SCHEMA, XBeeDigitalOut, XBeeDigitalOutConfig
-
-CONF_ON_STATE = "on_state"
-
-DEFAULT_ON_STATE = "high"
-STATES = ["high", "low"]
+from . import (
+    CONF_ON_STATE,
+    DEFAULT_ON_STATE,
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    STATES,
+    XBeeDigitalOut,
+    XBeeDigitalOutConfig,
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_ON_STATE, default=DEFAULT_ON_STATE): vol.In(STATES)}

--- a/homeassistant/components/xbee/light.py
+++ b/homeassistant/components/xbee/light.py
@@ -3,15 +3,8 @@ import voluptuous as vol
 
 from homeassistant.components.light import LightEntity
 
-from . import (
-    CONF_ON_STATE,
-    DEFAULT_ON_STATE,
-    DOMAIN,
-    PLATFORM_SCHEMA,
-    STATES,
-    XBeeDigitalOut,
-    XBeeDigitalOutConfig,
-)
+from . import PLATFORM_SCHEMA, XBeeDigitalOut, XBeeDigitalOutConfig
+from .const import CONF_ON_STATE, DEFAULT_ON_STATE, DOMAIN, STATES
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {vol.Optional(CONF_ON_STATE, default=DEFAULT_ON_STATE): vol.In(STATES)}

--- a/homeassistant/components/xbee/sensor.py
+++ b/homeassistant/components/xbee/sensor.py
@@ -5,14 +5,13 @@ import logging
 import voluptuous as vol
 from xbee_helper.exceptions import ZigBeeException, ZigBeeTxFailure
 
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import CONF_TYPE, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
 
 from . import DOMAIN, PLATFORM_SCHEMA, XBeeAnalogIn, XBeeAnalogInConfig, XBeeConfig
 
 _LOGGER = logging.getLogger(__name__)
 
-CONF_TYPE = "type"
 CONF_MAX_VOLTS = "max_volts"
 
 DEFAULT_VOLTS = 1.2

--- a/homeassistant/components/xbee/switch.py
+++ b/homeassistant/components/xbee/switch.py
@@ -3,14 +3,8 @@ import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
 
-from . import (
-    CONF_ON_STATE,
-    DOMAIN,
-    PLATFORM_SCHEMA,
-    STATES,
-    XBeeDigitalOut,
-    XBeeDigitalOutConfig,
-)
+from . import PLATFORM_SCHEMA, XBeeDigitalOut, XBeeDigitalOutConfig
+from .const import CONF_ON_STATE, DOMAIN, STATES
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_ON_STATE): vol.In(STATES)})
 

--- a/homeassistant/components/xbee/switch.py
+++ b/homeassistant/components/xbee/switch.py
@@ -3,13 +3,14 @@ import voluptuous as vol
 
 from homeassistant.components.switch import SwitchEntity
 
-from . import DOMAIN, PLATFORM_SCHEMA, XBeeDigitalOut, XBeeDigitalOutConfig
-
-CONF_ON_STATE = "on_state"
-
-DEFAULT_ON_STATE = "high"
-
-STATES = ["high", "low"]
+from . import (
+    CONF_ON_STATE,
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    STATES,
+    XBeeDigitalOut,
+    XBeeDigitalOutConfig,
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Optional(CONF_ON_STATE): vol.In(STATES)})
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up xbee.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
