### PR TITLE
Support all Xiaomi Miio gateway switches

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -26,7 +26,7 @@ from .gateway import ConnectXiaomiGateway
 
 _LOGGER = logging.getLogger(__name__)
 
-GATEWAY_PLATFORMS = ["alarm_control_panel", "sensor", "switch", "light"]
+GATEWAY_PLATFORMS = ["alarm_control_panel", "light", "sensor", "switch"]
 SWITCH_PLATFORMS = ["switch"]
 FAN_PLATFORMS = ["fan"]
 LIGHT_PLATFORMS = ["light"]

--- a/homeassistant/components/xiaomi_miio/sensor.py
+++ b/homeassistant/components/xiaomi_miio/sensor.py
@@ -21,9 +21,11 @@ from homeassistant.const import (
     CONF_TOKEN,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
     PERCENTAGE,
+    POWER_WATT,
     PRESSURE_HPA,
     TEMP_CELSIUS,
 )
@@ -76,6 +78,9 @@ GATEWAY_SENSOR_TYPES = {
     ),
     "pressure": SensorType(
         unit=PRESSURE_HPA, icon=None, device_class=DEVICE_CLASS_PRESSURE
+    ),
+    "load_power": SensorType(
+        unit=POWER_WATT, icon=None, device_class=DEVICE_CLASS_POWER
     ),
 }
 

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -47,7 +47,11 @@ MODEL_POWER_STRIP_V2 = "zimi.powerstrip.v2"
 MODEL_PLUG_V3 = "chuangmi.plug.v3"
 
 KEY_CHANNEL = "channel"
-GATEWAY_SWITCH_VARS = {"status_ch0": {KEY_CHANNEL: 0}, "status_ch1": {KEY_CHANNEL: 1}, "status_ch2": {KEY_CHANNEL: 2}}
+GATEWAY_SWITCH_VARS = {
+    "status_ch0": {KEY_CHANNEL: 0},
+    "status_ch1": {KEY_CHANNEL: 1},
+    "status_ch2": {KEY_CHANNEL: 2},
+}
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
@@ -278,21 +282,15 @@ class XiaomiGatewaySwitch(XiaomiGatewayDevice, SwitchEntity):
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
-        await self.hass.async_add_executor_job(
-            self._sub_device.on, self._channel
-        )
+        await self.hass.async_add_executor_job(self._sub_device.on, self._channel)
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
-        await self.hass.async_add_executor_job(
-            self._sub_device.off, self._channel
-        )
+        await self.hass.async_add_executor_job(self._sub_device.off, self._channel)
 
     async def async_toggle(self, **kwargs):
         """Toggle the switch."""
-        await self.hass.async_add_executor_job(
-            self._sub_device.toggle, self._channel
-        )
+        await self.hass.async_add_executor_job(self._sub_device.toggle, self._channel)
 
 
 class XiaomiPlugGenericSwitch(XiaomiMiioEntity, SwitchEntity):

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -277,19 +277,19 @@ class XiaomiGatewaySwitch(XiaomiGatewayDevice, SwitchEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         await self.hass.async_add_executor_job(
-            partial(self._sub_device.on, self._channel)
+            self._sub_device.on, self._channel
         )
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         await self.hass.async_add_executor_job(
-            partial(self._sub_device.off, self._channel)
+            self._sub_device.off, self._channel
         )
 
     async def async_toggle(self, **kwargs):
         """Toggle the switch."""
         await self.hass.async_add_executor_job(
-            partial(self._sub_device.toggle, self._channel)
+            self._sub_device.toggle, self._channel
         )
 
 

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -147,19 +147,20 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         sub_devices = gateway.devices
         coordinator = hass.data[DOMAIN][config_entry.entry_id][KEY_COORDINATOR]
         for sub_device in sub_devices.values():
-            if sub_device.device_type == "Switch":
-                if "status_ch0" in sub_device.status.keys():
-                    entities.append(
-                        XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 0)
-                    )
-                if "status_ch1" in sub_device.status.keys():
-                    entities.append(
-                        XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 1)
-                    )
-                if "status_ch2" in sub_device.status.keys():
-                    entities.append(
-                        XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 2)
-                    )
+            if sub_device.device_type != "Switch":
+                continue
+            if "status_ch0" in sub_device.status:
+                entities.append(
+                    XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 0)
+                )
+            if "status_ch1" in sub_device.status:
+                entities.append(
+                    XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 1)
+                )
+            if "status_ch2" in sub_device.status:
+                entities.append(
+                    XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 2)
+                )
 
     if config_entry.data[CONF_FLOW_TYPE] == CONF_DEVICE or (
         config_entry.data[CONF_FLOW_TYPE] == CONF_GATEWAY

--- a/homeassistant/components/xiaomi_miio/switch.py
+++ b/homeassistant/components/xiaomi_miio/switch.py
@@ -7,7 +7,11 @@ from miio import AirConditioningCompanionV3, ChuangmiPlug, DeviceException, Powe
 from miio.powerstrip import PowerMode
 import voluptuous as vol
 
-from homeassistant.components.switch import DEVICE_CLASS_SWITCH, PLATFORM_SCHEMA, SwitchEntity
+from homeassistant.components.switch import (
+    DEVICE_CLASS_SWITCH,
+    PLATFORM_SCHEMA,
+    SwitchEntity,
+)
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -25,6 +29,7 @@ from .const import (
     CONF_GATEWAY,
     CONF_MODEL,
     DOMAIN,
+    KEY_COORDINATOR,
     SERVICE_SET_POWER_MODE,
     SERVICE_SET_POWER_PRICE,
     SERVICE_SET_WIFI_LED_OFF,
@@ -144,11 +149,17 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for sub_device in sub_devices.values():
             if sub_device.device_type == "Switch":
                 if "status_ch0" in sub_device.status.keys():
-                    entities.append(XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 0))
+                    entities.append(
+                        XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 0)
+                    )
                 if "status_ch1" in sub_device.status.keys():
-                    entities.append(XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 1))
+                    entities.append(
+                        XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 1)
+                    )
                 if "status_ch2" in sub_device.status.keys():
-                    entities.append(XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 2))
+                    entities.append(
+                        XiaomiGatewaySwitch(coordinator, sub_device, config_entry, 2)
+                    )
 
     if config_entry.data[CONF_FLOW_TYPE] == CONF_DEVICE or (
         config_entry.data[CONF_FLOW_TYPE] == CONF_GATEWAY
@@ -248,6 +259,7 @@ class XiaomiGatewaySwitch(XiaomiGatewayDevice, SwitchEntity):
     def __init__(self, coordinator, sub_device, entry, channel):
         """Initialize the XiaomiSensor."""
         super().__init__(coordinator, sub_device, entry)
+        self._channel = channel
         self._data_key = f"status_ch{channel}"
         self._unique_id = f"{sub_device.sid}-ch{channel}"
         self._name = f"{sub_device.name} ch{channel} ({sub_device.sid})"
@@ -260,25 +272,25 @@ class XiaomiGatewaySwitch(XiaomiGatewayDevice, SwitchEntity):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self._sub_device.status[self._data_key] == 'on'
+        return self._sub_device.status[self._data_key] == "on"
 
     async def async_turn_on(self, **kwargs):
         """Turn the switch on."""
         await self.hass.async_add_executor_job(
-                partial(self._sub_device.on, channel)
-            )
+            partial(self._sub_device.on, self._channel)
+        )
 
     async def async_turn_off(self, **kwargs):
         """Turn the switch off."""
         await self.hass.async_add_executor_job(
-                partial(self._sub_device.off, channel)
-            )
+            partial(self._sub_device.off, self._channel)
+        )
 
     async def async_toggle(self, **kwargs):
         """Toggle the switch."""
         await self.hass.async_add_executor_job(
-                partial(self._sub_device.toggle, channel)
-            )
+            partial(self._sub_device.toggle, self._channel)
+        )
 
 
 class XiaomiPlugGenericSwitch(XiaomiMiioEntity, SwitchEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for all zigbee switches connected to a xiaomi gateway:

- lumi.relay.c2acn01
- lumi.ctrl_86plug.aq1
- lumi.ctrl_86plug.v1
- lumi.plug
- lumi.switch.l3acn3
- lumi.switch.n3acn3
- lumi.ctrl_ln2.aq1
- lumi.ctrl_ln1.aq1
- lumi.ctrl_ln2
- lumi.ctrl_ln1
- lumi.ctrl_neutral1.v1
- lumi.ctrl_neutral2

Python-miio 0.5.5 version bump:
https://github.com/rytilahti/python-miio/releases/tag/0.5.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Config Flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16617

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
