### PR TITLE
Rollback stream StreamOutput refactoring in PR#46610

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -24,11 +24,7 @@ from homeassistant.components.media_player.const import (
     SERVICE_PLAY_MEDIA,
 )
 from homeassistant.components.stream import Stream, create_stream
-from homeassistant.components.stream.const import (
-    FORMAT_CONTENT_TYPE,
-    HLS_OUTPUT,
-    OUTPUT_FORMATS,
-)
+from homeassistant.components.stream.const import FORMAT_CONTENT_TYPE, OUTPUT_FORMATS
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_FILENAME,
@@ -259,7 +255,7 @@ async def async_setup(hass, config):
             if not stream:
                 continue
             stream.keepalive = True
-            stream.hls_output()
+            stream.add_provider("hls")
             stream.start()
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_START, preload_stream)
@@ -707,8 +703,6 @@ async def async_handle_play_stream_service(camera, service_call):
 
 
 async def _async_stream_endpoint_url(hass, camera, fmt):
-    if fmt != HLS_OUTPUT:
-        raise ValueError("Only format {HLS_OUTPUT} is supported")
     stream = await camera.create_stream()
     if not stream:
         raise HomeAssistantError(
@@ -719,9 +713,9 @@ async def _async_stream_endpoint_url(hass, camera, fmt):
     camera_prefs = hass.data[DATA_CAMERA_PREFS].get(camera.entity_id)
     stream.keepalive = camera_prefs.preload_stream
 
-    stream.hls_output()
+    stream.add_provider(fmt)
     stream.start()
-    return stream.endpoint_url()
+    return stream.endpoint_url(fmt)
 
 
 async def async_handle_record_service(camera, call):

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -1,14 +1,10 @@
 """Constants for Stream component."""
 DOMAIN = "stream"
 
-ATTR_HLS_ENDPOINT = "hls_endpoint"
+ATTR_ENDPOINTS = "endpoints"
 ATTR_STREAMS = "streams"
 
-HLS_OUTPUT = "hls"
-OUTPUT_FORMATS = [HLS_OUTPUT]
-OUTPUT_CONTAINER_FORMAT = "mp4"
-OUTPUT_VIDEO_CODECS = {"hevc", "h264"}
-OUTPUT_AUDIO_CODECS = {"aac", "mp3"}
+OUTPUT_FORMATS = ["hls"]
 
 FORMAT_CONTENT_TYPE = {"hls": "application/vnd.apple.mpegurl"}
 

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -1,15 +1,13 @@
 """Provide functionality to stream HLS."""
-import asyncio
-from collections import deque
 import io
-from typing import Any, Callable, List
+from typing import Callable
 
 from aiohttp import web
 
 from homeassistant.core import callback
 
-from .const import FORMAT_CONTENT_TYPE, MAX_SEGMENTS, NUM_PLAYLIST_SEGMENTS
-from .core import Segment, StreamOutput, StreamView
+from .const import FORMAT_CONTENT_TYPE, NUM_PLAYLIST_SEGMENTS
+from .core import PROVIDERS, StreamOutput, StreamView
 from .fmp4utils import get_codec_string, get_init, get_m4s
 
 
@@ -50,7 +48,8 @@ class HlsMasterPlaylistView(StreamView):
 
     async def handle(self, request, stream, sequence):
         """Return m3u8 playlist."""
-        track = stream.hls_output()
+        track = stream.add_provider("hls")
+        stream.start()
         # Wait for a segment to be ready
         if not track.segments:
             if not await track.recv():
@@ -109,7 +108,8 @@ class HlsPlaylistView(StreamView):
 
     async def handle(self, request, stream, sequence):
         """Return m3u8 playlist."""
-        track = stream.hls_output()
+        track = stream.add_provider("hls")
+        stream.start()
         # Wait for a segment to be ready
         if not track.segments:
             if not await track.recv():
@@ -127,7 +127,7 @@ class HlsInitView(StreamView):
 
     async def handle(self, request, stream, sequence):
         """Return init.mp4."""
-        track = stream.hls_output()
+        track = stream.add_provider("hls")
         segments = track.get_segment()
         if not segments:
             return web.HTTPNotFound()
@@ -144,7 +144,7 @@ class HlsSegmentView(StreamView):
 
     async def handle(self, request, stream, sequence):
         """Return fmp4 segment."""
-        track = stream.hls_output()
+        track = stream.add_provider("hls")
         segment = track.get_segment(int(sequence))
         if not segment:
             return web.HTTPNotFound()
@@ -155,15 +155,29 @@ class HlsSegmentView(StreamView):
         )
 
 
+@PROVIDERS.register("hls")
 class HlsStreamOutput(StreamOutput):
     """Represents HLS Output formats."""
 
-    def __init__(self, hass) -> None:
-        """Initialize HlsStreamOutput."""
-        super().__init__(hass)
-        self._cursor = None
-        self._event = asyncio.Event()
-        self._segments = deque(maxlen=MAX_SEGMENTS)
+    @property
+    def name(self) -> str:
+        """Return provider name."""
+        return "hls"
+
+    @property
+    def format(self) -> str:
+        """Return container format."""
+        return "mp4"
+
+    @property
+    def audio_codecs(self) -> str:
+        """Return desired audio codecs."""
+        return {"aac", "mp3"}
+
+    @property
+    def video_codecs(self) -> tuple:
+        """Return desired video codecs."""
+        return {"hevc", "h264"}
 
     @property
     def container_options(self) -> Callable[[int], dict]:
@@ -174,51 +188,3 @@ class HlsStreamOutput(StreamOutput):
             "avoid_negative_ts": "make_non_negative",
             "fragment_index": str(sequence),
         }
-
-    @property
-    def segments(self) -> List[int]:
-        """Return current sequence from segments."""
-        return [s.sequence for s in self._segments]
-
-    @property
-    def target_duration(self) -> int:
-        """Return the max duration of any given segment in seconds."""
-        segment_length = len(self._segments)
-        if not segment_length:
-            return 1
-        durations = [s.duration for s in self._segments]
-        return round(max(durations)) or 1
-
-    def get_segment(self, sequence: int = None) -> Any:
-        """Retrieve a specific segment, or the whole list."""
-        if not sequence:
-            return self._segments
-
-        for segment in self._segments:
-            if segment.sequence == sequence:
-                return segment
-        return None
-
-    async def recv(self) -> Segment:
-        """Wait for and retrieve the latest segment."""
-        last_segment = max(self.segments, default=0)
-        if self._cursor is None or self._cursor <= last_segment:
-            await self._event.wait()
-
-        if not self._segments:
-            return None
-
-        segment = self.get_segment()[-1]
-        self._cursor = segment.sequence
-        return segment
-
-    def _async_put(self, segment: Segment) -> None:
-        """Store output from event loop."""
-        self._segments.append(segment)
-        self._event.set()
-        self._event.clear()
-
-    def cleanup(self):
-        """Handle cleanup."""
-        self._event.set()
-        self._segments = deque(maxlen=MAX_SEGMENTS)

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -352,7 +352,7 @@ async def test_hls_playlist_view_discontinuity(hass, hls_stream, stream_worker_s
 
     stream = create_stream(hass, STREAM_SOURCE)
     stream_worker_sync.pause()
-    hls = stream.hls_output()
+    hls = stream.add_provider("hls")
 
     hls.put(Segment(1, SEQUENCE_BYTES, DURATION, stream_id=0))
     hls.put(Segment(2, SEQUENCE_BYTES, DURATION, stream_id=0))
@@ -382,7 +382,7 @@ async def test_hls_max_segments_discontinuity(hass, hls_stream, stream_worker_sy
 
     stream = create_stream(hass, STREAM_SOURCE)
     stream_worker_sync.pause()
-    hls = stream.hls_output()
+    hls = stream.add_provider("hls")
 
     hls_client = await hls_stream(stream)
 

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -45,7 +45,7 @@ def hls_stream(hass, hass_client):
 
     async def create_client_for_stream(stream):
         http_client = await hass_client()
-        parsed_url = urlparse(stream.endpoint_url())
+        parsed_url = urlparse(stream.endpoint_url("hls"))
         return HlsClient(http_client, parsed_url)
 
     return create_client_for_stream
@@ -91,7 +91,7 @@ async def test_hls_stream(hass, hls_stream, stream_worker_sync):
     stream = create_stream(hass, source)
 
     # Request stream
-    stream.hls_output()
+    stream.add_provider("hls")
     stream.start()
 
     hls_client = await hls_stream(stream)
@@ -132,9 +132,9 @@ async def test_stream_timeout(hass, hass_client, stream_worker_sync):
     stream = create_stream(hass, source)
 
     # Request stream
-    stream.hls_output()
+    stream.add_provider("hls")
     stream.start()
-    url = stream.endpoint_url()
+    url = stream.endpoint_url("hls")
 
     http_client = await hass_client()
 
@@ -174,16 +174,8 @@ async def test_stream_timeout_after_stop(hass, hass_client, stream_worker_sync):
     stream = create_stream(hass, source)
 
     # Request stream
-    stream.hls_output()
+    stream.add_provider("hls")
     stream.start()
-    url = stream.endpoint_url()
-
-    http_client = await hass_client()
-
-    # Fetch playlist
-    parsed_url = urlparse(url)
-    playlist_response = await http_client.get(parsed_url.path)
-    assert playlist_response.status == 200
 
     stream_worker_sync.resume()
     stream.stop()
@@ -204,10 +196,12 @@ async def test_stream_ended(hass, stream_worker_sync):
     # Setup demo HLS track
     source = generate_h264_video()
     stream = create_stream(hass, source)
+    track = stream.add_provider("hls")
 
     # Request stream
-    track = stream.hls_output()
+    stream.add_provider("hls")
     stream.start()
+    stream.endpoint_url("hls")
 
     # Run it dead
     while True:
@@ -233,7 +227,7 @@ async def test_stream_keepalive(hass):
     # Setup demo HLS track
     source = "test_stream_keepalive_source"
     stream = create_stream(hass, source)
-    track = stream.hls_output()
+    track = stream.add_provider("hls")
     track.num_segments = 2
     stream.start()
 
@@ -264,12 +258,12 @@ async def test_stream_keepalive(hass):
     stream.stop()
 
 
-async def test_hls_playlist_view_no_output(hass, hls_stream):
+async def test_hls_playlist_view_no_output(hass, hass_client, hls_stream):
     """Test rendering the hls playlist with no output segments."""
     await async_setup_component(hass, "stream", {"stream": {}})
 
     stream = create_stream(hass, STREAM_SOURCE)
-    stream.hls_output()
+    stream.add_provider("hls")
 
     hls_client = await hls_stream(stream)
 
@@ -284,7 +278,7 @@ async def test_hls_playlist_view(hass, hls_stream, stream_worker_sync):
 
     stream = create_stream(hass, STREAM_SOURCE)
     stream_worker_sync.pause()
-    hls = stream.hls_output()
+    hls = stream.add_provider("hls")
 
     hls.put(Segment(1, SEQUENCE_BYTES, DURATION))
     await hass.async_block_till_done()
@@ -313,7 +307,7 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
 
     stream = create_stream(hass, STREAM_SOURCE)
     stream_worker_sync.pause()
-    hls = stream.hls_output()
+    hls = stream.add_provider("hls")
 
     hls_client = await hls_stream(stream)
 

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -31,6 +31,7 @@ from homeassistant.components.stream.worker import SegmentBuffer, stream_worker
 
 STREAM_SOURCE = "some-stream-source"
 # Formats here are arbitrary, not exercised by tests
+STREAM_OUTPUT_FORMAT = "hls"
 AUDIO_STREAM_FORMAT = "mp3"
 VIDEO_STREAM_FORMAT = "h264"
 VIDEO_FRAME_RATE = 12
@@ -187,7 +188,7 @@ class MockPyAv:
 async def async_decode_stream(hass, packets, py_av=None):
     """Start a stream worker that decodes incoming stream packets into output segments."""
     stream = Stream(hass, STREAM_SOURCE)
-    stream.hls_output()
+    stream.add_provider(STREAM_OUTPUT_FORMAT)
 
     if not py_av:
         py_av = MockPyAv()
@@ -207,7 +208,7 @@ async def async_decode_stream(hass, packets, py_av=None):
 async def test_stream_open_fails(hass):
     """Test failure on stream open."""
     stream = Stream(hass, STREAM_SOURCE)
-    stream.hls_output()
+    stream.add_provider(STREAM_OUTPUT_FORMAT)
     with patch("av.open") as av_open:
         av_open.side_effect = av.error.InvalidDataError(-2, "error")
         segment_buffer = SegmentBuffer(stream.outputs)
@@ -484,7 +485,7 @@ async def test_stream_stopped_while_decoding(hass):
     worker_wake = threading.Event()
 
     stream = Stream(hass, STREAM_SOURCE)
-    stream.hls_output()
+    stream.add_provider(STREAM_OUTPUT_FORMAT)
 
     py_av = MockPyAv()
     py_av.container.packets = PacketSequence(TEST_SEQUENCE_LENGTH)
@@ -511,7 +512,7 @@ async def test_update_stream_source(hass):
     worker_wake = threading.Event()
 
     stream = Stream(hass, STREAM_SOURCE)
-    stream.hls_output()
+    stream.add_provider(STREAM_OUTPUT_FORMAT)
     # Note that keepalive is not set here.  The stream is "restarted" even though
     # it is not stopping due to failure.
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Rollback `stream` refactoring that split responsibilities of `StreamOutput`.  This adds back the generic abstraction since it turned out not to be necessary to split when implementing PR #46683 -- it ended up being proposed via `SegmentBuffer` rather than `StreamOutput`.

This is a clean rollback except for the changes merged in from these PRs:
- https://github.com/home-assistant/core/pull/46642
- https://github.com/home-assistant/core/pull/46640


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/architecture/issues/482
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
