### PR TITLE
Add selectors to Vacuum service definitions

### DIFF
--- a/homeassistant/components/vacuum/services.yaml
+++ b/homeassistant/components/vacuum/services.yaml
@@ -1,87 +1,70 @@
 # Describes the format for available vacuum services
 
 turn_on:
-  description: Start a new cleaning task.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Start a new cleaning task
+  target:
 
 turn_off:
-  description: Stop the current cleaning task and return to home.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Stop the current cleaning task and return to home
+  target:
 
 stop:
-  description: Stop the current cleaning task.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Stop the current cleaning task
+  target:
 
 locate:
-  description: Locate the vacuum cleaner robot.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Locate the vacuum cleaner robot
+  target:
 
 start_pause:
-  description: Start, pause, or resume the cleaning task.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Start, pause, or resume the cleaning task
+  target:
 
 start:
-  description: Start or resume the cleaning task.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Start or resume the cleaning task
+  target:
 
 pause:
-  description: Pause the cleaning task.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Pause the cleaning task
+  target:
 
 return_to_base:
-  description: Tell the vacuum cleaner to return to its dock.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Tell the vacuum cleaner to return to its dock
+  target:
 
 clean_spot:
-  description: Tell the vacuum cleaner to do a spot clean-up.
-  fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
+  description: Tell the vacuum cleaner to do a spot clean-up
+  target:
 
 send_command:
-  description: Send a raw command to the vacuum cleaner.
+  description: Send a raw command to the vacuum cleaner
+  target:
   fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
     command:
+      name: Command
       description: Command to execute.
+      required: true
       example: "set_dnd_timer"
+      selector:
+        text:
+
     params:
+      name: Parameters
       description: Parameters for the command.
       example: '{ "key": "value" }'
+      selector:
+        object:
 
 set_fan_speed:
-  description: Set the fan speed of the vacuum cleaner.
+  description: Set the fan speed of the vacuum cleaner
+  target:
   fields:
-    entity_id:
-      description: Name of the vacuum entity.
-      example: "vacuum.xiaomi_vacuum_cleaner"
     fan_speed:
-      description: Platform dependent vacuum cleaner fan speed, with speed steps, like 'medium' or by percentage, between 0 and 100.
+      name: Fan speed
+      description:
+        Platform dependent vacuum cleaner fan speed, with speed steps, like
+        'medium' or by percentage, between 0 and 100.
+      required: true
       example: "low"
+      selector:
+        text:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add selectors to the service descriptions of the vacuum integration.

Implemented in #46410

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
