### PR TITLE
Bump pywemo to 0.6.2

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 
 import pywemo
-import requests
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -229,10 +228,10 @@ def validate_static_config(host, port):
         return None
 
     try:
-        device = pywemo.discovery.device_from_description(url, None)
+        device = pywemo.discovery.device_from_description(url)
     except (
-        requests.exceptions.ConnectionError,
-        requests.exceptions.Timeout,
+        pywemo.exceptions.ActionException,
+        pywemo.exceptions.HTTPException,
     ) as err:
         _LOGGER.error("Unable to access WeMo at %s (%s)", url, err)
         return None

--- a/homeassistant/components/wemo/entity.py
+++ b/homeassistant/components/wemo/entity.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, Generator, Optional
 
 import async_timeout
 from pywemo import WeMoDevice
-from pywemo.ouimeaux_device.api.service import ActionException
+from pywemo.exceptions import ActionException
 
 from homeassistant.helpers.entity import Entity
 

--- a/homeassistant/components/wemo/manifest.json
+++ b/homeassistant/components/wemo/manifest.json
@@ -3,7 +3,7 @@
   "name": "Belkin WeMo",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wemo",
-  "requirements": ["pywemo==0.6.1"],
+  "requirements": ["pywemo==0.6.2"],
   "ssdp": [
     {
       "manufacturer": "Belkin International Inc."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1902,7 +1902,7 @@ pyvolumio==0.1.3
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.6.1
+pywemo==0.6.2
 
 # homeassistant.components.wilight
 pywilight==0.0.68

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -981,7 +981,7 @@ pyvolumio==0.1.3
 pywebpush==1.9.2
 
 # homeassistant.components.wemo
-pywemo==0.6.1
+pywemo==0.6.2
 
 # homeassistant.components.wilight
 pywilight==0.0.68


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Update pyWeMo to 0.6.2

pyWemo changes: https://github.com/pavoni/pywemo/compare/0.6.1...0.6.2

- Fixes
  - Add timeout and threading for serving http requests to solve deadlock
  - Add a 10 second timeout for resubscribe requests to solve deadlock
  - Catch RequestException & ActionException when reconnecting for discovery (fixes #46415)
  - Fix timeout header on UPnP SUBSCRIBE messages
  - Reset UPnP description cache each scan
  - Verify device IDs when probing
- Features
  - Update the dimmer attributes due to a subscription update event (for #45904)
  - Support multiple subscriptions for the Insight device (for #45904)
  - Clients can check if a subscription is active (for #45904)
  - Speed improvements for device discovery
  - Add retries for individual SOAP actions (for #45904)
  - Reconnect without creating a new device (for #45904)
  - pyWeMo raises its own exceptions rather than lower-level library exceptions

I'm including some small code changes in this PR that are related to the version bump:
- The 2nd argument to `pywemo.discovery.device_from_description` has been deprecated and causes a deprecation warning if used. I've removed that argument in this PR
- pywemo now raises its own exception, rather than the exceptions from lower-level dependencies. That required a couple of changes to the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46415
- This PR is related to issue: #45904 (Please keep this issue open. Requires one more PR to fix)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
