### PR TITLE
Add "cron patterns" to define utility_meter cycles

### DIFF
--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -2,6 +2,7 @@
 from datetime import timedelta
 import logging
 
+from croniter import croniter
 import voluptuous as vol
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -14,6 +15,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
     ATTR_TARIFF,
+    CONF_CRON_PATTERN,
     CONF_METER,
     CONF_METER_NET_CONSUMPTION,
     CONF_METER_OFFSET,
@@ -40,6 +42,13 @@ ATTR_TARIFFS = "tariffs"
 DEFAULT_OFFSET = timedelta(hours=0)
 
 
+def validate_cron_pattern(pattern):
+    """Check that the pattern is well-formed."""
+    if croniter.is_valid(pattern):
+        return pattern
+    raise vol.Invalid("Invalid pattern")
+
+
 METER_CONFIG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_SOURCE_SENSOR): cv.entity_id,
@@ -50,6 +59,7 @@ METER_CONFIG_SCHEMA = vol.Schema(
         ),
         vol.Optional(CONF_METER_NET_CONSUMPTION, default=False): cv.boolean,
         vol.Optional(CONF_TARIFFS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_CRON_PATTERN): validate_cron_pattern,
     }
 )
 

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -61,7 +61,7 @@ def period_or_cron(config):
         and config[CONF_METER_OFFSET] != DEFAULT_OFFSET
     ):
         raise vol.Invalid(
-            f"When <{CONF_CRON_PATTERN}> is used <{CONF_METER_OFFSET}> has no meaning and must be removed"
+            f"When <{CONF_CRON_PATTERN}> is used <{CONF_METER_OFFSET}> has no meaning"
         )
     return config
 

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -53,7 +53,7 @@ def period_or_cron(config):
     """Check that if cron pattern is used, then meter type and offsite must be removed."""
     if CONF_CRON_PATTERN in config and CONF_METER_TYPE in config:
         raise vol.Invalid(
-            f"You can either use <{CONF_CRON_PATTERN}> or <{CONF_METER_TYPE}>"
+            f"Use <{CONF_CRON_PATTERN}> or <{CONF_METER_TYPE}>"
         )
     if (
         CONF_CRON_PATTERN in config

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -52,9 +52,7 @@ def validate_cron_pattern(pattern):
 def period_or_cron(config):
     """Check that if cron pattern is used, then meter type and offsite must be removed."""
     if CONF_CRON_PATTERN in config and CONF_METER_TYPE in config:
-        raise vol.Invalid(
-            f"Use <{CONF_CRON_PATTERN}> or <{CONF_METER_TYPE}>"
-        )
+        raise vol.Invalid(f"Use <{CONF_CRON_PATTERN}> or <{CONF_METER_TYPE}>")
     if (
         CONF_CRON_PATTERN in config
         and CONF_METER_OFFSET in config

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -36,6 +36,7 @@ CONF_CRON_PATTERN = "cron"
 
 ATTR_TARIFF = "tariff"
 ATTR_VALUE = "value"
+ATTR_CRON_PATTERN = "cron pattern"
 
 SIGNAL_START_PAUSE_METER = "utility_meter_start_pause"
 SIGNAL_RESET_METER = "utility_meter_reset"

--- a/homeassistant/components/utility_meter/const.py
+++ b/homeassistant/components/utility_meter/const.py
@@ -32,6 +32,7 @@ CONF_PAUSED = "paused"
 CONF_TARIFFS = "tariffs"
 CONF_TARIFF = "tariff"
 CONF_TARIFF_ENTITY = "tariff_entity"
+CONF_CRON_PATTERN = "cron"
 
 ATTR_TARIFF = "tariff"
 ATTR_VALUE = "value"

--- a/homeassistant/components/utility_meter/manifest.json
+++ b/homeassistant/components/utility_meter/manifest.json
@@ -2,6 +2,7 @@
   "domain": "utility_meter",
   "name": "Utility Meter",
   "documentation": "https://www.home-assistant.io/integrations/utility_meter",
+  "requirements": ["croniter==1.0.6"],
   "codeowners": ["@dgomes"],
   "quality_scale": "internal",
   "iot_class": "local_push"

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.helpers.restore_state import RestoreEntity
 import homeassistant.util.dt as dt_util
 
 from .const import (
+    ATTR_CRON_PATTERN,
     ATTR_VALUE,
     BIMONTHLY,
     CONF_CRON_PATTERN,
@@ -377,6 +378,8 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         }
         if self._period is not None:
             state_attr[ATTR_PERIOD] = self._period
+        if self._cron_pattern is not None:
+            state_attr[ATTR_CRON_PATTERN] = self._cron_pattern
         if self._tariff is not None:
             state_attr[ATTR_TARIFF] = self._tariff
         return state_attr

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -216,7 +216,11 @@ class UtilityMeterSensor(RestoreEntity, SensorEntity):
         """Determine cycle - Helper function for larger than daily cycles."""
         now = dt_util.now().date()
         if self._cron_pattern is not None:
-            pass
+            async_track_point_in_time(
+                self.hass,
+                self._async_reset_meter,
+                croniter(self._cron_pattern, dt_util.now()).get_next(datetime),
+            )
         elif (
             self._period == WEEKLY
             and now != now - timedelta(days=now.weekday()) + self._period_offset

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -486,6 +486,9 @@ construct==2.10.56
 # homeassistant.components.coronavirus
 coronavirus==1.1.1
 
+# homeassistant.components.utility_meter
+croniter==1.0.6
+
 # homeassistant.components.datadog
 datadog==0.15.0
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -28,6 +28,7 @@ responses==0.12.0
 respx==0.17.0
 stdlib-list==0.7.0
 tqdm==4.49.0
+types-croniter==1.0.0
 types-backports==0.1.3
 types-certifi==0.1.4
 types-chardet==0.1.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -282,6 +282,9 @@ construct==2.10.56
 # homeassistant.components.coronavirus
 coronavirus==1.1.1
 
+# homeassistant.components.utility_meter
+croniter==1.0.6
+
 # homeassistant.components.datadog
 datadog==0.15.0
 

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -10,9 +10,11 @@ from homeassistant.components.utility_meter.const import (
     SERVICE_SELECT_NEXT_TARIFF,
     SERVICE_SELECT_TARIFF,
 )
+import homeassistant.components.utility_meter.sensor as um_sensor
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_PLATFORM,
     ENERGY_KILO_WATT_HOUR,
     EVENT_HOMEASSISTANT_START,
 )
@@ -224,3 +226,8 @@ async def test_bad_cron(hass, legacy_patchable_time):
     }
 
     assert not await async_setup_component(hass, DOMAIN, config)
+
+
+async def test_setup_missing_discovery(hass):
+    """Test setup with configuration missing discovery_info."""
+    assert not await um_sensor.async_setup_platform(hass, {CONF_PLATFORM: DOMAIN}, None)

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -152,6 +152,21 @@ async def test_services(hass):
     assert state.state == "0"
 
 
+async def test_cron(hass, legacy_patchable_time):
+    """Test cron pattern and offset fails."""
+
+    config = {
+        "utility_meter": {
+            "energy_bill": {
+                "source": "sensor.energy",
+                "cron": "*/5 * * * *",
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+
+
 async def test_cron_and_meter(hass, legacy_patchable_time):
     """Test cron pattern and meter type fails."""
     config = {

--- a/tests/components/utility_meter/test_init.py
+++ b/tests/components/utility_meter/test_init.py
@@ -167,6 +167,24 @@ async def test_cron_and_meter(hass, legacy_patchable_time):
     assert not await async_setup_component(hass, DOMAIN, config)
 
 
+async def test_both_cron_and_meter(hass, legacy_patchable_time):
+    """Test cron pattern and meter type passes in different meter."""
+    config = {
+        "utility_meter": {
+            "energy_bill": {
+                "source": "sensor.energy",
+                "cron": "0 0 1 * *",
+            },
+            "water_bill": {
+                "source": "sensor.water",
+                "cycle": "hourly",
+            },
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+
+
 async def test_cron_and_offset(hass, legacy_patchable_time):
     """Test cron pattern and offset fails."""
 

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -11,7 +11,10 @@ from homeassistant.components.sensor import (
 from homeassistant.components.utility_meter.const import (
     ATTR_TARIFF,
     ATTR_VALUE,
+    DAILY,
     DOMAIN,
+    HOURLY,
+    QUARTER_HOURLY,
     SERVICE_CALIBRATE_METER,
     SERVICE_SELECT_TARIFF,
 )
@@ -27,6 +30,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     ENERGY_KILO_WATT_HOUR,
     EVENT_HOMEASSISTANT_START,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
@@ -156,6 +160,26 @@ async def test_state(hass):
         SERVICE_CALIBRATE_METER,
         {ATTR_ENTITY_ID: "sensor.energy_bill_midpeak", ATTR_VALUE: "0.123"},
         blocking=True,
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.energy_bill_midpeak")
+    assert state is not None
+    assert state.state == "0.123"
+
+    # test invalid state
+    entity_id = config[DOMAIN]["energy_bill"]["source"]
+    hass.states.async_set(
+        entity_id, "*", {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.energy_bill_midpeak")
+    assert state is not None
+    assert state.state == "0.123"
+
+    # test unavailable source
+    entity_id = config[DOMAIN]["energy_bill"]["source"]
+    hass.states.async_set(
+        entity_id, STATE_UNAVAILABLE, {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR}
     )
     await hass.async_block_till_done()
     state = hass.states.get("sensor.energy_bill_midpeak")
@@ -421,21 +445,43 @@ async def _test_self_reset(hass, config, start_time, expect_reset=True):
         start_time_str = dt_util.parse_datetime(start_time).isoformat()
         assert state.attributes.get("last_reset") == start_time_str
 
+    # Check next day when nothing should happen for weekly, monthly, bimonthly and yearly
+    if config["utility_meter"]["energy_bill"].get("cycle") in [
+        QUARTER_HOURLY,
+        HOURLY,
+        DAILY,
+    ]:
+        now += timedelta(minutes=5)
+    else:
+        now += timedelta(days=5)
+    with alter_time(now):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+        hass.states.async_set(
+            entity_id,
+            10,
+            {ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR},
+            force_update=True,
+        )
+        await hass.async_block_till_done()
+    state = hass.states.get("sensor.energy_bill")
+    if expect_reset:
+        assert state.attributes.get("last_period") == "2"
+        assert state.state == "7"
+    else:
+        assert state.attributes.get("last_period") == 0
+        assert state.state == "9"
+
 
 async def test_self_reset_cron_pattern(hass, legacy_patchable_time):
     """Test cron pattern reset of meter."""
-    config = gen_config("yearly")  # ignored because cron is defined
-    config["utility_meter"]["energy_bill"]["cron"] = "0 0 1 * *"
+    config = {
+        "utility_meter": {
+            "energy_bill": {"source": "sensor.energy", "cron": "0 0 1 * *"}
+        }
+    }
 
     await _test_self_reset(hass, config, "2017-01-31T23:59:00.000000+00:00")
-
-
-async def test_bad_cron_pattern(hass, legacy_patchable_time):
-    """Test cron pattern reset of meter."""
-    config = gen_config("hourly")
-    config["utility_meter"]["energy_bill"]["cron"] = "trash"
-
-    assert not await async_setup_component(hass, DOMAIN, config)
 
 
 async def test_self_reset_quarter_hourly(hass, legacy_patchable_time):

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -422,6 +422,22 @@ async def _test_self_reset(hass, config, start_time, expect_reset=True):
         assert state.attributes.get("last_reset") == start_time_str
 
 
+async def test_self_reset_cron_pattern(hass, legacy_patchable_time):
+    """Test cron pattern reset of meter."""
+    config = gen_config("yearly")  # ignored because cron is defined
+    config["utility_meter"]["energy_bill"]["cron"] = "0 0 1 * *"
+
+    await _test_self_reset(hass, config, "2017-01-31T23:59:00.000000+00:00")
+
+
+async def test_bad_cron_pattern(hass, legacy_patchable_time):
+    """Test cron pattern reset of meter."""
+    config = gen_config("hourly")
+    config["utility_meter"]["energy_bill"]["cron"] = "trash"
+
+    assert not await async_setup_component(hass, DOMAIN, config)
+
+
 async def test_self_reset_quarter_hourly(hass, legacy_patchable_time):
     """Test quarter-hourly reset of meter."""
     await _test_self_reset(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In https://github.com/home-assistant/core/pull/46700#issuecomment-781325736 @frenck proposed we should make cycles configurable. This is the best I could come up with :)

It uses (well known) crontab format, which I believe to be quite flexible, although less user friendly...

I propose to keep existing cycles configuration and make this an advanced option that overrides the cycle configuration, thus avoiding a breaking change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
utility_meter:
  energy:
    source: sensor.energy_in_kwh
    cron: 0 0 1 * *
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/46700
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/19078

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
