### PR TITLE
Avoid having to ask for the bond token when possible during config

### DIFF
--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -14,16 +14,17 @@ from homeassistant.const import (
     HTTP_UNAUTHORIZED,
 )
 
-from .const import CONF_BOND_ID
 from .const import DOMAIN  # pylint:disable=unused-import
 from .utils import BondHub
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA_USER = vol.Schema(
+
+USER_SCHEMA = vol.Schema(
     {vol.Required(CONF_HOST): str, vol.Required(CONF_ACCESS_TOKEN): str}
 )
-DATA_SCHEMA_DISCOVERY = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
+DISCOVERY_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
+TOKEN_SCHEMA = vol.Schema({})
 
 
 async def _validate_input(data: Dict[str, Any]) -> Tuple[str, Optional[str]]:
@@ -56,7 +57,30 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
 
-    _discovered: dict = None
+    def __init__(self):
+        """Initialize config flow."""
+        self._discovered: dict = None
+
+    async def _async_try_automatic_configure(self):
+        """Try to auto configure the device.
+
+        Failure is acceptable here since the device may have been
+        online longer then the allowed setup period, and we will
+        instead ask them to manually enter the token.
+        """
+        bond = Bond(self._discovered[CONF_HOST], "")
+        try:
+            response = await bond.token()
+        except ClientConnectionError:
+            return
+
+        token = response.get("token")
+        if token is None:
+            return
+
+        self._discovered[CONF_ACCESS_TOKEN] = token
+        _, hub_name = await _validate_input(self._discovered)
+        self._discovered[CONF_NAME] = hub_name
 
     async def async_step_zeroconf(
         self, discovery_info: Optional[Dict[str, Any]] = None
@@ -68,11 +92,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(bond_id)
         self._abort_if_unique_id_configured({CONF_HOST: host})
 
-        self._discovered = {
-            CONF_HOST: host,
-            CONF_BOND_ID: bond_id,
-        }
-        self.context.update({"title_placeholders": self._discovered})
+        self._discovered = {CONF_HOST: host, CONF_NAME: bond_id}
+        await self._async_try_automatic_configure()
+
+        self.context.update(
+            {
+                "title_placeholders": {
+                    CONF_HOST: self._discovered[CONF_HOST],
+                    CONF_NAME: self._discovered[CONF_NAME],
+                }
+            }
+        )
 
         return await self.async_step_confirm()
 
@@ -82,16 +112,37 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Handle confirmation flow for discovered bond hub."""
         errors = {}
         if user_input is not None:
-            data = user_input.copy()
-            data[CONF_HOST] = self._discovered[CONF_HOST]
+            if CONF_ACCESS_TOKEN in self._discovered:
+                return self.async_create_entry(
+                    title=self._discovered[CONF_NAME],
+                    data={
+                        CONF_ACCESS_TOKEN: self._discovered[CONF_ACCESS_TOKEN],
+                        CONF_HOST: self._discovered[CONF_HOST],
+                    },
+                )
+
+            data = {
+                CONF_ACCESS_TOKEN: user_input[CONF_ACCESS_TOKEN],
+                CONF_HOST: self._discovered[CONF_HOST],
+            }
             try:
-                return await self._try_create_entry(data)
+                _, hub_name = await _validate_input(data)
             except InputValidationError as error:
                 errors["base"] = error.base
+            else:
+                return self.async_create_entry(
+                    title=hub_name,
+                    data=data,
+                )
+
+        if CONF_ACCESS_TOKEN in self._discovered:
+            data_schema = TOKEN_SCHEMA
+        else:
+            data_schema = DISCOVERY_SCHEMA
 
         return self.async_show_form(
             step_id="confirm",
-            data_schema=DATA_SCHEMA_DISCOVERY,
+            data_schema=data_schema,
             errors=errors,
             description_placeholders=self._discovered,
         )
@@ -103,20 +154,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         if user_input is not None:
             try:
-                return await self._try_create_entry(user_input)
+                bond_id, hub_name = await _validate_input(user_input)
             except InputValidationError as error:
                 errors["base"] = error.base
+            else:
+                await self.async_set_unique_id(bond_id)
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=hub_name, data=user_input)
 
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA_USER, errors=errors
+            step_id="user", data_schema=USER_SCHEMA, errors=errors
         )
-
-    async def _try_create_entry(self, data: Dict[str, Any]) -> Dict[str, Any]:
-        bond_id, name = await _validate_input(data)
-        await self.async_set_unique_id(bond_id)
-        self._abort_if_unique_id_configured()
-        hub_name = name or bond_id
-        return self.async_create_entry(title=hub_name, data=data)
 
 
 class InputValidationError(exceptions.HomeAssistantError):

--- a/homeassistant/components/bond/manifest.json
+++ b/homeassistant/components/bond/manifest.json
@@ -3,7 +3,7 @@
   "name": "Bond",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/bond",
-  "requirements": ["bond-api==0.1.10"],
+  "requirements": ["bond-api==0.1.11"],
   "zeroconf": ["_bond._tcp.local."],
   "codeowners": ["@prystupa"],
   "quality_scale": "platinum"

--- a/homeassistant/components/bond/strings.json
+++ b/homeassistant/components/bond/strings.json
@@ -1,9 +1,9 @@
 {
   "config": {
-    "flow_title": "Bond: {bond_id} ({host})",
+    "flow_title": "Bond: {name} ({host})",
     "step": {
       "confirm": {
-        "description": "Do you want to set up {bond_id}?",
+        "description": "Do you want to set up {name}?",
         "data": {
           "access_token": "[%key:common::config_flow::data::access_token%]"
         }

--- a/homeassistant/components/bond/translations/en.json
+++ b/homeassistant/components/bond/translations/en.json
@@ -9,13 +9,13 @@
             "old_firmware": "Unsupported old firmware on the Bond device - please upgrade before continuing",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Bond: {bond_id} ({host})",
+        "flow_title": "Bond: {name} ({host})",
         "step": {
             "confirm": {
                 "data": {
                     "access_token": "Access Token"
                 },
-                "description": "Do you want to set up {bond_id}?"
+                "description": "Do you want to set up {name}?"
             },
             "user": {
                 "data": {

--- a/homeassistant/components/bond/utils.py
+++ b/homeassistant/components/bond/utils.py
@@ -150,11 +150,11 @@ class BondHub:
         return self._version.get("make", BRIDGE_MAKE)
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str:
         """Get the name of this bridge."""
         if not self.is_bridge and self._devices:
             return self._devices[0].name
-        return self._bridge.get("name")
+        return self._bridge["name"]
 
     @property
     def location(self) -> Optional[str]:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -371,7 +371,7 @@ blockchain==1.4.4
 # bme680==1.0.5
 
 # homeassistant.components.bond
-bond-api==0.1.10
+bond-api==0.1.11
 
 # homeassistant.components.amazon_polly
 # homeassistant.components.route53

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -205,7 +205,7 @@ blebox_uniapi==1.3.2
 blinkpy==0.17.0
 
 # homeassistant.components.bond
-bond-api==0.1.10
+bond-api==0.1.11
 
 # homeassistant.components.braviatv
 bravia-tv==1.0.8

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -205,7 +205,37 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
 
     with patch_bond_version(
         return_value={"bondid": "test-bond-id"}
-    ), patch_bond_token(), patch_bond_bridge(), patch_bond_device_ids(), _patch_async_setup() as mock_setup, _patch_async_setup_entry() as mock_setup_entry:
+    ), patch_bond_bridge(), patch_bond_device_ids(), _patch_async_setup() as mock_setup, _patch_async_setup_entry() as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_ACCESS_TOKEN: "test-token"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "bond-name"
+    assert result2["data"] == {
+        CONF_HOST: "test-host",
+        CONF_ACCESS_TOKEN: "test-token",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_form_token_unavailable(hass: core.HomeAssistant):
+    """Test we get the discovery form and we handle the token being unavailable."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch_bond_version(), patch_bond_token():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data={"name": "test-bond-id.some-other-tail-info", "host": "test-host"},
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch_bond_version(), patch_bond_bridge(), patch_bond_device_ids(), _patch_async_setup() as mock_setup, _patch_async_setup_entry() as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_ACCESS_TOKEN: "test-token"},

--- a/tests/components/bond/test_config_flow.py
+++ b/tests/components/bond/test_config_flow.py
@@ -13,6 +13,7 @@ from .common import (
     patch_bond_device,
     patch_bond_device_ids,
     patch_bond_device_properties,
+    patch_bond_token,
     patch_bond_version,
 )
 
@@ -204,7 +205,7 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
 
     with patch_bond_version(
         return_value={"bondid": "test-bond-id"}
-    ), patch_bond_bridge(), patch_bond_device_ids(), _patch_async_setup() as mock_setup, _patch_async_setup_entry() as mock_setup_entry:
+    ), patch_bond_token(), patch_bond_bridge(), patch_bond_device_ids(), _patch_async_setup() as mock_setup, _patch_async_setup_entry() as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {CONF_ACCESS_TOKEN: "test-token"},
@@ -216,6 +217,40 @@ async def test_zeroconf_form(hass: core.HomeAssistant):
     assert result2["data"] == {
         CONF_HOST: "test-host",
         CONF_ACCESS_TOKEN: "test-token",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_zeroconf_form_with_token_available(hass: core.HomeAssistant):
+    """Test we get the discovery form when we can get the token."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    with patch_bond_version(return_value={"bondid": "test-bond-id"}), patch_bond_token(
+        return_value={"token": "discovered-token"}
+    ), patch_bond_bridge(
+        return_value={"name": "discovered-name"}
+    ), patch_bond_device_ids():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data={"name": "test-bond-id.some-other-tail-info", "host": "test-host"},
+        )
+        await hass.async_block_till_done()
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with _patch_async_setup() as mock_setup, _patch_async_setup_entry() as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "discovered-name"
+    assert result2["data"] == {
+        CONF_HOST: "test-host",
+        CONF_ACCESS_TOKEN: "discovered-token",
     }
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Upstream changelog: https://github.com/prystupa/bond-api/compare/v0.1.10...v0.1.11

The bond device will be unlocked for the first 10 minutes
after boot. We now try to fetch the token as soon as we
see the device so they do not have to go find it in the app
which avoids the need for the user to have to enter anything
in the form.  This also allows us to discover the name of the
bond bridge or device instead of presenting the non-friendly
bondid


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
