### PR TITLE
Update xknx to 0.17.0

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -376,6 +376,7 @@ class KNXModule:
             self.telegram_received_cb,
             address_filters=address_filters,
             group_addresses=[],
+            match_for_outgoing=True,
         )
 
     async def service_event_register_modify(self, call):

--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -40,7 +40,9 @@ class KNXBinarySensor(KnxEntity, BinarySensorEntity):
     @property
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return device specific state attributes."""
-        return {ATTR_COUNTER: self._device.counter}
+        if self._device.counter is not None:
+            return {ATTR_COUNTER: self._device.counter}
+        return None
 
     @property
     def force_update(self) -> bool:

--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -264,6 +264,9 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
         max_temp=config.get(ClimateSchema.CONF_MAX_TEMP),
         mode=climate_mode,
         on_off_invert=config[ClimateSchema.CONF_ON_OFF_INVERT],
+        create_temperature_sensors=config.get(
+            ClimateSchema.CONF_CREATE_TEMPERATURE_SENSORS
+        ),
     )
 
 
@@ -332,7 +335,7 @@ def _create_weather(knx_module: XKNX, config: ConfigType) -> XknxWeather:
         knx_module,
         name=config[CONF_NAME],
         sync_state=config[WeatherSchema.CONF_SYNC_STATE],
-        expose_sensors=config[WeatherSchema.CONF_KNX_EXPOSE_SENSORS],
+        create_sensors=config[WeatherSchema.CONF_KNX_CREATE_SENSORS],
         group_address_temperature=config[WeatherSchema.CONF_KNX_TEMPERATURE_ADDRESS],
         group_address_brightness_south=config.get(
             WeatherSchema.CONF_KNX_BRIGHTNESS_SOUTH_ADDRESS
@@ -347,6 +350,9 @@ def _create_weather(knx_module: XKNX, config: ConfigType) -> XknxWeather:
             WeatherSchema.CONF_KNX_BRIGHTNESS_NORTH_ADDRESS
         ),
         group_address_wind_speed=config.get(WeatherSchema.CONF_KNX_WIND_SPEED_ADDRESS),
+        group_address_wind_bearing=config.get(
+            WeatherSchema.CONF_KNX_WIND_BEARING_ADDRESS
+        ),
         group_address_rain_alarm=config.get(WeatherSchema.CONF_KNX_RAIN_ALARM_ADDRESS),
         group_address_frost_alarm=config.get(
             WeatherSchema.CONF_KNX_FROST_ALARM_ADDRESS

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.16.3"],
+  "requirements": ["xknx==0.17.0"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver"
 }

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -240,6 +240,7 @@ class ClimateSchema:
     CONF_ON_OFF_INVERT = "on_off_invert"
     CONF_MIN_TEMP = "min_temp"
     CONF_MAX_TEMP = "max_temp"
+    CONF_CREATE_TEMPERATURE_SENSORS = "create_temperature_sensors"
 
     DEFAULT_NAME = "KNX Climate"
     DEFAULT_SETPOINT_SHIFT_MODE = "DPT6010"
@@ -295,6 +296,9 @@ class ClimateSchema:
                 ),
                 vol.Optional(CONF_MIN_TEMP): vol.Coerce(float),
                 vol.Optional(CONF_MAX_TEMP): vol.Coerce(float),
+                vol.Optional(
+                    CONF_CREATE_TEMPERATURE_SENSORS, default=False
+                ): cv.boolean,
             }
         ),
     )
@@ -397,13 +401,14 @@ class WeatherSchema:
     CONF_KNX_BRIGHTNESS_WEST_ADDRESS = "address_brightness_west"
     CONF_KNX_BRIGHTNESS_NORTH_ADDRESS = "address_brightness_north"
     CONF_KNX_WIND_SPEED_ADDRESS = "address_wind_speed"
+    CONF_KNX_WIND_BEARING_ADDRESS = "address_wind_bearing"
     CONF_KNX_RAIN_ALARM_ADDRESS = "address_rain_alarm"
     CONF_KNX_FROST_ALARM_ADDRESS = "address_frost_alarm"
     CONF_KNX_WIND_ALARM_ADDRESS = "address_wind_alarm"
     CONF_KNX_DAY_NIGHT_ADDRESS = "address_day_night"
     CONF_KNX_AIR_PRESSURE_ADDRESS = "address_air_pressure"
     CONF_KNX_HUMIDITY_ADDRESS = "address_humidity"
-    CONF_KNX_EXPOSE_SENSORS = "expose_sensors"
+    CONF_KNX_CREATE_SENSORS = "create_sensors"
 
     DEFAULT_NAME = "KNX Weather Station"
 
@@ -415,13 +420,14 @@ class WeatherSchema:
                 cv.boolean,
                 cv.string,
             ),
-            vol.Optional(CONF_KNX_EXPOSE_SENSORS, default=False): cv.boolean,
+            vol.Optional(CONF_KNX_CREATE_SENSORS, default=False): cv.boolean,
             vol.Required(CONF_KNX_TEMPERATURE_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_BRIGHTNESS_SOUTH_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_BRIGHTNESS_EAST_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_BRIGHTNESS_WEST_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_BRIGHTNESS_NORTH_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_WIND_SPEED_ADDRESS): cv.string,
+            vol.Optional(CONF_KNX_WIND_BEARING_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_RAIN_ALARM_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_FROST_ALARM_ADDRESS): cv.string,
             vol.Optional(CONF_KNX_WIND_ALARM_ADDRESS): cv.string,

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -30,7 +30,7 @@ class KNXSensor(KnxEntity, Entity):
         return self._device.resolve_state()
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the unit this state is expressed in."""
         return self._device.unit_of_measurement()
 

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -53,7 +53,12 @@ class KNXWeather(KnxEntity, WeatherEntity):
     @property
     def humidity(self):
         """Return current humidity."""
-        return self._device.humidity if self._device.humidity is not None else None
+        return self._device.humidity
+
+    @property
+    def wind_bearing(self):
+        """Return current wind bearing in degrees."""
+        return self._device.wind_bearing
 
     @property
     def wind_speed(self):
@@ -63,11 +68,4 @@ class KNXWeather(KnxEntity, WeatherEntity):
             self._device.wind_speed * 3.6
             if self._device.wind_speed is not None
             else None
-        )
-
-    @property
-    def wind_bearing(self):
-        """Return current wind bearing in degrees."""
-        return (
-            self._device.wind_bearing if self._device.wind_bearing is not None else None
         )

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -64,3 +64,10 @@ class KNXWeather(KnxEntity, WeatherEntity):
             if self._device.wind_speed is not None
             else None
         )
+
+    @property
+    def wind_bearing(self):
+        """Return current wind bearing in degrees."""
+        return (
+            self._device.wind_bearing if self._device.wind_bearing is not None else None
+        )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2321,7 +2321,7 @@ xbox-webapi==2.0.8
 xboxapi==2.0.1
 
 # homeassistant.components.knx
-xknx==0.16.3
+xknx==0.17.0
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
- Weather entity: Renamed `expose_sensors` to `create_sensors` to prevent confusion with the XKNX expose_sensor function

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update xknx to 0.17.0
[xknx 0.17.0 Release notes / changelog](https://github.com/XKNX/xknx/releases/tag/0.17.0)

HA integration relevant changes:
- knx_event: Trigger event also for outgoing telegrams (this can be matched with the `direction` data attribute)
- Climate entity: Add `create_temperature_sensors` function to create extra Sensor entities for temperature and target_temperature
- Weather entity: Renamed `expose_sensors` to `create_sensors` to prevent confusion with the XKNX expose_sensor function
- Weather entity: Add `address_wind_bearing` accepting values in degrees (DPT 5.003) for determining wind direction
- BinarySensor entity: omit state attribute `counter` when context timeout is not used

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16660

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
