### PR TITLE
Add selectors to Logger, System Log & Logbook service definitions

### DIFF
--- a/homeassistant/components/logbook/services.yaml
+++ b/homeassistant/components/logbook/services.yaml
@@ -1,15 +1,29 @@
 log:
-  description: Create a custom entry in your logbook.
+  description: Create a custom entry in your logbook
   fields:
     name:
+      name: Name
       description: Custom name for an entity, can be referenced with entity_id
+      required: true
       example: "Kitchen"
+      selector:
+        text:
     message:
+      name: Message
       description: Message of the custom logbook entry
+      required: true
       example: "is being used"
+      selector:
+        text:
     entity_id:
+      name: Entity ID
       description: Entity to reference in custom logbook entry [Optional]
       example: "light.kitchen"
+      selector:
+        entity:
     domain:
+      name: Domain
       description: Icon of domain to display in custom logbook entry [Optional]
       example: "light"
+      selector:
+        text:

--- a/homeassistant/components/logger/services.yaml
+++ b/homeassistant/components/logger/services.yaml
@@ -1,22 +1,43 @@
 set_default_level:
-  description: Set the default log level for components.
+  description: Set the default log level for components
   fields:
     level:
-      description: "Default severity level. Possible values are debug, info, warn, warning, error, fatal, critical"
+      name: Level
+      description:
+        "Default severity level. Possible values are debug, info, warn, warning,
+        error, fatal, critical"
       example: debug
+      selector:
+        select:
+          options:
+            - debug
+            - info
+            - warning
+            - error
+            - fatal
+            - critical
 
 set_level:
-  description: Set log level for components.
+  description: Set log level for components
   fields:
     homeassistant.core:
-      description: "Example on how to change the logging level for a Home Assistant core components. Possible values are debug, info, warn, warning, error, fatal, critical"
+      description:
+        "Example on how to change the logging level for a Home Assistant core
+        components. Possible values are debug, info, warn, warning, error,
+        fatal, critical"
       example: debug
     homeassistant.components.mqtt:
-      description: "Example on how to change the logging level for an Integration. Possible values are debug, info, warn, warning, error, fatal, critical"
+      description:
+        "Example on how to change the logging level for an Integration. Possible
+        values are debug, info, warn, warning, error, fatal, critical"
       example: warning
     custom_components.my_integration:
-      description: "Example on how to change the logging level for a Custom Integration. Possible values are debug, info, warn, warning, error, fatal, critical"
+      description:
+        "Example on how to change the logging level for a Custom Integration.
+        Possible values are debug, info, warn, warning, error, fatal, critical"
       example: debug
     aiohttp:
-      description: "Example on how to change the logging level for a Python module. Possible values are debug, info, warn, warning, error, fatal, critical"
+      description:
+        "Example on how to change the logging level for a Python module.
+        Possible values are debug, info, warn, warning, error, fatal, critical"
       example: error

--- a/homeassistant/components/system_log/services.yaml
+++ b/homeassistant/components/system_log/services.yaml
@@ -1,15 +1,34 @@
 clear:
-  description: Clear all log entries.
+  description: Clear all log entries
 
 write:
-  description: Write log entry.
+  description: Write log entry
   fields:
     message:
-      description: Message to log. [Required]
+      name: Message
+      description: Message to log.
+      required: true
       example: Something went wrong
+      selector:
+        text:
     level:
-      description: "Log level: debug, info, warning, error, critical. Defaults to 'error'."
+      name: Level
+      description: "Log level: debug, info, warning, error, critical."
+      default: error
       example: debug
+      selector:
+        select:
+          options:
+            - "debug"
+            - "info"
+            - "warning"
+            - "error"
+            - "critical"
     logger:
-      description: Logger name under which to log the message. Defaults to 'system_log.external'.
+      name: Logger
+      description:
+        Logger name under which to log the message. Defaults to
+        'system_log.external'.
       example: mycomponent.myplatform
+      selector:
+        text:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add selectors to the service descriptions of the Logger, System Log & Logbooks integrations.

Implemented in #46410

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
