### PR TITLE
Vestaboard notification platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1036,6 +1036,7 @@ omit =
     homeassistant/components/venstar/climate.py
     homeassistant/components/verisure/*
     homeassistant/components/versasense/*
+    homeassistant/components/vestaboard/*
     homeassistant/components/vesync/__init__.py
     homeassistant/components/vesync/common.py
     homeassistant/components/vesync/const.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -508,6 +508,7 @@ homeassistant/components/vera/* @vangorra
 homeassistant/components/verisure/* @frenck
 homeassistant/components/versasense/* @flamm3blemuff1n
 homeassistant/components/version/* @fabaff @ludeeus
+homeassistant/components/vestaboard/* @robbiet480
 homeassistant/components/vesync/* @markperdue @webdjoe @thegardenmonkey
 homeassistant/components/vicare/* @oischinger
 homeassistant/components/vilfo/* @ManneW

--- a/homeassistant/components/vestaboard/__init__.py
+++ b/homeassistant/components/vestaboard/__init__.py
@@ -1,0 +1,63 @@
+"""Support for Vestaboard."""
+import logging
+
+import vestaboard
+import voluptuous as vol
+
+from homeassistant.const import CONF_API_KEY
+import homeassistant.helpers.config_validation as cv
+
+CONF_API_SECRET = "api_secret"
+
+_LOGGER = logging.getLogger(__name__)
+
+
+DOMAIN = "vestaboard"
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_API_KEY): cv.string,
+                vol.Required(CONF_API_SECRET): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def setup(hass, config):
+    """Set up the VestaboardManager."""
+    _LOGGER.debug("Setting up Vestaboard platform")
+    conf = config[DOMAIN]
+    hvbm = HassVestaboardManager(
+        apiKey=conf[CONF_API_KEY], apiSecret=conf[CONF_API_SECRET]
+    )
+    subscriptions = hvbm.manager.get_subscriptions()
+    if not subscriptions:
+        _LOGGER.error("No Vestaboard subscriptions found")
+        return False
+
+    hass.data[DOMAIN] = hvbm
+    for sub in subscriptions:
+        _LOGGER.debug("Discovered Vestaboard subscription: %s", sub)
+
+    return True
+
+
+class HassVestaboardManager:
+    """A class that encapsulated requests to the Vestaboard manager."""
+
+    def __init__(self, apiKey, apiSecret):
+        """Initialize HassVestaboardManager and connect to Vestaboard."""
+
+        _LOGGER.debug("Connecting to Vestaboard")
+        self.manager = vestaboard.Installable(
+            apiKey=apiKey,
+            apiSecret=apiSecret,
+            getSubscription=False,
+            saveCredentials=False,
+        )
+        self._apiKey = apiKey
+        self._apiSecret = apiSecret

--- a/homeassistant/components/vestaboard/manifest.json
+++ b/homeassistant/components/vestaboard/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "vestaboard",
+  "name": "Vestaboard",
+  "documentation": "https://www.home-assistant.io/integrations/vestaboard",
+  "requirements": ["Vestaboard==0.4.0"],
+  "codeowners": ["@robbiet480"]
+}

--- a/homeassistant/components/vestaboard/notify.py
+++ b/homeassistant/components/vestaboard/notify.py
@@ -1,0 +1,50 @@
+"""Support for Vestaboard notifications."""
+import logging
+
+import vestaboard
+
+from homeassistant.components.notify import ATTR_TARGET, BaseNotificationService
+
+from . import DOMAIN as VESTABOARD_DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def get_service(hass, config, discovery_info=None):
+    """Get the Vestaboard notification service."""
+    hvbm = hass.data.get(VESTABOARD_DOMAIN)
+    return VestaboardNotificationService(hvbm)
+
+
+class VestaboardNotificationService(BaseNotificationService):
+    """Implement the notification service for Vestaboard."""
+
+    def __init__(self, vbm):
+        """Initialize the service."""
+        self.vbm = vbm
+        self._subscriptions = []
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to some Vestaboard subscription."""
+
+        targets = kwargs.get(ATTR_TARGET)
+        _LOGGER.debug("Targets: %s", targets)
+
+        self._subscriptions = self.vbm.manager.get_subscriptions()
+
+        for board_info in self._subscriptions:
+            if targets is None or board_info["_id"] in targets:
+                board = vestaboard.Board(
+                    apiKey=self.vbm.manager.apiKey,
+                    apiSecret=self.vbm.manager.apiSecret,
+                    subscriptionId=board_info["_id"],
+                )
+                try:
+                    board.post(message)
+                    _LOGGER.debug(
+                        "Sent notification to Vestaboard %s", board_info["_id"]
+                    )
+                except OSError:
+                    _LOGGER.warning(
+                        "Cannot connect to Vestaboard %s", board_info["_id"]
+                    )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -86,6 +86,9 @@ TwitterAPI==2.6.5
 # homeassistant.components.tof
 # VL53L1X2==0.1.5
 
+# homeassistant.components.vestaboard
+Vestaboard==0.4.0
+
 # homeassistant.components.onvif
 WSDiscovery==2.0.0
 


### PR DESCRIPTION
## Proposed change

Adds a notification platform for the [Vestaboard](https://www.vestaboard.com/).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
# Example configuration.yaml
vestaboard:
  api_key: 39dd8f59-ff37-4185-9385-74a4f11ee167
  api_secret: YmM2OTlhNTEtNzI2NC00MmE2LWFkMmYtY2QxNzA4ZGI0OTA9

notify:
  name: vb_test
  platform: vestaboard

```

## Additional information

- Link to documentation pull request: 

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
