### PR TITLE
Switch ssdp to be async by using async_upnp_client for scanning

### DIFF
--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.2"],
+  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.2", "async-upnp-client==0.14.13"],
   "after_dependencies": ["zeroconf"],
   "codeowners": []
 }

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -3,6 +3,7 @@ PyNaCl==1.3.0
 aiohttp==3.7.3
 aiohttp_cors==0.7.0
 astral==1.10.1
+async-upnp-client==0.14.13
 async_timeout==3.0.1
 attrs==19.3.0
 awesomeversion==21.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -284,6 +284,7 @@ asmog==0.0.6
 asterisk_mbox==0.5.0
 
 # homeassistant.components.dlna_dmr
+# homeassistant.components.ssdp
 # homeassistant.components.upnp
 async-upnp-client==0.14.13
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -173,6 +173,7 @@ aprslib==0.6.46
 arcam-fmj==0.5.3
 
 # homeassistant.components.dlna_dmr
+# homeassistant.components.ssdp
 # homeassistant.components.upnp
 async-upnp-client==0.14.13
 

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -14,15 +14,18 @@ async def test_scan_match_st(hass, caplog):
     """Test matching based on ST."""
     scanner = ssdp.Scanner(hass, {"mock-domain": [{"st": "mock-st"}]})
 
-    with patch(
-        "netdisco.ssdp.scan",
-        return_value=[
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
             Mock(
                 st="mock-st",
                 location=None,
                 values={"usn": "mock-usn", "server": "mock-server", "ext": ""},
             )
-        ],
+        )
+
+    with patch(
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -58,9 +61,14 @@ async def test_scan_match_upnp_devicedesc(hass, aioclient_mock, key):
     )
     scanner = ssdp.Scanner(hass, {"mock-domain": [{key: "Paulus"}]})
 
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
+            Mock(st="mock-st", location="http://1.1.1.1", values={})
+        )
+
     with patch(
-        "netdisco.ssdp.scan",
-        return_value=[Mock(st="mock-st", location="http://1.1.1.1", values={})],
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -95,9 +103,14 @@ async def test_scan_not_all_present(hass, aioclient_mock):
         },
     )
 
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
+            Mock(st="mock-st", location="http://1.1.1.1", values={})
+        )
+
     with patch(
-        "netdisco.ssdp.scan",
-        return_value=[Mock(st="mock-st", location="http://1.1.1.1", values={})],
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -131,9 +144,14 @@ async def test_scan_not_all_match(hass, aioclient_mock):
         },
     )
 
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
+            Mock(st="mock-st", location="http://1.1.1.1", values={})
+        )
+
     with patch(
-        "netdisco.ssdp.scan",
-        return_value=[Mock(st="mock-st", location="http://1.1.1.1", values={})],
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -148,9 +166,14 @@ async def test_scan_description_fetch_fail(hass, aioclient_mock, exc):
     aioclient_mock.get("http://1.1.1.1", exc=exc)
     scanner = ssdp.Scanner(hass, {})
 
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
+            Mock(st="mock-st", location="http://1.1.1.1", values={})
+        )
+
     with patch(
-        "netdisco.ssdp.scan",
-        return_value=[Mock(st="mock-st", location="http://1.1.1.1", values={})],
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ):
         await scanner.async_scan(None)
 
@@ -165,9 +188,14 @@ async def test_scan_description_parse_fail(hass, aioclient_mock):
     )
     scanner = ssdp.Scanner(hass, {})
 
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
+            Mock(st="mock-st", location="http://1.1.1.1", values={})
+        )
+
     with patch(
-        "netdisco.ssdp.scan",
-        return_value=[Mock(st="mock-st", location="http://1.1.1.1", values={})],
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ):
         await scanner.async_scan(None)
 
@@ -196,9 +224,14 @@ async def test_invalid_characters(hass, aioclient_mock):
         },
     )
 
+    async def _inject_entry(*args, **kwargs):
+        scanner.async_store_entry(
+            Mock(st="mock-st", location="http://1.1.1.1", values={})
+        )
+
     with patch(
-        "netdisco.ssdp.scan",
-        return_value=[Mock(st="mock-st", location="http://1.1.1.1", values={})],
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_inject_entry,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
SSDP searches now binds to `0.0.0.0` instead of each interface separately.

Everything was still discovered in testing on a server with multiple interfaces, but since everyone's network config is different, we could `asyncio.gather` with `zeroconf.get_all_addresses()` similar to https://github.com/home-assistant/netdisco/blob/master/netdisco/ssdp.py#L226 if we really need this.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSDP scans no longer runs in the executor. This avoids a lot of thread switching since SSDP causes the scanning thread to wake each time a new response is received. 

This is an interim step that converts the async_upnp_client
response to netdisco's object to ensure fully backwards
compatibility


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
