### PR TITLE
Support value_template in MQTT triggers

### DIFF
--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_PAYLOAD, CONF_PLATFORM
+from homeassistant.const import CONF_PAYLOAD, CONF_PLATFORM, CONF_VALUE_TEMPLATE
 from homeassistant.core import HassJob, callback
 from homeassistant.helpers import config_validation as cv, template
 
@@ -23,6 +23,7 @@ TRIGGER_SCHEMA = vol.Schema(
         vol.Required(CONF_PLATFORM): mqtt.DOMAIN,
         vol.Required(CONF_TOPIC): mqtt.util.valid_subscribe_topic_template,
         vol.Optional(CONF_PAYLOAD): cv.template,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
         vol.Optional(CONF_QOS, default=DEFAULT_QOS): vol.All(
             vol.Coerce(int), vol.In([0, 1, 2])
@@ -36,7 +37,8 @@ _LOGGER = logging.getLogger(__name__)
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     topic = config[CONF_TOPIC]
-    payload = config.get(CONF_PAYLOAD)
+    wanted_payload = config.get(CONF_PAYLOAD)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
     encoding = config[CONF_ENCODING] or None
     qos = config[CONF_QOS]
     job = HassJob(action)
@@ -44,19 +46,29 @@ async def async_attach_trigger(hass, config, action, automation_info):
     if automation_info:
         variables = automation_info.get("variables")
 
-    template.attach(hass, payload)
-    if payload:
-        payload = payload.async_render(variables, limited=True)
+    template.attach(hass, wanted_payload)
+    if wanted_payload:
+        wanted_payload = wanted_payload.async_render(variables, limited=True)
 
     template.attach(hass, topic)
     if isinstance(topic, template.Template):
         topic = topic.async_render(variables, limited=True)
         topic = mqtt.util.valid_subscribe_topic(topic)
 
+    template.attach(hass, value_template)
+
     @callback
     def mqtt_automation_listener(mqttmsg):
         """Listen for MQTT messages."""
-        if payload is None or payload == mqttmsg.payload:
+        payload = mqttmsg.payload
+
+        if value_template is not None:
+            payload = value_template.async_render_with_possible_json_value(
+                payload,
+                error_value=None,
+            )
+
+        if wanted_payload is None or wanted_payload == payload:
             data = {
                 "platform": "mqtt",
                 "topic": mqttmsg.topic,
@@ -73,7 +85,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
             hass.async_run_hass_job(job, {"trigger": data})
 
     _LOGGER.debug(
-        "Attaching MQTT trigger for topic: '%s', payload: '%s'", topic, payload
+        "Attaching MQTT trigger for topic: '%s', payload: '%s'", topic, wanted_payload
     )
 
     remove = await mqtt.async_subscribe(

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -4,7 +4,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_PAYLOAD, CONF_PLATFORM
+from homeassistant.const import CONF_PAYLOAD, CONF_PLATFORM, CONF_VALUE_TEMPLATE
 from homeassistant.core import HassJob, callback
 from homeassistant.helpers import config_validation as cv, template
 
@@ -13,7 +13,6 @@ from .. import mqtt
 # mypy: allow-untyped-defs
 
 CONF_ENCODING = "encoding"
-CONF_PAYLOAD_TEMPLATE = "payload_template"
 CONF_QOS = "qos"
 CONF_TOPIC = "topic"
 DEFAULT_ENCODING = "utf-8"
@@ -24,7 +23,7 @@ TRIGGER_SCHEMA = vol.Schema(
         vol.Required(CONF_PLATFORM): mqtt.DOMAIN,
         vol.Required(CONF_TOPIC): mqtt.util.valid_subscribe_topic_template,
         vol.Optional(CONF_PAYLOAD): cv.template,
-        vol.Optional(CONF_PAYLOAD_TEMPLATE): cv.template,
+        vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
         vol.Optional(CONF_ENCODING, default=DEFAULT_ENCODING): cv.string,
         vol.Optional(CONF_QOS, default=DEFAULT_QOS): vol.All(
             vol.Coerce(int), vol.In([0, 1, 2])
@@ -39,7 +38,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
     topic = config[CONF_TOPIC]
     wanted_payload = config.get(CONF_PAYLOAD)
-    payload_template = config.get(CONF_PAYLOAD_TEMPLATE)
+    value_template = config.get(CONF_VALUE_TEMPLATE)
     encoding = config[CONF_ENCODING] or None
     qos = config[CONF_QOS]
     job = HassJob(action)
@@ -56,15 +55,15 @@ async def async_attach_trigger(hass, config, action, automation_info):
         topic = topic.async_render(variables, limited=True)
         topic = mqtt.util.valid_subscribe_topic(topic)
 
-    template.attach(hass, payload_template)
+    template.attach(hass, value_template)
 
     @callback
     def mqtt_automation_listener(mqttmsg):
         """Listen for MQTT messages."""
         payload = mqttmsg.payload
 
-        if payload_template is not None:
-            payload = payload_template.async_render_with_possible_json_value(
+        if value_template is not None:
+            payload = value_template.async_render_with_possible_json_value(
                 payload,
                 error_value=None,
             )

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -122,7 +122,7 @@ async def test_if_fires_on_payload_template(hass, calls):
                     "platform": "mqtt",
                     "topic": "test-topic",
                     "payload": "hello",
-                    "value_template": "{{ value_json.wanted_key }}",
+                    "payload_template": "{{ value_json.wanted_key }}",
                 },
                 "action": {"service": "test.automation"},
             }

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -122,7 +122,7 @@ async def test_if_fires_on_payload_template(hass, calls):
                     "platform": "mqtt",
                     "topic": "test-topic",
                     "payload": "hello",
-                    "payload_template": "{{ value_json.wanted_key }}",
+                    "value_template": "{{ value_json.wanted_key }}",
                 },
                 "action": {"service": "test.automation"},
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support value_template in MQTT triggers, to for example allow picking out a JSON key from the incoming MQTT message.

This is a follow up to #45614 which introduced templating of the payload and topic to match on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example trigger configuration.
# The trigger will fire when receiving '{"wanted_key":"hello", "other_key":"abc"}'
- platform: "mqtt",
  topic: "test-topic",
  payload: "hello",
  value_template: "{{ value_json.wanted_key }}",
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16754

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
