### PR TITLE
Add a service to reload config entries that can easily be called though automations

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -23,13 +23,17 @@ from homeassistant.exceptions import HomeAssistantError, Unauthorized, UnknownUs
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import async_extract_referenced_entity_ids
 
+ATTR_CONFIG_ENTRY_ID = "config_entry_id"
+
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = ha.DOMAIN
 SERVICE_RELOAD_CORE_CONFIG = "reload_core_config"
+SERVICE_RELOAD_CONFIG_ENTRY = "reload_config_entry"
 SERVICE_CHECK_CONFIG = "check_config"
 SERVICE_UPDATE_ENTITY = "update_entity"
 SERVICE_SET_LOCATION = "set_location"
 SCHEMA_UPDATE_ENTITY = vol.Schema({ATTR_ENTITY_ID: cv.entity_ids})
+SCHEMA_RELOAD_CONFIG_ENTRY = vol.Schema({vol.Required(ATTR_CONFIG_ENTRY_ID): str})
 
 
 async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
@@ -201,6 +205,17 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
         SERVICE_SET_LOCATION,
         async_set_location,
         vol.Schema({ATTR_LATITUDE: cv.latitude, ATTR_LONGITUDE: cv.longitude}),
+    )
+
+    async def async_handle_reload_config_entry(call):
+        """Service handler for reloading a config entry."""
+        await hass.config_entries.async_reload(call.data[ATTR_CONFIG_ENTRY_ID])
+
+    hass.helpers.service.async_register_admin_service(
+        ha.DOMAIN,
+        SERVICE_RELOAD_CONFIG_ENTRY,
+        async_handle_reload_config_entry,
+        schema=SCHEMA_RELOAD_CONFIG_ENTRY,
     )
 
     return True

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -26,8 +26,6 @@ from homeassistant.helpers.service import (
     async_extract_referenced_entity_ids,
 )
 
-ATTR_CONFIG_ENTRY_ID = "config_entry_id"
-
 _LOGGER = logging.getLogger(__name__)
 DOMAIN = ha.DOMAIN
 SERVICE_RELOAD_CORE_CONFIG = "reload_core_config"

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -20,9 +20,9 @@ from homeassistant.const import (
 )
 import homeassistant.core as ha
 from homeassistant.exceptions import HomeAssistantError, Unauthorized, UnknownUser
-from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.service import (
-    async_extract_entity_ids,
+    async_extract_config_entry_ids,
     async_extract_referenced_entity_ids,
 )
 
@@ -209,14 +209,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
 
     async def async_handle_reload_config_entry(call):
         """Service handler for reloading a config entry."""
-        reload_entries = set()
-        referenced = await async_extract_entity_ids(hass, call)
-        ent_reg = entity_registry.async_get(hass)
-        for entity_id in referenced:
-            entry = ent_reg.async_get(entity_id)
-            if entry is None:
-                raise ValueError("{entity_id} was not found in the entity registry")
-            reload_entries.add(entry.config_entry_id)
+        reload_entries = await async_extract_config_entry_ids(hass, call)
         if not reload_entries:
             raise ValueError("There were no matching config entries to reload")
         await asyncio.gather(

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -232,15 +232,11 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
         elif ATTR_ENTITY_ID:
             referenced = await async_extract_referenced_entity_ids(hass, call)
             ent_reg = entity_registry.async_get(hass)
-            for entity_id in referenced.referenced:
+            for entity_id in referenced.referenced | referenced.indirectly_referenced:
                 entry = ent_reg.async_get(entity_id)
                 if entry is None:
                     raise ValueError("{entity_id} was not found in the entity registry")
                 reload_entries.add(entry.config_entry_id)
-            for entity_id in referenced.indirectly_referenced:
-                entry = ent_reg.async_get(entity_id)
-                if entry is not None:
-                    reload_entries.add(entry.config_entry_id)
         await asyncio.gather(
             *[
                 hass.config_entries.async_reload(config_entry_id)

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -34,15 +34,13 @@ SERVICE_CHECK_CONFIG = "check_config"
 SERVICE_UPDATE_ENTITY = "update_entity"
 SERVICE_SET_LOCATION = "set_location"
 SCHEMA_UPDATE_ENTITY = vol.Schema({ATTR_ENTITY_ID: cv.entity_ids})
-SCHEMA_RELOAD_CONFIG_ENTRY = vol.All(
-    cv.has_at_least_one_key(ATTR_DOMAIN, ATTR_ENTITY_ID, ATTR_CONFIG_ENTRY_ID),
-    vol.Schema(
-        {
-            vol.Optional(ATTR_DOMAIN): cv.string,
-            vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-            vol.Optional(ATTR_CONFIG_ENTRY_ID): str,
-        }
-    ),
+SCHEMA_RELOAD_CONFIG_ENTRY = vol.Schema(
+    {
+        ATTR_DOMAIN: cv.string,
+        ATTR_ENTITY_ID: cv.entity_ids,
+        ATTR_CONFIG_ENTRY_ID: str,
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 
@@ -229,7 +227,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             if not config_entries:
                 raise ValueError(f"{domain} has no config entries")
             reload_entries.update(entry.entry_id for entry in config_entries)
-        elif ATTR_ENTITY_ID:
+        else:
             referenced = await async_extract_referenced_entity_ids(hass, call)
             ent_reg = entity_registry.async_get(hass)
             for entity_id in referenced.referenced | referenced.indirectly_referenced:

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -218,7 +218,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
                 raise ValueError("{entity_id} was not found in the entity registry")
             reload_entries.add(entry.config_entry_id)
         if not reload_entries:
-            raise ValueError("There were not matching config entries to reload")
+            raise ValueError("There were no matching config entries to reload")
         await asyncio.gather(
             *[
                 hass.config_entries.async_reload(config_entry_id)

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -63,7 +63,6 @@ reload_config_entry:
   name: Reload config entry
   description: Reload a config entry that matches an area, device, entity_id, config entry id, or integration domain.
   target:
-    entity: {}
   fields:
     config_entry_id:
       name: Config entry id

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -58,3 +58,14 @@ update_entity:
   description: Force one or more entities to update its data
   target:
     entity: {}
+
+reload_config_entry:
+  description: Reload a config entry
+  fields:
+    config_entry_id:
+      name: Config Entry Id
+      description: The configuration entry id
+      required: true
+      example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        text:

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -61,20 +61,5 @@ update_entity:
 
 reload_config_entry:
   name: Reload config entry
-  description: Reload a config entry that matches an area, device, entity_id, config entry id, or integration domain.
+  description: Reload a config entry that matches a target.
   target:
-  fields:
-    config_entry_id:
-      name: Config entry id
-      description: A configuration entry id
-      required: false
-      example: 8955375327824e14ba89e4b29cc3ec9a
-      selector:
-        text:
-    domain:
-      name: Integration domain
-      description: An integration domain. All configuration entries for the domain will be reloaded.
-      required: false
-      example: hue
-      selector:
-        text:

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -65,3 +65,12 @@ reload_config_entry:
   target:
     entity: {}
     device: {}
+  fields:
+    entry_id:
+      advanced: true
+      name: Config entry id
+      description: A configuration entry id
+      required: false
+      example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        text:

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -60,12 +60,21 @@ update_entity:
     entity: {}
 
 reload_config_entry:
-  description: Reload a config entry
+  description: Reload a config entry by providing a config_entry_id, a matching entity_id, or a domain.
+  target:
+    entity: {}
   fields:
     config_entry_id:
-      name: Config Entry Id
-      description: The configuration entry id
-      required: true
+      name: Config entry id
+      description: A configuration entry id
+      required: false
       example: 8955375327824e14ba89e4b29cc3ec9a
+      selector:
+        text:
+    domain:
+      name: Integration domain
+      description: An integration domain. All configuration entries for the domain will be reloaded.
+      required: false
+      example: hue
       selector:
         text:

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -63,3 +63,5 @@ reload_config_entry:
   name: Reload config entry
   description: Reload a config entry that matches a target.
   target:
+    entity: {}
+    device: {}

--- a/homeassistant/components/homeassistant/services.yaml
+++ b/homeassistant/components/homeassistant/services.yaml
@@ -60,7 +60,8 @@ update_entity:
     entity: {}
 
 reload_config_entry:
-  description: Reload a config entry by providing a config_entry_id, a matching entity_id, or a domain.
+  name: Reload config entry
+  description: Reload a config entry that matches an area, device, entity_id, config entry id, or integration domain.
   target:
     entity: {}
   fields:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -11,9 +11,9 @@ from typing import (
     Awaitable,
     Callable,
     Iterable,
-    Tuple,
+    Optional,
     TypedDict,
-    cast,
+    Union,
 )
 
 import voluptuous as vol
@@ -384,7 +384,7 @@ async def async_extract_config_entry_ids(
     )
     ent_reg = entity_registry.async_get(hass)
     dev_reg = device_registry.async_get(hass)
-    config_entry_ids: Set[str] = set()
+    config_entry_ids: set[str] = set()
 
     # Some devices may have no entities
     for device_id in referenced.referenced_devices:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -346,13 +346,13 @@ async def async_extract_referenced_entity_ids(
 
     ent_reg = entity_registry.async_get(hass)
     dev_reg = device_registry.async_get(hass)
+    area_reg = area_registry.async_get(hass)
 
     selected.referenced_devices.update(selector.device_ids)
     for device_id in selected.referenced_devices:
         if device_id not in dev_reg.devices:
             selected.missing_devices.add(device_id)
 
-    area_reg = area_registry.async_get(hass)
     for area_id in selector.area_ids:
         if area_id not in area_reg.areas:
             selected.missing_areas.add(area_id)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -78,15 +78,15 @@ class ServiceParams(TypedDict):
     target: dict | None
 
 
-class _ServiceTargetSelector:
+class ServiceTargetSelector:
     """Class to hold a target selector for a service."""
 
-    def __init__(
-        self,
-        entity_ids: Optional[Union[str, list]],
-        device_ids: Optional[Union[str, list]],
-        area_ids: Optional[Union[str, list]],
-    ):
+    def __init__(self, service_call: ha.ServiceCall):
+        """Extract ids from service call data."""
+        entity_ids: Optional[Union[str, list]] = service_call.data.get(ATTR_ENTITY_ID)
+        device_ids: Optional[Union[str, list]] = service_call.data.get(ATTR_DEVICE_ID)
+        area_ids: Optional[Union[str, list]] = service_call.data.get(ATTR_AREA_ID)
+
         self.entity_ids = cv.ensure_list(entity_ids)
         self.device_ids = cv.ensure_list(device_ids)
         self.area_ids = cv.ensure_list(area_ids)
@@ -96,6 +96,7 @@ class _ServiceTargetSelector:
 
     @property
     def has_any_selector(self) -> bool:
+        """Determine if any selectors are present."""
         return bool(self.selects_entity or self.selects_device or self.selects_area)
 
 
@@ -327,11 +328,7 @@ async def async_extract_referenced_entity_ids(
     hass: HomeAssistantType, service_call: ha.ServiceCall, expand_group: bool = True
 ) -> SelectedEntities:
     """Extract referenced entity IDs from a service call."""
-    selector = _ServiceTargetSelector(
-        service_call.data.get(ATTR_ENTITY_ID),
-        service_call.data.get(ATTR_DEVICE_ID),
-        service_call.data.get(ATTR_AREA_ID),
-    )
+    selector = ServiceTargetSelector(service_call)
     selected = SelectedEntities()
 
     if not selector.has_any_selector:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -78,6 +78,27 @@ class ServiceParams(TypedDict):
     target: dict | None
 
 
+class _ServiceTargetSelector:
+    """Class to hold a target selector for a service."""
+
+    def __init__(
+        self,
+        entity_ids: Optional[Union[str, list]],
+        device_ids: Optional[Union[str, list]],
+        area_ids: Optional[Union[str, list]],
+    ):
+        self.entity_ids = cv.ensure_list(entity_ids)
+        self.device_ids = cv.ensure_list(device_ids)
+        self.area_ids = cv.ensure_list(area_ids)
+        self.selects_entity: bool = _has_selects(entity_ids)
+        self.selects_device: bool = _has_selects(device_ids)
+        self.selects_area: bool = _has_selects(area_ids)
+
+    @property
+    def has_any_selector(self) -> bool:
+        return bool(self.selects_entity or self.selects_device or self.selects_area)
+
+
 @dataclasses.dataclass
 class SelectedEntities:
     """Class to hold the selected entities."""
@@ -92,6 +113,9 @@ class SelectedEntities:
     # Referenced items that could not be found.
     missing_devices: set[str] = dataclasses.field(default_factory=set)
     missing_areas: set[str] = dataclasses.field(default_factory=set)
+
+    # Referenced devices
+    referenced_devices: set[str] = dataclasses.field(default_factory=set)
 
     def log_missing(self, missing_entities: set[str]) -> None:
         """Log about missing items."""
@@ -293,72 +317,48 @@ async def async_extract_entity_ids(
     return referenced.referenced | referenced.indirectly_referenced
 
 
+def _has_selects(ids: Optional[Union[str, list]]) -> bool:
+    """Check if ids select anything."""
+    return ids not in (None, ENTITY_MATCH_NONE)
+
+
 @bind_hass
 async def async_extract_referenced_entity_ids(
     hass: HomeAssistantType, service_call: ha.ServiceCall, expand_group: bool = True
 ) -> SelectedEntities:
     """Extract referenced entity IDs from a service call."""
-    entity_ids = service_call.data.get(ATTR_ENTITY_ID)
-    device_ids = service_call.data.get(ATTR_DEVICE_ID)
-    area_ids = service_call.data.get(ATTR_AREA_ID)
-
-    selects_entity_ids = entity_ids not in (None, ENTITY_MATCH_NONE)
-    selects_device_ids = device_ids not in (None, ENTITY_MATCH_NONE)
-    selects_area_ids = area_ids not in (None, ENTITY_MATCH_NONE)
-
+    selector = _ServiceTargetSelector(
+        service_call.data.get(ATTR_ENTITY_ID),
+        service_call.data.get(ATTR_DEVICE_ID),
+        service_call.data.get(ATTR_AREA_ID),
+    )
     selected = SelectedEntities()
 
-    if not selects_entity_ids and not selects_device_ids and not selects_area_ids:
+    if not selector.has_any_selector:
         return selected
 
-    if selects_entity_ids:
-        assert entity_ids is not None
-
-        # Entity ID attr can be a list or a string
-        if isinstance(entity_ids, str):
-            entity_ids = [entity_ids]
-
+    if selector.selects_entity:
+        entity_ids = selector.entity_ids
         if expand_group:
             entity_ids = hass.components.group.expand_entity_ids(entity_ids)
 
         selected.referenced.update(entity_ids)
 
-    if not selects_device_ids and not selects_area_ids:
+    if not selector.selects_device and not selector.selects_area:
         return selected
 
-    area_reg, dev_reg, ent_reg = cast(
-        Tuple[
-            area_registry.AreaRegistry,
-            device_registry.DeviceRegistry,
-            entity_registry.EntityRegistry,
-        ],
-        await asyncio.gather(
-            area_registry.async_get_registry(hass),
-            device_registry.async_get_registry(hass),
-            entity_registry.async_get_registry(hass),
-        ),
-    )
+    ent_reg = entity_registry.async_get(hass)
+    dev_reg = device_registry.async_get(hass)
 
-    picked_devices = set()
-
-    if selects_device_ids:
-        if isinstance(device_ids, str):
-            picked_devices = {device_ids}
-        else:
-            assert isinstance(device_ids, list)
-            picked_devices = set(device_ids)
-
-        for device_id in picked_devices:
+    if selector.selects_device:
+        selected.referenced_devices.update(selector.device_ids)
+        for device_id in selected.referenced_devices:
             if device_id not in dev_reg.devices:
                 selected.missing_devices.add(device_id)
 
-    if selects_area_ids:
-        assert area_ids is not None
-
-        if isinstance(area_ids, str):
-            area_lookup = {area_ids}
-        else:
-            area_lookup = set(area_ids)
+    if selector.selects_area:
+        area_reg = area_registry.async_get(hass)
+        area_lookup = set(selector.area_ids)
 
         for area_id in area_lookup:
             if area_id not in area_reg.areas:
@@ -373,16 +373,46 @@ async def async_extract_referenced_entity_ids(
         # Find devices for this area
         for device_entry in dev_reg.devices.values():
             if device_entry.area_id in area_lookup:
-                picked_devices.add(device_entry.id)
+                selected.referenced_devices.add(device_entry.id)
 
-    if not picked_devices:
+    if not selected.referenced_devices:
         return selected
 
     for entity_entry in ent_reg.entities.values():
-        if not entity_entry.area_id and entity_entry.device_id in picked_devices:
+        if (
+            not entity_entry.area_id
+            and entity_entry.device_id in selected.referenced_devices
+        ):
             selected.indirectly_referenced.add(entity_entry.entity_id)
 
     return selected
+
+
+@bind_hass
+async def async_extract_config_entry_ids(
+    hass: HomeAssistantType, service_call: ha.ServiceCall, expand_group: bool = True
+) -> set:
+    """Extract referenced config entry ids from a service call."""
+    referenced = await async_extract_referenced_entity_ids(
+        hass, service_call, expand_group
+    )
+    ent_reg = entity_registry.async_get(hass)
+    dev_reg = device_registry.async_get(hass)
+    config_entry_ids: Set[str] = set()
+
+    # Some devices may have no entities
+    for device_id in referenced.referenced_devices:
+        if device_id in dev_reg.devices:
+            device = dev_reg.async_get(device_id)
+            if device is not None:
+                config_entry_ids.update(device.config_entries)
+
+    for entity_id in referenced.referenced | referenced.indirectly_referenced:
+        entry = ent_reg.async_get(entity_id)
+        if entry is not None and entry.config_entry_id is not None:
+            config_entry_ids.add(entry.config_entry_id)
+
+    return config_entry_ids
 
 
 def _load_services_file(hass: HomeAssistantType, integration: Integration) -> JSON_TYPE:

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -87,17 +87,14 @@ class ServiceTargetSelector:
         device_ids: Optional[Union[str, list]] = service_call.data.get(ATTR_DEVICE_ID)
         area_ids: Optional[Union[str, list]] = service_call.data.get(ATTR_AREA_ID)
 
-        self.entity_ids = cv.ensure_list(entity_ids)
-        self.device_ids = cv.ensure_list(device_ids)
-        self.area_ids = cv.ensure_list(area_ids)
-        self.selects_entity: bool = _has_selects(entity_ids)
-        self.selects_device: bool = _has_selects(device_ids)
-        self.selects_area: bool = _has_selects(area_ids)
+        self.entity_ids = cv.ensure_list(entity_ids) if _has_selects(entity_ids) else []
+        self.device_ids = cv.ensure_list(device_ids) if _has_selects(device_ids) else []
+        self.area_ids = cv.ensure_list(area_ids) if _has_selects(area_ids) else []
 
     @property
     def has_any_selector(self) -> bool:
         """Determine if any selectors are present."""
-        return bool(self.selects_entity or self.selects_device or self.selects_area)
+        return bool(self.entity_ids or self.device_ids or self.area_ids)
 
 
 @dataclasses.dataclass
@@ -334,43 +331,40 @@ async def async_extract_referenced_entity_ids(
     if not selector.has_any_selector:
         return selected
 
-    if selector.selects_entity:
-        entity_ids = selector.entity_ids
-        if expand_group:
-            entity_ids = hass.components.group.expand_entity_ids(entity_ids)
+    entity_ids = selector.entity_ids
+    if expand_group:
+        entity_ids = hass.components.group.expand_entity_ids(entity_ids)
 
-        selected.referenced.update(entity_ids)
+    selected.referenced.update(entity_ids)
 
-    if not selector.selects_device and not selector.selects_area:
+    if not selector.device_ids and not selector.area_ids:
         return selected
 
     ent_reg = entity_registry.async_get(hass)
     dev_reg = device_registry.async_get(hass)
 
-    if selector.selects_device:
-        selected.referenced_devices.update(selector.device_ids)
-        for device_id in selected.referenced_devices:
-            if device_id not in dev_reg.devices:
-                selected.missing_devices.add(device_id)
+    selected.referenced_devices.update(selector.device_ids)
+    for device_id in selected.referenced_devices:
+        if device_id not in dev_reg.devices:
+            selected.missing_devices.add(device_id)
 
-    if selector.selects_area:
-        area_reg = area_registry.async_get(hass)
-        area_lookup = set(selector.area_ids)
+    area_reg = area_registry.async_get(hass)
+    area_lookup = set(selector.area_ids)
 
-        for area_id in area_lookup:
-            if area_id not in area_reg.areas:
-                selected.missing_areas.add(area_id)
-                continue
+    for area_id in area_lookup:
+        if area_id not in area_reg.areas:
+            selected.missing_areas.add(area_id)
+            continue
 
-        # Find entities tied to an area
-        for entity_entry in ent_reg.entities.values():
-            if entity_entry.area_id in area_lookup:
-                selected.indirectly_referenced.add(entity_entry.entity_id)
+    # Find entities tied to an area
+    for entity_entry in ent_reg.entities.values():
+        if entity_entry.area_id in area_lookup:
+            selected.indirectly_referenced.add(entity_entry.entity_id)
 
-        # Find devices for this area
-        for device_entry in dev_reg.devices.values():
-            if device_entry.area_id in area_lookup:
-                selected.referenced_devices.add(device_entry.id)
+    # Find devices for this area
+    for device_entry in dev_reg.devices.values():
+        if device_entry.area_id in area_lookup:
+            selected.referenced_devices.add(device_entry.id)
 
     if not selected.referenced_devices:
         return selected

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -348,17 +348,16 @@ async def async_extract_referenced_entity_ids(
     dev_reg = device_registry.async_get(hass)
     area_reg = area_registry.async_get(hass)
 
-    selected.referenced_devices.update(selector.device_ids)
-    for device_id in selected.referenced_devices:
+    for device_id in selector.device_ids:
         if device_id not in dev_reg.devices:
             selected.missing_devices.add(device_id)
 
     for area_id in selector.area_ids:
         if area_id not in area_reg.areas:
             selected.missing_areas.add(area_id)
-            continue
 
     # Find devices for this area
+    selected.referenced_devices.update(selector.device_ids)
     for device_entry in dev_reg.devices.values():
         if device_entry.area_id in selector.area_ids:
             selected.referenced_devices.add(device_entry.id)

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -358,21 +358,18 @@ async def async_extract_referenced_entity_ids(
             selected.missing_areas.add(area_id)
             continue
 
-    # Find entities tied to an area
-    for entity_entry in ent_reg.entities.values():
-        if entity_entry.area_id in selector.area_ids:
-            selected.indirectly_referenced.add(entity_entry.entity_id)
-
     # Find devices for this area
     for device_entry in dev_reg.devices.values():
         if device_entry.area_id in selector.area_ids:
             selected.referenced_devices.add(device_entry.id)
 
-    if not selected.referenced_devices:
+    if not selector.area_ids and not selected.referenced_devices:
         return selected
 
     for ent_entry in ent_reg.entities.values():
-        if not ent_entry.area_id and ent_entry.device_id in selected.referenced_devices:
+        if ent_entry.area_id in selector.area_ids or (
+            not ent_entry.area_id and ent_entry.device_id in selected.referenced_devices
+        ):
             selected.indirectly_referenced.add(ent_entry.entity_id)
 
     return selected

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -385,3 +385,22 @@ async def test_not_allowing_recursion(hass, caplog):
             f"Called service homeassistant.{service} with invalid entities homeassistant.light"
             in caplog.text
         ), service
+
+
+async def test_reload_config_entry(hass):
+    """Test being able to reload a config entry."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        return_value=None,
+    ) as mock_reload:
+        await hass.services.async_call(
+            "homeassistant",
+            "reload_config_entry",
+            {"config_entry_id": "8955375327824e14ba89e4b29cc3ec9a"},
+            blocking=True,
+        )
+
+    assert len(mock_reload.mock_calls) == 1
+    assert mock_reload.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -389,59 +389,6 @@ async def test_not_allowing_recursion(hass, caplog):
         ), service
 
 
-async def test_reload_config_entry_by_entry_id(hass):
-    """Test being able to reload a config entry by config entry id."""
-    await async_setup_component(hass, "homeassistant", {})
-
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_reload",
-        return_value=None,
-    ) as mock_reload:
-        await hass.services.async_call(
-            "homeassistant",
-            "reload_config_entry",
-            {"config_entry_id": "8955375327824e14ba89e4b29cc3ec9a"},
-            blocking=True,
-        )
-
-    assert len(mock_reload.mock_calls) == 1
-    assert mock_reload.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"
-
-
-async def test_reload_config_entry_by_domain(hass):
-    """Test being able to reload a config entry by domain."""
-    await async_setup_component(hass, "homeassistant", {})
-    entry1 = MockConfigEntry(domain="mockdomain")
-    entry1.add_to_hass(hass)
-    entry2 = MockConfigEntry(domain="mockdomain")
-    entry2.add_to_hass(hass)
-
-    with patch(
-        "homeassistant.config_entries.ConfigEntries.async_reload",
-        return_value=None,
-    ) as mock_reload:
-        await hass.services.async_call(
-            "homeassistant",
-            "reload_config_entry",
-            {"domain": "mockdomain"},
-            blocking=True,
-        )
-
-    assert len(mock_reload.mock_calls) == 2
-    assert {mock_reload.mock_calls[0][1][0], mock_reload.mock_calls[1][1][0]} == {
-        entry1.entry_id,
-        entry2.entry_id,
-    }
-
-    with pytest.raises(ValueError):
-        await hass.services.async_call(
-            "homeassistant",
-            "reload_config_entry",
-            {"domain": "nonexist"},
-            blocking=True,
-        )
-
-
 async def test_reload_config_entry_by_entity_id(hass):
     """Test being able to reload a config entry by entity_id."""
     await async_setup_component(hass, "homeassistant", {})

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -428,8 +428,10 @@ async def test_reload_config_entry_by_domain(hass):
         )
 
     assert len(mock_reload.mock_calls) == 2
-    assert mock_reload.mock_calls[0][1][0] == entry1.entry_id
-    assert mock_reload.mock_calls[1][1][0] == entry2.entry_id
+    assert {mock_reload.mock_calls[0][1][0], mock_reload.mock_calls[1][1][0]} == {
+        entry1.entry_id,
+        entry2.entry_id,
+    }
 
     with pytest.raises(ValueError):
         await hass.services.async_call(
@@ -441,7 +443,7 @@ async def test_reload_config_entry_by_domain(hass):
 
 
 async def test_reload_config_entry_by_entity_id(hass):
-    """Test being able to reload a config entry by domain."""
+    """Test being able to reload a config entry by entity_id."""
     await async_setup_component(hass, "homeassistant", {})
     entity_reg = mock_registry(hass)
     entry1 = MockConfigEntry(domain="mockdomain")
@@ -466,8 +468,10 @@ async def test_reload_config_entry_by_entity_id(hass):
         )
 
     assert len(mock_reload.mock_calls) == 2
-    assert mock_reload.mock_calls[0][1][0] == entry1.entry_id
-    assert mock_reload.mock_calls[1][1][0] == entry2.entry_id
+    assert {mock_reload.mock_calls[0][1][0], mock_reload.mock_calls[1][1][0]} == {
+        entry1.entry_id,
+        entry2.entry_id,
+    }
 
     with pytest.raises(ValueError):
         await hass.services.async_call(

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -11,6 +11,7 @@ import yaml
 from homeassistant import config
 import homeassistant.components as comps
 from homeassistant.components.homeassistant import (
+    ATTR_ENTRY_ID,
     SERVICE_CHECK_CONFIG,
     SERVICE_RELOAD_CORE_CONFIG,
     SERVICE_SET_LOCATION,
@@ -427,3 +428,22 @@ async def test_reload_config_entry_by_entity_id(hass):
             {"entity_id": "unknown.entity_id"},
             blocking=True,
         )
+
+
+async def test_reload_config_entry_by_entry_id(hass):
+    """Test being able to reload a config entry by config entry id."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload",
+        return_value=None,
+    ) as mock_reload:
+        await hass.services.async_call(
+            "homeassistant",
+            "reload_config_entry",
+            {ATTR_ENTRY_ID: "8955375327824e14ba89e4b29cc3ec9a"},
+            blocking=True,
+        )
+
+    assert len(mock_reload.mock_calls) == 1
+    assert mock_reload.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1015,3 +1015,28 @@ async def test_async_extract_entities_warn_referenced(hass, caplog):
         "Unable to find referenced areas non-existent-area, devices non-existent-device, entities non.existent"
         in caplog.text
     )
+
+
+async def test_async_extract_config_entry_ids(hass):
+    """Test we can find devices that have no entities."""
+
+    device_no_entities = dev_reg.DeviceEntry(
+        id="device-no-entities", config_entries={"abc"}
+    )
+
+    call = ha.ServiceCall(
+        "homeassistant",
+        "reload_config_entry",
+        {
+            "device_id": "device-no-entities",
+        },
+    )
+
+    mock_device_registry(
+        hass,
+        {
+            device_no_entities.id: device_no_entities,
+        },
+    )
+
+    assert await service.async_extract_config_entry_ids(hass, call) == {"abc"}


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a service to reload config entries that can easily be called though automations.

The use case is to reload a homekit accessory when the underlying entity has a characteristic change.

Closes #46515

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16976

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
