### PR TITLE
Fill openweathermap option dialog with setup values

### DIFF
--- a/homeassistant/components/openweathermap/config_flow.py
+++ b/homeassistant/components/openweathermap/config_flow.py
@@ -108,19 +108,18 @@ class OpenWeatherMapOptionsFlow(config_entries.OptionsFlow):
         return vol.Schema(
             {
                 vol.Optional(
-                    CONF_MODE,
-                    default=self.config_entry.options.get(
-                        CONF_MODE, DEFAULT_FORECAST_MODE
-                    ),
+                    CONF_MODE, default=self._get_config_value(CONF_MODE)
                 ): vol.In(FORECAST_MODES),
                 vol.Optional(
-                    CONF_LANGUAGE,
-                    default=self.config_entry.options.get(
-                        CONF_LANGUAGE, DEFAULT_LANGUAGE
-                    ),
+                    CONF_LANGUAGE, default=self._get_config_value(CONF_LANGUAGE)
                 ): vol.In(LANGUAGES),
             }
         )
+
+    def _get_config_value(self, key):
+        if self.config_entry.options:
+            return self.config_entry.options[key]
+        return self.config_entry.data[key]
 
 
 async def _is_owm_api_online(hass, api_key, lat, lon):

--- a/tests/components/openweathermap/test_config_flow.py
+++ b/tests/components/openweathermap/test_config_flow.py
@@ -127,6 +127,120 @@ async def test_form_options(hass):
         assert config_entry.state == "loaded"
 
 
+async def test_form_options_default_language(hass):
+    """Test that the options form."""
+    mocked_owm = _create_mocked_owm(True)
+
+    with patch(
+        "pyowm.weatherapi25.weather_manager.WeatherManager",
+        return_value=mocked_owm,
+    ):
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, unique_id="openweathermap_unique_id", data=CONFIG
+        )
+        config_entry.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert config_entry.state == "loaded"
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_MODE: "daily"}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options == {
+            CONF_MODE: "daily",
+            CONF_LANGUAGE: DEFAULT_LANGUAGE,
+        }
+
+        await hass.async_block_till_done()
+
+        assert config_entry.state == "loaded"
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={CONF_LANGUAGE: "it"}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options == {
+            CONF_MODE: "daily",
+            CONF_LANGUAGE: "it",
+        }
+
+        await hass.async_block_till_done()
+
+        assert config_entry.state == "loaded"
+
+
+async def test_form_options_defaults_all(hass):
+    """Test that the options form."""
+    mocked_owm = _create_mocked_owm(True)
+
+    with patch(
+        "pyowm.weatherapi25.weather_manager.WeatherManager",
+        return_value=mocked_owm,
+    ):
+        config_entry = MockConfigEntry(
+            domain=DOMAIN, unique_id="openweathermap_unique_id", data=CONFIG
+        )
+        config_entry.add_to_hass(hass)
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert config_entry.state == "loaded"
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options == {
+            CONF_MODE: DEFAULT_FORECAST_MODE,
+            CONF_LANGUAGE: DEFAULT_LANGUAGE,
+        }
+
+        await hass.async_block_till_done()
+
+        assert config_entry.state == "loaded"
+
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input={}
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+        assert config_entry.options == {
+            CONF_MODE: DEFAULT_FORECAST_MODE,
+            CONF_LANGUAGE: DEFAULT_LANGUAGE,
+        }
+
+        await hass.async_block_till_done()
+
+        assert config_entry.state == "loaded"
+
+
 async def test_form_invalid_api_key(hass):
     """Test that the form is served with no input."""
     mocked_owm = _create_mocked_owm(True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change makes sure that the options selected in the integration setup are loaded in the options dialog too. fixes: #45517

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45517


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
