### PR TITLE
Test zwave_js GE 12730 fan controller device-specific discovery

### DIFF
--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -382,7 +382,7 @@ def iblinds_cover_fixture(client, iblinds_v2_state):
 
 
 @pytest.fixture(name="ge_12730")
-def ge_12730_fan_fixture(client, ge_12730_state):
+def ge_12730_fixture(client, ge_12730_state):
     """Mock a GE 12730 fan controller node."""
     node = Node(client, ge_12730_state)
     client.driver.controller.nodes[node.node_id] = node

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -170,6 +170,12 @@ def iblinds_v2_state_fixture():
     return json.loads(load_fixture("zwave_js/cover_iblinds_v2_state.json"))
 
 
+@pytest.fixture(name="ge_12730_state", scope="session")
+def ge_12730_state_fixture():
+    """Load the GE 12730 node state fixture data."""
+    return json.loads(load_fixture("zwave_js/fan_ge_12730_state.json"))
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state):
     """Mock a client."""
@@ -371,5 +377,13 @@ def motorized_barrier_cover_fixture(client, gdc_zw062_state):
 def iblinds_cover_fixture(client, iblinds_v2_state):
     """Mock an iBlinds v2.0 window cover node."""
     node = Node(client, iblinds_v2_state)
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="ge_12730")
+def ge_12730_fan_fixture(client, ge_12730_state):
+    """Mock a GE 12730 fan controller node."""
+    node = Node(client, ge_12730_state)
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -14,7 +14,7 @@ async def test_iblinds_v2(hass, client, iblinds_v2, integration):
 
 
 async def test_ge_12730(hass, client, ge_12730, integration):
-    """Test that a GE 12730 Fan Controller v2.0 multilevel switch value is discovered as a fan."""
+    """Test GE 12730 Fan Controller v2.0 multilevel switch is discovered as a fan."""
     node = ge_12730
     assert node.device_class.specific == "Multilevel Power Switch"
 

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -3,7 +3,6 @@
 
 async def test_iblinds_v2(hass, client, iblinds_v2, integration):
     """Test that an iBlinds v2.0 multilevel switch value is discovered as a cover."""
-
     node = iblinds_v2
     assert node.device_class.specific == "Unused"
 
@@ -11,4 +10,16 @@ async def test_iblinds_v2(hass, client, iblinds_v2, integration):
     assert not state
 
     state = hass.states.get("cover.window_blind_controller")
+    assert state
+
+
+async def test_ge_12730(hass, client, ge_12730, integration):
+    """Test that a GE 12730 Fan Controller v2.0 multilevel switch value is discovered as a fan."""
+    node = ge_12730
+    assert node.device_class.specific == "Multilevel Power Switch"
+
+    state = hass.states.get("light.in_wall_smart_fan_control")
+    assert not state
+
+    state = hass.states.get("fan.in_wall_smart_fan_control")
     assert state

--- a/tests/fixtures/zwave_js/fan_ge_12730_state.json
+++ b/tests/fixtures/zwave_js/fan_ge_12730_state.json
@@ -1,0 +1,434 @@
+{
+    "nodeId": 24,
+    "index": 0,
+    "status": 4,
+    "ready": true,
+    "deviceClass": {
+        "basic": "Routing Slave",
+        "generic": "Multilevel Switch",
+        "specific": "Multilevel Power Switch",
+        "mandatorySupportedCCs": [
+            "Basic",
+            "Multilevel Switch",
+            "All Switch"
+        ],
+        "mandatoryControlCCs": []
+    },
+    "isListening": true,
+    "isFrequentListening": false,
+    "isRouting": true,
+    "maxBaudRate": 40000,
+    "isSecure": false,
+    "version": 4,
+    "isBeaming": true,
+    "manufacturerId": 99,
+    "productId": 12340,
+    "productType": 18756,
+    "firmwareVersion": "3.10",
+    "deviceConfig": {
+        "manufacturerId": 99,
+        "manufacturer": "GE/Jasco",
+        "label": "12730  / ZW4002",
+        "description": "In-Wall Smart Fan Control",
+        "devices": [
+            {
+                "productType": "0x4944",
+                "productId": "0x3034"
+            }
+        ],
+        "firmwareVersion": {
+            "min": "0.0",
+            "max": "255.255"
+        },
+        "paramInformation": {
+            "_map": {}
+        }
+    },
+    "label": "12730  / ZW4002",
+    "neighbors": [
+        1,
+        12
+    ],
+    "interviewAttempts": 1,
+    "interviewStage": 7,
+    "endpoints": [
+        {
+            "nodeId": 24,
+            "index": 0
+        }
+    ],
+    "values": [
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "targetValue",
+            "propertyName": "targetValue",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "min": 0,
+                "max": 99,
+                "label": "Target value"
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "duration",
+            "propertyName": "duration",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "duration",
+                "readable": true,
+                "writeable": true,
+                "label": "Transition duration"
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "currentValue",
+            "propertyName": "currentValue",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 99,
+                "label": "Current value"
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "Up",
+            "propertyName": "Up",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": true,
+                "label": "Perform a level change (Up)",
+                "ccSpecific": {
+                    "switchType": 2
+                }
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 38,
+            "commandClassName": "Multilevel Switch",
+            "property": "Down",
+            "propertyName": "Down",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "boolean",
+                "readable": true,
+                "writeable": true,
+                "label": "Perform a level change (Down)",
+                "ccSpecific": {
+                    "switchType": 2
+                }
+            }
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 3,
+            "propertyName": "LED Light",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 2,
+                "default": 0,
+                "format": 0,
+                "allowManualEntry": false,
+                "states": {
+                    "0": "LED on when light off",
+                    "1": "LED on when light on",
+                    "2": "LED always off"
+                },
+                "label": "LED Light",
+                "description": "Sets when the LED on the switch is lit.",
+                "isFromConfig": true
+            },
+            "value": 1
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 4,
+            "propertyName": "Invert Switch",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 1,
+                "default": 0,
+                "format": 0,
+                "allowManualEntry": false,
+                "states": {
+                    "0": "No",
+                    "1": "Yes"
+                },
+                "label": "Invert Switch",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 7,
+            "propertyName": "Dim Rate Steps (Z-Wave Command)",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 0,
+                "max": 99,
+                "default": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Dim Rate Steps (Z-Wave Command)",
+                "description": "Number of steps or levels",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 8,
+            "propertyName": "Dim Rate Timing (Z-Wave)",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 2,
+                "min": 1,
+                "max": 255,
+                "default": 3,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Dim Rate Timing (Z-Wave)",
+                "description": "Timing of steps or levels",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 9,
+            "propertyName": "Dim Rate Steps (Manual)",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 1,
+                "max": 99,
+                "default": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Dim Rate Steps (Manual)",
+                "description": "Number of steps or levels",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 10,
+            "propertyName": "Dim Rate Timing (Manual)",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 2,
+                "min": 1,
+                "max": 255,
+                "default": 3,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Dim Rate Timing (Manual)",
+                "description": "Timing of steps",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 11,
+            "propertyName": "Dim Rate Steps (All-On/All-Off)",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 1,
+                "min": 1,
+                "max": 99,
+                "default": 1,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Dim Rate Steps (All-On/All-Off)",
+                "description": "Number of steps or levels",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 112,
+            "commandClassName": "Configuration",
+            "property": 12,
+            "propertyName": "Dim Rate Timing (All-On/All-Off)",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": true,
+                "valueSize": 2,
+                "min": 1,
+                "max": 255,
+                "default": 3,
+                "format": 1,
+                "allowManualEntry": true,
+                "label": "Dim Rate Timing (All-On/All-Off)",
+                "description": "Timing of steps or levels",
+                "isFromConfig": true
+            },
+            "value": 0
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "manufacturerId",
+            "propertyName": "manufacturerId",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Manufacturer ID"
+            },
+            "value": 99
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "productType",
+            "propertyName": "productType",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Product type"
+            },
+            "value": 18756
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 114,
+            "commandClassName": "Manufacturer Specific",
+            "property": "productId",
+            "propertyName": "productId",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "number",
+                "readable": true,
+                "writeable": false,
+                "min": 0,
+                "max": 65535,
+                "label": "Product ID"
+            },
+            "value": 12340
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "libraryType",
+            "propertyName": "libraryType",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Library type"
+            },
+            "value": 6
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "protocolVersion",
+            "propertyName": "protocolVersion",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave protocol version"
+            },
+            "value": "3.67"
+        },
+        {
+            "endpoint": 0,
+            "commandClass": 134,
+            "commandClassName": "Version",
+            "property": "firmwareVersions",
+            "propertyName": "firmwareVersions",
+            "ccVersion": 1,
+            "metadata": {
+                "type": "any",
+                "readable": true,
+                "writeable": false,
+                "label": "Z-Wave chip firmware versions"
+            },
+            "value": [
+                "3.10"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a test for device-specific discovery of a GE 12730 fan controller.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
