### PR TITLE
Added Slovenian language (sl-si) to Microsoft TTS

### DIFF
--- a/homeassistant/components/microsoft/tts.py
+++ b/homeassistant/components/microsoft/tts.py
@@ -64,7 +64,7 @@ SUPPORTED_LANGUAGES = [
 ]
 
 GENDERS = ["Female", "Male"]
-OUTPUT = ["audio-16khz-128kbitrate-mono-mp3", "audio-48khz-192kbitrate-mono-mp3"]
+
 DEFAULT_LANG = "en-us"
 DEFAULT_GENDER = "Female"
 DEFAULT_TYPE = "ZiraRUS"
@@ -80,7 +80,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_API_KEY): cv.string,
         vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORTED_LANGUAGES),
         vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): vol.In(GENDERS),
-        vol.Optional(CONF_OUTPUT, default=DEFAULT_OUTPUT): vol.In(OUTPUT),
         vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
         vol.Optional(CONF_RATE, default=DEFAULT_RATE): vol.All(
             vol.Coerce(int), vol.Range(-100, 100)
@@ -101,7 +100,6 @@ def get_engine(hass, config, discovery_info=None):
         config[CONF_API_KEY],
         config[CONF_LANG],
         config[CONF_GENDER],
-        config[CONF_OUTPUT],
         config[CONF_TYPE],
         config[CONF_RATE],
         config[CONF_VOLUME],
@@ -115,14 +113,14 @@ class MicrosoftProvider(Provider):
     """The Microsoft speech API provider."""
 
     def __init__(
-        self, apikey, lang, gender, output, ttype, rate, volume, pitch, contour, region
+        self, apikey, lang, gender, ttype, rate, volume, pitch, contour, region
     ):
         """Init Microsoft TTS service."""
         self._apikey = apikey
         self._lang = lang
         self._gender = gender
         self._type = ttype
-        self._output = output
+        self._output = DEFAULT_OUTPUT
         self._rate = f"{rate}{PERCENTAGE}"
         self._volume = f"{volume}{PERCENTAGE}"
         self._pitch = pitch

--- a/homeassistant/components/microsoft/tts.py
+++ b/homeassistant/components/microsoft/tts.py
@@ -54,6 +54,7 @@ SUPPORTED_LANGUAGES = [
     "ro-ro",
     "ru-ru",
     "sk-sk",
+    "sl-si",
     "sv-se",
     "th-th",
     "tr-tr",
@@ -63,7 +64,7 @@ SUPPORTED_LANGUAGES = [
 ]
 
 GENDERS = ["Female", "Male"]
-
+OUTPUT = ["audio-16khz-128kbitrate-mono-mp3", "audio-48khz-192kbitrate-mono-mp3"]
 DEFAULT_LANG = "en-us"
 DEFAULT_GENDER = "Female"
 DEFAULT_TYPE = "ZiraRUS"
@@ -79,6 +80,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_API_KEY): cv.string,
         vol.Optional(CONF_LANG, default=DEFAULT_LANG): vol.In(SUPPORTED_LANGUAGES),
         vol.Optional(CONF_GENDER, default=DEFAULT_GENDER): vol.In(GENDERS),
+        vol.Optional(CONF_OUTPUT, default=DEFAULT_OUTPUT): vol.In(OUTPUT),
         vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): cv.string,
         vol.Optional(CONF_RATE, default=DEFAULT_RATE): vol.All(
             vol.Coerce(int), vol.Range(-100, 100)
@@ -99,6 +101,7 @@ def get_engine(hass, config, discovery_info=None):
         config[CONF_API_KEY],
         config[CONF_LANG],
         config[CONF_GENDER],
+        config[CONF_OUTPUT],
         config[CONF_TYPE],
         config[CONF_RATE],
         config[CONF_VOLUME],
@@ -112,14 +115,14 @@ class MicrosoftProvider(Provider):
     """The Microsoft speech API provider."""
 
     def __init__(
-        self, apikey, lang, gender, ttype, rate, volume, pitch, contour, region
+        self, apikey, lang, gender, output, ttype, rate, volume, pitch, contour, region
     ):
         """Init Microsoft TTS service."""
         self._apikey = apikey
         self._lang = lang
         self._gender = gender
         self._type = ttype
-        self._output = DEFAULT_OUTPUT
+        self._output = output
         self._rate = f"{rate}{PERCENTAGE}"
         self._volume = f"{volume}{PERCENTAGE}"
         self._pitch = pitch


### PR DESCRIPTION
Add support for Slovenian language.
I wanted to include configuration for additional audio options too, but decided to undo them after receiving a helpfull comment, therefore there are two commits. 

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
  - platform: microsoft
    api_key: YOURAPIKEYHERE
    region: westeurope
    gender: Female
    language: sl-si
    type: PetraNeural

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46621

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
