### PR TITLE
Add discontinuity support to HLS streams and fix nest expiring stream urls

### DIFF
--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -169,7 +169,7 @@ class Stream:
 
     def update_source(self, new_source):
         """Restart the stream with a new stream source."""
-        _LOGGER.debug("Updating stream source %s", self.source)
+        _LOGGER.debug("Updating stream source %s", new_source)
         self.source = new_source
         self._fast_restart_once = True
         self._thread_quit.set()
@@ -185,10 +185,10 @@ class Stream:
         while not self._thread_quit.wait(timeout=wait_timeout):
             start_time = time.time()
             stream_worker(self.source, self.options, segment_buffer, self._thread_quit)
+            segment_buffer.discontinuity()
             if not self.keepalive or self._thread_quit.is_set():
                 if self._fast_restart_once:
                     # The stream source is updated, restart without any delay.
-                    segment_buffer.discontinuity()
                     self._fast_restart_once = False
                     self._thread_quit.clear()
                     continue

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -30,6 +30,8 @@ class Segment:
     sequence: int = attr.ib()
     segment: io.BytesIO = attr.ib()
     duration: float = attr.ib()
+    # For detecting discontinuities across stream restarts
+    stream_id: int = attr.ib(default=None)
 
 
 class IdleTimer:

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -31,7 +31,7 @@ class Segment:
     segment: io.BytesIO = attr.ib()
     duration: float = attr.ib()
     # For detecting discontinuities across stream restarts
-    stream_id: int = attr.ib(default=None)
+    stream_id: int = attr.ib(default=0)
 
 
 class IdleTimer:

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -89,9 +89,9 @@ class HlsPlaylistView(StreamView):
                 "#EXT-X-DISCONTINUITY-SEQUENCE:{}".format(segments[0].stream_id)
             )
 
-        last_stream_id = None
+        last_stream_id = segments[0].stream_id
         for segment in segments:
-            if last_stream_id is not None and last_stream_id != segment.stream_id:
+            if last_stream_id != segment.stream_id:
                 playlist.append("#EXT-X-DISCONTINUITY")
             playlist.extend(
                 [

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -83,11 +83,10 @@ class HlsPlaylistView(StreamView):
         if not segments:
             return []
 
-        playlist = ["#EXT-X-MEDIA-SEQUENCE:{}".format(segments[0].sequence)]
-        if segments[0].stream_id:
-            playlist.append(
-                "#EXT-X-DISCONTINUITY-SEQUENCE:{}".format(segments[0].stream_id)
-            )
+        playlist = [
+            "#EXT-X-MEDIA-SEQUENCE:{}".format(segments[0].sequence),
+            "#EXT-X-DISCONTINUITY-SEQUENCE:{}".format(segments[0].stream_id),
+        ]
 
         last_stream_id = segments[0].stream_id
         for segment in segments:

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -24,45 +24,48 @@ def recorder_save_worker(file_out: str, segments: List[Segment], container_forma
     if not os.path.exists(os.path.dirname(file_out)):
         os.makedirs(os.path.dirname(file_out), exist_ok=True)
 
-    first_pts = {"video": None, "audio": None}
+    pts_adjuster = {"video": None, "audio": None}
     output = av.open(file_out, "w", format=container_format)
     output_v = None
     output_a = None
 
-    # Get first_pts values from first segment
-    if len(segments) > 0:
-        segment = segments[0]
-        source = av.open(segment.segment, "r", format=container_format)
-        source_v = source.streams.video[0]
-        first_pts["video"] = source_v.start_time
-        if len(source.streams.audio) > 0:
-            source_a = source.streams.audio[0]
-            first_pts["audio"] = int(
-                source_v.start_time * source_v.time_base / source_a.time_base
-            )
-        source.close()
+    last_stream_id = None
+    running_duration = 0  # the running duration of processed segments
 
     for segment in segments:
         # Open segment
         source = av.open(segment.segment, "r", format=container_format)
         source_v = source.streams.video[0]
-        # Add output streams
+        source_a = source.streams.audio[0] if len(source.streams.audio) > 0 else None
+
+        # Add output streams if necessary
         if not output_v:
             output_v = output.add_stream(template=source_v)
             context = output_v.codec_context
             context.flags |= "GLOBAL_HEADER"
-        if not output_a and len(source.streams.audio) > 0:
-            source_a = source.streams.audio[0]
+        if source_a and not output_a:
             output_a = output.add_stream(template=source_a)
+
+        # Recalculate pts adjustments on first segment and on any discontinuity
+        # We are assuming time base is the same across all discontinuities
+        if last_stream_id != segment.stream_id:
+            last_stream_id = segment.stream_id
+            pts_adjuster["video"] = running_duration - source_v.start_time
+            if source_a:
+                pts_adjuster["audio"] = running_duration - int(
+                    source_v.start_time * source_v.time_base / source_a.time_base
+                )
 
         # Remux video
         for packet in source.demux():
             if packet.dts is None:
                 continue
-            packet.pts -= first_pts[packet.stream.type]
-            packet.dts -= first_pts[packet.stream.type]
+            packet.pts += pts_adjuster[packet.stream.type]
+            packet.dts += pts_adjuster[packet.stream.type]
             packet.stream = output_v if packet.stream.type == "video" else output_a
             output.mux(packet)
+
+        running_duration += source_v.duration
 
         source.close()
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -115,9 +115,9 @@ class SegmentBuffer:
 
     def discontinuity(self):
         """Mark the stream as having been restarted."""
-        # Note: Sequence numbers are preserved to keep existing HLS view logic
-        # simple. The cursor logic expects unique sequence numbers though
-        # that is not required by the HLS protocol given a discontinuity.
+        # Preserving sequence and stream_id here keep the HLS playlist logic
+        # simple to check for discontinuity at output time, and to determine
+        # the discontinuity sequence number.
         self._stream_id += 1
 
     def close(self):

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -49,15 +49,21 @@ def create_stream_buffer(stream_output, video_stream, audio_stream, sequence):
 class SegmentBuffer:
     """Buffer for writing a sequence of packets to the output as a segment."""
 
-    def __init__(self, video_stream, audio_stream, outputs_callback) -> None:
+    def __init__(self, outputs_callback) -> None:
         """Initialize SegmentBuffer."""
-        self._video_stream = video_stream
-        self._audio_stream = audio_stream
+        self._stream_id = 0
+        self._video_stream = None
+        self._audio_stream = None
         self._outputs_callback = outputs_callback
         # tuple of StreamOutput, StreamBuffer
         self._outputs = []
         self._sequence = 0
         self._segment_start_pts = None
+
+    def set_streams(self, video_stream, audio_stream):
+        """Initialize output buffer with streams from container."""
+        self._video_stream = video_stream
+        self._audio_stream = audio_stream
 
     def reset(self, video_pts):
         """Initialize a new stream segment."""
@@ -103,7 +109,16 @@ class SegmentBuffer:
         """Create a segment from the buffered packets and write to output."""
         for (buffer, stream_output) in self._outputs:
             buffer.output.close()
-            stream_output.put(Segment(self._sequence, buffer.segment, duration))
+            stream_output.put(
+                Segment(self._sequence, buffer.segment, duration, self._stream_id)
+            )
+
+    def discontinuity(self):
+        """Mark the stream as having been restarted."""
+        # Note: Sequence numbers are preserved to keep existing HLS view logic
+        # simple. The cursor logic expects unique sequence numbers though
+        # that is not required by the HLS protocol given a discontinuity.
+        self._stream_id += 1
 
     def close(self):
         """Close all StreamBuffers."""
@@ -111,7 +126,7 @@ class SegmentBuffer:
             buffer.output.close()
 
 
-def stream_worker(source, options, outputs_callback, quit_event):
+def stream_worker(source, options, segment_buffer, quit_event):
     """Handle consuming streams."""
 
     try:
@@ -143,8 +158,6 @@ def stream_worker(source, options, outputs_callback, quit_event):
     last_dts = {video_stream: float("-inf"), audio_stream: float("-inf")}
     # Keep track of consecutive packets without a dts to detect end of stream.
     missing_dts = 0
-    # Holds the buffers for each stream provider
-    segment_buffer = SegmentBuffer(video_stream, audio_stream, outputs_callback)
     # The video pts at the beginning of the segment
     segment_start_pts = None
     # Because of problems 1 and 2 below, we need to store the first few packets and replay them
@@ -225,6 +238,7 @@ def stream_worker(source, options, outputs_callback, quit_event):
         container.close()
         return
 
+    segment_buffer.set_streams(video_stream, audio_stream)
     segment_buffer.reset(segment_start_pts)
 
     while not quit_event.is_set():

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -60,7 +60,7 @@ def make_segment(segment, discontinuity=False):
     return "\n".join(response)
 
 
-def make_playlist(sequence, discontinuity_sequence=None, segments=[]):
+def make_playlist(sequence, discontinuity_sequence=0, segments=[]):
     """Create a an hls playlist response for tests to assert on."""
     response = [
         "#EXTM3U",
@@ -68,9 +68,8 @@ def make_playlist(sequence, discontinuity_sequence=None, segments=[]):
         "#EXT-X-TARGETDURATION:10",
         '#EXT-X-MAP:URI="init.mp4"',
         f"#EXT-X-MEDIA-SEQUENCE:{sequence}",
+        f"#EXT-X-DISCONTINUITY-SEQUENCE:{discontinuity_sequence}",
     ]
-    if discontinuity_sequence:
-        response.append(f"#EXT-X-DISCONTINUITY-SEQUENCE:{discontinuity_sequence}")
     response.extend(segments)
     response.append("")
     return "\n".join(response)

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -51,7 +51,16 @@ def hls_stream(hass, hass_client):
     return create_client_for_stream
 
 
-def playlist_response(sequence, segments):
+def make_segment(segment, discontinuity=False):
+    """Create a playlist response for a segment."""
+    response = []
+    if discontinuity:
+        response.append("#EXT-X-DISCONTINUITY")
+    response.extend(["#EXTINF:10.0000,", f"./segment/{segment}.m4s"]),
+    return "\n".join(response)
+
+
+def make_playlist(sequence, discontinuity_sequence=None, segments=[]):
     """Create a an hls playlist response for tests to assert on."""
     response = [
         "#EXTM3U",
@@ -60,13 +69,9 @@ def playlist_response(sequence, segments):
         '#EXT-X-MAP:URI="init.mp4"',
         f"#EXT-X-MEDIA-SEQUENCE:{sequence}",
     ]
-    for segment in segments:
-        response.extend(
-            [
-                "#EXTINF:10.0000,",
-                f"./segment/{segment}.m4s",
-            ]
-        )
+    if discontinuity_sequence:
+        response.append(f"#EXT-X-DISCONTINUITY-SEQUENCE:{discontinuity_sequence}")
+    response.extend(segments)
     response.append("")
     return "\n".join(response)
 
@@ -289,13 +294,15 @@ async def test_hls_playlist_view(hass, hls_stream, stream_worker_sync):
 
     resp = await hls_client.get("/playlist.m3u8")
     assert resp.status == 200
-    assert await resp.text() == playlist_response(sequence=1, segments=[1])
+    assert await resp.text() == make_playlist(sequence=1, segments=[make_segment(1)])
 
     hls.put(Segment(2, SEQUENCE_BYTES, DURATION))
     await hass.async_block_till_done()
     resp = await hls_client.get("/playlist.m3u8")
     assert resp.status == 200
-    assert await resp.text() == playlist_response(sequence=1, segments=[1, 2])
+    assert await resp.text() == make_playlist(
+        sequence=1, segments=[make_segment(1), make_segment(2)]
+    )
 
     stream_worker_sync.resume()
     stream.stop()
@@ -321,8 +328,12 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
 
     # Only NUM_PLAYLIST_SEGMENTS are returned in the playlist.
     start = MAX_SEGMENTS + 2 - NUM_PLAYLIST_SEGMENTS
-    assert await resp.text() == playlist_response(
-        sequence=start, segments=range(start, MAX_SEGMENTS + 2)
+    segments = []
+    for sequence in range(start, MAX_SEGMENTS + 2):
+        segments.append(make_segment(sequence))
+    assert await resp.text() == make_playlist(
+        sequence=start,
+        segments=segments,
     )
 
     # Fetch the actual segments with a fake byte payload
@@ -337,6 +348,73 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
         for sequence in range(2, MAX_SEGMENTS + 2):
             segment_response = await hls_client.get(f"/segment/{sequence}.m4s")
             assert segment_response.status == 200
+
+    stream_worker_sync.resume()
+    stream.stop()
+
+
+async def test_hls_playlist_view_discontinuity(hass, hls_stream, stream_worker_sync):
+    """Test a discontinuity across segments in the stream with 3 segments."""
+    await async_setup_component(hass, "stream", {"stream": {}})
+
+    stream = create_stream(hass, STREAM_SOURCE)
+    stream_worker_sync.pause()
+    hls = stream.hls_output()
+
+    hls.put(Segment(1, SEQUENCE_BYTES, DURATION, stream_id=0))
+    hls.put(Segment(2, SEQUENCE_BYTES, DURATION, stream_id=0))
+    hls.put(Segment(3, SEQUENCE_BYTES, DURATION, stream_id=1))
+    await hass.async_block_till_done()
+
+    hls_client = await hls_stream(stream)
+
+    resp = await hls_client.get("/playlist.m3u8")
+    assert resp.status == 200
+    assert await resp.text() == make_playlist(
+        sequence=1,
+        segments=[
+            make_segment(1),
+            make_segment(2),
+            make_segment(3, discontinuity=True),
+        ],
+    )
+
+    stream_worker_sync.resume()
+    stream.stop()
+
+
+async def test_hls_max_segments_discontinuity(hass, hls_stream, stream_worker_sync):
+    """Test a discontinuity with more segments than the segment deque can hold."""
+    await async_setup_component(hass, "stream", {"stream": {}})
+
+    stream = create_stream(hass, STREAM_SOURCE)
+    stream_worker_sync.pause()
+    hls = stream.hls_output()
+
+    hls_client = await hls_stream(stream)
+
+    hls.put(Segment(1, SEQUENCE_BYTES, DURATION, stream_id=0))
+
+    # Produce enough segments to overfill the output buffer by one
+    for sequence in range(1, MAX_SEGMENTS + 2):
+        hls.put(Segment(sequence, SEQUENCE_BYTES, DURATION, stream_id=1))
+    await hass.async_block_till_done()
+
+    resp = await hls_client.get("/playlist.m3u8")
+    assert resp.status == 200
+
+    # Only NUM_PLAYLIST_SEGMENTS are returned in the playlist causing the
+    # EXT-X-DISCONTINUITY tag to be omitted and EXT-X-DISCONTINUITY-SEQUENCE
+    # returned instead.
+    start = MAX_SEGMENTS + 2 - NUM_PLAYLIST_SEGMENTS
+    segments = []
+    for sequence in range(start, MAX_SEGMENTS + 2):
+        segments.append(make_segment(sequence))
+    assert await resp.text() == make_playlist(
+        sequence=start,
+        discontinuity_sequence=1,
+        segments=segments,
+    )
 
     stream_worker_sync.resume()
     stream.stop()

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -27,7 +27,7 @@ from homeassistant.components.stream.const import (
     MIN_SEGMENT_DURATION,
     PACKETS_TO_WAIT_FOR_AUDIO,
 )
-from homeassistant.components.stream.worker import stream_worker
+from homeassistant.components.stream.worker import SegmentBuffer, stream_worker
 
 STREAM_SOURCE = "some-stream-source"
 # Formats here are arbitrary, not exercised by tests
@@ -197,7 +197,8 @@ async def async_decode_stream(hass, packets, py_av=None):
         "homeassistant.components.stream.core.StreamOutput.put",
         side_effect=py_av.capture_buffer.capture_output_segment,
     ):
-        stream_worker(STREAM_SOURCE, {}, stream.outputs, threading.Event())
+        segment_buffer = SegmentBuffer(stream.outputs)
+        stream_worker(STREAM_SOURCE, {}, segment_buffer, threading.Event())
         await hass.async_block_till_done()
 
     return py_av.capture_buffer
@@ -209,7 +210,8 @@ async def test_stream_open_fails(hass):
     stream.hls_output()
     with patch("av.open") as av_open:
         av_open.side_effect = av.error.InvalidDataError(-2, "error")
-        stream_worker(STREAM_SOURCE, {}, stream.outputs, threading.Event())
+        segment_buffer = SegmentBuffer(stream.outputs)
+        stream_worker(STREAM_SOURCE, {}, segment_buffer, threading.Event())
         await hass.async_block_till_done()
         av_open.assert_called_once()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for discontinuity in streams to better support `nest` expiring stream URLs and improving behavior when a `keepalive` stream fails and is restarted.

This is implemented using new tags [EXT-X-DISCONTINUITY](https://tools.ietf.org/html/rfc8216#section-4.3.2.3) and [EXT-X-DISCONTINUITY-SEQUENCE](https://tools.ietf.org/html/rfc8216#section-4.3.3.3).  The implementation turned out to be simpler than expected, entirely within `SegmentBuffer` and `HlsPlaylistView`without modifying `HlsStreamOutput`.  The approach is as follows:
- `SegmentBuffer` is now created in `Stream` and passed into `stream_worker`.  When a `stream_worker` exits, we can simply let `SegmentBuffer` know that a discontinuity was present
- The `SegmentBuffer` keeps track of the `stream_id`, which is effectively the stream discontinuity sequence number `EXT-X-DISCONTINUITY-SEQUENCE`
- The `HlsPlaylistView` includes a `EXT-X-DISCONTINUITY` tag when two back to back packets do not have the same `stream_id`
- The `EXT-X-DISCONTINUITY-SEQUENCE` is the id from the first packet in the playlist, elegantly handling the case where a previous discontinuity tag falls off the front of the playlist.

This was tested manually in chrome on mac for the expiring nest url case and a transient stream failure due to a keepalive stream.

Aside: I originally sent PR #46610 because during a previous implementation, I had all the logic in the `StreamOutput`: it was not preserving sequence numbers, and so the logic to implement `HlsSegmentView` was about to get more complex to identify segments across discontinuities.  Now that sequence numbers are preserved in `SegmentBuffer`, we can revert that change since this added no new logic to `StreamOutput`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42793
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/482
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
