### PR TITLE
Use httpx in generic camera

### DIFF
--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -133,21 +133,18 @@ async def test_limit_refetch(hass, hass_client):
 
     with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
         resp = await client.get("/api/camera_proxy/camera.config_test")
-        # assert aioclient_mock.call_count == 0
         assert respx.calls.call_count == 0
         assert resp.status == HTTP_INTERNAL_SERVER_ERROR
 
     hass.states.async_set("sensor.temp", "10")
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    # assert aioclient_mock.call_count == 1
     assert respx.calls.call_count == 1
     assert resp.status == 200
     body = await resp.text()
     assert body == "hello world"
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    # assert aioclient_mock.call_count == 1
     assert respx.calls.call_count == 1
     assert resp.status == 200
     body = await resp.text()
@@ -157,7 +154,6 @@ async def test_limit_refetch(hass, hass_client):
 
     # Url change = fetch new image
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    # assert aioclient_mock.call_count == 2
     assert respx.calls.call_count == 2
     assert resp.status == 200
     body = await resp.text()
@@ -166,7 +162,6 @@ async def test_limit_refetch(hass, hass_client):
     # Cause a template render error
     hass.states.async_remove("sensor.temp")
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    # assert aioclient_mock.call_count == 2
     assert respx.calls.call_count == 2
     assert resp.status == 200
     body = await resp.text()

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -3,6 +3,8 @@ import asyncio
 from os import path
 from unittest.mock import patch
 
+import respx
+
 from homeassistant import config as hass_config
 from homeassistant.components.generic import DOMAIN
 from homeassistant.components.websocket_api.const import TYPE_RESULT
@@ -14,9 +16,10 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 
 
-async def test_fetching_url(aioclient_mock, hass, hass_client):
+@respx.mock
+async def test_fetching_url(hass, hass_client):
     """Test that it fetches the given url."""
-    aioclient_mock.get("http://example.com", text="hello world")
+    respx.get("http://example.com").respond(text="hello world")
 
     await async_setup_component(
         hass,
@@ -38,12 +41,12 @@ async def test_fetching_url(aioclient_mock, hass, hass_client):
     resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == 200
-    assert aioclient_mock.call_count == 1
+    assert respx.calls.call_count == 1
     body = await resp.text()
     assert body == "hello world"
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert aioclient_mock.call_count == 2
+    assert respx.calls.call_count == 2
 
 
 async def test_fetching_without_verify_ssl(aioclient_mock, hass, hass_client):
@@ -100,12 +103,13 @@ async def test_fetching_url_with_verify_ssl(aioclient_mock, hass, hass_client):
     assert resp.status == 200
 
 
-async def test_limit_refetch(aioclient_mock, hass, hass_client):
+@respx.mock
+async def test_limit_refetch(hass, hass_client):
     """Test that it fetches the given url."""
-    aioclient_mock.get("http://example.com/5a", text="hello world")
-    aioclient_mock.get("http://example.com/10a", text="hello world")
-    aioclient_mock.get("http://example.com/15a", text="hello planet")
-    aioclient_mock.get("http://example.com/20a", status=HTTP_NOT_FOUND)
+    respx.get("http://example.com/5a").respond(text="hello world")
+    respx.get("http://example.com/10a").respond(text="hello world")
+    respx.get("http://example.com/15a").respond(text="hello planet")
+    respx.get("http://example.com/20a").respond(status_code=HTTP_NOT_FOUND)
 
     await async_setup_component(
         hass,
@@ -129,19 +133,22 @@ async def test_limit_refetch(aioclient_mock, hass, hass_client):
 
     with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError()):
         resp = await client.get("/api/camera_proxy/camera.config_test")
-        assert aioclient_mock.call_count == 0
+        # assert aioclient_mock.call_count == 0
+        assert respx.calls.call_count == 0
         assert resp.status == HTTP_INTERNAL_SERVER_ERROR
 
     hass.states.async_set("sensor.temp", "10")
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert aioclient_mock.call_count == 1
+    # assert aioclient_mock.call_count == 1
+    assert respx.calls.call_count == 1
     assert resp.status == 200
     body = await resp.text()
     assert body == "hello world"
 
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert aioclient_mock.call_count == 1
+    # assert aioclient_mock.call_count == 1
+    assert respx.calls.call_count == 1
     assert resp.status == 200
     body = await resp.text()
     assert body == "hello world"
@@ -150,7 +157,8 @@ async def test_limit_refetch(aioclient_mock, hass, hass_client):
 
     # Url change = fetch new image
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert aioclient_mock.call_count == 2
+    # assert aioclient_mock.call_count == 2
+    assert respx.calls.call_count == 2
     assert resp.status == 200
     body = await resp.text()
     assert body == "hello planet"
@@ -158,7 +166,8 @@ async def test_limit_refetch(aioclient_mock, hass, hass_client):
     # Cause a template render error
     hass.states.async_remove("sensor.temp")
     resp = await client.get("/api/camera_proxy/camera.config_test")
-    assert aioclient_mock.call_count == 2
+    # assert aioclient_mock.call_count == 2
+    assert respx.calls.call_count == 2
     assert resp.status == 200
     body = await resp.text()
     assert body == "hello planet"
@@ -285,11 +294,12 @@ async def test_no_stream_source(aioclient_mock, hass, hass_client, hass_ws_clien
         }
 
 
-async def test_camera_content_type(aioclient_mock, hass, hass_client):
+@respx.mock
+async def test_camera_content_type(hass, hass_client):
     """Test generic camera with custom content_type."""
     svg_image = "<some image>"
     urlsvg = "https://upload.wikimedia.org/wikipedia/commons/0/02/SVG_logo.svg"
-    aioclient_mock.get(urlsvg, text=svg_image)
+    respx.get(urlsvg).respond(text=svg_image)
 
     cam_config_svg = {
         "name": "config_test_svg",
@@ -309,23 +319,24 @@ async def test_camera_content_type(aioclient_mock, hass, hass_client):
     client = await hass_client()
 
     resp_1 = await client.get("/api/camera_proxy/camera.config_test_svg")
-    assert aioclient_mock.call_count == 1
+    assert respx.calls.call_count == 1
     assert resp_1.status == 200
     assert resp_1.content_type == "image/svg+xml"
     body = await resp_1.text()
     assert body == svg_image
 
     resp_2 = await client.get("/api/camera_proxy/camera.config_test_jpg")
-    assert aioclient_mock.call_count == 2
+    assert respx.calls.call_count == 2
     assert resp_2.status == 200
     assert resp_2.content_type == "image/jpeg"
     body = await resp_2.text()
     assert body == svg_image
 
 
-async def test_reloading(aioclient_mock, hass, hass_client):
+@respx.mock
+async def test_reloading(hass, hass_client):
     """Test we can cleanly reload."""
-    aioclient_mock.get("http://example.com", text="hello world")
+    respx.get("http://example.com").respond(text="hello world")
 
     await async_setup_component(
         hass,
@@ -347,7 +358,7 @@ async def test_reloading(aioclient_mock, hass, hass_client):
     resp = await client.get("/api/camera_proxy/camera.config_test")
 
     assert resp.status == 200
-    assert aioclient_mock.call_count == 1
+    assert respx.calls.call_count == 1
     body = await resp.text()
     assert body == "hello world"
 
@@ -374,7 +385,7 @@ async def test_reloading(aioclient_mock, hass, hass_client):
     resp = await client.get("/api/camera_proxy/camera.reload")
 
     assert resp.status == 200
-    assert aioclient_mock.call_count == 2
+    assert respx.calls.call_count == 2
     body = await resp.text()
     assert body == "hello world"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
The current generic camera component uses a mix of `aiohttp` and `requests` as `aiohttp` does not support digest authentication. However, there are a few unresolved [issues](https://github.com/psf/requests/issues?q=is%3Aissue+is%3Aopen+digest) with digest authentication in `requests`. This one [particular issue](https://github.com/psf/requests/issues/5178) was identified quite some time ago and the PR to address it has not been merged. This seems to cause digest authentication to fail intermittently, and repeated authentication failures can result in the camera/NVR locking out further connections for a period of time.
This PR uses httpx to replace both `aiohttp` and `requests` to grab the images in `generic` camera.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
