### PR TITLE
Add support for "alias" in script steps device, device_condition, and conditions

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -888,9 +888,11 @@ def script_action(value: Any) -> dict:
 
 SCRIPT_SCHEMA = vol.All(ensure_list, [script_action])
 
+SCRIPT_ACTION_BASE_SCHEMA = {vol.Optional(CONF_ALIAS): string}
+
 EVENT_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_EVENT): string,
         vol.Optional(CONF_EVENT_DATA): vol.All(dict, template_complex),
         vol.Optional(CONF_EVENT_DATA_TEMPLATE): vol.All(dict, template_complex),
@@ -900,7 +902,7 @@ EVENT_SCHEMA = vol.Schema(
 SERVICE_SCHEMA = vol.All(
     vol.Schema(
         {
-            vol.Optional(CONF_ALIAS): string,
+            **SCRIPT_ACTION_BASE_SCHEMA,
             vol.Exclusive(CONF_SERVICE, "service name"): vol.Any(
                 service, dynamic_template
             ),
@@ -920,10 +922,12 @@ NUMERIC_STATE_THRESHOLD_SCHEMA = vol.Any(
     vol.Coerce(float), vol.All(str, entity_domain("input_number"))
 )
 
+CONDITION_BASE_SCHEMA = {vol.Optional(CONF_ALIAS): string}
+
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
-            vol.Optional(CONF_ALIAS): string,
+            **CONDITION_BASE_SCHEMA,
             vol.Required(CONF_CONDITION): "numeric_state",
             vol.Required(CONF_ENTITY_ID): entity_ids,
             vol.Optional(CONF_ATTRIBUTE): str,
@@ -936,7 +940,7 @@ NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
 )
 
 STATE_CONDITION_BASE_SCHEMA = {
-    vol.Optional(CONF_ALIAS): string,
+    **CONDITION_BASE_SCHEMA,
     vol.Required(CONF_CONDITION): "state",
     vol.Required(CONF_ENTITY_ID): entity_ids,
     vol.Optional(CONF_ATTRIBUTE): str,
@@ -977,7 +981,7 @@ def STATE_CONDITION_SCHEMA(value: Any) -> dict:  # pylint: disable=invalid-name
 SUN_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
-            vol.Optional(CONF_ALIAS): string,
+            **CONDITION_BASE_SCHEMA,
             vol.Required(CONF_CONDITION): "sun",
             vol.Optional("before"): sun_event,
             vol.Optional("before_offset"): time_period,
@@ -992,7 +996,7 @@ SUN_CONDITION_SCHEMA = vol.All(
 
 TEMPLATE_CONDITION_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **CONDITION_BASE_SCHEMA,
         vol.Required(CONF_CONDITION): "template",
         vol.Required(CONF_VALUE_TEMPLATE): template,
     }
@@ -1001,7 +1005,7 @@ TEMPLATE_CONDITION_SCHEMA = vol.Schema(
 TIME_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
-            vol.Optional(CONF_ALIAS): string,
+            **CONDITION_BASE_SCHEMA,
             vol.Required(CONF_CONDITION): "time",
             "before": vol.Any(time, vol.All(str, entity_domain("input_datetime"))),
             "after": vol.Any(time, vol.All(str, entity_domain("input_datetime"))),
@@ -1013,7 +1017,7 @@ TIME_CONDITION_SCHEMA = vol.All(
 
 ZONE_CONDITION_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **CONDITION_BASE_SCHEMA,
         vol.Required(CONF_CONDITION): "zone",
         vol.Required(CONF_ENTITY_ID): entity_ids,
         "zone": entity_ids,
@@ -1025,7 +1029,7 @@ ZONE_CONDITION_SCHEMA = vol.Schema(
 
 AND_CONDITION_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **CONDITION_BASE_SCHEMA,
         vol.Required(CONF_CONDITION): "and",
         vol.Required(CONF_CONDITIONS): vol.All(
             ensure_list,
@@ -1037,7 +1041,7 @@ AND_CONDITION_SCHEMA = vol.Schema(
 
 OR_CONDITION_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **CONDITION_BASE_SCHEMA,
         vol.Required(CONF_CONDITION): "or",
         vol.Required(CONF_CONDITIONS): vol.All(
             ensure_list,
@@ -1049,7 +1053,7 @@ OR_CONDITION_SCHEMA = vol.Schema(
 
 NOT_CONDITION_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **CONDITION_BASE_SCHEMA,
         vol.Required(CONF_CONDITION): "not",
         vol.Required(CONF_CONDITIONS): vol.All(
             ensure_list,
@@ -1061,7 +1065,7 @@ NOT_CONDITION_SCHEMA = vol.Schema(
 
 DEVICE_CONDITION_BASE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **CONDITION_BASE_SCHEMA,
         vol.Required(CONF_CONDITION): "device",
         vol.Required(CONF_DEVICE_ID): str,
         vol.Required(CONF_DOMAIN): str,
@@ -1097,14 +1101,14 @@ TRIGGER_SCHEMA = vol.All(
 
 _SCRIPT_DELAY_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_DELAY): positive_time_period_template,
     }
 )
 
 _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_WAIT_TEMPLATE): template,
         vol.Optional(CONF_TIMEOUT): positive_time_period_template,
         vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
@@ -1113,7 +1117,7 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
 
 DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_DEVICE_ID): string,
         vol.Required(CONF_DOMAIN): str,
     }
@@ -1122,12 +1126,12 @@ DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
 DEVICE_ACTION_SCHEMA = DEVICE_ACTION_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
 _SCRIPT_SCENE_SCHEMA = vol.Schema(
-    {vol.Optional(CONF_ALIAS): string, vol.Required(CONF_SCENE): entity_domain("scene")}
+    {**SCRIPT_ACTION_BASE_SCHEMA, vol.Required(CONF_SCENE): entity_domain("scene")}
 )
 
 _SCRIPT_REPEAT_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_REPEAT): vol.All(
             {
                 vol.Exclusive(CONF_COUNT, "repeat"): vol.Any(vol.Coerce(int), template),
@@ -1146,7 +1150,7 @@ _SCRIPT_REPEAT_SCHEMA = vol.Schema(
 
 _SCRIPT_CHOOSE_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_CHOOSE): vol.All(
             ensure_list,
             [
@@ -1165,7 +1169,7 @@ _SCRIPT_CHOOSE_SCHEMA = vol.Schema(
 
 _SCRIPT_WAIT_FOR_TRIGGER_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_WAIT_FOR_TRIGGER): TRIGGER_SCHEMA,
         vol.Optional(CONF_TIMEOUT): positive_time_period_template,
         vol.Optional(CONF_CONTINUE_ON_TIMEOUT): boolean,
@@ -1174,7 +1178,7 @@ _SCRIPT_WAIT_FOR_TRIGGER_SCHEMA = vol.Schema(
 
 _SCRIPT_SET_SCHEMA = vol.Schema(
     {
-        vol.Optional(CONF_ALIAS): string,
+        **SCRIPT_ACTION_BASE_SCHEMA,
         vol.Required(CONF_VARIABLES): SCRIPT_VARIABLES_SCHEMA,
     }
 )

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -923,6 +923,7 @@ NUMERIC_STATE_THRESHOLD_SCHEMA = vol.Any(
 NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
+            vol.Optional(CONF_ALIAS): string,
             vol.Required(CONF_CONDITION): "numeric_state",
             vol.Required(CONF_ENTITY_ID): entity_ids,
             vol.Optional(CONF_ATTRIBUTE): str,
@@ -935,6 +936,7 @@ NUMERIC_STATE_CONDITION_SCHEMA = vol.All(
 )
 
 STATE_CONDITION_BASE_SCHEMA = {
+    vol.Optional(CONF_ALIAS): string,
     vol.Required(CONF_CONDITION): "state",
     vol.Required(CONF_ENTITY_ID): entity_ids,
     vol.Optional(CONF_ATTRIBUTE): str,
@@ -975,6 +977,7 @@ def STATE_CONDITION_SCHEMA(value: Any) -> dict:  # pylint: disable=invalid-name
 SUN_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
+            vol.Optional(CONF_ALIAS): string,
             vol.Required(CONF_CONDITION): "sun",
             vol.Optional("before"): sun_event,
             vol.Optional("before_offset"): time_period,
@@ -989,6 +992,7 @@ SUN_CONDITION_SCHEMA = vol.All(
 
 TEMPLATE_CONDITION_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_CONDITION): "template",
         vol.Required(CONF_VALUE_TEMPLATE): template,
     }
@@ -997,6 +1001,7 @@ TEMPLATE_CONDITION_SCHEMA = vol.Schema(
 TIME_CONDITION_SCHEMA = vol.All(
     vol.Schema(
         {
+            vol.Optional(CONF_ALIAS): string,
             vol.Required(CONF_CONDITION): "time",
             "before": vol.Any(time, vol.All(str, entity_domain("input_datetime"))),
             "after": vol.Any(time, vol.All(str, entity_domain("input_datetime"))),
@@ -1008,6 +1013,7 @@ TIME_CONDITION_SCHEMA = vol.All(
 
 ZONE_CONDITION_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_CONDITION): "zone",
         vol.Required(CONF_ENTITY_ID): entity_ids,
         "zone": entity_ids,
@@ -1019,6 +1025,7 @@ ZONE_CONDITION_SCHEMA = vol.Schema(
 
 AND_CONDITION_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_CONDITION): "and",
         vol.Required(CONF_CONDITIONS): vol.All(
             ensure_list,
@@ -1030,6 +1037,7 @@ AND_CONDITION_SCHEMA = vol.Schema(
 
 OR_CONDITION_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_CONDITION): "or",
         vol.Required(CONF_CONDITIONS): vol.All(
             ensure_list,
@@ -1041,6 +1049,7 @@ OR_CONDITION_SCHEMA = vol.Schema(
 
 NOT_CONDITION_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_CONDITION): "not",
         vol.Required(CONF_CONDITIONS): vol.All(
             ensure_list,
@@ -1052,6 +1061,7 @@ NOT_CONDITION_SCHEMA = vol.Schema(
 
 DEVICE_CONDITION_BASE_SCHEMA = vol.Schema(
     {
+        vol.Optional(CONF_ALIAS): string,
         vol.Required(CONF_CONDITION): "device",
         vol.Required(CONF_DEVICE_ID): str,
         vol.Required(CONF_DOMAIN): str,
@@ -1102,12 +1112,18 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
 )
 
 DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
-    {vol.Required(CONF_DEVICE_ID): string, vol.Required(CONF_DOMAIN): str}
+    {
+        vol.Optional(CONF_ALIAS): string,
+        vol.Required(CONF_DEVICE_ID): string,
+        vol.Required(CONF_DOMAIN): str,
+    }
 )
 
 DEVICE_ACTION_SCHEMA = DEVICE_ACTION_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)
 
-_SCRIPT_SCENE_SCHEMA = vol.Schema({vol.Required(CONF_SCENE): entity_domain("scene")})
+_SCRIPT_SCENE_SCHEMA = vol.Schema(
+    {vol.Optional(CONF_ALIAS): string, vol.Required(CONF_SCENE): entity_domain("scene")}
+)
 
 _SCRIPT_REPEAT_SCHEMA = vol.Schema(
     {

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1151,6 +1151,7 @@ _SCRIPT_CHOOSE_SCHEMA = vol.Schema(
             ensure_list,
             [
                 {
+                    vol.Optional(CONF_ALIAS): string,
                     vol.Required(CONF_CONDITIONS): vol.All(
                         ensure_list, [CONDITION_SCHEMA]
                     ),

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -347,13 +347,13 @@ class _ScriptRun:
     async def _async_wait_template_step(self):
         """Handle a wait template."""
         if CONF_TIMEOUT in self._action:
-            delay = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
+            timeout = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
         else:
-            delay = None
+            timeout = None
 
-        self._step_log("wait template", delay)
+        self._step_log("wait template", timeout)
 
-        self._variables["wait"] = {"remaining": delay, "completed": False}
+        self._variables["wait"] = {"remaining": timeout, "completed": False}
 
         wait_template = self._action[CONF_WAIT_TEMPLATE]
         wait_template.hass = self._hass
@@ -367,7 +367,7 @@ class _ScriptRun:
         def async_script_wait(entity_id, from_s, to_s):
             """Handle script after template condition is true."""
             self._variables["wait"] = {
-                "remaining": to_context.remaining if to_context else delay,
+                "remaining": to_context.remaining if to_context else timeout,
                 "completed": True,
             }
             done.set()
@@ -383,7 +383,7 @@ class _ScriptRun:
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with async_timeout.timeout(delay) as to_context:
+            async with async_timeout.timeout(timeout) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError as ex:
             if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
@@ -622,20 +622,20 @@ class _ScriptRun:
     async def _async_wait_for_trigger_step(self):
         """Wait for a trigger event."""
         if CONF_TIMEOUT in self._action:
-            delay = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
+            timeout = self._get_pos_time_period_template(CONF_TIMEOUT).total_seconds()
         else:
-            delay = None
+            timeout = None
 
-        self._step_log("wait for trigger", delay)
+        self._step_log("wait for trigger", timeout)
 
         variables = {**self._variables}
-        self._variables["wait"] = {"remaining": delay, "trigger": None}
+        self._variables["wait"] = {"remaining": timeout, "trigger": None}
 
         done = asyncio.Event()
 
         async def async_done(variables, context=None):
             self._variables["wait"] = {
-                "remaining": to_context.remaining if to_context else delay,
+                "remaining": to_context.remaining if to_context else timeout,
                 "trigger": variables["trigger"],
             }
             done.set()
@@ -661,7 +661,7 @@ class _ScriptRun:
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with async_timeout.timeout(delay) as to_context:
+            async with async_timeout.timeout(timeout) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError as ex:
             if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -235,6 +235,11 @@ class _ScriptRun:
             msg, *args, level=level, **kwargs
         )
 
+    def _step_log(self, default_message, delay=None):
+        self._script.last_action = self._action.get(CONF_ALIAS, default_message)
+        _timeout = "" if delay is None else f" (timeout: {timedelta(seconds=delay)})"
+        self._log("Executing step %s%s", self._script.last_action, _timeout)
+
     async def async_run(self) -> None:
         """Run script."""
         try:
@@ -327,8 +332,7 @@ class _ScriptRun:
         """Handle delay."""
         delay = self._get_pos_time_period_template(CONF_DELAY)
 
-        self._script.last_action = self._action.get(CONF_ALIAS, f"delay {delay}")
-        self._log("Executing step %s", self._script.last_action)
+        self._step_log(f"delay {delay}")
 
         delay = delay.total_seconds()
         self._changed()
@@ -345,12 +349,7 @@ class _ScriptRun:
         else:
             delay = None
 
-        self._script.last_action = self._action.get(CONF_ALIAS, "wait template")
-        self._log(
-            "Executing step %s%s",
-            self._script.last_action,
-            "" if delay is None else f" (timeout: {timedelta(seconds=delay)})",
-        )
+        self._step_log("wait template", delay)
 
         self._variables["wait"] = {"remaining": delay, "completed": False}
 
@@ -431,8 +430,7 @@ class _ScriptRun:
 
     async def _async_call_service_step(self):
         """Call the service specified in the action."""
-        self._script.last_action = self._action.get(CONF_ALIAS, "call service")
-        self._log("Executing step %s", self._script.last_action)
+        self._step_log("call service")
 
         params = service.async_prepare_call_from_config(
             self._hass, self._action, self._variables
@@ -467,8 +465,7 @@ class _ScriptRun:
 
     async def _async_device_step(self):
         """Perform the device automation specified in the action."""
-        self._script.last_action = self._action.get(CONF_ALIAS, "device automation")
-        self._log("Executing step %s", self._script.last_action)
+        self._step_log("device automation")
         platform = await device_automation.async_get_device_automation_platform(
             self._hass, self._action[CONF_DOMAIN], "action"
         )
@@ -478,8 +475,7 @@ class _ScriptRun:
 
     async def _async_scene_step(self):
         """Activate the scene specified in the action."""
-        self._script.last_action = self._action.get(CONF_ALIAS, "activate scene")
-        self._log("Executing step %s", self._script.last_action)
+        self._step_log("activate scene")
         await self._hass.services.async_call(
             scene.DOMAIN,
             SERVICE_TURN_ON,
@@ -490,10 +486,7 @@ class _ScriptRun:
 
     async def _async_event_step(self):
         """Fire an event."""
-        self._script.last_action = self._action.get(
-            CONF_ALIAS, self._action[CONF_EVENT]
-        )
-        self._log("Executing step %s", self._script.last_action)
+        self._step_log(self._action.get(CONF_ALIAS, self._action[CONF_EVENT]))
         event_data = {}
         for conf in [CONF_EVENT_DATA, CONF_EVENT_DATA_TEMPLATE]:
             if conf not in self._action:
@@ -631,12 +624,7 @@ class _ScriptRun:
         else:
             delay = None
 
-        self._script.last_action = self._action.get(CONF_ALIAS, "wait for trigger")
-        self._log(
-            "Executing step %s%s",
-            self._script.last_action,
-            "" if delay is None else f" (timeout: {timedelta(seconds=delay)})",
-        )
+        self._step_log("wait for trigger", delay)
 
         variables = {**self._variables}
         self._variables["wait"] = {"remaining": delay, "trigger": None}
@@ -685,8 +673,7 @@ class _ScriptRun:
 
     async def _async_variables_step(self):
         """Set a variable value."""
-        self._script.last_action = self._action.get(CONF_ALIAS, "setting variables")
-        self._log("Executing step %s", self._script.last_action)
+        self._step_log("setting variables")
         self._variables = self._action[CONF_VARIABLES].async_render(
             self._hass, self._variables, render_as_defaults=False
         )

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -18,7 +18,7 @@ from typing import (
     cast,
 )
 
-from async_timeout import timeout
+import async_timeout
 import voluptuous as vol
 
 from homeassistant import exceptions
@@ -339,7 +339,7 @@ class _ScriptRun:
         delay = delay.total_seconds()
         self._changed()
         try:
-            async with timeout(delay):
+            async with async_timeout.timeout(delay):
                 await self._stop.wait()
         except asyncio.TimeoutError:
             pass
@@ -383,7 +383,7 @@ class _ScriptRun:
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with timeout(delay) as to_context:
+            async with async_timeout.timeout(delay) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError as ex:
             if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):
@@ -661,7 +661,7 @@ class _ScriptRun:
             self._hass.async_create_task(flag.wait()) for flag in (self._stop, done)
         ]
         try:
-            async with timeout(delay) as to_context:
+            async with async_timeout.timeout(delay) as to_context:
                 await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
         except asyncio.TimeoutError as ex:
             if not self._action.get(CONF_CONTINUE_ON_TIMEOUT, True):

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1098,10 +1098,11 @@ class Script:
                 await self._async_get_condition(config)
                 for config in choice.get(CONF_CONDITIONS, [])
             ]
+            choice_name = choice.get(CONF_ALIAS, f"choice {idx}")
             sub_script = Script(
                 self._hass,
                 choice[CONF_SEQUENCE],
-                f"{self.name}: {step_name}: choice {idx}",
+                f"{self.name}: {step_name}: {choice_name}",
                 self.domain,
                 running_description=self.running_description,
                 script_mode=SCRIPT_MODE_PARALLEL,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -235,9 +235,11 @@ class _ScriptRun:
             msg, *args, level=level, **kwargs
         )
 
-    def _step_log(self, default_message, delay=None):
+    def _step_log(self, default_message, timeout=None):
         self._script.last_action = self._action.get(CONF_ALIAS, default_message)
-        _timeout = "" if delay is None else f" (timeout: {timedelta(seconds=delay)})"
+        _timeout = (
+            "" if timeout is None else f" (timeout: {timedelta(seconds=timeout)})"
+        )
         self._log("Executing step %s%s", self._script.last_action, _timeout)
 
     async def async_run(self) -> None:

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -34,6 +34,7 @@ async def test_and_condition(hass):
     test = await condition.async_from_config(
         hass,
         {
+            "alias": "And Condition",
             "condition": "and",
             "conditions": [
                 {
@@ -68,6 +69,7 @@ async def test_and_condition_with_template(hass):
             "condition": "and",
             "conditions": [
                 {
+                    "alias": "Template Condition",
                     "condition": "template",
                     "value_template": '{{ states.sensor.temperature.state == "100" }}',
                 },
@@ -95,6 +97,7 @@ async def test_or_condition(hass):
     test = await condition.async_from_config(
         hass,
         {
+            "alias": "Or Condition",
             "condition": "or",
             "conditions": [
                 {
@@ -153,6 +156,7 @@ async def test_not_condition(hass):
     test = await condition.async_from_config(
         hass,
         {
+            "alias": "Not Condition",
             "condition": "not",
             "conditions": [
                 {
@@ -430,6 +434,7 @@ async def test_multiple_states(hass):
             "condition": "and",
             "conditions": [
                 {
+                    "alias": "State Condition",
                     "condition": "state",
                     "entity_id": "sensor.temperature",
                     "state": ["100", "200"],
@@ -699,6 +704,7 @@ async def test_numeric_state_multiple_entities(hass):
             "condition": "and",
             "conditions": [
                 {
+                    "alias": "Numeric State Condition",
                     "condition": "numeric_state",
                     "entity_id": ["sensor.temperature_1", "sensor.temperature_2"],
                     "below": 50,
@@ -819,6 +825,7 @@ async def test_zone_multiple_entities(hass):
             "condition": "and",
             "conditions": [
                 {
+                    "alias": "Zone Condition",
                     "condition": "zone",
                     "entity_id": ["device_tracker.person_1", "device_tracker.person_2"],
                     "zone": "zone.home",

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -221,36 +221,45 @@ async def test_not_condition_with_template(hass):
 
 async def test_time_window(hass):
     """Test time condition windows."""
-    sixam = dt.parse_time("06:00:00")
-    sixpm = dt.parse_time("18:00:00")
+    sixam = "06:00:00"
+    sixpm = "18:00:00"
+
+    test1 = await condition.async_from_config(
+        hass,
+        {"alias": "Time Cond", "condition": "time", "after": sixam, "before": sixpm},
+    )
+    test2 = await condition.async_from_config(
+        hass,
+        {"alias": "Time Cond", "condition": "time", "after": sixpm, "before": sixam},
+    )
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=3),
     ):
-        assert not condition.time(hass, after=sixam, before=sixpm)
-        assert condition.time(hass, after=sixpm, before=sixam)
+        assert not test1(hass)
+        assert test2(hass)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=9),
     ):
-        assert condition.time(hass, after=sixam, before=sixpm)
-        assert not condition.time(hass, after=sixpm, before=sixam)
+        assert test1(hass)
+        assert not test2(hass)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=15),
     ):
-        assert condition.time(hass, after=sixam, before=sixpm)
-        assert not condition.time(hass, after=sixpm, before=sixam)
+        assert test1(hass)
+        assert not test2(hass)
 
     with patch(
         "homeassistant.helpers.condition.dt_util.now",
         return_value=dt.now().replace(hour=21),
     ):
-        assert not condition.time(hass, after=sixam, before=sixpm)
-        assert condition.time(hass, after=sixpm, before=sixam)
+        assert not test1(hass)
+        assert test2(hass)
 
 
 async def test_time_using_input_datetime(hass):

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -10,7 +10,6 @@ import pytest
 import voluptuous as vol
 
 import homeassistant
-from homeassistant.const import CONF_ALIAS
 from homeassistant.helpers import config_validation as cv, template
 
 
@@ -329,31 +328,6 @@ def test_service():
         schema("invalid_turn_on")
 
     schema("homeassistant.turn_on")
-
-
-def test_action_type_schemas_support_alias():
-    """Test that all action type schemas allow alias field."""
-
-    def find_root_schema(node):
-        """Traverse schema to find the root validation dictionary."""
-        if isinstance(node, dict):
-            return vol.Schema(node)
-
-        if isinstance(node, vol.Schema):
-            return find_root_schema(node.schema)
-
-        if isinstance(node, vol.All):
-            return find_root_schema(node.validators[0])
-
-        return None
-
-    for action_type, action_schema in cv.ACTION_TYPE_SCHEMAS.items():
-        # Condition schema is tricky to find a root dictionary for
-        if action_type == cv.SCRIPT_ACTION_CHECK_CONDITION:
-            continue
-        root_schema = find_root_schema(action_schema)
-        schema_keys = root_schema.schema.keys()
-        assert CONF_ALIAS in schema_keys
 
 
 def test_service_schema():

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -10,6 +10,7 @@ import pytest
 import voluptuous as vol
 
 import homeassistant
+from homeassistant.const import CONF_ALIAS
 from homeassistant.helpers import config_validation as cv, template
 
 
@@ -330,6 +331,31 @@ def test_service():
     schema("homeassistant.turn_on")
 
 
+def test_action_type_schemas_support_alias():
+    """Test that all action type schemas allow alias field."""
+
+    def find_root_schema(node):
+        """Traverse schema to find the root validation dictionary."""
+        if isinstance(node, dict):
+            return vol.Schema(node)
+
+        if isinstance(node, vol.Schema):
+            return find_root_schema(node.schema)
+
+        if isinstance(node, vol.All):
+            return find_root_schema(node.validators[0])
+
+        return None
+
+    for action_type, action_schema in cv.ACTION_TYPE_SCHEMAS.items():
+        # Condition schema is tricky to find a root dictionary for
+        if action_type == cv.SCRIPT_ACTION_CHECK_CONDITION:
+            continue
+        root_schema = find_root_schema(action_schema)
+        schema_keys = root_schema.schema.keys()
+        assert CONF_ALIAS in schema_keys
+
+
 def test_service_schema():
     """Test service_schema validation."""
     options = (
@@ -357,6 +383,11 @@ def test_service_schema():
         {
             "service": "homeassistant.turn_on",
             "entity_id": ["light.kitchen", "light.ceiling"],
+        },
+        {
+            "service": "light.turn_on",
+            "entity_id": "all",
+            "alias": "turn on kitchen lights",
         },
     )
     for value in options:

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -50,7 +50,10 @@ async def test_firing_event_basic(hass, caplog):
     context = Context()
     events = async_capture_events(hass, event)
 
-    sequence = cv.SCRIPT_SCHEMA({"event": event, "event_data": {"hello": "world"}})
+    alias = "event step"
+    sequence = cv.SCRIPT_SCHEMA(
+        {"alias": alias, "event": event, "event_data": {"hello": "world"}}
+    )
     script_obj = script.Script(
         hass, sequence, "Test Name", "test_domain", running_description="test script"
     )
@@ -63,6 +66,7 @@ async def test_firing_event_basic(hass, caplog):
     assert events[0].data.get("hello") == "world"
     assert ".test_name:" in caplog.text
     assert "Test Name: Running test script" in caplog.text
+    assert f"Executing step {alias}" in caplog.text
 
 
 async def test_firing_event_template(hass):
@@ -107,12 +111,15 @@ async def test_firing_event_template(hass):
     }
 
 
-async def test_calling_service_basic(hass):
+async def test_calling_service_basic(hass, caplog):
     """Test the calling of a service."""
     context = Context()
     calls = async_mock_service(hass, "test", "script")
 
-    sequence = cv.SCRIPT_SCHEMA({"service": "test.script", "data": {"hello": "world"}})
+    alias = "service step"
+    sequence = cv.SCRIPT_SCHEMA(
+        {"alias": alias, "service": "test.script", "data": {"hello": "world"}}
+    )
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(context=context)
@@ -121,6 +128,7 @@ async def test_calling_service_basic(hass):
     assert len(calls) == 1
     assert calls[0].context is context
     assert calls[0].data.get("hello") == "world"
+    assert f"Executing step {alias}" in caplog.text
 
 
 async def test_calling_service_template(hass):
@@ -250,12 +258,13 @@ async def test_multiple_runs_no_wait(hass):
     assert len(calls) == 4
 
 
-async def test_activating_scene(hass):
+async def test_activating_scene(hass, caplog):
     """Test the activation of a scene."""
     context = Context()
     calls = async_mock_service(hass, scene.DOMAIN, SERVICE_TURN_ON)
 
-    sequence = cv.SCRIPT_SCHEMA({"scene": "scene.hello"})
+    alias = "scene step"
+    sequence = cv.SCRIPT_SCHEMA({"alias": alias, "scene": "scene.hello"})
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(context=context)
@@ -264,6 +273,7 @@ async def test_activating_scene(hass):
     assert len(calls) == 1
     assert calls[0].context is context
     assert calls[0].data.get(ATTR_ENTITY_ID) == "scene.hello"
+    assert f"Executing step {alias}" in caplog.text
 
 
 @pytest.mark.parametrize("count", [1, 3])
@@ -1063,14 +1073,16 @@ async def test_condition_warning(hass, caplog):
     assert len(events) == 1
 
 
-async def test_condition_basic(hass):
+async def test_condition_basic(hass, caplog):
     """Test if we can use conditions in a script."""
     event = "test_event"
     events = async_capture_events(hass, event)
+    alias = "condition step"
     sequence = cv.SCRIPT_SCHEMA(
         [
             {"event": event},
             {
+                "alias": alias,
                 "condition": "template",
                 "value_template": "{{ states.test.entity.state == 'hello' }}",
             },
@@ -1083,6 +1095,8 @@ async def test_condition_basic(hass):
     await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
+    assert f"Test condition {alias}: True" in caplog.text
+    caplog.clear()
     assert len(events) == 2
 
     hass.states.async_set("test.entity", "goodbye")
@@ -1090,6 +1104,7 @@ async def test_condition_basic(hass):
     await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
 
+    assert f"Test condition {alias}: False" in caplog.text
     assert len(events) == 3
 
 
@@ -1140,14 +1155,16 @@ async def test_condition_all_cached(hass):
     assert len(script_obj._config_cache) == 2
 
 
-async def test_repeat_count(hass):
+async def test_repeat_count(hass, caplog):
     """Test repeat action w/ count option."""
     event = "test_event"
     events = async_capture_events(hass, event)
     count = 3
 
+    alias = "condition step"
     sequence = cv.SCRIPT_SCHEMA(
         {
+            "alias": alias,
             "repeat": {
                 "count": count,
                 "sequence": {
@@ -1158,7 +1175,7 @@ async def test_repeat_count(hass):
                         "last": "{{ repeat.last }}",
                     },
                 },
-            }
+            },
         }
     )
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
@@ -1171,6 +1188,7 @@ async def test_repeat_count(hass):
         assert event.data.get("first") == (index == 0)
         assert event.data.get("index") == index + 1
         assert event.data.get("last") == (index == count - 1)
+    assert caplog.text.count(f"Repeating {alias}") == count
 
 
 @pytest.mark.parametrize("condition", ["while", "until"])
@@ -1470,26 +1488,44 @@ async def test_choose_warning(hass, caplog):
 
 
 @pytest.mark.parametrize("var,result", [(1, "first"), (2, "second"), (3, "default")])
-async def test_choose(hass, var, result):
+async def test_choose(hass, caplog, var, result):
     """Test choose action."""
     event = "test_event"
     events = async_capture_events(hass, event)
+    alias = "choose step"
+    choice = {1: "choice one", 2: "choice two", 3: None}
+    aliases = {1: "sequence one", 2: "sequence two", 3: "default sequence"}
     sequence = cv.SCRIPT_SCHEMA(
         {
+            "alias": alias,
             "choose": [
                 {
+                    "alias": choice[1],
                     "conditions": {
                         "condition": "template",
                         "value_template": "{{ var == 1 }}",
                     },
-                    "sequence": {"event": event, "event_data": {"choice": "first"}},
+                    "sequence": {
+                        "alias": aliases[1],
+                        "event": event,
+                        "event_data": {"choice": "first"},
+                    },
                 },
                 {
+                    "alias": choice[2],
                     "conditions": "{{ var == 2 }}",
-                    "sequence": {"event": event, "event_data": {"choice": "second"}},
+                    "sequence": {
+                        "alias": aliases[2],
+                        "event": event,
+                        "event_data": {"choice": "second"},
+                    },
                 },
             ],
-            "default": {"event": event, "event_data": {"choice": "default"}},
+            "default": {
+                "alias": aliases[3],
+                "event": event,
+                "event_data": {"choice": "default"},
+            },
         }
     )
     script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
@@ -1499,6 +1535,10 @@ async def test_choose(hass, var, result):
 
     assert len(events) == 1
     assert events[0].data["choice"] == result
+    expected_choice = choice[var]
+    if var == 3:
+        expected_choice = "default"
+    assert f"{alias}: {expected_choice}: Executing step {aliases[var]}" in caplog.text
 
 
 @pytest.mark.parametrize(
@@ -2115,9 +2155,10 @@ async def test_started_action(hass, caplog):
 
 async def test_set_variable(hass, caplog):
     """Test setting variables in scripts."""
+    alias = "variables step"
     sequence = cv.SCRIPT_SCHEMA(
         [
-            {"variables": {"variable": "value"}},
+            {"alias": alias, "variables": {"variable": "value"}},
             {"service": "test.script", "data": {"value": "{{ variable }}"}},
         ]
     )
@@ -2129,6 +2170,7 @@ async def test_set_variable(hass, caplog):
     await hass.async_block_till_done()
 
     assert mock_calls[0].data["value"] == "value"
+    assert f"Executing step {alias}" in caplog.text
 
 
 async def test_set_redefines_variable(hass, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
See: [WTH can’t we annotate sequence steps for logging?](https://community.home-assistant.io/t/wth-cant-we-annotate-sequence-steps-for-logging-executing-step-call-service-make-lights-blue/224447).

The backend already has the `alias` field to mostly achieve this WTH. But `alias` is not supported for all action steps.

This PR:
- Adds `alias` to the following action step type schemas:
  - `device`
  - `scene`
  - alias for `choose` choices
- Adds `alias` to all conditions -- "numeric_state", "state", "sun", etc..
- Consolidates duplicate calls to `self._log("Executing step ...` into a common method

This is #40772 by @donkawechico, with updated tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example script.yaml
test_alias:
  alias: Test Alias
  sequence:
  - type: turn_off
    device_id: 401d32d1bfd440f0b887f02d2b8d5c66
    entity_id: light.chandelier
    domain: light
    alias: TURN OFF CHANDELIER
  - condition: state
    entity_id: light.chandelier
    state: 'off'
    alias: LEAVE SCRIPT IF CHANDELIER DIDNT TURN ON
  - scene: scene.warm
    alias: ACTUALLY FORGET THE CHANDELIER JUST MAKE IT NICE
  mode: single
  # ...
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to WTH thread: https://community.home-assistant.io/t/wth-cant-we-annotate-sequence-steps-for-logging-executing-step-call-service-make-lights-blue/224447
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16695, https://github.com/home-assistant/home-assistant.io/pull/16697

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
