### PR TITLE
Add events to Broadlink after learning a code

### DIFF
--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -24,8 +24,7 @@ from homeassistant.components.remote import (
     ATTR_NUM_REPEATS,
     DEFAULT_DELAY_SECS,
     DOMAIN as RM_DOMAIN,
-    EVENT_DATA_TYPE_LEARNED_CODE as RM_EVENT_DATA_TYPE_LEARNED_CODE,
-    EVENT_TYPE as RM_EVENT_TYPE,
+    EVENT_LEARNED_COMMAND as RM_EVENT_LEARNED_COMMAND,
     PLATFORM_SCHEMA,
     SERVICE_DELETE_COMMAND,
     SERVICE_LEARN_COMMAND,
@@ -284,16 +283,12 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
         service = f"{RM_DOMAIN}.{SERVICE_LEARN_COMMAND}"
 
         if not self._attr_is_on:
-            error_message = (
-                "%s canceled: %s entity is turned off",
-                service,
-                self.entity_id,
-            )
+            error_message = f"{service} canceled: {self.entity_id} entity is turned off"
+
             self.hass.bus.async_fire(
-                RM_EVENT_TYPE,
+                RM_EVENT_LEARNED_COMMAND,
                 {
                     "device_id": self.unique_id,
-                    "type": RM_EVENT_DATA_TYPE_LEARNED_CODE,
                     "error": error_message,
                 },
             )
@@ -325,10 +320,9 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
 
                 except (AuthorizationError, NetworkTimeoutError, OSError) as err:
                     self.hass.bus.async_fire(
-                        RM_EVENT_TYPE,
+                        RM_EVENT_LEARNED_COMMAND,
                         {
                             "device_id": self.unique_id,
-                            "type": RM_EVENT_DATA_TYPE_LEARNED_CODE,
                             "command": command,
                             "error": str(err),
                         },
@@ -338,10 +332,9 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
 
                 except BroadlinkException as err:
                     self.hass.bus.async_fire(
-                        RM_EVENT_TYPE,
+                        RM_EVENT_LEARNED_COMMAND,
                         {
                             "device_id": self.unique_id,
-                            "type": RM_EVENT_DATA_TYPE_LEARNED_CODE,
                             "command": command,
                             "error": str(err),
                         },
@@ -352,10 +345,9 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
                 self._codes.setdefault(device, {}).update({command: code})
 
                 self.hass.bus.async_fire(
-                    RM_EVENT_TYPE,
+                    RM_EVENT_LEARNED_COMMAND,
                     {
                         "device_id": self.unique_id,
-                        "type": RM_EVENT_DATA_TYPE_LEARNED_CODE,
                         "command": command,
                         "code": code,
                     },

--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -25,6 +25,7 @@ from homeassistant.components.remote import (
     DEFAULT_DELAY_SECS,
     DOMAIN as RM_DOMAIN,
     EVENT_LEARNED_COMMAND as RM_EVENT_LEARNED_COMMAND,
+    EVENT_LEARNED_COMMAND_FAILED as RM_EVENT_LEARNED_COMMAND_FAILED,
     PLATFORM_SCHEMA,
     SERVICE_DELETE_COMMAND,
     SERVICE_LEARN_COMMAND,
@@ -286,7 +287,7 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
             error_message = f"{service} canceled: {self.entity_id} entity is turned off"
 
             self.hass.bus.async_fire(
-                RM_EVENT_LEARNED_COMMAND,
+                RM_EVENT_LEARNED_COMMAND_FAILED,
                 {
                     "device_id": self.unique_id,
                     "error": error_message,
@@ -320,7 +321,7 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
 
                 except (AuthorizationError, NetworkTimeoutError, OSError) as err:
                     self.hass.bus.async_fire(
-                        RM_EVENT_LEARNED_COMMAND,
+                        RM_EVENT_LEARNED_COMMAND_FAILED,
                         {
                             "device_id": self.unique_id,
                             "command": command,
@@ -332,7 +333,7 @@ class BroadlinkRemote(BroadlinkEntity, RemoteEntity, RestoreEntity):
 
                 except BroadlinkException as err:
                     self.hass.bus.async_fire(
-                        RM_EVENT_LEARNED_COMMAND,
+                        RM_EVENT_LEARNED_COMMAND_FAILED,
                         {
                             "device_id": self.unique_id,
                             "command": command,

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -64,6 +64,9 @@ SUPPORT_LEARN_COMMAND = 1
 SUPPORT_DELETE_COMMAND = 2
 SUPPORT_ACTIVITY = 4
 
+EVENT_TYPE = "remote_event"
+EVENT_DATA_TYPE_LEARNED_CODE = "learned_code"
+
 REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(
     {vol.Optional(ATTR_ACTIVITY): cv.string}
 )

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -64,8 +64,7 @@ SUPPORT_LEARN_COMMAND = 1
 SUPPORT_DELETE_COMMAND = 2
 SUPPORT_ACTIVITY = 4
 
-EVENT_TYPE = "remote_event"
-EVENT_DATA_TYPE_LEARNED_CODE = "learned_code"
+EVENT_LEARNED_COMMAND = "remote_learned_command"
 
 REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(
     {vol.Optional(ATTR_ACTIVITY): cv.string}

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -65,6 +65,7 @@ SUPPORT_DELETE_COMMAND = 2
 SUPPORT_ACTIVITY = 4
 
 EVENT_LEARNED_COMMAND = "remote_learned_command"
+EVENT_LEARNED_COMMAND_FAILED = "remote_learned_command_failed"
 
 REMOTE_SERVICE_ACTIVITY_SCHEMA = make_entity_service_schema(
     {vol.Optional(ATTR_ACTIVITY): cv.string}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a code is learned by the Broadlink remote component, there isn't a simple way to get the learned code back into an external system. I added events being sent when a code is learnt (and events when an error occurs). I created new events based on the `remote` component (`remote_event`) so that this idea can be expanded to other `remote` components, or additional event types added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16615

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
