### PR TITLE
Refine printing of ConditionError

### DIFF
--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -112,7 +112,7 @@ async def async_attach_trigger(
                 armed_entities.add(entity_id)
         except exceptions.ConditionError as ex:
             _LOGGER.warning(
-                "Error initializing 'numeric_state' trigger for '%s': %s",
+                "Error initializing '%s' trigger: %s",
                 automation_info["name"],
                 ex,
             )

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -1,5 +1,7 @@
 """The exceptions used by Home Assistant."""
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Generator, Optional, Sequence
+
+import attr
 
 if TYPE_CHECKING:
     from .core import Context  # noqa: F401 pylint: disable=unused-import
@@ -25,8 +27,73 @@ class TemplateError(HomeAssistantError):
         super().__init__(f"{exception.__class__.__name__}: {exception}")
 
 
+@attr.s
 class ConditionError(HomeAssistantError):
     """Error during condition evaluation."""
+
+    # The name of the failed condition, such as 'and' or 'numeric_state'
+    name: str = attr.ib()
+
+    @staticmethod
+    def _indent(indent: int, message: str) -> str:
+        """Return indentation."""
+        return "  " * indent + message
+
+    def output(self, indent: int) -> Generator:
+        """Yield an indented representation."""
+        raise NotImplementedError()
+
+    def __str__(self) -> str:
+        """Return string representation."""
+        return "\n".join(list(self.output(indent=0)))
+
+
+@attr.s
+class ConditionErrorMessage(ConditionError):
+    """Condition error message."""
+
+    # A message describing this error
+    message: str = attr.ib()
+
+    def output(self, indent: int) -> Generator:
+        """Yield an indented representation."""
+        yield self._indent(indent, f"In '{self.name}' condition: {self.message}")
+
+
+@attr.s
+class ConditionErrorIndex(ConditionError):
+    """Condition error with index."""
+
+    # The zero-based index of the failed condition, for conditions with multiple parts
+    index: int = attr.ib()
+    # The total number of parts in this condition, including non-failed parts
+    total: int = attr.ib()
+    # The error that this error wraps
+    error: ConditionError = attr.ib()
+
+    def output(self, indent: int) -> Generator:
+        """Yield an indented representation."""
+        if self.total > 1:
+            yield self._indent(
+                indent, f"In '{self.name}' (item {self.index+1} of {self.total}):"
+            )
+        else:
+            yield self._indent(indent, f"In '{self.name}':")
+
+        yield from self.error.output(indent + 1)
+
+
+@attr.s
+class ConditionErrorContainer(ConditionError):
+    """Condition error with index."""
+
+    # List of ConditionErrors that this error wraps
+    errors: Sequence[ConditionError] = attr.ib()
+
+    def output(self, indent: int) -> Generator:
+        """Yield an indented representation."""
+        for item in self.errors:
+            yield from item.output(indent)
 
 
 class PlatformNotReady(HomeAssistantError):

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -31,8 +31,8 @@ class TemplateError(HomeAssistantError):
 class ConditionError(HomeAssistantError):
     """Error during condition evaluation."""
 
-    # The name of the failed condition, such as 'and' or 'numeric_state'
-    name: str = attr.ib()
+    # The type of the failed condition, such as 'and' or 'numeric_state'
+    type: str = attr.ib()
 
     @staticmethod
     def _indent(indent: int, message: str) -> str:
@@ -57,7 +57,7 @@ class ConditionErrorMessage(ConditionError):
 
     def output(self, indent: int) -> Generator:
         """Yield an indented representation."""
-        yield self._indent(indent, f"In '{self.name}' condition: {self.message}")
+        yield self._indent(indent, f"In '{self.type}' condition: {self.message}")
 
 
 @attr.s
@@ -75,10 +75,10 @@ class ConditionErrorIndex(ConditionError):
         """Yield an indented representation."""
         if self.total > 1:
             yield self._indent(
-                indent, f"In '{self.name}' (item {self.index+1} of {self.total}):"
+                indent, f"In '{self.type}' (item {self.index+1} of {self.total}):"
             )
         else:
-            yield self._indent(indent, f"In '{self.name}':")
+            yield self._indent(indent, f"In '{self.type}':")
 
         yield from self.error.output(indent + 1)
 

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -36,7 +36,14 @@ from homeassistant.const import (
     WEEKDAYS,
 )
 from homeassistant.core import HomeAssistant, State, callback
-from homeassistant.exceptions import ConditionError, HomeAssistantError, TemplateError
+from homeassistant.exceptions import (
+    ConditionError,
+    ConditionErrorContainer,
+    ConditionErrorIndex,
+    ConditionErrorMessage,
+    HomeAssistantError,
+    TemplateError,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.sun import get_astral_event_date
 from homeassistant.helpers.template import Template
@@ -109,18 +116,25 @@ async def async_and_from_config(
     ) -> bool:
         """Test and condition."""
         errors = []
-        for check in checks:
+        for index, check in enumerate(checks):
             try:
                 if not check(hass, variables):
                     return False
             except ConditionError as ex:
-                errors.append(str(ex))
+                errors.append(
+                    ConditionErrorIndex("and", index=index, total=len(checks), error=ex)
+                )
             except Exception as ex:  # pylint: disable=broad-except
-                errors.append(str(ex))
+                error = ConditionErrorMessage("and", f"unhandled exception: {ex}")
+                errors.append(
+                    ConditionErrorIndex(
+                        "and", index=index, total=len(checks), error=error
+                    )
+                )
 
         # Raise the errors if no check was false
         if errors:
-            raise ConditionError("Error in 'and' condition: " + ", ".join(errors))
+            raise ConditionErrorContainer("and", errors=errors)
 
         return True
 
@@ -142,18 +156,25 @@ async def async_or_from_config(
     ) -> bool:
         """Test or condition."""
         errors = []
-        for check in checks:
+        for index, check in enumerate(checks):
             try:
                 if check(hass, variables):
                     return True
             except ConditionError as ex:
-                errors.append(str(ex))
+                errors.append(
+                    ConditionErrorIndex("or", index=index, total=len(checks), error=ex)
+                )
             except Exception as ex:  # pylint: disable=broad-except
-                errors.append(str(ex))
+                error = ConditionErrorMessage("or", f"unhandled exception: {ex}")
+                errors.append(
+                    ConditionErrorIndex(
+                        "or", index=index, total=len(checks), error=error
+                    )
+                )
 
         # Raise the errors if no check was true
         if errors:
-            raise ConditionError("Error in 'or' condition: " + ", ".join(errors))
+            raise ConditionErrorContainer("or", errors=errors)
 
         return False
 
@@ -175,18 +196,25 @@ async def async_not_from_config(
     ) -> bool:
         """Test not condition."""
         errors = []
-        for check in checks:
+        for index, check in enumerate(checks):
             try:
                 if check(hass, variables):
                     return False
             except ConditionError as ex:
-                errors.append(str(ex))
+                errors.append(
+                    ConditionErrorIndex("not", index=index, total=len(checks), error=ex)
+                )
             except Exception as ex:  # pylint: disable=broad-except
-                errors.append(str(ex))
+                error = ConditionErrorMessage("not", f"unhandled exception: {ex}")
+                errors.append(
+                    ConditionErrorIndex(
+                        "not", index=index, total=len(checks), error=error
+                    )
+                )
 
         # Raise the errors if no check was true
         if errors:
-            raise ConditionError("Error in 'not' condition: " + ", ".join(errors))
+            raise ConditionErrorContainer("not", errors=errors)
 
         return True
 
@@ -225,20 +253,21 @@ def async_numeric_state(
 ) -> bool:
     """Test a numeric state condition."""
     if entity is None:
-        raise ConditionError("No entity specified")
+        raise ConditionErrorMessage("numeric_state", "no entity specified")
 
     if isinstance(entity, str):
         entity_id = entity
         entity = hass.states.get(entity)
 
         if entity is None:
-            raise ConditionError(f"Unknown entity {entity_id}")
+            raise ConditionErrorMessage("numeric_state", f"unknown entity {entity_id}")
     else:
         entity_id = entity.entity_id
 
     if attribute is not None and attribute not in entity.attributes:
-        raise ConditionError(
-            f"Attribute '{attribute}' (of entity {entity_id}) does not exist"
+        raise ConditionErrorMessage(
+            "numeric_state",
+            f"attribute '{attribute}' (of entity {entity_id}) does not exist",
         )
 
     value: Any = None
@@ -253,16 +282,21 @@ def async_numeric_state(
         try:
             value = value_template.async_render(variables)
         except TemplateError as ex:
-            raise ConditionError(f"Template error: {ex}") from ex
+            raise ConditionErrorMessage(
+                "numeric_state", f"template error: {ex}"
+            ) from ex
 
     if value in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-        raise ConditionError("State is not available")
+        raise ConditionErrorMessage(
+            "numeric_state", f"state of {entity_id} is unavailable"
+        )
 
     try:
         fvalue = float(value)
     except ValueError as ex:
-        raise ConditionError(
-            f"Entity {entity_id} state '{value}' cannot be processed as a number"
+        raise ConditionErrorMessage(
+            "numeric_state",
+            f"entity {entity_id} state '{value}' cannot be processed as a number",
         ) from ex
 
     if below is not None:
@@ -272,7 +306,9 @@ def async_numeric_state(
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                raise ConditionError(f"The below entity {below} is not available")
+                raise ConditionErrorMessage(
+                    "numeric_state", f"the 'below' entity {below} is unavailable"
+                )
             if fvalue >= float(below_entity.state):
                 return False
         elif fvalue >= below:
@@ -285,7 +321,9 @@ def async_numeric_state(
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                raise ConditionError(f"The above entity {above} is not available")
+                raise ConditionErrorMessage(
+                    "numeric_state", f"the 'above' entity {above} is unavailable"
+                )
             if fvalue <= float(above_entity.state):
                 return False
         elif fvalue <= above:
@@ -335,20 +373,20 @@ def state(
     Async friendly.
     """
     if entity is None:
-        raise ConditionError("No entity specified")
+        raise ConditionErrorMessage("state", "no entity specified")
 
     if isinstance(entity, str):
         entity_id = entity
         entity = hass.states.get(entity)
 
         if entity is None:
-            raise ConditionError(f"Unknown entity {entity_id}")
+            raise ConditionErrorMessage("state", f"unknown entity {entity_id}")
     else:
         entity_id = entity.entity_id
 
     if attribute is not None and attribute not in entity.attributes:
-        raise ConditionError(
-            f"Attribute '{attribute}' (of entity {entity_id}) does not exist"
+        raise ConditionErrorMessage(
+            "state", f"attribute '{attribute}' (of entity {entity_id}) does not exist"
         )
 
     assert isinstance(entity, State)
@@ -495,7 +533,7 @@ def async_template(
     try:
         value: str = value_template.async_render(variables, parse_result=False)
     except TemplateError as ex:
-        raise ConditionError(f"Error in 'template' condition: {ex}") from ex
+        raise ConditionErrorMessage("template", str(ex)) from ex
 
     return value.lower() == "true"
 
@@ -538,9 +576,7 @@ def time(
     elif isinstance(after, str):
         after_entity = hass.states.get(after)
         if not after_entity:
-            raise ConditionError(
-                f"Error in 'time' condition: The 'after' entity {after} is not available"
-            )
+            raise ConditionErrorMessage("time", f"unknown 'after' entity {after}")
         after = dt_util.dt.time(
             after_entity.attributes.get("hour", 23),
             after_entity.attributes.get("minute", 59),
@@ -552,9 +588,7 @@ def time(
     elif isinstance(before, str):
         before_entity = hass.states.get(before)
         if not before_entity:
-            raise ConditionError(
-                f"Error in 'time' condition: The 'before' entity {before} is not available"
-            )
+            raise ConditionErrorMessage("time", f"unknown 'before' entity {before}")
         before = dt_util.dt.time(
             before_entity.attributes.get("hour", 23),
             before_entity.attributes.get("minute", 59),
@@ -609,24 +643,24 @@ def zone(
     Async friendly.
     """
     if zone_ent is None:
-        raise ConditionError("No zone specified")
+        raise ConditionErrorMessage("zone", "no zone specified")
 
     if isinstance(zone_ent, str):
         zone_ent_id = zone_ent
         zone_ent = hass.states.get(zone_ent)
 
         if zone_ent is None:
-            raise ConditionError(f"Unknown zone {zone_ent_id}")
+            raise ConditionErrorMessage("zone", f"unknown zone {zone_ent_id}")
 
     if entity is None:
-        raise ConditionError("No entity specified")
+        raise ConditionErrorMessage("zone", "no entity specified")
 
     if isinstance(entity, str):
         entity_id = entity
         entity = hass.states.get(entity)
 
         if entity is None:
-            raise ConditionError(f"Unknown entity {entity_id}")
+            raise ConditionErrorMessage("zone", f"unknown entity {entity_id}")
     else:
         entity_id = entity.entity_id
 
@@ -634,10 +668,14 @@ def zone(
     longitude = entity.attributes.get(ATTR_LONGITUDE)
 
     if latitude is None:
-        raise ConditionError(f"Entity {entity_id} has no 'latitude' attribute")
+        raise ConditionErrorMessage(
+            "zone", f"entity {entity_id} has no 'latitude' attribute"
+        )
 
     if longitude is None:
-        raise ConditionError(f"Entity {entity_id} has no 'longitude' attribute")
+        raise ConditionErrorMessage(
+            "zone", f"entity {entity_id} has no 'longitude' attribute"
+        )
 
     return zone_cmp.in_zone(
         zone_ent, latitude, longitude, entity.attributes.get(ATTR_GPS_ACCURACY, 0)
@@ -664,15 +702,20 @@ def zone_from_config(
                 try:
                     if zone(hass, zone_entity_id, entity_id):
                         entity_ok = True
-                except ConditionError as ex:
-                    errors.append(str(ex))
+                except ConditionErrorMessage as ex:
+                    errors.append(
+                        ConditionErrorMessage(
+                            "zone",
+                            f"error matching {entity_id} with {zone_entity_id}: {ex.message}",
+                        )
+                    )
 
             if not entity_ok:
                 all_ok = False
 
         # Raise the errors only if no definitive result was found
         if errors and not all_ok:
-            raise ConditionError("Error in 'zone' condition: " + ", ".join(errors))
+            raise ConditionErrorContainer("zone", errors=errors)
 
         return all_ok
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -521,7 +521,7 @@ class _ScriptRun:
         try:
             check = cond(self._hass, self._variables)
         except exceptions.ConditionError as ex:
-            _LOGGER.warning("Error in 'condition' evaluation: %s", ex)
+            _LOGGER.warning("Error in 'condition' evaluation:\n%s", ex)
             check = False
 
         self._log("Test condition %s: %s", self._script.last_action, check)
@@ -580,7 +580,7 @@ class _ScriptRun:
                     ):
                         break
                 except exceptions.ConditionError as ex:
-                    _LOGGER.warning("Error in 'while' evaluation: %s", ex)
+                    _LOGGER.warning("Error in 'while' evaluation:\n%s", ex)
                     break
 
                 await async_run_sequence(iteration)
@@ -598,7 +598,7 @@ class _ScriptRun:
                     ):
                         break
                 except exceptions.ConditionError as ex:
-                    _LOGGER.warning("Error in 'until' evaluation: %s", ex)
+                    _LOGGER.warning("Error in 'until' evaluation:\n%s", ex)
                     break
 
         if saved_repeat_vars:
@@ -619,7 +619,7 @@ class _ScriptRun:
                     await self._async_run_script(script)
                     return
             except exceptions.ConditionError as ex:
-                _LOGGER.warning("Error in 'choose' evaluation: %s", ex)
+                _LOGGER.warning("Error in 'choose' evaluation:\n%s", ex)
 
         if choose_data["default"]:
             await self._async_run_script(choose_data["default"])

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -374,7 +374,7 @@ async def test_if_numeric_state_raises_on_unavailable(hass, caplog):
 async def test_state_raises(hass):
     """Test that state raises ConditionError on errors."""
     # Unknown entity_id
-    with pytest.raises(ConditionError, match="Unknown entity"):
+    with pytest.raises(ConditionError, match="unknown entity"):
         test = await condition.async_from_config(
             hass,
             {
@@ -387,7 +387,7 @@ async def test_state_raises(hass):
         test(hass)
 
     # Unknown attribute
-    with pytest.raises(ConditionError, match=r"Attribute .* does not exist"):
+    with pytest.raises(ConditionError, match=r"attribute .* does not exist"):
         test = await condition.async_from_config(
             hass,
             {
@@ -602,7 +602,7 @@ async def test_state_using_input_entities(hass):
 async def test_numeric_state_raises(hass):
     """Test that numeric_state raises ConditionError on errors."""
     # Unknown entity_id
-    with pytest.raises(ConditionError, match="Unknown entity"):
+    with pytest.raises(ConditionError, match="unknown entity"):
         test = await condition.async_from_config(
             hass,
             {
@@ -615,7 +615,7 @@ async def test_numeric_state_raises(hass):
         test(hass)
 
     # Unknown attribute
-    with pytest.raises(ConditionError, match=r"Attribute .* does not exist"):
+    with pytest.raises(ConditionError, match=r"attribute .* does not exist"):
         test = await condition.async_from_config(
             hass,
             {
@@ -645,7 +645,7 @@ async def test_numeric_state_raises(hass):
         test(hass)
 
     # Unavailable state
-    with pytest.raises(ConditionError, match="State is not available"):
+    with pytest.raises(ConditionError, match="state of .* is unavailable"):
         test = await condition.async_from_config(
             hass,
             {
@@ -673,7 +673,7 @@ async def test_numeric_state_raises(hass):
         test(hass)
 
     # Below entity missing
-    with pytest.raises(ConditionError, match="below entity"):
+    with pytest.raises(ConditionError, match="'below' entity"):
         test = await condition.async_from_config(
             hass,
             {
@@ -687,7 +687,7 @@ async def test_numeric_state_raises(hass):
         test(hass)
 
     # Above entity missing
-    with pytest.raises(ConditionError, match="above entity"):
+    with pytest.raises(ConditionError, match="'above' entity"):
         test = await condition.async_from_config(
             hass,
             {
@@ -834,7 +834,7 @@ async def test_zone_raises(hass):
         },
     )
 
-    with pytest.raises(ConditionError, match="Unknown zone"):
+    with pytest.raises(ConditionError, match="unknown zone"):
         test(hass)
 
     hass.states.async_set(
@@ -843,7 +843,7 @@ async def test_zone_raises(hass):
         {"name": "home", "latitude": 2.1, "longitude": 1.1, "radius": 10},
     )
 
-    with pytest.raises(ConditionError, match="Unknown entity"):
+    with pytest.raises(ConditionError, match="unknown entity"):
         test(hass)
 
     hass.states.async_set(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,46 @@
+"""Test to verify that Home Assistant exceptions work."""
+from homeassistant.exceptions import (
+    ConditionErrorContainer,
+    ConditionErrorIndex,
+    ConditionErrorMessage,
+)
+
+
+def test_conditionerror_format():
+    """Test ConditionError stringifiers."""
+    error1 = ConditionErrorMessage("test", "A test error")
+    assert str(error1) == "In 'test' condition: A test error"
+
+    error2 = ConditionErrorMessage("test", "Another error")
+    assert str(error2) == "In 'test' condition: Another error"
+
+    error_pos1 = ConditionErrorIndex("box", index=0, total=2, error=error1)
+    assert (
+        str(error_pos1)
+        == """In 'box' (item 1 of 2):
+  In 'test' condition: A test error"""
+    )
+
+    error_pos2 = ConditionErrorIndex("box", index=1, total=2, error=error2)
+    assert (
+        str(error_pos2)
+        == """In 'box' (item 2 of 2):
+  In 'test' condition: Another error"""
+    )
+
+    error_container1 = ConditionErrorContainer("box", errors=[error_pos1, error_pos2])
+    print(error_container1)
+    assert (
+        str(error_container1)
+        == """In 'box' (item 1 of 2):
+  In 'test' condition: A test error
+In 'box' (item 2 of 2):
+  In 'test' condition: Another error"""
+    )
+
+    error_pos3 = ConditionErrorIndex("box", index=0, total=1, error=error1)
+    assert (
+        str(error_pos3)
+        == """In 'box':
+  In 'test' condition: A test error"""
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Scripts and automations are now more careful about reporting problems with conditions. For example, a `state` condition that references an unavailable entity will log a message warning about the problem. Depending on the circumstances when such errors happen, the flow of the automation (i.e. stop/continue) might end up different from before.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR improves the reporting of `ConditionError`. Each condition now builds a tree of exception classes and the formatting is left to those classes.

For example, this silly condition:

```yaml
  condition:
  - condition: or
    conditions:
    - condition: numeric_state
      entity_id: sensor.front_door_battery_level
      below: 90
    - condition: not
      conditions:
      - condition: state
        entity_id: sensor.front_door
        state: input_number.not_here
```
can now log a warning like this
```
2021-02-20 23:17:55 WARNING (MainThread) [homeassistant.components.automation] Error evaluating condition:
In 'condition':
  In 'or' (item 1 of 2):
    In 'numeric_state' condition: entity sensor.front_door_battery_level state 'x' cannot be processed as a number
  In 'or' (item 2 of 2):
    In 'not':
      In 'state' condition: the 'state' entity input_number.not_here is unavailable
```

I also added a "breaking change" note that covers all the `ConditionError` changes, not so much this PR.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
