### PR TITLE
Deprecate knx config_file

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -75,8 +75,6 @@ SERVICE_KNX_READ = "read"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
-            # deprecated since 2021.3
-            cv.deprecated(CONF_KNX_CONFIG),
             # deprecated since 2021.2
             cv.deprecated(CONF_KNX_FIRE_EVENT),
             cv.deprecated("fire_event_filter", replacement_key=CONF_KNX_EVENT_FILTER),

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -75,6 +75,8 @@ SERVICE_KNX_READ = "read"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
+            # deprecated since 2021.3
+            cv.deprecated(CONF_KNX_CONFIG),
             # deprecated since 2021.2
             cv.deprecated(CONF_KNX_FIRE_EVENT),
             cv.deprecated("fire_event_filter", replacement_key=CONF_KNX_EVENT_FILTER),
@@ -232,15 +234,11 @@ async def async_setup(hass, config):
 
     # deprecation warning since 2021.3
     if CONF_KNX_CONFIG in config[DOMAIN]:
-        config_file_deprecation_warning = (
-            f"The 'config_file' option will soon be deprecated. Please replace it with Home Assistant config schema "
-            f"directly in `configuration.yaml` (see https://www.home-assistant.io/integrations/knx/). \n"
-            f"An online configuration converter tool for your `{config[DOMAIN][CONF_KNX_CONFIG]}` is available at https://xknx.io/config-converter/"
-        )
-        _LOGGER.warning(config_file_deprecation_warning)
-        hass.components.persistent_notification.async_create(
-            config_file_deprecation_warning,
-            title="KNX",
+        _LOGGER.warning(
+            "The 'config_file' option will soon be deprecated. Please replace it with Home Assistant config schema "
+            "directly in `configuration.yaml` (see https://www.home-assistant.io/integrations/knx/). \n"
+            "An online configuration converter tool for your `%s` is available at https://xknx.io/config-converter/",
+            config[DOMAIN][CONF_KNX_CONFIG],
         )
 
     hass.services.async_register(

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -233,9 +233,9 @@ async def async_setup(hass, config):
     # deprecation warning since 2021.3
     if CONF_KNX_CONFIG in config[DOMAIN]:
         config_file_deprecation_warning = (
-            f"The 'config_file' option will soon be deprecated, please replace it with Home Assistant config schema "
-            f"directly in configuration.yaml https://www.home-assistant.io/integrations/knx/. \n"
-            f"A configuration converter tool for your `{config[DOMAIN][CONF_KNX_CONFIG]}` is available at https://xknx.io/config-converter/"
+            f"The 'config_file' option will soon be deprecated. Please replace it with Home Assistant config schema "
+            f"directly in `configuration.yaml` (see https://www.home-assistant.io/integrations/knx/). \n"
+            f"An online configuration converter tool for your `{config[DOMAIN][CONF_KNX_CONFIG]}` is available at https://xknx.io/config-converter/"
         )
         _LOGGER.warning(config_file_deprecation_warning)
         hass.components.persistent_notification.async_create(

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -80,6 +80,9 @@ SERVICE_KNX_READ = "read"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
+            # deprecated since 2021.3
+            cv.deprecated(CONF_KNX_CONFIG, replacement_key=CONF_KNX_CONFIG),
+            # deprecated since 2021.2
             cv.deprecated(CONF_KNX_FIRE_EVENT),
             cv.deprecated("fire_event_filter", replacement_key=CONF_KNX_EVENT_FILTER),
             vol.Schema(
@@ -211,6 +214,14 @@ async def async_setup(hass, config):
         _LOGGER.warning(
             "No KNX devices are configured. Please read "
             "https://www.home-assistant.io/blog/2020/09/17/release-115/#breaking-changes"
+        )
+
+    if config[DOMAIN].get(CONF_KNX_CONFIG):
+        _LOGGER.warning(
+            "Deprecated configuration method `config_file: %s` used. Please move to Home Assistant config schema "
+            "https://www.home-assistant.io/integrations/knx/. A configuration converter tool is available at "
+            "https://xknx.io/config-converter/",
+            config[DOMAIN].get(CONF_KNX_CONFIG),
         )
 
     hass.services.async_register(

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -75,8 +75,6 @@ SERVICE_KNX_READ = "read"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
-            # deprecated since 2021.3
-            cv.deprecated(CONF_KNX_CONFIG, replacement_key=CONF_KNX_CONFIG),
             # deprecated since 2021.2
             cv.deprecated(CONF_KNX_FIRE_EVENT),
             cv.deprecated("fire_event_filter", replacement_key=CONF_KNX_EVENT_FILTER),
@@ -232,12 +230,17 @@ async def async_setup(hass, config):
             "https://www.home-assistant.io/blog/2020/09/17/release-115/#breaking-changes"
         )
 
-    if config[DOMAIN].get(CONF_KNX_CONFIG):
-        _LOGGER.warning(
-            "Deprecated configuration method `config_file: %s` used. Please move to Home Assistant config schema "
-            "https://www.home-assistant.io/integrations/knx/. A configuration converter tool is available at "
-            "https://xknx.io/config-converter/",
-            config[DOMAIN].get(CONF_KNX_CONFIG),
+    # deprecation warning since 2021.3
+    if CONF_KNX_CONFIG in config[DOMAIN]:
+        config_file_deprecation_warning = (
+            f"The 'config_file' option will soon be deprecated, please replace it with Home Assistant config schema "
+            f"directly in configuration.yaml https://www.home-assistant.io/integrations/knx/. \n"
+            f"A configuration converter tool for your `{config[DOMAIN][CONF_KNX_CONFIG]}` is available at https://xknx.io/config-converter/"
+        )
+        _LOGGER.warning(config_file_deprecation_warning)
+        hass.components.persistent_notification.async_create(
+            config_file_deprecation_warning,
+            title="KNX",
         )
 
     hass.services.async_register(

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -235,7 +235,7 @@ async def async_setup(hass, config):
     # deprecation warning since 2021.3
     if CONF_KNX_CONFIG in config[DOMAIN]:
         _LOGGER.warning(
-            "The 'config_file' option will soon be deprecated. Please replace it with Home Assistant config schema "
+            "The 'config_file' option is deprecated. Please replace it with Home Assistant config schema "
             "directly in `configuration.yaml` (see https://www.home-assistant.io/integrations/knx/). \n"
             "An online configuration converter tool for your `%s` is available at https://xknx.io/config-converter/",
             config[DOMAIN][CONF_KNX_CONFIG],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
xknx.yaml `config_file` is deprecated.

With this PR only a deprecation message and a warning in the logs is displayed. The `config_file` will continue to work as before until it is removed.
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The KNX integration currently supports 2 configuration Schemes
- HA-Schema: used in Home Assistant configuration.yaml and documented at https://www.home-assistant.io/integrations/knx/
- XKNX-Schema: provided in a separate .yaml file whose path is configured with the `config_file:` key

Having 2 different configuration Schemes is a constant source for issues and bugs.

We want to deprecate the XKNX-Schema and only support HA-Schema in the future. 
To help users with the schema transition we set up an online config-converter at https://xknx.io/config-converter/ where users can paste their XKNX-Schema and get a HA-Schema to copy to configuration.yaml .

This will allow us to take complexity out of the HA-integration and xknx at the same time. Maintainability and building new features will also be easier.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16684

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
