### PR TITLE
Swap octoprint to use an external library

### DIFF
--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -1,5 +1,5 @@
 """Support for monitoring OctoPrint 3D printers."""
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
 
 from pyoctoprintapi import OctoprintClient
@@ -215,4 +215,4 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
             if self.data and "printer" in self.data:
                 printer = self.data["printer"]
 
-        return {"job": job, "printer": printer}
+        return {"job": job, "printer": printer, "last_read_time": datetime.utcnow()}

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -199,6 +199,7 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=interval),
         )
         self._octoprint = octoprint
+        self.data = {"printer": None, "job": None, "last_read_time": None}
 
     async def _async_update_data(self):
         """Update data via API."""

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -150,26 +150,30 @@ async def async_setup(hass, config):
         printers[base_url] = coordinator
 
         sensors = printer[CONF_SENSORS][CONF_MONITORED_CONDITIONS]
-        await async_load_platform(
-            hass,
-            "sensor",
-            DOMAIN,
-            {
-                "name": name,
-                "base_url": base_url,
-                "sensors": sensors,
-                CONF_NUMBER_OF_TOOLS: printer[CONF_NUMBER_OF_TOOLS],
-                CONF_BED: printer[CONF_BED],
-            },
-            config,
+        hass.async_create_task(
+            async_load_platform(
+                hass,
+                "sensor",
+                DOMAIN,
+                {
+                    "name": name,
+                    "base_url": base_url,
+                    "sensors": sensors,
+                    CONF_NUMBER_OF_TOOLS: printer[CONF_NUMBER_OF_TOOLS],
+                    CONF_BED: printer[CONF_BED],
+                },
+                config,
+            )
         )
         b_sensors = printer[CONF_BINARY_SENSORS][CONF_MONITORED_CONDITIONS]
-        await async_load_platform(
-            hass,
-            "binary_sensor",
-            DOMAIN,
-            {"name": name, "base_url": base_url, "sensors": b_sensors},
-            config,
+        hass.async_create_task(
+            async_load_platform(
+                hass,
+                "binary_sensor",
+                DOMAIN,
+                {"name": name, "base_url": base_url, "sensors": b_sensors},
+                config,
+            )
         )
         success = True
 

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+import aiohttp
 from pyoctoprintapi import OctoprintClient
 import voluptuous as vol
 
@@ -208,14 +209,14 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
         printer = None
         try:
             job = await self._octoprint.get_job_info()
-        except Exception as error:  # pylint: disable=broad-except
+        except aiohttp.ClientResponseError as error:
             _LOGGER.error("Failed to update job data %s", error)
             if self.data and "job" in self.data:
                 job = self.data["job"]
 
         try:
             printer = await self._octoprint.get_printer_info()
-        except Exception as error:  # pylint: disable=broad-except
+        except aiohttp.ClientResponseError as error:
             _LOGGER.error("Failed to update printer data %s", error)
             if self.data and "printer" in self.data:
                 printer = self.data["printer"]

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -1,5 +1,5 @@
 """Support for monitoring OctoPrint 3D printers."""
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
 
 from pyoctoprintapi import OctoprintClient
@@ -24,6 +24,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_load_platform
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify as util_slugify
+import homeassistant.util.dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -215,4 +216,4 @@ class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
             if self.data and "printer" in self.data:
                 printer = self.data["printer"]
 
-        return {"job": job, "printer": printer, "last_read_time": datetime.utcnow()}
+        return {"job": job, "printer": printer, "last_read_time": dt_util.utcnow()}

--- a/homeassistant/components/octoprint/__init__.py
+++ b/homeassistant/components/octoprint/__init__.py
@@ -1,9 +1,8 @@
 """Support for monitoring OctoPrint 3D printers."""
+from datetime import timedelta
 import logging
-import time
 
-from aiohttp.hdrs import CONTENT_TYPE
-import requests
+from pyoctoprintapi import OctoprintClient
 import voluptuous as vol
 
 from homeassistant.components.discovery import SERVICE_OCTOPRINT
@@ -17,14 +16,13 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SENSORS,
     CONF_SSL,
-    CONTENT_TYPE_JSON,
-    PERCENTAGE,
-    TEMP_CELSIUS,
-    TIME_SECONDS,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.discovery import load_platform
+from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import slugify as util_slugify
 
 _LOGGER = logging.getLogger(__name__)
@@ -53,11 +51,10 @@ def ensure_valid_path(value):
     return value
 
 
-BINARY_SENSOR_TYPES = {
-    # API Endpoint, Group, Key, unit
-    "Printing": ["printer", "state", "printing", None],
-    "Printing Error": ["printer", "state", "error", None],
-}
+BINARY_SENSOR_TYPES = [
+    "Printing",
+    "Printing Error",
+]
 
 BINARY_SENSOR_SCHEMA = vol.Schema(
     {
@@ -68,26 +65,13 @@ BINARY_SENSOR_SCHEMA = vol.Schema(
     }
 )
 
-SENSOR_TYPES = {
-    # API Endpoint, Group, Key, unit, icon
-    "Temperatures": ["printer", "temperature", "*", TEMP_CELSIUS],
-    "Current State": ["printer", "state", "text", None, "mdi:printer-3d"],
-    "Job Percentage": [
-        "job",
-        "progress",
-        "completion",
-        PERCENTAGE,
-        "mdi:file-percent",
-    ],
-    "Time Remaining": [
-        "job",
-        "progress",
-        "printTimeLeft",
-        TIME_SECONDS,
-        "mdi:clock-end",
-    ],
-    "Time Elapsed": ["job", "progress", "printTime", TIME_SECONDS, "mdi:clock-start"],
-}
+SENSOR_TYPES = [
+    "Temperatures",
+    "Current State",
+    "Job Percentage",
+    "Time Remaining",
+    "Time Elapsed",
+]
 
 SENSOR_SCHEMA = vol.Schema(
     {
@@ -127,16 +111,16 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-def setup(hass, config):
+async def async_setup(hass, config):
     """Set up the OctoPrint component."""
     printers = hass.data[DOMAIN] = {}
     success = False
 
-    def device_discovered(service, info):
+    async def device_discovered(service, info):
         """Get called when an Octoprint server has been discovered."""
         _LOGGER.debug("Found an Octoprint server: %s", info)
 
-    discovery.listen(hass, SERVICE_OCTOPRINT, device_discovered)
+    discovery.async_listen(hass, SERVICE_OCTOPRINT, device_discovered)
 
     if DOMAIN not in config:
         # Skip the setup if there is no configuration present
@@ -147,30 +131,39 @@ def setup(hass, config):
         protocol = "https" if printer[CONF_SSL] else "http"
         base_url = (
             f"{protocol}://{printer[CONF_HOST]}:{printer[CONF_PORT]}"
-            f"{printer[CONF_PATH]}api/"
+            f"{printer[CONF_PATH]}"
         )
-        api_key = printer[CONF_API_KEY]
-        number_of_tools = printer[CONF_NUMBER_OF_TOOLS]
-        bed = printer[CONF_BED]
-        try:
-            octoprint_api = OctoPrintAPI(base_url, api_key, bed, number_of_tools)
-            printers[base_url] = octoprint_api
-            octoprint_api.get("printer")
-            octoprint_api.get("job")
-        except requests.exceptions.RequestException as conn_err:
-            _LOGGER.error("Error setting up OctoPrint API: %r", conn_err)
-            continue
+
+        session = async_get_clientsession(hass)
+        octoprint = OctoprintClient(
+            printer[CONF_HOST],
+            session,
+            printer[CONF_PORT],
+            printer[CONF_SSL],
+            printer[CONF_PATH],
+        )
+        octoprint.set_api_key(printer[CONF_API_KEY])
+        coordinator = OctoprintDataUpdateCoordinator(hass, octoprint, base_url, 30)
+        await coordinator.async_refresh()
+
+        printers[base_url] = coordinator
 
         sensors = printer[CONF_SENSORS][CONF_MONITORED_CONDITIONS]
-        load_platform(
+        await async_load_platform(
             hass,
             "sensor",
             DOMAIN,
-            {"name": name, "base_url": base_url, "sensors": sensors},
+            {
+                "name": name,
+                "base_url": base_url,
+                "sensors": sensors,
+                CONF_NUMBER_OF_TOOLS: printer[CONF_NUMBER_OF_TOOLS],
+                CONF_BED: printer[CONF_BED],
+            },
             config,
         )
         b_sensors = printer[CONF_BINARY_SENSORS][CONF_MONITORED_CONDITIONS]
-        load_platform(
+        await async_load_platform(
             hass,
             "binary_sensor",
             DOMAIN,
@@ -182,134 +175,44 @@ def setup(hass, config):
     return success
 
 
-class OctoPrintAPI:
-    """Simple JSON wrapper for OctoPrint's API."""
+class OctoprintDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Octoprint data."""
 
-    def __init__(self, api_url, key, bed, number_of_tools):
-        """Initialize OctoPrint API and set headers needed later."""
-        self.api_url = api_url
-        self.headers = {CONTENT_TYPE: CONTENT_TYPE_JSON, "X-Api-Key": key}
-        self.printer_last_reading = [{}, None]
-        self.job_last_reading = [{}, None]
-        self.job_available = False
-        self.printer_available = False
-        self.printer_error_logged = False
-        self.available = False
-        self.available_error_logged = False
-        self.job_error_logged = False
-        self.bed = bed
-        self.number_of_tools = number_of_tools
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        octoprint: OctoprintClient,
+        device_id: str,
+        interval: int,
+    ):
+        """Initialize."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"octoprint-{device_id}",
+            update_interval=timedelta(seconds=interval),
+        )
+        self._octoprint = octoprint
 
-    def get_tools(self):
-        """Get the list of tools that temperature is monitored on."""
-        tools = []
-        if self.number_of_tools > 0:
-            for tool_number in range(0, self.number_of_tools):
-                tools.append(f"tool{tool_number!s}")
-        if self.bed:
-            tools.append("bed")
-        if not self.bed and self.number_of_tools == 0:
-            temps = self.printer_last_reading[0].get("temperature")
-            if temps is not None:
-                tools = temps.keys()
-        return tools
-
-    def get(self, endpoint):
-        """Send a get request, and return the response as a dict."""
-        # Only query the API at most every 30 seconds
-        now = time.time()
-        if endpoint == "job":
-            last_time = self.job_last_reading[1]
-            if last_time is not None:
-                if now - last_time < 30.0:
-                    return self.job_last_reading[0]
-        elif endpoint == "printer":
-            last_time = self.printer_last_reading[1]
-            if last_time is not None:
-                if now - last_time < 30.0:
-                    return self.printer_last_reading[0]
-
-        url = self.api_url + endpoint
+    async def _async_update_data(self):
+        """Update data via API."""
+        # If octoprint is on, but the printer is disconnected
+        # printer will return a 409, so continue using the last
+        # reading if there is one
+        job = None
+        printer = None
         try:
-            response = requests.get(url, headers=self.headers, timeout=9)
-            response.raise_for_status()
-            if endpoint == "job":
-                self.job_last_reading[0] = response.json()
-                self.job_last_reading[1] = time.time()
-                self.job_available = True
-            elif endpoint == "printer":
-                self.printer_last_reading[0] = response.json()
-                self.printer_last_reading[1] = time.time()
-                self.printer_available = True
+            job = await self._octoprint.get_job_info()
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.error("Failed to update job data %s", error)
+            if self.data and "job" in self.data:
+                job = self.data["job"]
 
-            self.available = self.printer_available and self.job_available
-            if self.available:
-                self.job_error_logged = False
-                self.printer_error_logged = False
-                self.available_error_logged = False
+        try:
+            printer = await self._octoprint.get_printer_info()
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.error("Failed to update printer data %s", error)
+            if self.data and "printer" in self.data:
+                printer = self.data["printer"]
 
-            return response.json()
-
-        except requests.ConnectionError as exc_con:
-            log_string = "Failed to connect to Octoprint server. Error: %s" % exc_con
-
-            if not self.available_error_logged:
-                _LOGGER.error(log_string)
-                self.job_available = False
-                self.printer_available = False
-                self.available_error_logged = True
-
-            return None
-
-        except requests.HTTPError as ex_http:
-            status_code = ex_http.response.status_code
-
-            log_string = "Failed to update OctoPrint status. Error: %s" % ex_http
-            # Only log the first failure
-            if endpoint == "job":
-                log_string = f"Endpoint: job {log_string}"
-                if not self.job_error_logged:
-                    _LOGGER.error(log_string)
-                    self.job_error_logged = True
-                    self.job_available = False
-            elif endpoint == "printer":
-                if (
-                    status_code == 409
-                ):  # octoprint returns HTTP 409 when printer is not connected (and many other states)
-                    self.printer_available = False
-                else:
-                    log_string = f"Endpoint: printer {log_string}"
-                    if not self.printer_error_logged:
-                        _LOGGER.error(log_string)
-                        self.printer_error_logged = True
-                        self.printer_available = False
-
-            self.available = False
-
-            return None
-
-    def update(self, sensor_type, end_point, group, tool=None):
-        """Return the value for sensor_type from the provided endpoint."""
-        response = self.get(end_point)
-        if response is not None:
-            return get_value_from_json(response, sensor_type, group, tool)
-
-        return response
-
-
-def get_value_from_json(json_dict, sensor_type, group, tool):
-    """Return the value for sensor_type from the JSON."""
-    if group not in json_dict:
-        return None
-
-    if sensor_type in json_dict[group]:
-        if sensor_type == "target" and json_dict[sensor_type] is None:
-            return 0
-
-        return json_dict[group][sensor_type]
-
-    if tool is not None:
-        if sensor_type in json_dict[group][tool]:
-            return json_dict[group][tool][sensor_type]
-
-    return None
+        return {"job": job, "printer": printer}

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -59,11 +59,6 @@ class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
         return self._name
 
     @property
-    def device_class(self):
-        """Return the class of this sensor, from DEVICE_CLASSES."""
-        return None
-
-    @property
     def is_on(self):
         """Return true if binary sensor is on."""
         printer = self.coordinator.data["printer"]

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -69,7 +69,7 @@ class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
 
     @abstractmethod
     def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> Optional[bool]:
-        return None
+        """Return the value of the sensor flag."""
 
 
 class OctoPrintPrintingBinarySensor(OctoPrintBinarySensorBase):

--- a/homeassistant/components/octoprint/binary_sensor.py
+++ b/homeassistant/components/octoprint/binary_sensor.py
@@ -1,60 +1,54 @@
 """Support for monitoring OctoPrint binary sensors."""
 import logging
 
-import requests
+from pyoctoprintapi import OctoprintPrinterInfo
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
-from . import BINARY_SENSOR_TYPES, DOMAIN as COMPONENT_DOMAIN
+from . import DOMAIN as COMPONENT_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     """Set up the available OctoPrint binary sensors."""
+
     if discovery_info is None:
         return
 
     name = discovery_info["name"]
     base_url = discovery_info["base_url"]
     monitored_conditions = discovery_info["sensors"]
-    octoprint_api = hass.data[COMPONENT_DOMAIN][base_url]
+    coordinator: DataUpdateCoordinator = hass.data[COMPONENT_DOMAIN][base_url]
 
     devices = []
-    for octo_type in monitored_conditions:
-        new_sensor = OctoPrintBinarySensor(
-            octoprint_api,
-            octo_type,
-            BINARY_SENSOR_TYPES[octo_type][2],
-            name,
-            BINARY_SENSOR_TYPES[octo_type][3],
-            BINARY_SENSOR_TYPES[octo_type][0],
-            BINARY_SENSOR_TYPES[octo_type][1],
-            "flags",
-        )
-        devices.append(new_sensor)
+    if "Printing" in monitored_conditions:
+        devices.append(OctoPrintPrintingBinarySensor(coordinator, name))
+
+    if "Printing Error" in monitored_conditions:
+        devices.append(OctoPrintPrintingErrorBinarySensor(coordinator, name))
+
     add_entities(devices, True)
 
 
-class OctoPrintBinarySensor(BinarySensorEntity):
+class OctoPrintBinarySensorBase(CoordinatorEntity, BinarySensorEntity):
     """Representation an OctoPrint binary sensor."""
 
     def __init__(
-        self, api, condition, sensor_type, sensor_name, unit, endpoint, group, tool=None
+        self,
+        coordinator: DataUpdateCoordinator,
+        sensor_name: str,
+        sensor_type: str,
     ):
         """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator)
         self.sensor_name = sensor_name
-        if tool is None:
-            self._name = f"{sensor_name} {condition}"
-        else:
-            self._name = f"{sensor_name} {condition}"
+        self._name = f"{sensor_name} {sensor_type}"
         self.sensor_type = sensor_type
-        self.api = api
-        self._state = False
-        self._unit_of_measurement = unit
-        self.api_endpoint = endpoint
-        self.api_group = group
-        self.api_tool = tool
         _LOGGER.debug("Created OctoPrint binary sensor %r", self)
 
     @property
@@ -63,21 +57,42 @@ class OctoPrintBinarySensor(BinarySensorEntity):
         return self._name
 
     @property
-    def is_on(self):
-        """Return true if binary sensor is on."""
-        return bool(self._state)
-
-    @property
     def device_class(self):
         """Return the class of this sensor, from DEVICE_CLASSES."""
         return None
 
-    def update(self):
-        """Update state of sensor."""
-        try:
-            self._state = self.api.update(
-                self.sensor_type, self.api_endpoint, self.api_group, self.api_tool
-            )
-        except requests.exceptions.ConnectionError:
-            # Error calling the api, already logged in api.update()
-            return
+    @property
+    def is_on(self):
+        """Return true if binary sensor is on."""
+        printer = self.coordinator.data["printer"]
+        if not printer:
+            return None
+
+        return bool(self._get_flag_state(printer))
+
+    def _get_flag_state(  # pylint: disable=no-self-use
+        self, printer_info: OctoprintPrinterInfo
+    ) -> bool or None:
+        return None
+
+
+class OctoPrintPrintingBinarySensor(OctoPrintBinarySensorBase):
+    """Representation an OctoPrint binary sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, sensor_name: str):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, "Printing")
+
+    def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> bool or None:
+        return bool(printer_info.state.flags.printing)
+
+
+class OctoPrintPrintingErrorBinarySensor(OctoPrintBinarySensorBase):
+    """Representation an OctoPrint binary sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, sensor_name: str):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, "Printing Error")
+
+    def _get_flag_state(self, printer_info: OctoprintPrinterInfo) -> bool or None:
+        return bool(printer_info.state.flags.error)

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -3,6 +3,6 @@
   "name": "OctoPrint",
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
   "after_dependencies": ["discovery"],
-  "requirements":["pyoctoprintapi==0.1.1"],
+  "requirements":["pyoctoprintapi==0.1.3"],
   "codeowners": []
 }

--- a/homeassistant/components/octoprint/manifest.json
+++ b/homeassistant/components/octoprint/manifest.json
@@ -3,5 +3,6 @@
   "name": "OctoPrint",
   "documentation": "https://www.home-assistant.io/integrations/octoprint",
   "after_dependencies": ["discovery"],
+  "requirements":["pyoctoprintapi==0.1.1"],
   "codeowners": []
 }

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -37,7 +37,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         tools = [tool.name for tool in coordinator.data["printer"].temperatures]
     else:
         if number_of_tools > 0:
-            for tool_number in range(0, number_of_tools):
+            for tool_number in range(number_of_tools):
                 tools.append(f"tool{tool_number!s}")
         if bed:
             tools.append("bed")
@@ -161,11 +161,6 @@ class OctoPrintEstimatedFinishTimeSensor(OctoPrintSensorBase):
         """Return the device class of the sensor."""
         return DEVICE_CLASS_TIMESTAMP
 
-    @property
-    def icon(self):
-        """Icon to use in the frontend."""
-        return "mdi:clock-end"
-
 
 class OctoPrintStartTimeSensor(OctoPrintSensorBase):
     """Representation of an OctoPrint sensor."""
@@ -192,11 +187,6 @@ class OctoPrintStartTimeSensor(OctoPrintSensorBase):
     def device_class(self):
         """Return the device class of the sensor."""
         return DEVICE_CLASS_TIMESTAMP
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend."""
-        return "mdi:clock-start"
 
 
 class OctoPrintTemperatureSensor(OctoPrintSensorBase):

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -1,17 +1,18 @@
 """Support for monitoring OctoPrint sensors."""
 import logging
 
-import requests
+from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
 
-from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
+from homeassistant.const import PERCENTAGE, TEMP_CELSIUS, TIME_SECONDS
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
-from . import DOMAIN as COMPONENT_DOMAIN, SENSOR_TYPES
+from . import CONF_BED, CONF_NUMBER_OF_TOOLS, DOMAIN as COMPONENT_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-NOTIFICATION_ID = "octoprint_notification"
-NOTIFICATION_TITLE = "OctoPrint sensor setup error"
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
@@ -22,118 +23,203 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     name = discovery_info["name"]
     base_url = discovery_info["base_url"]
     monitored_conditions = discovery_info["sensors"]
-    octoprint_api = hass.data[COMPONENT_DOMAIN][base_url]
-    tools = octoprint_api.get_tools()
-
-    if "Temperatures" in monitored_conditions:
-        if not tools:
-            hass.components.persistent_notification.create(
-                "Your printer appears to be offline.<br />"
-                "If you do not want to have your printer on <br />"
-                " at all times, and you would like to monitor <br /> "
-                "temperatures, please add <br />"
-                "bed and/or number&#95;of&#95;tools to your configuration <br />"
-                "and restart.",
-                title=NOTIFICATION_TITLE,
-                notification_id=NOTIFICATION_ID,
-            )
+    number_of_tools = discovery_info[CONF_NUMBER_OF_TOOLS]
+    bed = discovery_info[CONF_BED]
+    coordinator: DataUpdateCoordinator = hass.data[COMPONENT_DOMAIN][base_url]
+    tools = []
+    if coordinator.data["printer"]:
+        tools = [tool.name for tool in coordinator.data["printer"].temperatures]
+    else:
+        if number_of_tools > 0:
+            for tool_number in range(0, number_of_tools):
+                tools.append(f"tool{tool_number!s}")
+        if bed:
+            tools.append("bed")
 
     devices = []
     types = ["actual", "target"]
-    for octo_type in monitored_conditions:
-        if octo_type == "Temperatures":
-            for tool in tools:
-                for temp_type in types:
-                    new_sensor = OctoPrintSensor(
-                        octoprint_api,
-                        temp_type,
-                        temp_type,
-                        name,
-                        SENSOR_TYPES[octo_type][3],
-                        SENSOR_TYPES[octo_type][0],
-                        SENSOR_TYPES[octo_type][1],
-                        tool,
-                    )
-                    devices.append(new_sensor)
-        else:
-            new_sensor = OctoPrintSensor(
-                octoprint_api,
-                octo_type,
-                SENSOR_TYPES[octo_type][2],
-                name,
-                SENSOR_TYPES[octo_type][3],
-                SENSOR_TYPES[octo_type][0],
-                SENSOR_TYPES[octo_type][1],
-                None,
-                SENSOR_TYPES[octo_type][4],
-            )
-            devices.append(new_sensor)
+
+    if "Temperatures" in monitored_conditions and tools:
+        for tool in tools:
+            for temp_type in types:
+                devices.append(
+                    OctoPrintTemperatureSensor(coordinator, name, tool, temp_type)
+                )
+
+    if "Current State" in monitored_conditions:
+        devices.append(OctoPrintStatusSensor(coordinator, name))
+    if "Job Percentage" in monitored_conditions:
+        devices.append(OctoPrintJobPercentageSensor(coordinator, name))
+    if "Time Remaining" in monitored_conditions:
+        devices.append(OctoPrintTimeRemainingSensor(coordinator, name))
+    if "Time Elapsed" in monitored_conditions:
+        devices.append(OctoPrintTimeRemainingSensor(coordinator, name))
+
     add_entities(devices, True)
 
 
-class OctoPrintSensor(Entity):
+class OctoPrintSensorBase(CoordinatorEntity, Entity):
     """Representation of an OctoPrint sensor."""
 
     def __init__(
         self,
-        api,
-        condition,
-        sensor_type,
-        sensor_name,
-        unit,
-        endpoint,
-        group,
-        tool=None,
-        icon=None,
+        coordinator: DataUpdateCoordinator,
+        sensor_name: str,
+        sensor_type: str,
     ):
         """Initialize a new OctoPrint sensor."""
-        self.sensor_name = sensor_name
-        if tool is None:
-            self._name = f"{sensor_name} {condition}"
-        else:
-            self._name = f"{sensor_name} {condition} {tool} temp"
-        self.sensor_type = sensor_type
-        self.api = api
+        super().__init__(coordinator)
         self._state = None
-        self._unit_of_measurement = unit
-        self.api_endpoint = endpoint
-        self.api_group = group
-        self.api_tool = tool
-        self._icon = icon
-        _LOGGER.debug("Created OctoPrint sensor %r", self)
+        self._sensor_name = sensor_name
+        self._name = f"{sensor_name} {sensor_type}"
 
     @property
     def name(self):
         """Return the name of the sensor."""
         return self._name
 
+
+class OctoPrintStatusSensor(OctoPrintSensorBase):
+    """Representation of an OctoPrint sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, sensor_name: str):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, "Current State")
+
     @property
     def state(self):
-        """Return the state of the sensor."""
-        sensor_unit = self.unit_of_measurement
-        if sensor_unit in (TEMP_CELSIUS, PERCENTAGE):
-            # API sometimes returns null and not 0
-            if self._state is None:
-                self._state = 0
-            return round(self._state, 2)
-        return self._state
+        """Return sensor state."""
+        printer: OctoprintPrinterInfo = self.coordinator.data["printer"]
+        if not printer:
+            return None
 
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, if any."""
-        return self._unit_of_measurement
-
-    def update(self):
-        """Update state of sensor."""
-        try:
-            self._state = self.api.update(
-                self.sensor_type, self.api_endpoint, self.api_group, self.api_tool
-            )
-        except requests.exceptions.ConnectionError:
-            # Error calling the api, already logged in api.update()
-            return
+        return printer.state.text
 
     @property
     def icon(self):
         """Icon to use in the frontend."""
-        return self._icon
+        return "mdi:printer-3d"
+
+
+class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
+    """Representation of an OctoPrint sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, sensor_name: str):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, "Job Percentage")
+
+    @property
+    def state(self):
+        """Return sensor state."""
+        job: OctoprintJobInfo = self.coordinator.data["job"]
+        if not job:
+            return 0
+
+        state = job.progress.completion
+        if not state:
+            return 0
+
+        return round(state, 2)
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return PERCENTAGE
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return "mdi:file-percent"
+
+
+class OctoPrintTimeRemainingSensor(OctoPrintSensorBase):
+    """Representation of an OctoPrint sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, sensor_name: str):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, "Time Remaining")
+
+    @property
+    def state(self):
+        """Return sensor state."""
+        job: OctoprintJobInfo = self.coordinator.data["job"]
+        if not job:
+            return None
+
+        return job.progress.print_time_left
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return TIME_SECONDS
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return "mdi:clock-start"
+
+
+class OctoPrintTimeElapsedSensor(OctoPrintSensorBase):
+    """Representation of an OctoPrint sensor."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, sensor_name: str):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, "Time Elapsed")
+
+    @property
+    def state(self):
+        """Return sensor state."""
+        job: OctoprintJobInfo = self.coordinator.data["job"]
+        if not job:
+            return None
+
+        return job.progress.print_time
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return TIME_SECONDS
+
+    @property
+    def icon(self):
+        """Icon to use in the frontend."""
+        return "mdi:clock-end"
+
+
+class OctoPrintTemperatureSensor(OctoPrintSensorBase):
+    """Representation of an OctoPrint sensor."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        sensor_name: str,
+        tool: str,
+        temp_type: str,
+    ):
+        """Initialize a new OctoPrint sensor."""
+        super().__init__(coordinator, sensor_name, f"{temp_type} {tool} temp")
+        self._temp_type = temp_type
+        self._api_tool = tool
+        self._state = 0
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement of this entity, if any."""
+        return TEMP_CELSIUS
+
+    @property
+    def state(self):
+        """Return sensor state."""
+        printer: OctoprintPrinterInfo = self.coordinator.data["printer"]
+        if not printer:
+            return None
+
+        for temp in printer.temperatures:
+            if temp.name == self._api_tool:
+                return (
+                    temp.actual_temp
+                    if self._temp_type == "actual"
+                    else temp.target_temp
+                )
+
+        return None

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -216,10 +216,11 @@ class OctoPrintTemperatureSensor(OctoPrintSensorBase):
 
         for temp in printer.temperatures:
             if temp.name == self._api_tool:
-                return (
+                return round(
                     temp.actual_temp
                     if self._temp_type == "actual"
-                    else temp.target_temp
+                    else temp.target_temp,
+                    2,
                 )
 
         return None

--- a/homeassistant/components/octoprint/sensor.py
+++ b/homeassistant/components/octoprint/sensor.py
@@ -119,7 +119,7 @@ class OctoPrintJobPercentageSensor(OctoPrintSensorBase):
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
         if not job:
-            return 0
+            return None
 
         state = job.progress.completion
         if not state:
@@ -173,8 +173,6 @@ class OctoPrintStartTimeSensor(OctoPrintSensorBase):
     def state(self):
         """Return sensor state."""
         job: OctoprintJobInfo = self.coordinator.data["job"]
-        if not job:
-            return None
 
         if not job or not job.progress.print_time:
             return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1581,7 +1581,7 @@ pynzbgetapi==0.2.0
 pyobihai==1.3.1
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.1
+pyoctoprintapi==0.1.3
 
 # homeassistant.components.ombi
 pyombi==0.1.10

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1580,6 +1580,9 @@ pynzbgetapi==0.2.0
 # homeassistant.components.obihai
 pyobihai==1.3.1
 
+# homeassistant.components.octoprint
+pyoctoprintapi==0.1.1
+
 # homeassistant.components.ombi
 pyombi==0.1.10
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -832,7 +832,7 @@ pynx584==0.5
 pynzbgetapi==0.2.0
 
 # homeassistant.components.octoprint
-pyoctoprintapi==0.1.1
+pyoctoprintapi==0.1.3
 
 # homeassistant.components.openuv
 pyopenuv==1.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -831,6 +831,9 @@ pynx584==0.5
 # homeassistant.components.nzbget
 pynzbgetapi==0.2.0
 
+# homeassistant.components.octoprint
+pyoctoprintapi==0.1.1
+
 # homeassistant.components.openuv
 pyopenuv==1.0.9
 

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -1,1 +1,46 @@
 """Tests for the OctoPrint integration."""
+from unittest.mock import patch
+
+from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
+
+from homeassistant.components.octoprint import DOMAIN
+from homeassistant.setup import async_setup_component
+
+DEFAULT_JOB = {
+    "job": {},
+    "progress": {"completion": 50},
+}
+
+DEFAULT_PRINTER = {
+    "state": {
+        "flags": {"printing": True, "error": False},
+        "text": "Operational",
+    },
+    "temperature": [],
+}
+
+
+async def init_integration(
+    hass, platform, printer: dict = DEFAULT_PRINTER, job: dict = DEFAULT_JOB
+):
+    """Set up the octoprint integration in Home Assistant."""
+    config = {
+        DOMAIN: {
+            "host": "192.168.1.5",
+            "api_key": "test-key",
+            "ssl": False,
+            "port": 80,
+            "path": "/",
+            "name": "Octoprint",
+        }
+    }
+    with patch(
+        "pyoctoprintapi.OctoprintClient.get_printer_info",
+        return_value=OctoprintPrinterInfo(printer),
+    ), patch(
+        "pyoctoprintapi.OctoprintClient.get_job_info",
+        return_value=OctoprintJobInfo(job),
+    ):
+        assert await async_setup_component(hass, DOMAIN, config)
+        assert await async_setup_component(hass, platform, config)
+        await hass.async_block_till_done()

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the OctoPrint integration."""

--- a/tests/components/octoprint/__init__.py
+++ b/tests/components/octoprint/__init__.py
@@ -42,5 +42,4 @@ async def init_integration(
         return_value=OctoprintJobInfo(job),
     ):
         assert await async_setup_component(hass, DOMAIN, config)
-        assert await async_setup_component(hass, platform, config)
         await hass.async_block_till_done()

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,97 +1,27 @@
 """The tests for Octoptint binary sensor module."""
-import logging
 
-from pyoctoprintapi import OctoprintPrinterInfo
-
-from homeassistant.components.octoprint import binary_sensor as sensor
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-_LOGGER = logging.getLogger(__name__)
-
-
-def test_OctoPrintPrintingBinarySensor_properties(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {"printer": {}}
-    test_sensor = sensor.OctoPrintPrintingBinarySensor(coordinator, "OctoPrint")
-    assert "OctoPrint Printing" == test_sensor.name
+from . import init_integration
 
 
-def test_OctoPrintPrintingErrorBinarySensor_properties(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {"printer": {}}
-    test_sensor = sensor.OctoPrintPrintingErrorBinarySensor(coordinator, "OctoPrint")
-    assert "OctoPrint Printing Error" == test_sensor.name
-    assert not test_sensor.device_class
-
-
-def test_OctoPrintPrintingBinarySensor_is_on(hass):
-    """Test the is_on property."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "printer": OctoprintPrinterInfo(
-            {
-                "state": {
-                    "flags": {
-                        "printing": True,
-                    },
-                    "text": "Operational",
-                },
-                "temperature": [],
-            }
-        )
+async def test_sensors(hass):
+    """Test the underlying sensors."""
+    printer = {
+        "state": {
+            "flags": {"printing": True, "error": False},
+            "text": "Operational",
+        },
+        "temperature": [],
     }
-    test_sensor = sensor.OctoPrintPrintingBinarySensor(coordinator, "OctoPrint")
-    assert STATE_ON == test_sensor.state
+    await init_integration(hass, "binary_sensor", printer=printer)
 
-    coordinator.data = {
-        "printer": OctoprintPrinterInfo(
-            {
-                "state": {
-                    "flags": {
-                        "printing": False,
-                    },
-                    "text": "Operational",
-                },
-                "temperature": [],
-            }
-        )
-    }
-    assert STATE_OFF == test_sensor.state
+    state = hass.states.get("binary_sensor.octoprint_printing")
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.name == "Octoprint Printing"
 
-
-def test_OctoPrintPrintingErrorBinarySensor_is_on(hass):
-    """Test the is_on property."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "printer": OctoprintPrinterInfo(
-            {
-                "state": {
-                    "flags": {
-                        "error": True,
-                    },
-                    "text": "Operational",
-                },
-                "temperature": [],
-            }
-        )
-    }
-    test_sensor = sensor.OctoPrintPrintingErrorBinarySensor(coordinator, "OctoPrint")
-    assert STATE_ON == test_sensor.state
-
-    coordinator.data = {
-        "printer": OctoprintPrinterInfo(
-            {
-                "state": {
-                    "flags": {
-                        "error": False,
-                    },
-                    "text": "Operational",
-                },
-                "temperature": [],
-            }
-        )
-    }
-    assert STATE_OFF == test_sensor.state
+    state = hass.states.get("binary_sensor.octoprint_printing_error")
+    assert state is not None
+    assert state.state == STATE_OFF
+    assert state.name == "Octoprint Printing Error"

--- a/tests/components/octoprint/test_binary_sensor.py
+++ b/tests/components/octoprint/test_binary_sensor.py
@@ -1,0 +1,97 @@
+"""The tests for Octoptint binary sensor module."""
+import logging
+
+from pyoctoprintapi import OctoprintPrinterInfo
+
+from homeassistant.components.octoprint import binary_sensor as sensor
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def test_OctoPrintPrintingBinarySensor_properties(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {"printer": {}}
+    test_sensor = sensor.OctoPrintPrintingBinarySensor(coordinator, "OctoPrint")
+    assert "OctoPrint Printing" == test_sensor.name
+
+
+def test_OctoPrintPrintingErrorBinarySensor_properties(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {"printer": {}}
+    test_sensor = sensor.OctoPrintPrintingErrorBinarySensor(coordinator, "OctoPrint")
+    assert "OctoPrint Printing Error" == test_sensor.name
+    assert not test_sensor.device_class
+
+
+def test_OctoPrintPrintingBinarySensor_is_on(hass):
+    """Test the is_on property."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "printer": OctoprintPrinterInfo(
+            {
+                "state": {
+                    "flags": {
+                        "printing": True,
+                    },
+                    "text": "Operational",
+                },
+                "temperature": [],
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintPrintingBinarySensor(coordinator, "OctoPrint")
+    assert STATE_ON == test_sensor.state
+
+    coordinator.data = {
+        "printer": OctoprintPrinterInfo(
+            {
+                "state": {
+                    "flags": {
+                        "printing": False,
+                    },
+                    "text": "Operational",
+                },
+                "temperature": [],
+            }
+        )
+    }
+    assert STATE_OFF == test_sensor.state
+
+
+def test_OctoPrintPrintingErrorBinarySensor_is_on(hass):
+    """Test the is_on property."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "printer": OctoprintPrinterInfo(
+            {
+                "state": {
+                    "flags": {
+                        "error": True,
+                    },
+                    "text": "Operational",
+                },
+                "temperature": [],
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintPrintingErrorBinarySensor(coordinator, "OctoPrint")
+    assert STATE_ON == test_sensor.state
+
+    coordinator.data = {
+        "printer": OctoprintPrinterInfo(
+            {
+                "state": {
+                    "flags": {
+                        "error": False,
+                    },
+                    "text": "Operational",
+                },
+                "temperature": [],
+            }
+        )
+    }
+    assert STATE_OFF == test_sensor.state

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,118 +1,59 @@
 """The tests for Octoptint binary sensor module."""
 from datetime import datetime
-import logging
+from unittest.mock import patch
 
-from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
-
-from homeassistant.components.octoprint import sensor
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-
-_LOGGER = logging.getLogger(__name__)
+from . import init_integration
 
 
-def test_OctoPrintSensorBase_properties(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {"job": {}}
-    test_sensor = sensor.OctoPrintSensorBase(coordinator, "OctoPrint", "type")
-    assert "OctoPrint type" == test_sensor.name
-    assert not test_sensor.device_class
-
-
-def test_OctoPrintJobPercentageSensor(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "job": OctoprintJobInfo(
-            {
-                "job": {},
-                "progress": {"completion": 50},
-            }
-        )
+async def test_sensors(hass):
+    """Test the underlying sensors."""
+    printer = {
+        "state": {
+            "flags": {},
+            "text": "Operational",
+        },
+        "temperature": {"tool1": {"actual": 18.83136, "target": 37.83136}},
     }
-    test_sensor = sensor.OctoPrintJobPercentageSensor(coordinator, "OctoPrint")
-    assert "OctoPrint Job Percentage" == test_sensor.name
-    assert 50 == test_sensor.state
-
-    coordinator.data["job"]._raw["progress"]["completion"] = None
-    assert 0 == test_sensor.state
-
-
-def test_OctoPrintStatusSensor(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "printer": OctoprintPrinterInfo(
-            {
-                "state": {
-                    "flags": {},
-                    "text": "Operational",
-                },
-                "temperature": [],
-            }
-        )
+    job = {
+        "job": {},
+        "progress": {"completion": 50, "printTime": 600, "printTimeLeft": 6000},
     }
-    test_sensor = sensor.OctoPrintStatusSensor(coordinator, "OctoPrint")
-    assert "OctoPrint Current State" == test_sensor.name
-    assert "Operational" == test_sensor.state
+    with patch(
+        "homeassistant.util.dt.utcnow", return_value=datetime(2020, 2, 20, 9, 10, 0)
+    ):
+        await init_integration(hass, "sensor", printer=printer, job=job)
 
+    state = hass.states.get("sensor.octoprint_job_percentage")
+    assert state is not None
+    assert state.state == "50"
+    assert state.name == "Octoprint Job Percentage"
 
-def test_OctoPrintStartTimeSensor(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "last_read_time": datetime(2020, 2, 14, 9, 10, 0, 0),
-        "job": OctoprintJobInfo(
-            {
-                "job": {},
-                "progress": {"printTime": 600},
-            }
-        ),
-    }
-    test_sensor = sensor.OctoPrintStartTimeSensor(coordinator, "OctoPrint")
-    assert "OctoPrint Start Time" == test_sensor.name
-    assert "2020-02-14T09:00:00" == test_sensor.state
+    state = hass.states.get("sensor.octoprint_current_state")
+    assert state is not None
+    assert state.state == "Operational"
+    assert state.name == "Octoprint Current State"
 
-    coordinator.data["job"]._raw["progress"]["printTime"] = None
-    assert not test_sensor.state
+    state = hass.states.get("sensor.octoprint_actual_tool1_temp")
+    assert state is not None
+    assert state.state == "18.83"
+    assert state.name == "Octoprint actual tool1 temp"
 
+    state = hass.states.get("sensor.octoprint_target_tool1_temp")
+    assert state is not None
+    assert state.state == "37.83"
+    assert state.name == "Octoprint target tool1 temp"
 
-def test_OctoPrintTemperatureSensor(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "printer": OctoprintPrinterInfo(
-            {
-                "state": {
-                    "flags": {},
-                    "text": "Operational",
-                },
-                "temperature": {"tool1": {"actual": 18.83136}},
-            }
-        )
-    }
-    test_sensor = sensor.OctoPrintTemperatureSensor(
-        coordinator, "OctoPrint", "tool1", "actual"
-    )
-    assert "OctoPrint actual tool1 temp" == test_sensor.name
-    assert 18.83 == test_sensor.state
+    state = hass.states.get("sensor.octoprint_target_tool1_temp")
+    assert state is not None
+    assert state.state == "37.83"
+    assert state.name == "Octoprint target tool1 temp"
 
+    state = hass.states.get("sensor.octoprint_start_time")
+    assert state is not None
+    assert state.state == "2020-02-20T09:00:00"
+    assert state.name == "Octoprint Start Time"
 
-def test_OctoPrintEstimatedFinishTimeSensor(hass):
-    """Test the properties."""
-    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
-    coordinator.data = {
-        "last_read_time": datetime(2020, 2, 14, 9, 10, 0, 0),
-        "job": OctoprintJobInfo(
-            {
-                "job": {},
-                "progress": {"printTimeLeft": 600},
-            }
-        ),
-    }
-    test_sensor = sensor.OctoPrintEstimatedFinishTimeSensor(coordinator, "OctoPrint")
-    assert "OctoPrint Estimated Finish Time" == test_sensor.name
-    assert "2020-02-14T09:20:00" == test_sensor.state
-
-    coordinator.data["job"]._raw["progress"]["printTimeLeft"] = None
-    assert not test_sensor.state
+    state = hass.states.get("sensor.octoprint_estimated_finish_time")
+    assert state is not None
+    assert state.state == "2020-02-20T10:50:00"
+    assert state.name == "Octoprint Estimated Finish Time"

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,4 +1,5 @@
 """The tests for Octoptint binary sensor module."""
+from datetime import datetime
 import logging
 
 from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
@@ -56,20 +57,21 @@ def test_OctoPrintStatusSensor(hass):
     assert "Operational" == test_sensor.state
 
 
-def test_OctoPrintTimeElapsedSensor(hass):
+def test_OctoPrintStartTimeSensor(hass):
     """Test the properties."""
     coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
     coordinator.data = {
+        "last_read_time": datetime(2020, 2, 14, 9, 10, 0, 0),
         "job": OctoprintJobInfo(
             {
                 "job": {},
-                "progress": {"printTime": 5000},
+                "progress": {"printTime": 600},
             }
-        )
+        ),
     }
-    test_sensor = sensor.OctoPrintTimeElapsedSensor(coordinator, "OctoPrint")
-    assert "OctoPrint Time Elapsed" == test_sensor.name
-    assert 5000 == test_sensor.state
+    test_sensor = sensor.OctoPrintStartTimeSensor(coordinator, "OctoPrint")
+    assert "OctoPrint Start Time" == test_sensor.name
+    assert "2020-02-14T09:00:00" == test_sensor.state
 
     coordinator.data["job"]._raw["progress"]["printTime"] = None
     assert not test_sensor.state
@@ -96,20 +98,21 @@ def test_OctoPrintTemperatureSensor(hass):
     assert 18.83 == test_sensor.state
 
 
-def test_OctoPrintTimeRemainingSensor(hass):
+def test_OctoPrintEstimatedFinishTimeSensor(hass):
     """Test the properties."""
     coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
     coordinator.data = {
+        "last_read_time": datetime(2020, 2, 14, 9, 10, 0, 0),
         "job": OctoprintJobInfo(
             {
                 "job": {},
-                "progress": {"printTimeLeft": 5000},
+                "progress": {"printTimeLeft": 600},
             }
-        )
+        ),
     }
-    test_sensor = sensor.OctoPrintTimeRemainingSensor(coordinator, "OctoPrint")
-    assert "OctoPrint Time Remaining" == test_sensor.name
-    assert 5000 == test_sensor.state
+    test_sensor = sensor.OctoPrintEstimatedFinishTimeSensor(coordinator, "OctoPrint")
+    assert "OctoPrint Estimated Finish Time" == test_sensor.name
+    assert "2020-02-14T09:20:00" == test_sensor.state
 
     coordinator.data["job"]._raw["progress"]["printTimeLeft"] = None
     assert not test_sensor.state

--- a/tests/components/octoprint/test_sensor.py
+++ b/tests/components/octoprint/test_sensor.py
@@ -1,0 +1,115 @@
+"""The tests for Octoptint binary sensor module."""
+import logging
+
+from pyoctoprintapi import OctoprintJobInfo, OctoprintPrinterInfo
+
+from homeassistant.components.octoprint import sensor
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def test_OctoPrintSensorBase_properties(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {"job": {}}
+    test_sensor = sensor.OctoPrintSensorBase(coordinator, "OctoPrint", "type")
+    assert "OctoPrint type" == test_sensor.name
+    assert not test_sensor.device_class
+
+
+def test_OctoPrintJobPercentageSensor(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "job": OctoprintJobInfo(
+            {
+                "job": {},
+                "progress": {"completion": 50},
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintJobPercentageSensor(coordinator, "OctoPrint")
+    assert "OctoPrint Job Percentage" == test_sensor.name
+    assert 50 == test_sensor.state
+
+    coordinator.data["job"]._raw["progress"]["completion"] = None
+    assert 0 == test_sensor.state
+
+
+def test_OctoPrintStatusSensor(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "printer": OctoprintPrinterInfo(
+            {
+                "state": {
+                    "flags": {},
+                    "text": "Operational",
+                },
+                "temperature": [],
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintStatusSensor(coordinator, "OctoPrint")
+    assert "OctoPrint Current State" == test_sensor.name
+    assert "Operational" == test_sensor.state
+
+
+def test_OctoPrintTimeElapsedSensor(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "job": OctoprintJobInfo(
+            {
+                "job": {},
+                "progress": {"printTime": 5000},
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintTimeElapsedSensor(coordinator, "OctoPrint")
+    assert "OctoPrint Time Elapsed" == test_sensor.name
+    assert 5000 == test_sensor.state
+
+    coordinator.data["job"]._raw["progress"]["printTime"] = None
+    assert not test_sensor.state
+
+
+def test_OctoPrintTemperatureSensor(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "printer": OctoprintPrinterInfo(
+            {
+                "state": {
+                    "flags": {},
+                    "text": "Operational",
+                },
+                "temperature": {"tool1": {"actual": 18.83136}},
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintTemperatureSensor(
+        coordinator, "OctoPrint", "tool1", "actual"
+    )
+    assert "OctoPrint actual tool1 temp" == test_sensor.name
+    assert 18.83 == test_sensor.state
+
+
+def test_OctoPrintTimeRemainingSensor(hass):
+    """Test the properties."""
+    coordinator = DataUpdateCoordinator(hass, _LOGGER, name="octoprint-test")
+    coordinator.data = {
+        "job": OctoprintJobInfo(
+            {
+                "job": {},
+                "progress": {"printTimeLeft": 5000},
+            }
+        )
+    }
+    test_sensor = sensor.OctoPrintTimeRemainingSensor(coordinator, "OctoPrint")
+    assert "OctoPrint Time Remaining" == test_sensor.name
+    assert 5000 == test_sensor.state
+
+    coordinator.data["job"]._raw["progress"]["printTimeLeft"] = None
+    assert not test_sensor.state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
To prepare to switching octoprint over to config_flow, move the API code out into a library.

I used a client that has wrapper classes around the DTOs, which required a few other changes. If the HA teams prefers the client return json instead, I can update to do that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
