### PR TITLE
Support multiple batteries from Danfoss devices with deCONZ

### DIFF
--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -200,7 +200,18 @@ class DeconzBattery(DeconzDevice):
 
     @property
     def unique_id(self):
-        """Return a unique identifier for this device."""
+        """Return a unique identifier for this device.
+
+        Normally there should only be one battery sensor per device from deCONZ.
+        With specific Danfoss devices each endpoint can report its own battery state.
+        """
+        if self._device.manufacturer == "Danfoss" and self._device.modelid in [
+            "0x8030",
+            "0x8031",
+            "0x8034",
+            "0x8035",
+        ]:
+            return f"{super().unique_id}-battery"
         return f"{self.serial}-battery"
 
     @property

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 
 from homeassistant.components.deconz.const import CONF_ALLOW_CLIP_SENSOR
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ILLUMINANCE,
@@ -239,6 +240,142 @@ async def test_add_battery_later(hass, aioclient_mock):
     assert len(remote._callbacks) == 2  # Event and battery entity
 
     assert hass.states.get("sensor.switch_1_battery_level")
+
+
+async def test_special_danfoss_battery_creation(hass, aioclient_mock):
+    """Test the special Danfoss battery creation works.
+
+    Normally there should only be one battery sensor per device from deCONZ.
+    With specific Danfoss devices each endpoint can report its own battery state.
+    """
+    data = deepcopy(DECONZ_WEB_REQUEST)
+    data["sensors"] = {
+        "1": {
+            "config": {
+                "battery": 70,
+                "heatsetpoint": 2300,
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+                "schedule": {},
+                "schedule_on": False,
+            },
+            "ep": 1,
+            "etag": "982d9acc38bee5b251e24a9be26558e4",
+            "lastseen": "2021-02-15T12:23Z",
+            "manufacturername": "Danfoss",
+            "modelid": "0x8030",
+            "name": "0x8030",
+            "state": {
+                "lastupdated": "2021-02-15T12:23:07.994",
+                "on": False,
+                "temperature": 2307,
+            },
+            "swversion": "YYYYMMDD",
+            "type": "ZHAThermostat",
+            "uniqueid": "58:8e:81:ff:fe:00:11:22-01-0201",
+        },
+        "2": {
+            "config": {
+                "battery": 86,
+                "heatsetpoint": 2300,
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+                "schedule": {},
+                "schedule_on": False,
+            },
+            "ep": 2,
+            "etag": "62f12749f9f51c950086aff37dd02b61",
+            "lastseen": "2021-02-15T12:23Z",
+            "manufacturername": "Danfoss",
+            "modelid": "0x8030",
+            "name": "0x8030",
+            "state": {
+                "lastupdated": "2021-02-15T12:23:22.399",
+                "on": False,
+                "temperature": 2316,
+            },
+            "swversion": "YYYYMMDD",
+            "type": "ZHAThermostat",
+            "uniqueid": "58:8e:81:ff:fe:00:11:22-02-0201",
+        },
+        "3": {
+            "config": {
+                "battery": 86,
+                "heatsetpoint": 2350,
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+                "schedule": {},
+                "schedule_on": False,
+            },
+            "ep": 3,
+            "etag": "f50061174bb7f18a3d95789bab8b646d",
+            "lastseen": "2021-02-15T12:23Z",
+            "manufacturername": "Danfoss",
+            "modelid": "0x8030",
+            "name": "0x8030",
+            "state": {
+                "lastupdated": "2021-02-15T12:23:25.466",
+                "on": False,
+                "temperature": 2337,
+            },
+            "swversion": "YYYYMMDD",
+            "type": "ZHAThermostat",
+            "uniqueid": "58:8e:81:ff:fe:00:11:22-03-0201",
+        },
+        "4": {
+            "config": {
+                "battery": 85,
+                "heatsetpoint": 2300,
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+                "schedule": {},
+                "schedule_on": False,
+            },
+            "ep": 4,
+            "etag": "eea97adf8ce1b971b8b6a3a31793f96b",
+            "lastseen": "2021-02-15T12:23Z",
+            "manufacturername": "Danfoss",
+            "modelid": "0x8030",
+            "name": "0x8030",
+            "state": {
+                "lastupdated": "2021-02-15T12:23:41.939",
+                "on": False,
+                "temperature": 2333,
+            },
+            "swversion": "YYYYMMDD",
+            "type": "ZHAThermostat",
+            "uniqueid": "58:8e:81:ff:fe:00:11:22-04-0201",
+        },
+        "5": {
+            "config": {
+                "battery": 83,
+                "heatsetpoint": 2300,
+                "offset": 0,
+                "on": True,
+                "reachable": True,
+                "schedule": {},
+                "schedule_on": False,
+            },
+            "ep": 5,
+            "etag": "1f7cd1a5d66dc27ac5eb44b8c47362fb",
+            "lastseen": "2021-02-15T12:23Z",
+            "manufacturername": "Danfoss",
+            "modelid": "0x8030",
+            "name": "0x8030",
+            "state": {"lastupdated": "none", "on": False, "temperature": 2325},
+            "swversion": "YYYYMMDD",
+            "type": "ZHAThermostat",
+            "uniqueid": "58:8e:81:ff:fe:00:11:22-05-0201",
+        },
+    }
+    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+
+    assert len(hass.states.async_all()) == 10
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 5
 
 
 async def test_air_quality_sensor(hass, aioclient_mock):


### PR DESCRIPTION
With these Danfoss devices each endpoint can report its own battery state.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/Kane610/deconz/issues/95
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
