### PR TITLE
Improve code quality of water_heater

### DIFF
--- a/homeassistant/components/demo/water_heater.py
+++ b/homeassistant/components/demo/water_heater.py
@@ -16,8 +16,28 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     """Set up the Demo water_heater devices."""
     async_add_entities(
         [
-            DemoWaterHeater("Demo Water Heater", 119, TEMP_FAHRENHEIT, False, "eco"),
-            DemoWaterHeater("Demo Water Heater Celsius", 45, TEMP_CELSIUS, True, "eco"),
+            DemoWaterHeater(
+                name="Demo Water Heater",
+                target_temperature=119,
+                unit_of_measurement=TEMP_FAHRENHEIT,
+                away=False,
+                current_operation="eco",
+            ),
+            DemoWaterHeater(
+                name="Demo Water Heater Celsius",
+                target_temperature=45,
+                unit_of_measurement=TEMP_CELSIUS,
+                away=True,
+                current_operation="eco",
+            ),
+            DemoWaterHeater(
+                name="Demo Water Heater (1 step)",
+                target_temperature=35,
+                unit_of_measurement=TEMP_CELSIUS,
+                away=True,
+                current_operation="eco",
+                target_temperature_step=1.0,
+            ),
         ]
     )
 
@@ -31,7 +51,13 @@ class DemoWaterHeater(WaterHeaterEntity):
     """Representation of a demo water_heater device."""
 
     def __init__(
-        self, name, target_temperature, unit_of_measurement, away, current_operation
+        self,
+        name,
+        target_temperature,
+        unit_of_measurement,
+        away,
+        current_operation,
+        target_temperature_step=None,
     ):
         """Initialize the water_heater device."""
         self._name = name
@@ -55,6 +81,7 @@ class DemoWaterHeater(WaterHeaterEntity):
             "gas",
             "off",
         ]
+        self._target_temperature_step = target_temperature_step
 
     @property
     def supported_features(self):
@@ -80,6 +107,11 @@ class DemoWaterHeater(WaterHeaterEntity):
     def target_temperature(self):
         """Return the temperature we try to reach."""
         return self._target_temperature
+
+    @property
+    def target_temperature_step(self):
+        """Return the supported step of target temperature."""
+        return self._target_temperature_step
 
     @property
     def current_operation(self):

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -2,9 +2,11 @@
 from datetime import timedelta
 import functools as ft
 import logging
+from typing import Optional
 
 import voluptuous as vol
 
+from homeassistant.components.climate.const import ATTR_TARGET_TEMP_STEP
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_TEMPERATURE,
@@ -160,6 +162,9 @@ class WaterHeaterEntity(Entity):
         if supported_features & SUPPORT_OPERATION_MODE:
             data[ATTR_OPERATION_LIST] = self.operation_list
 
+        if self.target_temperature_step:
+            data[ATTR_TARGET_TEMP_STEP] = self.target_temperature_step
+
         return data
 
     @property
@@ -226,6 +231,11 @@ class WaterHeaterEntity(Entity):
     @property
     def target_temperature(self):
         """Return the temperature we try to reach."""
+        return None
+
+    @property
+    def target_temperature_step(self) -> Optional[float]:
+        """Return the supported step of target temperature."""
         return None
 
     @property

--- a/homeassistant/components/water_heater/__init__.py
+++ b/homeassistant/components/water_heater/__init__.py
@@ -186,18 +186,6 @@ class WaterHeaterEntity(Entity):
                 self.temperature_unit,
                 self.precision,
             ),
-            ATTR_TARGET_TEMP_HIGH: show_temp(
-                self.hass,
-                self.target_temperature_high,
-                self.temperature_unit,
-                self.precision,
-            ),
-            ATTR_TARGET_TEMP_LOW: show_temp(
-                self.hass,
-                self.target_temperature_low,
-                self.temperature_unit,
-                self.precision,
-            ),
         }
 
         supported_features = self.supported_features
@@ -241,16 +229,6 @@ class WaterHeaterEntity(Entity):
     @property
     def target_temperature_step(self) -> Optional[float]:
         """Return the supported step of target temperature."""
-        return None
-
-    @property
-    def target_temperature_high(self) -> Optional[float]:
-        """Return the highbound target temperature we try to reach."""
-        return None
-
-    @property
-    def target_temperature_low(self) -> Optional[float]:
-        """Return the lowbound target temperature we try to reach."""
         return None
 
     @property


### PR DESCRIPTION
I stumbled upon the water_heater platform while adding support for new entities of the Somfy TaHoma platform. It looks like the water_heater platform isn't used that much, since there are a few bugs and/or features that aren't implemented.

This draft PR has been created to make it easier to retrieve help with the current `mypy` linting issues. Eventually it will be divided in multiple PR's, to make sure all water_heater entities receive all changes.

## Breaking change
- Entity services will look at the supported services where needed.
- Removed unused `temperature_high` and `temperature_low` 

(not implemented yet)
- Operation mode is a required attribute. Every water_heater should support on/off at least.
- `operation_list` has been renamed to `operation_mode`
- `STATE_ECO` (and others) have been renamed to `OPERATION_MODE_*`.

## Proposed change

- Add `target_temperature_step` attribute (already supported by front-end)
- Add demo device for water_heater which uses `target_temperature_step`
- Add missing types
- Added `async_turn_off` functionality, which is already added as a non functional service
- Added `async_turn_on` functionality, which is already added as a non functional service

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
