### PR TITLE
Add selectors to Input * service definitions

### DIFF
--- a/homeassistant/components/input_boolean/services.yaml
+++ b/homeassistant/components/input_boolean/services.yaml
@@ -1,20 +1,14 @@
 toggle:
-  description: Toggles an input boolean.
-  fields:
-    entity_id:
-      description: Entity id of the input boolean to toggle.
-      example: input_boolean.notify_alerts
+  description: Toggle an input boolean
+  target:
+
 turn_off:
-  description: Turns off an input boolean
-  fields:
-    entity_id:
-      description: Entity id of the input boolean to turn off.
-      example: input_boolean.notify_alerts
+  description: Turn off an input boolean
+  target:
+
 turn_on:
-  description: Turns on an input boolean.
-  fields:
-    entity_id:
-      description: Entity id of the input boolean to turn on.
-      example: input_boolean.notify_alerts
+  description: Turn on an input boolean
+  target:
+
 reload:
-  description: Reload the input_boolean configuration.
+  description: Reload the input_boolean configuration

--- a/homeassistant/components/input_datetime/services.yaml
+++ b/homeassistant/components/input_datetime/services.yaml
@@ -1,21 +1,36 @@
 set_datetime:
-  description: This can be used to dynamically set the date and/or time. Use date/time, datetime or timestamp.
+  description: This can be used to dynamically set the date and/or time
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input datetime to set the new value.
-      example: input_datetime.test_date_time
     date:
+      name: Date
       description: The target date the entity should be set to.
       example: '"2019-04-20"'
+      selector:
+        text:
     time:
+      name: Time
       description: The target time the entity should be set to.
       example: '"05:04:20"'
+      selector:
+        time:
     datetime:
+      name: Date & Time
       description: The target date & time the entity should be set to.
       example: '"2019-04-20 05:04:20"'
+      selector:
+        text:
     timestamp:
-      description: The target date & time the entity should be set to as expressed by a UNIX timestamp.
+      name: Timestamp
+      description:
+        The target date & time the entity should be set to as expressed by a
+        UNIX timestamp.
       example: 1598027400
+      selector:
+        number:
+          min: 0
+          max: 9223372036854775807
+          mode: box
 
 reload:
-  description: Reload the input_datetime configuration.
+  description: Reload the input_datetime configuration

--- a/homeassistant/components/input_number/services.yaml
+++ b/homeassistant/components/input_number/services.yaml
@@ -19,7 +19,7 @@ set_value:
         number:
           min: 0
           max: 9223372036854775807
-          step: 0.000001
+          step: 0.001
           mode: box
 reload:
   description: Reload the input_number configuration.

--- a/homeassistant/components/input_number/services.yaml
+++ b/homeassistant/components/input_number/services.yaml
@@ -1,23 +1,25 @@
 decrement:
-  description: Decrement the value of an input number entity by its stepping.
-  fields:
-    entity_id:
-      description: Entity id of the input number that should be decremented.
-      example: input_number.threshold
+  description: Decrement the value of an input number entity by its stepping
+  target:
+
 increment:
-  description: Increment the value of an input number entity by its stepping.
-  fields:
-    entity_id:
-      description: Entity id of the input number that should be incremented.
-      example: input_number.threshold
+  description: Increment the value of an input number entity by its stepping
+  target:
+
 set_value:
-  description: Set the value of an input number entity.
+  description: Set the value of an input number entity
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input number to set the new value.
-      example: input_number.threshold
     value:
+      name: Value
       description: The target value the entity should be set to.
+      required: true
       example: 42
+      selector:
+        number:
+          min: 0
+          max: 9223372036854775807
+          step: 0.000001
+          mode: box
 reload:
   description: Reload the input_number configuration.

--- a/homeassistant/components/input_select/services.yaml
+++ b/homeassistant/components/input_select/services.yaml
@@ -31,7 +31,8 @@ select_previous:
       description: If the option should cycle from the first to the last.
       default: true
       example: true
-      selector: boolean
+      selector:
+        boolean:
 
 select_first:
   description: Select the first option of an input select entity

--- a/homeassistant/components/input_select/services.yaml
+++ b/homeassistant/components/input_select/services.yaml
@@ -19,7 +19,7 @@ select_option:
       description: Option to be selected.
       required: true
       example: '"Item A"'
-      select:
+      selector:
         text:
 
 select_previous:

--- a/homeassistant/components/input_select/services.yaml
+++ b/homeassistant/components/input_select/services.yaml
@@ -1,50 +1,57 @@
 select_next:
-  description: Select the next options of an input select entity.
+  description: Select the next options of an input select entity
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input select to select the next value for.
-      example: input_select.my_select
     cycle:
-      description: If the option should cycle from the last to the first (defaults to true).
+      name: Cycle
+      description: If the option should cycle from the last to the first.
+      default: true
       example: true
+      selector:
+        boolean:
+
 select_option:
-  description: Select an option of an input select entity.
+  description: Select an option of an input select entity
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input select to select the value.
-      example: input_select.my_select
     option:
+      name: Option
       description: Option to be selected.
+      required: true
       example: '"Item A"'
+      select:
+        text:
+
 select_previous:
-  description: Select the previous options of an input select entity.
+  description: Select the previous options of an input select entity
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input select to select the previous value for.
-      example: input_select.my_select
     cycle:
-      description: If the option should cycle from the first to the last (defaults to true).
+      name: Cycle
+      description: If the option should cycle from the first to the last.
+      default: true
       example: true
+      selector: boolean
+
 select_first:
-  description: Select the first option of an input select entity.
-  fields:
-    entity_id:
-      description: Entity id of the input select to select the first value for.
-      example: input_select.my_select
+  description: Select the first option of an input select entity
+  target:
+
 select_last:
-  description: Select the last option of an input select entity.
-  fields:
-    entity_id:
-      description: Entity id of the input select to select the last value for.
-      example: input_select.my_select
+  description: Select the last option of an input select entity
+  target:
+
 set_options:
-  description: Set the options of an input select entity.
+  description: Set the options of an input select entity
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input select to set the new options for.
-      example: input_select.my_select
     options:
+      name: Options
       description: Options for the input select entity.
+      required: true
       example: '["Item A", "Item B", "Item C"]'
+      selector:
+        object:
+
 reload:
   description: Reload the input_select configuration.

--- a/homeassistant/components/input_text/services.yaml
+++ b/homeassistant/components/input_text/services.yaml
@@ -1,11 +1,14 @@
 set_value:
-  description: Set the value of an input text entity.
+  description: Set the value of an input text entity
+  target:
   fields:
-    entity_id:
-      description: Entity id of the input text to set the new value.
-      example: input_text.text1
     value:
+      name: Value
       description: The target value the entity should be set to.
+      required: true
       example: This is an example text
+      selector:
+        text:
+
 reload:
   description: Reload the input_text configuration.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add selectors to the service descriptions of all `input_*` integrations.

Implemented in #46410

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
