### PR TITLE
Add `lock` platform to Somfy TaHoma integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -921,6 +921,7 @@ omit =
     homeassistant/components/tahoma/__init__.py
     homeassistant/components/tahoma/binary_sensor.py
     homeassistant/components/tahoma/coordinator.py
+    homeassistant/components/tahoma/lock.py
     homeassistant/components/tahoma/overkiz_executor.py
     homeassistant/components/tahoma/tahoma_entity.py
     homeassistant/components/tank_utility/sensor.py

--- a/homeassistant/components/tahoma/const.py
+++ b/homeassistant/components/tahoma/const.py
@@ -1,5 +1,6 @@
 """Constants for the Somfy TaHoma integration."""
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR
+from homeassistant.components.lock import DOMAIN as LOCK
 
 DOMAIN = "tahoma"
 
@@ -16,6 +17,7 @@ TAHOMA_TYPES = {
     "AirFlowSensor": BINARY_SENSOR,  # widgetName, uiClass is AirSensor (sensor)
     "CarButtonSensor": BINARY_SENSOR,
     "ContactSensor": BINARY_SENSOR,
+    "DoorLock": LOCK,
     "MotionSensor": BINARY_SENSOR,
     "OccupancySensor": BINARY_SENSOR,
     "RainSensor": BINARY_SENSOR,

--- a/homeassistant/components/tahoma/lock.py
+++ b/homeassistant/components/tahoma/lock.py
@@ -1,0 +1,44 @@
+"""Support for TaHoma locks."""
+import logging
+
+from homeassistant.components.lock import DOMAIN as LOCK, LockEntity
+from homeassistant.const import STATE_LOCKED
+
+from .const import DOMAIN
+from .tahoma_entity import TahomaEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+COMMAND_LOCK = "lock"
+COMMAND_UNLOCK = "unlock"
+
+CORE_LOCKED_UNLOCKED_STATE = "core:LockedUnlockedState"
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the TaHoma locks from a config entry."""
+    data = hass.data[DOMAIN][entry.entry_id]
+    coordinator = data["coordinator"]
+
+    entities = [
+        TahomaLock(device.deviceurl, coordinator) for device in data["platforms"][LOCK]
+    ]
+
+    async_add_entities(entities)
+
+
+class TahomaLock(TahomaEntity, LockEntity):
+    """Representation of a TaHoma Lock."""
+
+    async def async_unlock(self, **_):
+        """Unlock method."""
+        await self.async_execute_command(COMMAND_UNLOCK)
+
+    async def async_lock(self, **_):
+        """Lock method."""
+        await self.async_execute_command(COMMAND_LOCK)
+
+    @property
+    def is_locked(self):
+        """Return True if the lock is locked."""
+        return self.select_state(CORE_LOCKED_UNLOCKED_STATE) == STATE_LOCKED

--- a/homeassistant/components/tahoma/lock.py
+++ b/homeassistant/components/tahoma/lock.py
@@ -32,13 +32,13 @@ class TahomaLock(TahomaEntity, LockEntity):
 
     async def async_unlock(self, **_):
         """Unlock method."""
-        await self.async_execute_command(COMMAND_UNLOCK)
+        await self.executor.async_execute_command(COMMAND_UNLOCK)
 
     async def async_lock(self, **_):
         """Lock method."""
-        await self.async_execute_command(COMMAND_LOCK)
+        await self.executor.async_execute_command(COMMAND_LOCK)
 
     @property
     def is_locked(self):
         """Return True if the lock is locked."""
-        return self.select_state(CORE_LOCKED_UNLOCKED_STATE) == STATE_LOCKED
+        return self.executor.select_state(CORE_LOCKED_UNLOCKED_STATE) == STATE_LOCKED


### PR DESCRIPTION
## Proposed change
Add lock platform to Somfy TaHoma integration. Part of bigger TaHoma integration rewrite, target of this PR is `rework-tahoma` branch.

Lock platform is pretty simple, but it does the job.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14920

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
