### PR TITLE
Recover and restart the recorder if the sqlite database encounters corruption while running

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -35,9 +35,20 @@ from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
 
 from . import migration, purge
-from .const import CONF_DB_INTEGRITY_CHECK, DATA_INSTANCE, DOMAIN, SQLITE_URL_PREFIX
+from .const import (
+    CONF_DB_INTEGRITY_CHECK,
+    DATA_INSTANCE,
+    DOMAIN,
+    SQLITE3_MALFORMED,
+    SQLITE_URL_PREFIX,
+)
 from .models import Base, Events, RecorderRuns, States
-from .util import session_scope, validate_or_move_away_sqlite_database
+from .util import (
+    dburl_to_path,
+    move_away_broken_database,
+    session_scope,
+    validate_or_move_away_sqlite_database,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -278,41 +289,8 @@ class Recorder(threading.Thread):
 
     def run(self):
         """Start processing events to save."""
-        tries = 1
-        connected = False
 
-        while not connected and tries <= self.db_max_retries:
-            if tries != 1:
-                time.sleep(self.db_retry_wait)
-            try:
-                self._setup_connection()
-                migration.migrate_schema(self)
-                self._setup_run()
-                connected = True
-                _LOGGER.debug("Connected to recorder database")
-            except Exception as err:  # pylint: disable=broad-except
-                _LOGGER.error(
-                    "Error during connection setup: %s (retrying in %s seconds)",
-                    err,
-                    self.db_retry_wait,
-                )
-                tries += 1
-
-        if not connected:
-
-            @callback
-            def connection_failed():
-                """Connect failed tasks."""
-                self.async_db_ready.set_result(False)
-                persistent_notification.async_create(
-                    self.hass,
-                    "The recorder could not start, please check the log",
-                    "Recorder",
-                )
-
-            self.hass.add_job(connection_failed)
-            return
-
+        self._setup_recorder()
         shutdown_task = object()
         hass_started = concurrent.futures.Future()
 
@@ -346,15 +324,13 @@ class Recorder(threading.Thread):
         self.hass.add_job(register)
         result = hass_started.result()
 
-        self.event_session = self.get_session()
-        self.event_session.expire_on_commit = False
+        self._open_event_session()
 
         # If shutdown happened before Home Assistant finished starting
         if result is shutdown_task:
             # Make sure we cleanly close the run if
             # we restart before startup finishes
-            self._close_run()
-            self._close_connection()
+            self._shutdown()
             return
 
         # Start periodic purge
@@ -375,170 +351,168 @@ class Recorder(threading.Thread):
         # has changed. This reduces the disk io.
         while True:
             event = self.queue.get()
-            if event is None:
-                self._close_run()
-                self._close_connection()
-                return
-            if isinstance(event, PurgeTask):
-                # Schedule a new purge task if this one didn't finish
-                if not purge.purge_old_data(self, event.keep_days, event.repack):
-                    self.queue.put(PurgeTask(event.keep_days, event.repack))
-                continue
-            if isinstance(event, WaitTask):
-                self._queue_watch.set()
-                continue
-            if event.event_type == EVENT_TIME_CHANGED:
-                self._keepalive_count += 1
-                if self._keepalive_count >= KEEPALIVE_TIME:
-                    self._keepalive_count = 0
-                    self._send_keep_alive()
-                if self.commit_interval:
-                    self._timechanges_seen += 1
-                    if self._timechanges_seen >= self.commit_interval:
-                        self._timechanges_seen = 0
-                        self._commit_event_session_or_retry()
-                continue
 
+            if event is None:
+                self._shutdown()
+                return
+
+            self._process_one_event(event)
+
+    def _setup_recorder(self) -> bool:
+        """Create schema and connect to the database."""
+        tries = 1
+
+        while tries <= self.db_max_retries:
             try:
-                if event.event_type == EVENT_STATE_CHANGED:
-                    dbevent = Events.from_event(event, event_data="{}")
-                else:
-                    dbevent = Events.from_event(event)
-                dbevent.created = event.time_fired
-                self.event_session.add(dbevent)
+                self._setup_connection()
+                migration.migrate_schema(self)
+                self._setup_run()
+                _LOGGER.debug("Connected to recorder database")
+                return True
+            except Exception as err:  # pylint: disable=broad-except
+                _LOGGER.error(
+                    "Error during connection setup: %s (retrying in %s seconds)",
+                    err,
+                    self.db_retry_wait,
+                )
+
+            tries += 1
+            time.sleep(self.db_retry_wait)
+
+        @callback
+        def connection_failed():
+            """Connect failed tasks."""
+            self.async_db_ready.set_result(False)
+            persistent_notification.async_create(
+                self.hass,
+                "The recorder could not start, please check the log",
+                "Recorder",
+            )
+
+        self.hass.add_job(connection_failed)
+        return False
+
+    def _process_one_event(self, event):
+        """Process one event."""
+        if isinstance(event, PurgeTask):
+            # Schedule a new purge task if this one didn't finish
+            if not purge.purge_old_data(self, event.keep_days, event.repack):
+                self.queue.put(PurgeTask(event.keep_days, event.repack))
+            return
+        if isinstance(event, WaitTask):
+            self._queue_watch.set()
+            return
+        if event.event_type == EVENT_TIME_CHANGED:
+            self._keepalive_count += 1
+            if self._keepalive_count >= KEEPALIVE_TIME:
+                self._keepalive_count = 0
+                self._send_keep_alive()
+            if self.commit_interval:
+                self._timechanges_seen += 1
+                if self._timechanges_seen >= self.commit_interval:
+                    self._timechanges_seen = 0
+                    self._commit_event_session_or_recover()
+            return
+
+        try:
+            if event.event_type == EVENT_STATE_CHANGED:
+                dbevent = Events.from_event(event, event_data="{}")
+            else:
+                dbevent = Events.from_event(event)
+            dbevent.created = event.time_fired
+            self.event_session.add(dbevent)
+        except (TypeError, ValueError):
+            _LOGGER.warning("Event is not JSON serializable: %s", event)
+        except Exception as err:  # pylint: disable=broad-except
+            # Must catch the exception to prevent the loop from collapsing
+            _LOGGER.exception("Error adding event: %s", err)
+
+        if dbevent and event.event_type == EVENT_STATE_CHANGED:
+            try:
+                dbstate = States.from_event(event)
+                has_new_state = event.data.get("new_state")
+                if dbstate.entity_id in self._old_states:
+                    old_state = self._old_states.pop(dbstate.entity_id)
+                    if old_state.state_id:
+                        dbstate.old_state_id = old_state.state_id
+                    else:
+                        dbstate.old_state = old_state
+                if not has_new_state:
+                    dbstate.state = None
+                dbstate.event = dbevent
+                dbstate.created = event.time_fired
+                self.event_session.add(dbstate)
+                if has_new_state:
+                    self._old_states[dbstate.entity_id] = dbstate
+                    self._pending_expunge.append(dbstate)
             except (TypeError, ValueError):
-                _LOGGER.warning("Event is not JSON serializable: %s", event)
+                _LOGGER.warning(
+                    "State is not JSON serializable: %s",
+                    event.data.get("new_state"),
+                )
             except Exception as err:  # pylint: disable=broad-except
                 # Must catch the exception to prevent the loop from collapsing
-                _LOGGER.exception("Error adding event: %s", err)
+                _LOGGER.exception("Error adding state change: %s", err)
 
-            if dbevent and event.event_type == EVENT_STATE_CHANGED:
-                try:
-                    dbstate = States.from_event(event)
-                    has_new_state = event.data.get("new_state")
-                    if dbstate.entity_id in self._old_states:
-                        old_state = self._old_states.pop(dbstate.entity_id)
-                        if old_state.state_id:
-                            dbstate.old_state_id = old_state.state_id
-                        else:
-                            dbstate.old_state = old_state
-                    if not has_new_state:
-                        dbstate.state = None
-                    dbstate.event = dbevent
-                    dbstate.created = event.time_fired
-                    self.event_session.add(dbstate)
-                    if has_new_state:
-                        self._old_states[dbstate.entity_id] = dbstate
-                        self._pending_expunge.append(dbstate)
-                except (TypeError, ValueError):
-                    _LOGGER.warning(
-                        "State is not JSON serializable: %s",
-                        event.data.get("new_state"),
-                    )
-                except Exception as err:  # pylint: disable=broad-except
-                    # Must catch the exception to prevent the loop from collapsing
-                    _LOGGER.exception("Error adding state change: %s", err)
+        # If they do not have a commit interval
+        # than we commit right away
+        if not self.commit_interval:
+            self._commit_event_session_or_recover()
 
-            # If they do not have a commit interval
-            # than we commit right away
-            if not self.commit_interval:
-                self._commit_event_session_or_retry()
-
-    def _send_keep_alive(self):
+    def _commit_event_session_or_recover(self):
+        """Commit changes to the database and recover if the database fails when possible."""
         try:
-            _LOGGER.debug("Sending keepalive")
-            self.event_session.connection().scalar(select([1]))
+            self._commit_event_session_or_retry()
+            return
+        except exc.DatabaseError as err:
+            if self._using_file_sqlite and SQLITE3_MALFORMED in str(err).lower():
+                self._handle_sqlite_corruption()
+                return
+
+            _LOGGER.exception("Database error while saving events: %s", err)
+            self._reopen_event_session()
             return
         except Exception as err:  # pylint: disable=broad-except
             # Must catch the exception to prevent the loop from collapsing
-            _LOGGER.error(
-                "Error in database connectivity during keepalive: %s",
-                err,
-            )
+            _LOGGER.exception("Unexpected error saving events: %s", err)
             self._reopen_event_session()
+            return
 
     def _commit_event_session_or_retry(self):
         tries = 1
         while tries <= self.db_max_retries:
-            if tries != 1:
-                time.sleep(self.db_retry_wait)
-
             try:
                 self._commit_event_session()
                 return
             except (exc.InternalError, exc.OperationalError) as err:
                 if err.connection_invalidated:
-                    _LOGGER.error(
-                        "Database connection invalidated: %s. "
-                        "(retrying in %s seconds)",
-                        err,
-                        self.db_retry_wait,
-                    )
+                    message = "Database connection invalidated"
                 else:
-                    _LOGGER.error(
-                        "Error in database connectivity during commit: %s. "
-                        "(retrying in %s seconds)",
-                        err,
-                        self.db_retry_wait,
-                    )
+                    message = "Error in database connectivity during commit"
+                _LOGGER.error(
+                    "%s: %s. (retrying in %s seconds)",
+                    message,
+                    err,
+                    self.db_retry_wait,
+                )
+                if tries == self.db_max_retries:
+                    raise
+
                 tries += 1
-
-            except Exception as err:  # pylint: disable=broad-except
-                # Must catch the exception to prevent the loop from collapsing
-                _LOGGER.exception("Error saving events: %s", err)
-                return
-
-        _LOGGER.error(
-            "Error in database update. Could not save " "after %d tries. Giving up",
-            tries,
-        )
-        self._reopen_event_session()
-
-    def _reopen_event_session(self):
-        try:
-            self.event_session.rollback()
-        except Exception as err:  # pylint: disable=broad-except
-            # Must catch the exception to prevent the loop from collapsing
-            _LOGGER.exception("Error while rolling back event session: %s", err)
-
-        try:
-            self.event_session.close()
-        except Exception as err:  # pylint: disable=broad-except
-            # Must catch the exception to prevent the loop from collapsing
-            _LOGGER.exception("Error while closing event session: %s", err)
-
-        try:
-            self.event_session = self.get_session()
-            self.event_session.expire_on_commit = False
-        except Exception as err:  # pylint: disable=broad-except
-            # Must catch the exception to prevent the loop from collapsing
-            _LOGGER.exception("Error while creating new event session: %s", err)
+                time.sleep(self.db_retry_wait)
 
     def _commit_event_session(self):
         self._commits_without_expire += 1
 
-        try:
-            if self._pending_expunge:
-                self.event_session.flush()
-                for dbstate in self._pending_expunge:
-                    # Expunge the state so its not expired
-                    # until we use it later for dbstate.old_state
-                    if dbstate in self.event_session:
-                        self.event_session.expunge(dbstate)
-                self._pending_expunge = []
-            self.event_session.commit()
-        except exc.IntegrityError as err:
-            _LOGGER.error(
-                "Integrity error executing query (database likely deleted out from under us): %s",
-                err,
-            )
-            self.event_session.rollback()
-            self._old_states = {}
-            raise
-        except Exception as err:
-            _LOGGER.error("Error executing query: %s", err)
-            self.event_session.rollback()
-            raise
+        if self._pending_expunge:
+            self.event_session.flush()
+            for dbstate in self._pending_expunge:
+                # Expunge the state so its not expired
+                # until we use it later for dbstate.old_state
+                if dbstate in self.event_session:
+                    self.event_session.expunge(dbstate)
+            self._pending_expunge = []
+        self.event_session.commit()
 
         # Expire is an expensive operation (frequently more expensive
         # than the flush and commit itself) so we only
@@ -546,6 +520,48 @@ class Recorder(threading.Thread):
         if self._commits_without_expire == EXPIRE_AFTER_COMMITS:
             self._commits_without_expire = 0
             self.event_session.expire_all()
+
+    def _handle_sqlite_corruption(self):
+        """Handle the sqlite3 database being corrupt."""
+        self._close_connection()
+        move_away_broken_database(dburl_to_path(self.db_url))
+        self._setup_recorder()
+        self._open_event_session()
+
+    def _reopen_event_session(self):
+        """Rollback the event session and reopen it after a failure."""
+        self._old_states = {}
+
+        try:
+            self.event_session.rollback()
+            self.event_session.close()
+        except Exception as err:  # pylint: disable=broad-except
+            # Must catch the exception to prevent the loop from collapsing
+            _LOGGER.exception(
+                "Error while rolling back and closing the event session: %s", err
+            )
+
+        self._open_event_session()
+
+    def _open_event_session(self):
+        """Open the event session."""
+        try:
+            self.event_session = self.get_session()
+            self.event_session.expire_on_commit = False
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.exception("Error while creating new event session: %s", err)
+
+    def _send_keep_alive(self):
+        try:
+            _LOGGER.debug("Sending keepalive")
+            self.event_session.connection().scalar(select([1]))
+            return
+        except Exception as err:  # pylint: disable=broad-except
+            _LOGGER.error(
+                "Error in database connectivity during keepalive: %s",
+                err,
+            )
+            self._reopen_event_session()
 
     @callback
     def event_listener(self, event):
@@ -603,9 +619,7 @@ class Recorder(threading.Thread):
         else:
             kwargs["echo"] = False
 
-        if self.db_url != SQLITE_URL_PREFIX and self.db_url.startswith(
-            SQLITE_URL_PREFIX
-        ):
+        if self._using_file_sqlite:
             with self.hass.timeout.freeze(DOMAIN):
                 #
                 # Here we run an sqlite3 quick_check.  In the majority
@@ -627,6 +641,13 @@ class Recorder(threading.Thread):
 
         Base.metadata.create_all(self.engine)
         self.get_session = scoped_session(sessionmaker(bind=self.engine))
+
+    @property
+    def _using_file_sqlite(self):
+        """Short version to check if we are using sqlite3 as a file."""
+        return self.db_url != SQLITE_URL_PREFIX and self.db_url.startswith(
+            SQLITE_URL_PREFIX
+        )
 
     def _close_connection(self):
         """Close the connection."""
@@ -652,12 +673,19 @@ class Recorder(threading.Thread):
             session.flush()
             session.expunge(self.run_info)
 
-    def _close_run(self):
+    def _shutdown(self):
         """Save end time for current run."""
         if self.event_session is not None:
             self.run_info.end = dt_util.utcnow()
             self.event_session.add(self.run_info)
-            self._commit_event_session_or_retry()
-            self.event_session.close()
+            try:
+                self._commit_event_session_or_retry()
+                self.event_session.close()
+            except Exception as err:  # pylint: disable=broad-except
+                # Must catch the exception to prevent the loop from collapsing
+                _LOGGER.exception(
+                    "Error saving the event session during shutdown: %s", err
+                )
 
         self.run_info = None
+        self._close_connection()

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -253,7 +253,7 @@ class Recorder(threading.Thread):
         self._pending_expunge = []
         self.event_session = None
         self.get_session = None
-        self._completed_database_setup = False
+        self._completed_database_setup = None
 
     @callback
     def async_initialize(self):
@@ -341,6 +341,7 @@ class Recorder(threading.Thread):
                 async_purge, hour=4, minute=12, second=0
             )
 
+        _LOGGER.debug("Recorder processing the queue")
         # Use a session for the event read loop
         # with a commit every time the event time
         # has changed. This reduces the disk io.
@@ -364,7 +365,8 @@ class Recorder(threading.Thread):
                 self._setup_run()
             except Exception as err:  # pylint: disable=broad-except
                 _LOGGER.error(
-                    "Error during connection setup: %s (retrying in %s seconds)",
+                    "Error during connection setup to %s: %s (retrying in %s seconds)",
+                    self.db_url,
                     err,
                     self.db_retry_wait,
                 )
@@ -584,6 +586,7 @@ class Recorder(threading.Thread):
     def _setup_connection(self):
         """Ensure database is ready to fly."""
         kwargs = {}
+        self._completed_database_setup = False
 
         def setup_recorder_connection(dbapi_connection, connection_record):
             """Dbapi specific connection settings."""

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -5,6 +5,7 @@ import concurrent.futures
 from datetime import datetime
 import logging
 import queue
+import sqlite3
 import threading
 import time
 from typing import Any, Callable, List, Optional
@@ -35,13 +36,7 @@ from homeassistant.helpers.typing import ConfigType
 import homeassistant.util.dt as dt_util
 
 from . import migration, purge
-from .const import (
-    CONF_DB_INTEGRITY_CHECK,
-    DATA_INSTANCE,
-    DOMAIN,
-    SQLITE3_MALFORMED,
-    SQLITE_URL_PREFIX,
-)
+from .const import CONF_DB_INTEGRITY_CHECK, DATA_INSTANCE, DOMAIN, SQLITE_URL_PREFIX
 from .models import Base, Events, RecorderRuns, States
 from .util import (
     dburl_to_path,
@@ -467,18 +462,19 @@ class Recorder(threading.Thread):
             self._commit_event_session_or_retry()
             return
         except exc.DatabaseError as err:
-            if self._using_file_sqlite and SQLITE3_MALFORMED in str(err).lower():
+            if isinstance(err.__cause__, sqlite3.DatabaseError):
+                _LOGGER.exception(
+                    "Unrecoverable sqlite3 database corruption detected: %s", err
+                )
                 self._handle_sqlite_corruption()
                 return
-
-            _LOGGER.exception("Database error while saving events: %s", err)
-            self._reopen_event_session()
-            return
+            _LOGGER.exception("Unexpected error saving events: %s", err)
         except Exception as err:  # pylint: disable=broad-except
             # Must catch the exception to prevent the loop from collapsing
             _LOGGER.exception("Unexpected error saving events: %s", err)
-            self._reopen_event_session()
-            return
+
+        self._reopen_event_session()
+        return
 
     def _commit_event_session_or_retry(self):
         tries = 1

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -422,11 +422,13 @@ class Recorder(threading.Thread):
             self.event_session.add(dbevent)
         except (TypeError, ValueError):
             _LOGGER.warning("Event is not JSON serializable: %s", event)
+            return
         except Exception as err:  # pylint: disable=broad-except
             # Must catch the exception to prevent the loop from collapsing
             _LOGGER.exception("Error adding event: %s", err)
+            return
 
-        if dbevent and event.event_type == EVENT_STATE_CHANGED:
+        if event.event_type == EVENT_STATE_CHANGED:
             try:
                 dbstate = States.from_event(event)
                 has_new_state = event.data.get("new_state")

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -290,7 +290,9 @@ class Recorder(threading.Thread):
     def run(self):
         """Start processing events to save."""
 
-        self._setup_recorder()
+        if not self._setup_recorder():
+            return
+
         shutdown_task = object()
         hass_started = concurrent.futures.Future()
 

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -492,7 +492,7 @@ class Recorder(threading.Thread):
                 else:
                     message = "Error in database connectivity during commit"
                 _LOGGER.error(
-                    "%s: %s. (retrying in %s seconds)",
+                    "%s: Error executing query: %s. (retrying in %s seconds)",
                     message,
                     err,
                     self.db_retry_wait,
@@ -684,7 +684,6 @@ class Recorder(threading.Thread):
                 self._commit_event_session_or_retry()
                 self.event_session.close()
             except Exception as err:  # pylint: disable=broad-except
-                # Must catch the exception to prevent the loop from collapsing
                 _LOGGER.exception(
                     "Error saving the event session during shutdown: %s", err
                 )

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -5,3 +5,5 @@ SQLITE_URL_PREFIX = "sqlite://"
 DOMAIN = "recorder"
 
 CONF_DB_INTEGRITY_CHECK = "db_integrity_check"
+
+SQLITE3_MALFORMED = "database disk image is malformed"

--- a/homeassistant/components/recorder/const.py
+++ b/homeassistant/components/recorder/const.py
@@ -5,5 +5,3 @@ SQLITE_URL_PREFIX = "sqlite://"
 DOMAIN = "recorder"
 
 CONF_DB_INTEGRITY_CHECK = "db_integrity_check"
-
-SQLITE3_MALFORMED = "database disk image is malformed"

--- a/homeassistant/components/recorder/util.py
+++ b/homeassistant/components/recorder/util.py
@@ -112,17 +112,22 @@ def execute(qry, to_native=False, validate_entity_ids=True):
 
 def validate_or_move_away_sqlite_database(dburl: str, db_integrity_check: bool) -> bool:
     """Ensure that the database is valid or move it away."""
-    dbpath = dburl[len(SQLITE_URL_PREFIX) :]
+    dbpath = dburl_to_path(dburl)
 
     if not os.path.exists(dbpath):
         # Database does not exist yet, this is OK
         return True
 
     if not validate_sqlite_database(dbpath, db_integrity_check):
-        _move_away_broken_database(dbpath)
+        move_away_broken_database(dbpath)
         return False
 
     return True
+
+
+def dburl_to_path(dburl):
+    """Convert the db url into a filesystem path."""
+    return dburl[len(SQLITE_URL_PREFIX) :]
 
 
 def last_run_was_recently_clean(cursor):
@@ -208,7 +213,7 @@ def run_checks_on_open_db(dbpath, cursor, db_integrity_check):
     cursor.execute("PRAGMA QUICK_CHECK")
 
 
-def _move_away_broken_database(dbfile: str) -> None:
+def move_away_broken_database(dbfile: str) -> None:
     """Move away a broken sqlite3 database."""
 
     isotime = dt_util.utcnow().isoformat()

--- a/tests/components/recorder/common.py
+++ b/tests/components/recorder/common.py
@@ -10,10 +10,16 @@ from tests.common import fire_time_changed
 
 def wait_recording_done(hass):
     """Block till recording is done."""
+    hass.block_till_done()
     trigger_db_commit(hass)
     hass.block_till_done()
     hass.data[recorder.DATA_INSTANCE].block_till_done()
     hass.block_till_done()
+
+
+async def async_wait_recording_done(hass):
+    """Block till recording is done."""
+    await hass.loop.run_in_executor(None, wait_recording_done, hass)
 
 
 def trigger_db_commit(hass):
@@ -21,3 +27,10 @@ def trigger_db_commit(hass):
     for _ in range(recorder.DEFAULT_COMMIT_INTERVAL):
         # We only commit on time change
         fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=1))
+
+
+def corrupt_db_file(test_db_file):
+    """Corrupt an sqlite3 database file."""
+    with open(test_db_file, "w+") as fhandle:
+        fhandle.seek(200)
+        fhandle.write("I am a corrupt db" * 100)

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -150,7 +150,7 @@ def test_last_run_was_recently_clean(hass_recorder):
 
     assert util.last_run_was_recently_clean(cursor) is False
 
-    hass.data[DATA_INSTANCE]._close_run()
+    hass.data[DATA_INSTANCE]._shutdown()
     wait_recording_done(hass)
 
     assert util.last_run_was_recently_clean(cursor) is True

--- a/tests/components/recorder/test_util.py
+++ b/tests/components/recorder/test_util.py
@@ -10,7 +10,7 @@ from homeassistant.components.recorder import util
 from homeassistant.components.recorder.const import DATA_INSTANCE, SQLITE_URL_PREFIX
 from homeassistant.util import dt as dt_util
 
-from .common import wait_recording_done
+from .common import corrupt_db_file, wait_recording_done
 
 from tests.common import get_test_home_assistant, init_recorder_component
 
@@ -90,7 +90,7 @@ def test_validate_or_move_away_sqlite_database_with_integrity_check(
         util.validate_or_move_away_sqlite_database(dburl, db_integrity_check) is False
     )
 
-    _corrupt_db_file(test_db_file)
+    corrupt_db_file(test_db_file)
 
     assert util.validate_sqlite_database(dburl, db_integrity_check) is False
 
@@ -127,7 +127,7 @@ def test_validate_or_move_away_sqlite_database_without_integrity_check(
         util.validate_or_move_away_sqlite_database(dburl, db_integrity_check) is False
     )
 
-    _corrupt_db_file(test_db_file)
+    corrupt_db_file(test_db_file)
 
     assert util.validate_sqlite_database(dburl, db_integrity_check) is False
 
@@ -244,10 +244,3 @@ def test_combined_checks(hass_recorder, caplog):
     caplog.clear()
     with pytest.raises(sqlite3.DatabaseError):
         util.run_checks_on_open_db("fake_db_path", cursor, True)
-
-
-def _corrupt_db_file(test_db_file):
-    """Corrupt an sqlite3 database file."""
-    f = open(test_db_file, "a")
-    f.write("I am a corrupt db")
-    f.close()


### PR DESCRIPTION
The amount of change here is smaller than it appears as there is a lot of moved code/whitespace changes.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ideally we detect the corruption before starting the recorder, however in practice its not possible to always detect it in advance. 

When we encounter corruption we will use the same strategy of moving away the corrupted database and making a new one.

The refactoring was done to break the code into smaller units as there wasn't a clean way to shutdown the recorder and start it again so we can do this:

```
    def _handle_sqlite_corruption(self):
        """Handle the sqlite3 database being corrupt."""
        self._close_connection()
        move_away_broken_database(dburl_to_path(self.db_url))
        self._setup_recorder()
```

Fixes (hopefully forever fix):
https://github.com/home-assistant/core/issues/44691
https://github.com/home-assistant/core/issues/46337
https://github.com/home-assistant/core/issues/46283
https://github.com/home-assistant/core/issues/45997
https://github.com/home-assistant/core/issues/33559

Testing
`dd if=/dev/urandom of=home-assistant_v2.db count=500` after the start event.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45742
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

