### PR TITLE
Centralize wemo exception handling

### DIFF
--- a/homeassistant/components/wemo/binary_sensor.py
+++ b/homeassistant/components/wemo/binary_sensor.py
@@ -2,8 +2,6 @@
 import asyncio
 import logging
 
-from pywemo.ouimeaux_device.api.service import ActionException
-
 from homeassistant.components.binary_sensor import BinarySensorEntity
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
@@ -35,12 +33,5 @@ class WemoBinarySensor(WemoSubscriptionEntity, BinarySensorEntity):
 
     def _update(self, force_update=True):
         """Update the sensor state."""
-        try:
+        with self._wemo_exception_handler("update status"):
             self._state = self.wemo.get_state(force_update)
-
-            if not self._available:
-                _LOGGER.info("Reconnected to %s", self.name)
-                self._available = True
-        except ActionException as err:
-            _LOGGER.warning("Could not update status for %s (%s)", self.name, err)
-            self._available = False

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -1,16 +1,30 @@
 """Classes shared among Wemo entities."""
 import asyncio
+import contextlib
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Generator, Optional
 
 import async_timeout
 from pywemo import WeMoDevice
+from pywemo.ouimeaux_device.api.service import ActionException
 
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN as WEMO_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class ExceptionHandlerStatus:
+    """Exit status from the _wemo_exception_handler context manager."""
+
+    # An exception if one was raised in the _wemo_exception_handler.
+    exception: Optional[Exception] = None
+
+    @property
+    def success(self) -> bool:
+        """Return True if the handler completed with no exception."""
+        return self.exception is None
 
 
 class WemoEntity(Entity):
@@ -35,6 +49,23 @@ class WemoEntity(Entity):
     def available(self) -> bool:
         """Return true if switch is available."""
         return self._available
+
+    @contextlib.contextmanager
+    def _wemo_exception_handler(
+        self, message: str
+    ) -> Generator[ExceptionHandlerStatus, None, None]:
+        """Wrap device calls to set `_available` when wemo exceptions happen."""
+        status = ExceptionHandlerStatus()
+        try:
+            yield status
+        except ActionException as err:
+            status.exception = err
+            _LOGGER.warning("Could not %s for %s (%s)", message, self.name, err)
+            self._available = False
+        else:
+            if not self._available:
+                _LOGGER.info("Reconnected to %s", self.name)
+                self._available = True
 
     def _update(self, force_update: Optional[bool] = True):
         """Update the device state."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are a few common steps that happen, to set `self._available`, during exception handling for calls to pywemo. The same boilerplate is copied several times across the platform code. This PR centralizes that logic inside the base `WemoEntity` class. After this PR all updates to `self._available` are encapsulated within the base class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
