### PR TITLE
[wip] Add a service to manually set the flux datetime

### DIFF
--- a/homeassistant/components/flux/switch.py
+++ b/homeassistant/components/flux/switch.py
@@ -159,6 +159,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
     async_add_entities([flux])
 
+    async def async_set_time(call=None):
+        time = call.data.get("datetime")
+        await flux.async_flux_update(utcnow=time)
+
+    service_name = slugify(f"{name} set time")
+    hass.services.async_register(
+        DOMAIN,
+        service_name,
+        async_set_time,
+        vol.Schema({vol.Required("datetime"): cv.datetime}),
+    )
+
     async def async_update(call=None):
         """Update lights."""
         await flux.async_flux_update()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

[I was finding it tricky to test my Flux configuration](https://community.home-assistant.io/t/testing-flux-light-platform-configuration/279928), as I would have to make updates and then watch the lights throughout the day to see if I was happy with them. This PR adds a service that allows a user to specify a datetime (`datetime: 2021-02-16T22:30:00-05:00` for example) to pass into Flux, which immediately updates the lights.

I'm not sure this is the "right" way to test integration configurations like this, as those without developer mode enabled won't be able to see this. However, flux has no UI currently so that doesn't seem like a big issue.

Todo:

- [ ] Add a services description to the new service
- [ ] Tests? `tests/components/flux/test_switch.py` doesn't appear to have any tests on the existing service, and I'm not clear if that's because services aren't considered testable or if the tests live somewhere else.
- [ ] Docs update showing how to test flux, as you have to disable the switch first to prevent it from being updated from under you.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: TBD

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone
* https://github.com/home-assistant/core/pull/46854

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
