### PR TITLE
Implement `suggested_area` for Somfy TaHoma integration

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -48,6 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     try:
         await client.login()
         devices = await client.get_devices()
+        places = await client.get_places()
     except BadCredentialsException:
         _LOGGER.error("Invalid authentication.")
         return False
@@ -74,6 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         name="device events",
         client=client,
         devices=devices,
+        places=places,
         update_interval=update_interval,
     )
 

--- a/homeassistant/components/tahoma/manifest.json
+++ b/homeassistant/components/tahoma/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tahoma",
   "requirements": [
-    "pyhoma==0.5.8"
+    "pyhoma==0.5.9"
   ],
   "codeowners": [
     "@imicknl",

--- a/homeassistant/components/tahoma/tahoma_entity.py
+++ b/homeassistant/components/tahoma/tahoma_entity.py
@@ -70,4 +70,5 @@ class TahomaEntity(CoordinatorEntity, Entity):
             "name": self.name,
             "model": model,
             "sw_version": self.device.controllable_name,
+            "suggested_area": self.coordinator.areas[self.device.placeoid],
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1434,7 +1434,7 @@ pyhik==0.2.8
 pyhiveapi==0.3.4.4
 
 # homeassistant.components.tahoma
-pyhoma==0.5.8
+pyhoma==0.5.9
 
 # homeassistant.components.homematic
 pyhomematic==0.1.71

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -751,7 +751,7 @@ pyhaversion==3.4.2
 pyheos==0.7.2
 
 # homeassistant.components.tahoma
-pyhoma==0.5.8
+pyhoma==0.5.9
 
 # homeassistant.components.homematic
 pyhomematic==0.1.71


### PR DESCRIPTION
## Proposed change
Add support for `suggested_area`, as suggested by @bdraco in https://github.com/home-assistant/core/pull/43966#discussion_r580296930.

Part of bigger TaHoma integration rewrite, target of this PR is `rework-tahoma` branch.

## Known issues / limitations

Currently areas do not show up in the first dialog, not sure if this is supported by `suggested_area`.
<img width="608" alt="Screen Shot 2021-02-22 at 21 59 55" src="https://user-images.githubusercontent.com/1424596/108773145-39153980-755e-11eb-86cf-f34dabb99ed6.png">

Currently areas are created if there is no exact match, not sure if this fuzzy matching is supported by `suggested_area`. 

<img width="1355" alt="Screen Shot 2021-02-22 at 22 00 29" src="https://user-images.githubusercontent.com/1424596/108773156-3b779380-755e-11eb-9f62-ed5c86c5b48e.png">

<img width="1355" alt="Screen Shot 2021-02-22 at 22 00 40" src="https://user-images.githubusercontent.com/1424596/108773166-3dd9ed80-755e-11eb-8fbe-601b0a685d0b.png">


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14920

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
