### PR TITLE
Fix KeyError in comfoconnect percentage

### DIFF
--- a/homeassistant/components/comfoconnect/fan.py
+++ b/homeassistant/components/comfoconnect/fan.py
@@ -96,7 +96,7 @@ class ComfoConnectFan(FanEntity):
     @property
     def percentage(self) -> str:
         """Return the current speed percentage."""
-        speed = self._ccb.data[SENSOR_FAN_SPEED_MODE]
+        speed = self._ccb.data.get(SENSOR_FAN_SPEED_MODE)
         if speed is None:
             return None
         return ranged_value_to_percentage(SPEED_RANGE, speed)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It looks like there is occasionally a race condition that occurs in the comfoconnect test_sensor::test_sensors method. It appears that sometimes the [update](https://github.com/home-assistant/core/blob/960b5b7d86dcb32a720b8e87e5403df9e5ae466b/homeassistant/components/comfoconnect/fan.py#L56) doesn't get scheduled before the [percentage is checked](https://github.com/home-assistant/core/blob/960b5b7d86dcb32a720b8e87e5403df9e5ae466b/homeassistant/components/comfoconnect/fan.py#L99). 

Tested 250 times and saw no flakes with this PR.
pytest --count=250 --timeout=3 tests/components/comfoconnect/test_sensor.py::test_sensors

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
https://github.com/home-assistant/core/runs/1913013607?check_suite_focus=true
```
__________________ ERROR at teardown of test_sensors[pyloop] ___________________
[gw0] linux -- Python 3.8.2 /__w/core/core/venv/bin/python

loop = <_UnixSelectorEventLoop running=False closed=True debug=False>
load_registries = True
hass_storage = {'core.entity_registry': {'data': {'entities': [{'area_id': None, 'capabilities': None, 'config_entry_id': None, 'devi...eed_list': [...]}, 'config_entry_id': None, 'device_class': None, ...}]}, 'key': 'core.entity_registry', 'version': 1}}
request = <SubRequest 'hass' for <Function test_sensors[pyloop]>>

    @pytest.fixture
    def hass(loop, load_registries, hass_storage, request):
        """Fixture to provide a test instance of Home Assistant."""
    
        def exc_handle(loop, context):
            """Handle exceptions by rethrowing them, which will fail the test."""
            # Most of these contexts will contain an exception, but not all.
            # The docs note the key as "optional"
            # See https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.call_exception_handler
            if "exception" in context:
                exceptions.append(context["exception"])
            else:
                exceptions.append(
                    Exception(
                        "Received exception handler without exception, but with message: %s"
                        % context["message"]
                    )
                )
            orig_exception_handler(loop, context)
    
        exceptions = []
        hass = loop.run_until_complete(async_test_home_assistant(loop, load_registries))
        orig_exception_handler = loop.get_exception_handler()
        loop.set_exception_handler(exc_handle)
    
        yield hass
    
        loop.run_until_complete(hass.async_stop(force=True))
        for ex in exceptions:
            if (
                request.module.__name__,
                request.function.__name__,
            ) in IGNORE_UNCAUGHT_EXCEPTIONS:
                continue
            if isinstance(ex, ServiceNotFound):
                continue
>           raise ex

tests/conftest.py:169: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
homeassistant/helpers/entity_platform.py:317: in async_add_entities
    await asyncio.gather(*tasks)
homeassistant/helpers/entity_platform.py:508: in _async_add_entity
    await entity.add_to_platform_finish()
homeassistant/helpers/entity.py:530: in add_to_platform_finish
    self.async_write_ha_state()
homeassistant/helpers/entity.py:295: in async_write_ha_state
    self._async_write_ha_state()
homeassistant/helpers/entity.py:319: in _async_write_ha_state
    sstate = self.state
homeassistant/helpers/entity.py:693: in state
    return STATE_ON if self.is_on else STATE_OFF
homeassistant/components/fan/__init__.py:364: in is_on
    return self.speed not in [SPEED_OFF, None]
homeassistant/components/fan/__init__.py:395: in speed
    percentage = self.percentage
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[KeyError(65) raised in repr()] ComfoConnectFan object at 0x7fb500092a30>

    @property
    def percentage(self) -> str:
        """Return the current speed percentage."""
>       speed = self._ccb.data[SENSOR_FAN_SPEED_MODE]
E       KeyError: 65

homeassistant/components/comfoconnect/fan.py:99: KeyError
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
