### PR TITLE
Add selectors to Cover service definitions

### DIFF
--- a/homeassistant/components/cover/services.yaml
+++ b/homeassistant/components/cover/services.yaml
@@ -3,26 +3,18 @@
 open_cover:
   description: Open all or specified cover
   target:
-    entity:
-      domain: cover
 
 close_cover:
   description: Close all or specified cover
   target:
-    entity:
-      domain: cover
 
 toggle:
   description: Toggles a cover open/closed
   target:
-    entity:
-      domain: cover
 
 set_cover_position:
   description: Move to specific position all or specified cover
   target:
-    entity:
-      domain: cover
   fields:
     position:
       name: Position
@@ -40,32 +32,22 @@ set_cover_position:
 stop_cover:
   description: Stop all or specified cover
   target:
-    entity:
-      domain: cover
 
 open_cover_tilt:
   description: Open all or specified cover tilt
   target:
-    entity:
-      domain: cover
 
 close_cover_tilt:
   description: Close all or specified cover tilt
   target:
-    entity:
-      domain: cover
 
 toggle_cover_tilt:
   description: Toggles a cover tilt open/closed
   target:
-    entity:
-      domain: cover
 
 set_cover_tilt_position:
   description: Move to specific position all or specified cover tilt
   target:
-    entity:
-      domain: cover
   fields:
     tilt_position:
       name: Tilt position
@@ -83,5 +65,3 @@ set_cover_tilt_position:
 stop_cover_tilt:
   description: Stop all or specified cover
   target:
-    entity:
-      domain: cover

--- a/homeassistant/components/cover/services.yaml
+++ b/homeassistant/components/cover/services.yaml
@@ -1,77 +1,87 @@
 # Describes the format for available cover services
 
 open_cover:
-  description: Open all or specified cover.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to open.
-      example: "cover.living_room"
+  description: Open all or specified cover
+  target:
+    entity:
+      domain: cover
 
 close_cover:
-  description: Close all or specified cover.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to close.
-      example: "cover.living_room"
+  description: Close all or specified cover
+  target:
+    entity:
+      domain: cover
 
 toggle:
-  description: Toggles a cover open/closed.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to toggle.
-      example: "cover.garage_door"
+  description: Toggles a cover open/closed
+  target:
+    entity:
+      domain: cover
 
 set_cover_position:
-  description: Move to specific position all or specified cover.
+  description: Move to specific position all or specified cover
+  target:
+    entity:
+      domain: cover
   fields:
-    entity_id:
-      description: Name(s) of cover(s) to set cover position.
-      example: "cover.living_room"
     position:
-      description: Position of the cover (0 to 100).
+      name: Position
+      description: Position of the cover
+      required: true
       example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider
 
 stop_cover:
-  description: Stop all or specified cover.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to stop.
-      example: "cover.living_room"
+  description: Stop all or specified cover
+  target:
+    entity:
+      domain: cover
 
 open_cover_tilt:
-  description: Open all or specified cover tilt.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) tilt to open.
-      example: "cover.living_room_blinds"
+  description: Open all or specified cover tilt
+  target:
+    entity:
+      domain: cover
 
 close_cover_tilt:
-  description: Close all or specified cover tilt.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to close tilt.
-      example: "cover.living_room_blinds"
+  description: Close all or specified cover tilt
+  target:
+    entity:
+      domain: cover
 
 toggle_cover_tilt:
-  description: Toggles a cover tilt open/closed.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to toggle tilt.
-      example: "cover.living_room_blinds"
+  description: Toggles a cover tilt open/closed
+  target:
+    entity:
+      domain: cover
 
 set_cover_tilt_position:
-  description: Move to specific position all or specified cover tilt.
+  description: Move to specific position all or specified cover tilt
+  target:
+    entity:
+      domain: cover
   fields:
-    entity_id:
-      description: Name(s) of cover(s) to set cover tilt position.
-      example: "cover.living_room_blinds"
     tilt_position:
-      description: Tilt position of the cover (0 to 100).
+      name: Tilt position
+      description: Tilt position of the cover.
+      required: true
       example: 30
+      selector:
+        number:
+          min: 0
+          max: 100
+          step: 1
+          unit_of_measurement: "%"
+          mode: slider
 
 stop_cover_tilt:
-  description: Stop all or specified cover.
-  fields:
-    entity_id:
-      description: Name(s) of cover(s) to stop.
-      example: "cover.living_room_blinds"
+  description: Stop all or specified cover
+  target:
+    entity:
+      domain: cover

--- a/homeassistant/components/cover/services.yaml
+++ b/homeassistant/components/cover/services.yaml
@@ -42,7 +42,7 @@ close_cover_tilt:
   target:
 
 toggle_cover_tilt:
-  description: Toggles a cover tilt open/closed
+  description: Toggle a cover tilt open/closed
   target:
 
 set_cover_tilt_position:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add selectors to the service descriptions of the Cover integration.

Implemented in #46410

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
