### PR TITLE
Add device_class attribute to ESPHome sensor entities

### DIFF
--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==2.6.4"],
+  "requirements": ["aioesphomeapi==2.6.5"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": ["@OttoWinter"],
   "after_dependencies": ["zeroconf", "tag"]

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -73,6 +73,11 @@ class EsphomeSensor(EsphomeEntity):
         """Return the unit the value is expressed in."""
         return self._static_info.unit_of_measurement
 
+    @property
+    def device_class(self) -> str:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return self._static_info.device_class
+
 
 class EsphomeTextSensor(EsphomeEntity):
     """A text sensor implementation for ESPHome."""

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -52,6 +52,8 @@ class EsphomeSensor(EsphomeEntity):
     @property
     def icon(self) -> str:
         """Return the icon."""
+        if self._static_info.icon == "":
+            return None
         return self._static_info.icon
 
     @property
@@ -71,11 +73,15 @@ class EsphomeSensor(EsphomeEntity):
     @property
     def unit_of_measurement(self) -> str:
         """Return the unit the value is expressed in."""
+        if self._static_info.unit_of_measurement == "":
+            return None
         return self._static_info.unit_of_measurement
 
     @property
     def device_class(self) -> str:
         """Return the class of this device, from component DEVICE_CLASSES."""
+        if self._static_info.device_class == "":
+            return None
         return self._static_info.device_class
 
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -154,7 +154,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.4
+aioesphomeapi==2.6.5
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -91,7 +91,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.esphome
-aioesphomeapi==2.6.4
+aioesphomeapi==2.6.5
 
 # homeassistant.components.flo
 aioflo==0.4.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pr fixes https://github.com/esphome/feature-requests/issues/553 which asked for the ability to assign a device class to ESPHome sensors natively in their own config. These changes here enable the [ESPHome integration](https://www.home-assistant.io/integrations/esphome/) to transfer this `device_class` attribute correctly to HA. To accomplish this, a dependency upgrade of the [aioesphomeapi](https://pypi.org/project/aioesphomeapi/) package from 2.6.4 to 2.6.5 was necessary.

- Release/Changelog of aioesphomeapi 2.6.5: https://github.com/esphome/aioesphomeapi/releases/tag/v2.6.5
- GitHub Diff 2.6.4 => 2.6.5: https://github.com/esphome/aioesphomeapi/compare/v2.6.4...v2.6.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/esphome/feature-requests/issues/553 and https://github.com/esphome/esphome/pull/1525
- Link to documentation pull request: https://github.com/esphome/esphome-docs/pull/996

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository] *(not necessary)*

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`. *(no new files)*

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
