### PR TITLE
Use core constants for xiaomi_aqara

### DIFF
--- a/homeassistant/components/xiaomi_aqara/__init__.py
+++ b/homeassistant/components/xiaomi_aqara/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_MAC,
     CONF_PORT,
+    CONF_PROTOCOL,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import callback
@@ -26,7 +27,6 @@ from homeassistant.util.dt import utcnow
 from .const import (
     CONF_INTERFACE,
     CONF_KEY,
-    CONF_PROTOCOL,
     CONF_SID,
     DEFAULT_DISCOVERY_RETRY,
     DOMAIN,

--- a/homeassistant/components/xiaomi_aqara/config_flow.py
+++ b/homeassistant/components/xiaomi_aqara/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from xiaomi_gateway import MULTICAST_PORT, XiaomiGateway, XiaomiGatewayDiscovery
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 
@@ -14,7 +14,6 @@ from homeassistant.helpers.device_registry import format_mac
 from .const import (
     CONF_INTERFACE,
     CONF_KEY,
-    CONF_PROTOCOL,
     CONF_SID,
     DEFAULT_DISCOVERY_RETRY,
     DOMAIN,

--- a/homeassistant/components/xiaomi_aqara/const.py
+++ b/homeassistant/components/xiaomi_aqara/const.py
@@ -9,7 +9,6 @@ ZEROCONF_GATEWAY = "lumi-gateway"
 ZEROCONF_ACPARTNER = "lumi-acpartner"
 
 CONF_INTERFACE = "interface"
-CONF_PROTOCOL = "protocol"
 CONF_KEY = "key"
 CONF_SID = "sid"
 

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -7,11 +7,12 @@ import pytest
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.xiaomi_aqara import config_flow, const
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_PROTOCOL
 
 ZEROCONF_NAME = "name"
 ZEROCONF_PROP = "properties"
 ZEROCONF_MAC = "mac"
+const.CONF_PROTOCOL = CONF_PROTOCOL
 
 TEST_HOST = "1.2.3.4"
 TEST_HOST_2 = "5.6.7.8"

--- a/tests/components/xiaomi_aqara/test_config_flow.py
+++ b/tests/components/xiaomi_aqara/test_config_flow.py
@@ -12,7 +12,6 @@ from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_
 ZEROCONF_NAME = "name"
 ZEROCONF_PROP = "properties"
 ZEROCONF_MAC = "mac"
-const.CONF_PROTOCOL = CONF_PROTOCOL
 
 TEST_HOST = "1.2.3.4"
 TEST_HOST_2 = "5.6.7.8"
@@ -108,7 +107,7 @@ async def test_config_flow_user_success(hass):
         CONF_PORT: TEST_PORT,
         CONF_MAC: TEST_MAC,
         const.CONF_INTERFACE: config_flow.DEFAULT_INTERFACE,
-        const.CONF_PROTOCOL: TEST_PROTOCOL,
+        CONF_PROTOCOL: TEST_PROTOCOL,
         const.CONF_KEY: TEST_KEY,
         const.CONF_SID: TEST_SID,
     }
@@ -160,7 +159,7 @@ async def test_config_flow_user_multiple_success(hass):
         CONF_PORT: TEST_PORT,
         CONF_MAC: TEST_MAC,
         const.CONF_INTERFACE: config_flow.DEFAULT_INTERFACE,
-        const.CONF_PROTOCOL: TEST_PROTOCOL,
+        CONF_PROTOCOL: TEST_PROTOCOL,
         const.CONF_KEY: TEST_KEY,
         const.CONF_SID: TEST_SID,
     }
@@ -197,7 +196,7 @@ async def test_config_flow_user_no_key_success(hass):
         CONF_PORT: TEST_PORT,
         CONF_MAC: TEST_MAC,
         const.CONF_INTERFACE: config_flow.DEFAULT_INTERFACE,
-        const.CONF_PROTOCOL: TEST_PROTOCOL,
+        CONF_PROTOCOL: TEST_PROTOCOL,
         const.CONF_KEY: None,
         const.CONF_SID: TEST_SID,
     }
@@ -244,7 +243,7 @@ async def test_config_flow_user_host_mac_success(hass):
         CONF_PORT: TEST_PORT,
         CONF_MAC: TEST_MAC,
         const.CONF_INTERFACE: config_flow.DEFAULT_INTERFACE,
-        const.CONF_PROTOCOL: TEST_PROTOCOL,
+        CONF_PROTOCOL: TEST_PROTOCOL,
         const.CONF_KEY: None,
         const.CONF_SID: TEST_SID,
     }
@@ -434,7 +433,7 @@ async def test_zeroconf_success(hass):
         CONF_PORT: TEST_PORT,
         CONF_MAC: TEST_MAC,
         const.CONF_INTERFACE: config_flow.DEFAULT_INTERFACE,
-        const.CONF_PROTOCOL: TEST_PROTOCOL,
+        CONF_PROTOCOL: TEST_PROTOCOL,
         const.CONF_KEY: TEST_KEY,
         const.CONF_SID: TEST_SID,
     }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use core constants for xiaomi_aqara.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
