### PR TITLE
Handle ConditionError with multiple entity_id for state/numeric_state

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -85,7 +85,7 @@ class ConditionErrorIndex(ConditionError):
 
 @attr.s
 class ConditionErrorContainer(ConditionError):
-    """Condition error with index."""
+    """Condition error with subconditions."""
 
     # List of ConditionErrors that this error wraps
     errors: Sequence[ConditionError] = attr.ib()

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -390,17 +390,18 @@ async def test_state_raises(hass):
     with pytest.raises(ConditionError, match="no entity"):
         condition.state(hass, entity=None, req_state="missing")
 
-    # Unknown entity_id
-    with pytest.raises(ConditionError, match="unknown entity"):
-        test = await condition.async_from_config(
-            hass,
-            {
-                "condition": "state",
-                "entity_id": "sensor.door_unknown",
-                "state": "open",
-            },
-        )
-
+    # Unknown entities
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "state",
+            "entity_id": ["sensor.door_unknown", "sensor.window_unknown"],
+            "state": "open",
+        },
+    )
+    with pytest.raises(ConditionError, match="unknown entity.*door"):
+        test(hass)
+    with pytest.raises(ConditionError, match="unknown entity.*window"):
         test(hass)
 
     # Unknown attribute
@@ -632,17 +633,18 @@ async def test_state_using_input_entities(hass):
 
 async def test_numeric_state_raises(hass):
     """Test that numeric_state raises ConditionError on errors."""
-    # Unknown entity_id
-    with pytest.raises(ConditionError, match="unknown entity"):
-        test = await condition.async_from_config(
-            hass,
-            {
-                "condition": "numeric_state",
-                "entity_id": "sensor.temperature_unknown",
-                "above": 0,
-            },
-        )
-
+    # Unknown entities
+    test = await condition.async_from_config(
+        hass,
+        {
+            "condition": "numeric_state",
+            "entity_id": ["sensor.temperature_unknown", "sensor.humidity_unknown"],
+            "above": 0,
+        },
+    )
+    with pytest.raises(ConditionError, match="unknown entity.*temperature"):
+        test(hass)
+    with pytest.raises(ConditionError, match="unknown entity.*humidity"):
         test(hass)
 
     # Unknown attribute


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I have missed that `state` and `numeric_state` can work on multiple `entity_id`. This PR makes them collect all errors rather than abort on the first one.

```yaml
  condition:
    - condition: numeric_state
      entity_id:
      - sensor.front_door_battery_level_1
      - sensor.front_door_battery_level_2
      - sensor.front_door_battery_level_3
      below: 90
    - condition: state
      entity_id:
      - sensor.front_door_battery_level_1
      - sensor.front_door_battery_level_2
      - sensor.front_door_battery_level_3
      state: "ok"
```
⬇️
```
2021-02-21 17:44:33 WARNING (MainThread) [homeassistant.components.automation] Error evaluating condition:
In 'condition' (item 1 of 2):
  In 'numeric_state' (item 1 of 3):
    In 'numeric_state' condition: unknown entity sensor.front_door_battery_level_1
  In 'numeric_state' (item 2 of 3):
    In 'numeric_state' condition: unknown entity sensor.front_door_battery_level_2
  In 'numeric_state' (item 3 of 3):
    In 'numeric_state' condition: unknown entity sensor.front_door_battery_level_3
In 'condition' (item 2 of 2):
  In 'state' (item 1 of 3):
    In 'state' condition: unknown entity sensor.front_door_battery_level_1
  In 'state' (item 2 of 3):
    In 'state' condition: unknown entity sensor.front_door_battery_level_2
  In 'state' (item 3 of 3):
    In 'state' condition: unknown entity sensor.front_door_battery_level_3
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
