### PR TITLE
Add ambient station particulate sensors and CO2 battery sensors

### DIFF
--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -60,6 +60,7 @@ TYPE_BATT6 = "batt6"
 TYPE_BATT7 = "batt7"
 TYPE_BATT8 = "batt8"
 TYPE_BATT9 = "batt9"
+TYPE_BATT_CO2 = "batt_co2"
 TYPE_BATTOUT = "battout"
 TYPE_CO2 = "co2"
 TYPE_DAILYRAININ = "dailyrainin"
@@ -82,6 +83,12 @@ TYPE_HUMIDITYIN = "humidityin"
 TYPE_LASTRAIN = "lastRain"
 TYPE_MAXDAILYGUST = "maxdailygust"
 TYPE_MONTHLYRAININ = "monthlyrainin"
+TYPE_PM25 = "pm25"
+TYPE_PM25_24H = "pm25_24h"
+TYPE_PM25_BATT = "batt_25"
+TYPE_PM25_IN = "pm25_in"
+TYPE_PM25_IN_24H = "pm25_in_24h"
+TYPE_PM25IN_BATT = "batt_25in"
 TYPE_RELAY1 = "relay1"
 TYPE_RELAY10 = "relay10"
 TYPE_RELAY2 = "relay2"
@@ -128,8 +135,6 @@ TYPE_TEMPF = "tempf"
 TYPE_TEMPINF = "tempinf"
 TYPE_TOTALRAININ = "totalrainin"
 TYPE_UV = "uv"
-TYPE_PM25 = "pm25"
-TYPE_PM25_24H = "pm25_24h"
 TYPE_WEEKLYRAININ = "weeklyrainin"
 TYPE_WINDDIR = "winddir"
 TYPE_WINDDIR_AVG10M = "winddir_avg10m"
@@ -155,6 +160,7 @@ SENSOR_TYPES = {
     TYPE_BATT8: ("Battery 8", None, TYPE_BINARY_SENSOR, "battery"),
     TYPE_BATT9: ("Battery 9", None, TYPE_BINARY_SENSOR, "battery"),
     TYPE_BATTOUT: ("Battery", None, TYPE_BINARY_SENSOR, "battery"),
+    TYPE_BATT_CO2: ("CO2 Battery", None, TYPE_BINARY_SENSOR, "battery"),
     TYPE_CO2: ("co2", CONCENTRATION_PARTS_PER_MILLION, TYPE_SENSOR, None),
     TYPE_DAILYRAININ: ("Daily Rain", "in", TYPE_SENSOR, None),
     TYPE_DEWPOINT: ("Dew Point", TEMP_FAHRENHEIT, TYPE_SENSOR, "temperature"),
@@ -176,6 +182,27 @@ SENSOR_TYPES = {
     TYPE_LASTRAIN: ("Last Rain", None, TYPE_SENSOR, "timestamp"),
     TYPE_MAXDAILYGUST: ("Max Gust", SPEED_MILES_PER_HOUR, TYPE_SENSOR, None),
     TYPE_MONTHLYRAININ: ("Monthly Rain", "in", TYPE_SENSOR, None),
+    TYPE_PM25_24H: (
+        "PM25 24h Avg",
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        TYPE_SENSOR,
+        None,
+    ),
+    TYPE_PM25_BATT: ("PM25 Battery", None, TYPE_BINARY_SENSOR, "battery"),
+    TYPE_PM25_IN: (
+        "PM25 Indoor",
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        TYPE_SENSOR,
+        None,
+    ),
+    TYPE_PM25_IN_24H: (
+        "PM25 Indoor 24h Avg",
+        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        TYPE_SENSOR,
+        None,
+    ),
+    TYPE_PM25: ("PM25", CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, TYPE_SENSOR, None),
+    TYPE_PM25IN_BATT: ("PM25 Indoor Battery", None, TYPE_BINARY_SENSOR, "battery"),
     TYPE_RELAY10: ("Relay 10", None, TYPE_BINARY_SENSOR, DEVICE_CLASS_CONNECTIVITY),
     TYPE_RELAY1: ("Relay 1", None, TYPE_BINARY_SENSOR, DEVICE_CLASS_CONNECTIVITY),
     TYPE_RELAY2: ("Relay 2", None, TYPE_BINARY_SENSOR, DEVICE_CLASS_CONNECTIVITY),
@@ -227,13 +254,6 @@ SENSOR_TYPES = {
     TYPE_TEMPINF: ("Inside Temp", TEMP_FAHRENHEIT, TYPE_SENSOR, "temperature"),
     TYPE_TOTALRAININ: ("Lifetime Rain", "in", TYPE_SENSOR, None),
     TYPE_UV: ("uv", "Index", TYPE_SENSOR, None),
-    TYPE_PM25: ("PM25", CONCENTRATION_MICROGRAMS_PER_CUBIC_METER, TYPE_SENSOR, None),
-    TYPE_PM25_24H: (
-        "PM25 24h Avg",
-        CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
-        TYPE_SENSOR,
-        None,
-    ),
     TYPE_WEEKLYRAININ: ("Weekly Rain", "in", TYPE_SENSOR, None),
     TYPE_WINDDIR: ("Wind Dir", DEGREE, TYPE_SENSOR, None),
     TYPE_WINDDIR_AVG10M: ("Wind Dir Avg 10m", DEGREE, TYPE_SENSOR, None),

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -16,6 +16,9 @@ from . import (
     TYPE_BATT9,
     TYPE_BATT10,
     TYPE_BATTOUT,
+    TYPE_PM25_CO2,
+    TYPE_PM25_BATT,
+    TYPE_PM25IN_BATT,
     AmbientWeatherEntity,
 )
 from .const import (
@@ -67,6 +70,9 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorEntity):
             TYPE_BATT7,
             TYPE_BATT8,
             TYPE_BATT9,
+            TYPE_PM25_CO2,
+            TYPE_PM25_BATT,
+            TYPE_PM25IN_BATT,
             TYPE_BATTOUT,
         ):
             return self._state == 0

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -70,10 +70,11 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorEntity):
             TYPE_BATT7,
             TYPE_BATT8,
             TYPE_BATT9,
+            TYPE_BATTOUT,
             TYPE_PM25_CO2,
             TYPE_PM25_BATT,
             TYPE_PM25IN_BATT,
-            TYPE_BATTOUT,
+            
         ):
             return self._state == 0
 

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -74,7 +74,6 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorEntity):
             TYPE_PM25_CO2,
             TYPE_PM25_BATT,
             TYPE_PM25IN_BATT,
-            
         ):
             return self._state == 0
 

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -16,8 +16,8 @@ from . import (
     TYPE_BATT9,
     TYPE_BATT10,
     TYPE_BATTOUT,
-    TYPE_PM25_CO2,
     TYPE_PM25_BATT,
+    TYPE_PM25_CO2,
     TYPE_PM25IN_BATT,
     AmbientWeatherEntity,
 )

--- a/homeassistant/components/ambient_station/binary_sensor.py
+++ b/homeassistant/components/ambient_station/binary_sensor.py
@@ -15,9 +15,9 @@ from . import (
     TYPE_BATT8,
     TYPE_BATT9,
     TYPE_BATT10,
+    TYPE_BATT_CO2,
     TYPE_BATTOUT,
     TYPE_PM25_BATT,
-    TYPE_PM25_CO2,
     TYPE_PM25IN_BATT,
     AmbientWeatherEntity,
 )
@@ -70,8 +70,8 @@ class AmbientWeatherBinarySensor(AmbientWeatherEntity, BinarySensorEntity):
             TYPE_BATT7,
             TYPE_BATT8,
             TYPE_BATT9,
+            TYPE_BATT_CO2,
             TYPE_BATTOUT,
-            TYPE_PM25_CO2,
             TYPE_PM25_BATT,
             TYPE_PM25IN_BATT,
         ):


### PR DESCRIPTION
Added Battery Sensors for Particulate Sensors and CO2

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.

Added in the Battery Sensors for PM25 Sensors and Co2
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
None
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X ] The code change is tested and works locally.
- [ X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
