### PR TITLE
Raise ConditionError for and/or/not errors

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -615,11 +615,20 @@ async def _async_process_if(hass, config, p_config):
 
     def if_action(variables=None):
         """AND all conditions."""
-        try:
-            return all(check(hass, variables) for check in checks)
-        except ConditionError as ex:
-            LOGGER.warning("Error in 'condition' evaluation: %s", ex)
+        errors = []
+        for check in checks:
+            try:
+                if not check(hass, variables):
+                    return False
+            except ConditionError as ex:
+                errors.append(f"Error in 'condition' evaluation: {ex}")
+
+        if errors:
+            for error in errors:
+                LOGGER.warning("%s", error)
             return False
+
+        return True
 
     if_action.config = if_configs
 

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -108,13 +108,19 @@ async def async_and_from_config(
         hass: HomeAssistant, variables: TemplateVarsType = None
     ) -> bool:
         """Test and condition."""
-        try:
-            for check in checks:
+        errors = []
+        for check in checks:
+            try:
                 if not check(hass, variables):
                     return False
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.warning("Error during and-condition: %s", ex)
-            return False
+            except ConditionError as ex:
+                errors.append(str(ex))
+            except Exception as ex:  # pylint: disable=broad-except
+                errors.append(str(ex))
+
+        # Raise the errors if no check was false
+        if errors:
+            raise ConditionError("Error in 'and' condition: " + ", ".join(errors))
 
         return True
 
@@ -134,13 +140,20 @@ async def async_or_from_config(
     def if_or_condition(
         hass: HomeAssistant, variables: TemplateVarsType = None
     ) -> bool:
-        """Test and condition."""
-        try:
-            for check in checks:
+        """Test or condition."""
+        errors = []
+        for check in checks:
+            try:
                 if check(hass, variables):
                     return True
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.warning("Error during or-condition: %s", ex)
+            except ConditionError as ex:
+                errors.append(str(ex))
+            except Exception as ex:  # pylint: disable=broad-except
+                errors.append(str(ex))
+
+        # Raise the errors if no check was true
+        if errors:
+            raise ConditionError("Error in 'or' condition: " + ", ".join(errors))
 
         return False
 
@@ -161,12 +174,19 @@ async def async_not_from_config(
         hass: HomeAssistant, variables: TemplateVarsType = None
     ) -> bool:
         """Test not condition."""
-        try:
-            for check in checks:
+        errors = []
+        for check in checks:
+            try:
                 if check(hass, variables):
                     return False
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.warning("Error during not-condition: %s", ex)
+            except ConditionError as ex:
+                errors.append(str(ex))
+            except Exception as ex:  # pylint: disable=broad-except
+                errors.append(str(ex))
+
+        # Raise the errors if no check was true
+        if errors:
+            raise ConditionError("Error in 'not' condition: " + ", ".join(errors))
 
         return True
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -50,6 +50,9 @@ async def test_and_condition(hass):
         },
     )
 
+    with pytest.raises(ConditionError):
+        test(hass)
+
     hass.states.async_set("sensor.temperature", 120)
     assert not test(hass)
 
@@ -111,6 +114,9 @@ async def test_or_condition(hass):
         },
     )
 
+    with pytest.raises(ConditionError):
+        test(hass)
+
     hass.states.async_set("sensor.temperature", 120)
     assert not test(hass)
 
@@ -168,6 +174,9 @@ async def test_not_condition(hass):
             ],
         },
     )
+
+    with pytest.raises(ConditionError):
+        test(hass)
 
     hass.states.async_set("sensor.temperature", 101)
     assert test(hass)
@@ -466,7 +475,8 @@ async def test_state_attribute(hass):
     )
 
     hass.states.async_set("sensor.temperature", 100, {"unkown_attr": 200})
-    assert not test(hass)
+    with pytest.raises(ConditionError):
+        test(hass)
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": 200})
     assert test(hass)
@@ -720,7 +730,7 @@ async def test_numeric_state_multiple_entities(hass):
     assert not test(hass)
 
 
-async def test_numberic_state_attribute(hass):
+async def test_numeric_state_attribute(hass):
     """Test with numeric state attribute in condition."""
     test = await condition.async_from_config(
         hass,
@@ -738,7 +748,8 @@ async def test_numberic_state_attribute(hass):
     )
 
     hass.states.async_set("sensor.temperature", 100, {"unkown_attr": 10})
-    assert not test(hass)
+    with pytest.raises(ConditionError):
+        assert test(hass)
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": 49})
     assert test(hass)
@@ -750,7 +761,8 @@ async def test_numberic_state_attribute(hass):
     assert not test(hass)
 
     hass.states.async_set("sensor.temperature", 100, {"attribute1": None})
-    assert not test(hass)
+    with pytest.raises(ConditionError):
+        assert test(hass)
 
 
 async def test_numeric_state_using_input_number(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add `ConditionError` (see #45923) for `and`, `or` and `not` conditions. The evaluations short-circuit so that errors are not raised if the condition can be decided without considering the failing parts.

This PR also updates the implicit `and` in automation conditions to work in the same way.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
