### PR TITLE
Fix climate hold bug in ecobee

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -559,7 +559,7 @@ class Thermostat(ClimateEntity):
 
         if preset_mode == PRESET_AWAY:
             self.data.ecobee.set_climate_hold(
-                self.thermostat_index, "away", "indefinite"
+                self.thermostat_index, "away", "indefinite", self.hold_hours()
             )
 
         elif preset_mode == PRESET_TEMPERATURE:
@@ -570,6 +570,7 @@ class Thermostat(ClimateEntity):
                 self.thermostat_index,
                 PRESET_TO_ECOBEE_HOLD[preset_mode],
                 self.hold_preference(),
+                self.hold_hours(),
             )
 
         elif preset_mode == PRESET_NONE:
@@ -585,14 +586,20 @@ class Thermostat(ClimateEntity):
 
             if climate_ref is not None:
                 self.data.ecobee.set_climate_hold(
-                    self.thermostat_index, climate_ref, self.hold_preference()
+                    self.thermostat_index,
+                    climate_ref,
+                    self.hold_preference(),
+                    self.hold_hours(),
                 )
             else:
                 _LOGGER.warning("Received unknown preset mode: %s", preset_mode)
 
         else:
             self.data.ecobee.set_climate_hold(
-                self.thermostat_index, preset_mode, self.hold_preference()
+                self.thermostat_index,
+                preset_mode,
+                self.hold_preference(),
+                self.hold_hours(),
             )
 
     @property

--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -743,7 +743,7 @@ class Thermostat(ClimateEntity):
             "useEndTime2hour": 2,
             "useEndTime4hour": 4,
         }
-        return hold_hours_map.get(device_preference, 0)
+        return hold_hours_map.get(device_preference)
 
     def create_vacation(self, service_data):
         """Create a vacation with user-specified parameters."""

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -3,6 +3,6 @@
   "name": "ecobee",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecobee",
-  "requirements": ["python-ecobee-api==0.2.8"],
+  "requirements": ["python-ecobee-api==0.2.10"],
   "codeowners": ["@marthoc"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1750,7 +1750,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.2.8
+python-ecobee-api==0.2.10
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -917,7 +917,7 @@ pysqueezebox==0.5.5
 pysyncthru==0.7.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.2.8
+python-ecobee-api==0.2.10
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -209,14 +209,14 @@ async def test_set_temperature(ecobee_fixture, thermostat, data):
     data.reset_mock()
     thermostat.set_temperature(target_temp_low=20, target_temp_high=30)
     data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 30, 20, "nextTransition", 0)]
+        [mock.call(1, 30, 20, "nextTransition", None)]
     )
 
     # Auto -> Hold
     data.reset_mock()
     thermostat.set_temperature(temperature=20)
     data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 25, 15, "nextTransition", 0)]
+        [mock.call(1, 25, 15, "nextTransition", None)]
     )
 
     # Cool -> Hold
@@ -224,7 +224,7 @@ async def test_set_temperature(ecobee_fixture, thermostat, data):
     ecobee_fixture["settings"]["hvacMode"] = "cool"
     thermostat.set_temperature(temperature=20.5)
     data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 20.5, 20.5, "nextTransition", 0)]
+        [mock.call(1, 20.5, 20.5, "nextTransition", None)]
     )
 
     # Heat -> Hold
@@ -232,7 +232,7 @@ async def test_set_temperature(ecobee_fixture, thermostat, data):
     ecobee_fixture["settings"]["hvacMode"] = "heat"
     thermostat.set_temperature(temperature=20)
     data.ecobee.set_hold_temp.assert_has_calls(
-        [mock.call(1, 20, 20, "nextTransition", 0)]
+        [mock.call(1, 20, 20, "nextTransition", None)]
     )
 
     # Heat -> Auto
@@ -311,7 +311,7 @@ def test_hold_hours(ecobee_fixture, thermostat):
         "askMe",
     ]:
         ecobee_fixture["settings"]["holdAction"] = action
-        assert thermostat.hold_hours() == 0
+        assert thermostat.hold_hours() is None
 
 
 async def test_set_fan_mode_on(thermostat, data):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR fixes a bug that was introduced in #40520 and which has been raised as an issue in #45936. As a result of the changes in #40520, we need to pass the holdHours parameter to the ecobee API when relevant. This PR ensures that the user's holdHours preference is always passed to the ecobee API call. The dependency bump of python-ecobee-api is required to implement support for filtering this parameter out of the API call when it is not relevant. 

Dependency diff: https://github.com/nkgilley/python-ecobee-api/compare/0.2.9...0.2.10


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45936

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
