### PR TITLE
Perform wemo state update quickly after a timeout

### DIFF
--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -58,7 +58,7 @@ class WemoEntity(Entity):
             return
 
         try:
-            with async_timeout.timeout(
+            async with async_timeout.timeout(
                 self.platform.scan_interval.seconds - 0.1
             ) as timeout:
                 await asyncio.shield(self._async_locked_update(True, timeout))

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -58,16 +58,28 @@ class WemoEntity(Entity):
             return
 
         try:
-            with async_timeout.timeout(self.platform.scan_interval.seconds - 0.1):
-                await asyncio.shield(self._async_locked_update(True))
+            with async_timeout.timeout(
+                self.platform.scan_interval.seconds - 0.1
+            ) as timeout:
+                await asyncio.shield(self._async_locked_update(True, timeout))
         except asyncio.TimeoutError:
             _LOGGER.warning("Lost connection to %s", self.name)
             self._available = False
 
-    async def _async_locked_update(self, force_update: bool) -> None:
+    async def _async_locked_update(
+        self, force_update: bool, timeout: Optional[async_timeout.timeout] = None
+    ) -> None:
         """Try updating within an async lock."""
         async with self._update_lock:
             await self.hass.async_add_executor_job(self._update, force_update)
+            # When the timeout expires HomeAssistant is no longer waiting for an
+            # update from the device. Instead, the state needs to be updated
+            # asynchronously. This also handles the case where an update came
+            # directly from the device (device push). In that case no polling
+            # update was involved and the state also needs to be updated
+            # asynchronously.
+            if not timeout or timeout.expired:
+                self.async_write_ha_state()
 
 
 class WemoSubscriptionEntity(WemoEntity):
@@ -121,4 +133,3 @@ class WemoSubscriptionEntity(WemoEntity):
             return
 
         await self._async_locked_update(force_update)
-        self.async_write_ha_state()

--- a/tests/components/wemo/entity_test_helpers.py
+++ b/tests/components/wemo/entity_test_helpers.py
@@ -6,6 +6,7 @@ import asyncio
 import threading
 from unittest.mock import patch
 
+import async_timeout
 from pywemo.ouimeaux_device.api.service import ActionException
 
 from homeassistant.components.homeassistant import (
@@ -146,7 +147,19 @@ async def test_async_update_with_timeout_and_recovery(hass, wemo_entity, pywemo_
     assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF
     await async_setup_component(hass, HA_DOMAIN, {})
 
-    with patch("async_timeout.timeout", side_effect=asyncio.TimeoutError):
+    event = threading.Event()
+
+    def get_state(*args):
+        event.wait()
+        return 0
+
+    if hasattr(pywemo_device, "bridge_update"):
+        pywemo_device.bridge_update.side_effect = get_state
+    else:
+        pywemo_device.get_state.side_effect = get_state
+    timeout = async_timeout.timeout(0)
+
+    with patch("async_timeout.timeout", return_value=timeout):
         await hass.services.async_call(
             HA_DOMAIN,
             SERVICE_UPDATE_ENTITY,
@@ -157,11 +170,6 @@ async def test_async_update_with_timeout_and_recovery(hass, wemo_entity, pywemo_
     assert hass.states.get(wemo_entity.entity_id).state == STATE_UNAVAILABLE
 
     # Check that the entity recovers and is available after the update succeeds.
-    await hass.services.async_call(
-        HA_DOMAIN,
-        SERVICE_UPDATE_ENTITY,
-        {ATTR_ENTITY_ID: [wemo_entity.entity_id]},
-        blocking=True,
-    )
-
+    event.set()
+    await hass.async_block_till_done()
     assert hass.states.get(wemo_entity.entity_id).state == STATE_OFF

--- a/tests/components/wemo/test_light_bridge.py
+++ b/tests/components/wemo/test_light_bridge.py
@@ -69,9 +69,10 @@ async def test_async_update_with_timeout_and_recovery(
     hass, pywemo_bridge_light, wemo_entity, pywemo_device
 ):
     """Test that the entity becomes unavailable after a timeout, and that it recovers."""
-    await entity_test_helpers.test_async_update_with_timeout_and_recovery(
-        hass, wemo_entity, pywemo_device
-    )
+    with _bypass_throttling():
+        await entity_test_helpers.test_async_update_with_timeout_and_recovery(
+            hass, wemo_entity, pywemo_device
+        )
 
 
 async def test_async_locked_update_with_exception(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The polling update for the wemo component entities has an async_timeout to prevent the update method from taking longer than the scan interval. If this timeout occurs then no further updates for the entity happen until the low-level device update completes. It then takes until the next scan interval before the update is processed. Rather than waiting till the next scan interval, this PR causes the state to be updated as soon as the low-level device update completes.

Note: This PR is not intended to close the linked issue. Further improvements are being made within pywemo.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #45904
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
