### PR TITLE
Add switches and sensors to Litter-Robot

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .const import DOMAIN
 from .hub import LitterRobotHub
 
-PLATFORMS = ["vacuum"]
+PLATFORMS = ["sensor", "switch", "vacuum"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -1,0 +1,54 @@
+"""Support for Litter-Robot sensors."""
+from homeassistant.const import PERCENTAGE
+from homeassistant.helpers.entity import Entity
+
+from .const import DOMAIN
+from .hub import LitterRobotEntity
+
+WASTE_DRAWER = "Waste Drawer"
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Litter-Robot sensors using config entry."""
+    hub = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+    for robot in hub.account.robots:
+        entities.append(LitterRobotSensor(robot, WASTE_DRAWER, hub))
+
+    if entities:
+        async_add_entities(entities, True)
+
+
+class LitterRobotSensor(LitterRobotEntity, Entity):
+    """Litter-Robot sensors."""
+
+    @property
+    def state(self):
+        """Return the state."""
+        return self.robot.waste_drawer_gauge
+
+    @property
+    def unit_of_measurement(self):
+        """Return unit of measurement."""
+        return PERCENTAGE
+
+    @property
+    def icon(self):
+        """Return the icon to use in the frontend, if any."""
+        if self.robot.waste_drawer_gauge <= 10:
+            return "mdi:gauge-empty"
+        if self.robot.waste_drawer_gauge < 50:
+            return "mdi:gauge-low"
+        if self.robot.waste_drawer_gauge <= 90:
+            return "mdi:gauge"
+        return "mdi:gauge-full"
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        return {
+            "cycle_count": self.robot.cycle_count,
+            "cycle_capacity": self.robot.cycle_capacity,
+            "cycles_after_drawer_full": self.robot.cycles_after_drawer_full,
+        }

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -1,0 +1,89 @@
+"""Support for Litter-Robot switches."""
+from homeassistant.helpers.entity import ToggleEntity
+import homeassistant.util.dt as dt_util
+
+from .const import DOMAIN
+from .hub import LitterRobotEntity
+
+NIGHT_LIGHT = "Night Light"
+PANEL_LOCKOUT = "Panel Lockout"
+SLEEP_MODE = "Sleep Mode"
+
+DEFAULT_SLEEP_TIME = "22:00"
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up Litter-Robot switches using config entry."""
+    hub = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+    for robot in hub.account.robots:
+        entities.append(LitterRobotSwitch(robot, NIGHT_LIGHT, hub))
+        entities.append(LitterRobotSwitch(robot, PANEL_LOCKOUT, hub))
+        entities.append(LitterRobotSwitch(robot, SLEEP_MODE, hub))
+
+    if entities:
+        async_add_entities(entities, True)
+
+
+class LitterRobotSwitch(LitterRobotEntity, ToggleEntity):
+    """Litter-Robot Switches."""
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        if self.entity_type == NIGHT_LIGHT:
+            return self.robot.night_light_active
+        if self.entity_type == PANEL_LOCKOUT:
+            return self.robot.panel_lock_active
+        if self.entity_type == SLEEP_MODE:
+            return self.robot.sleep_mode_active
+
+    @property
+    def icon(self):
+        """Return the icon based on the entity_type."""
+        if self.entity_type == NIGHT_LIGHT:
+            return "mdi:lightbulb-on" if self.is_on else "mdi:lightbulb-off"
+        if self.entity_type == PANEL_LOCKOUT:
+            return "mdi:lock" if self.is_on else "mdi:lock-open"
+        if self.entity_type == SLEEP_MODE:
+            return "mdi:sleep" if self.is_on else "mdi:sleep-off"
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        if self.entity_type == NIGHT_LIGHT:
+            await self.perform_action_and_refresh(self.robot.set_night_light, True)
+        elif self.entity_type == PANEL_LOCKOUT:
+            await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
+        elif self.entity_type == SLEEP_MODE:
+            await self.perform_action_and_refresh(
+                self.robot.set_sleep_mode,
+                True,
+                self.parse_time_at_default_timezone(DEFAULT_SLEEP_TIME),
+            )
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        if self.entity_type == NIGHT_LIGHT:
+            await self.perform_action_and_refresh(self.robot.set_night_light, False)
+        elif self.entity_type == PANEL_LOCKOUT:
+            await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
+        elif self.entity_type == SLEEP_MODE:
+            await self.perform_action_and_refresh(self.robot.set_sleep_mode, False)
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        if self.entity_type == SLEEP_MODE:
+            [start_time, end_time] = [None, None]
+            if self.is_on:
+                start_time = dt_util.as_local(
+                    self.robot.sleep_mode_start_time
+                ).strftime("%H:%M:00")
+                end_time = dt_util.as_local(self.robot.sleep_mode_end_time).strftime(
+                    "%H:%M:00"
+                )
+            return {
+                "start_time": start_time,
+                "end_time": end_time,
+            }

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -1,6 +1,5 @@
 """Support for Litter-Robot switches."""
 from homeassistant.helpers.entity import ToggleEntity
-import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 from .hub import LitterRobotEntity
@@ -50,54 +49,9 @@ class LitterRobotPanelLockoutSwitch(LitterRobotEntity, ToggleEntity):
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
 
 
-class LitterRobotSleepModeSwitch(LitterRobotEntity, ToggleEntity):
-    """Litter-Robot Sleep Mode Switch."""
-
-    DEFAULT_SLEEP_TIME = "22:00"
-
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        return self.robot.sleep_mode_active
-
-    @property
-    def icon(self):
-        """Return the icon."""
-        return "mdi:sleep" if self.is_on else "mdi:sleep-off"
-
-    async def async_turn_on(self, **kwargs):
-        """Turn the switch on."""
-        await self.perform_action_and_refresh(
-            self.robot.set_sleep_mode,
-            True,
-            self.parse_time_at_default_timezone(self.DEFAULT_SLEEP_TIME),
-        )
-
-    async def async_turn_off(self, **kwargs):
-        """Turn the switch off."""
-        await self.perform_action_and_refresh(self.robot.set_sleep_mode, False)
-
-    @property
-    def device_state_attributes(self):
-        """Return device specific state attributes."""
-        [start_time, end_time] = [None, None]
-        if self.is_on:
-            start_time = dt_util.as_local(self.robot.sleep_mode_start_time).strftime(
-                "%H:%M:00"
-            )
-            end_time = dt_util.as_local(self.robot.sleep_mode_end_time).strftime(
-                "%H:%M:00"
-            )
-        return {
-            "start_time": start_time,
-            "end_time": end_time,
-        }
-
-
 ROBOT_SWITCHES = {
     "Night Light": LitterRobotNightLightSwitch,
     "Panel Lockout": LitterRobotPanelLockoutSwitch,
-    "Sleep Mode": LitterRobotSleepModeSwitch,
 }
 
 

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -5,11 +5,100 @@ import homeassistant.util.dt as dt_util
 from .const import DOMAIN
 from .hub import LitterRobotEntity
 
-NIGHT_LIGHT = "Night Light"
-PANEL_LOCKOUT = "Panel Lockout"
-SLEEP_MODE = "Sleep Mode"
 
-DEFAULT_SLEEP_TIME = "22:00"
+class LitterRobotNightLightSwitch(LitterRobotEntity, ToggleEntity):
+    """Litter-Robot Night Light Switch."""
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.robot.night_light_active
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return "mdi:lightbulb-on" if self.is_on else "mdi:lightbulb-off"
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self.perform_action_and_refresh(self.robot.set_night_light, True)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self.perform_action_and_refresh(self.robot.set_night_light, False)
+
+
+class LitterRobotPanelLockoutSwitch(LitterRobotEntity, ToggleEntity):
+    """Litter-Robot Panel Lockout Switch."""
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.robot.panel_lock_active
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return "mdi:lock" if self.is_on else "mdi:lock-open"
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
+
+
+class LitterRobotSleepModeSwitch(LitterRobotEntity, ToggleEntity):
+    """Litter-Robot Sleep Mode Switch."""
+
+    DEFAULT_SLEEP_TIME = "22:00"
+
+    @property
+    def is_on(self):
+        """Return true if switch is on."""
+        return self.robot.sleep_mode_active
+
+    @property
+    def icon(self):
+        """Return the icon."""
+        return "mdi:sleep" if self.is_on else "mdi:sleep-off"
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the switch on."""
+        await self.perform_action_and_refresh(
+            self.robot.set_sleep_mode,
+            True,
+            self.parse_time_at_default_timezone(self.DEFAULT_SLEEP_TIME),
+        )
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the switch off."""
+        await self.perform_action_and_refresh(self.robot.set_sleep_mode, False)
+
+    @property
+    def device_state_attributes(self):
+        """Return device specific state attributes."""
+        [start_time, end_time] = [None, None]
+        if self.is_on:
+            start_time = dt_util.as_local(self.robot.sleep_mode_start_time).strftime(
+                "%H:%M:00"
+            )
+            end_time = dt_util.as_local(self.robot.sleep_mode_end_time).strftime(
+                "%H:%M:00"
+            )
+        return {
+            "start_time": start_time,
+            "end_time": end_time,
+        }
+
+
+ROBOT_SWITCHES = {
+    "Night Light": LitterRobotNightLightSwitch,
+    "Panel Lockout": LitterRobotPanelLockoutSwitch,
+    "Sleep Mode": LitterRobotSleepModeSwitch,
+}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -18,72 +107,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = []
     for robot in hub.account.robots:
-        entities.append(LitterRobotSwitch(robot, NIGHT_LIGHT, hub))
-        entities.append(LitterRobotSwitch(robot, PANEL_LOCKOUT, hub))
-        entities.append(LitterRobotSwitch(robot, SLEEP_MODE, hub))
+        for switch_type, switch_class in ROBOT_SWITCHES.items():
+            entities.append(switch_class(robot, switch_type, hub))
 
     if entities:
         async_add_entities(entities, True)
-
-
-class LitterRobotSwitch(LitterRobotEntity, ToggleEntity):
-    """Litter-Robot Switches."""
-
-    @property
-    def is_on(self):
-        """Return true if switch is on."""
-        if self.entity_type == NIGHT_LIGHT:
-            return self.robot.night_light_active
-        if self.entity_type == PANEL_LOCKOUT:
-            return self.robot.panel_lock_active
-        if self.entity_type == SLEEP_MODE:
-            return self.robot.sleep_mode_active
-
-    @property
-    def icon(self):
-        """Return the icon based on the entity_type."""
-        if self.entity_type == NIGHT_LIGHT:
-            return "mdi:lightbulb-on" if self.is_on else "mdi:lightbulb-off"
-        if self.entity_type == PANEL_LOCKOUT:
-            return "mdi:lock" if self.is_on else "mdi:lock-open"
-        if self.entity_type == SLEEP_MODE:
-            return "mdi:sleep" if self.is_on else "mdi:sleep-off"
-
-    async def async_turn_on(self, **kwargs):
-        """Turn the switch on."""
-        if self.entity_type == NIGHT_LIGHT:
-            await self.perform_action_and_refresh(self.robot.set_night_light, True)
-        elif self.entity_type == PANEL_LOCKOUT:
-            await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
-        elif self.entity_type == SLEEP_MODE:
-            await self.perform_action_and_refresh(
-                self.robot.set_sleep_mode,
-                True,
-                self.parse_time_at_default_timezone(DEFAULT_SLEEP_TIME),
-            )
-
-    async def async_turn_off(self, **kwargs):
-        """Turn the switch off."""
-        if self.entity_type == NIGHT_LIGHT:
-            await self.perform_action_and_refresh(self.robot.set_night_light, False)
-        elif self.entity_type == PANEL_LOCKOUT:
-            await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
-        elif self.entity_type == SLEEP_MODE:
-            await self.perform_action_and_refresh(self.robot.set_sleep_mode, False)
-
-    @property
-    def device_state_attributes(self):
-        """Return device specific state attributes."""
-        if self.entity_type == SLEEP_MODE:
-            [start_time, end_time] = [None, None]
-            if self.is_on:
-                start_time = dt_util.as_local(
-                    self.robot.sleep_mode_start_time
-                ).strftime("%H:%M:00")
-                end_time = dt_util.as_local(self.robot.sleep_mode_end_time).strftime(
-                    "%H:%M:00"
-                )
-            return {
-                "start_time": start_time,
-                "end_time": end_time,
-            }

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -5,8 +5,8 @@ from .const import DOMAIN
 from .hub import LitterRobotEntity
 
 
-class LitterRobotNightLightSwitch(LitterRobotEntity, ToggleEntity):
-    """Litter-Robot Night Light Switch."""
+class LitterRobotNightLightModeSwitch(LitterRobotEntity, ToggleEntity):
+    """Litter-Robot Night Light Mode Switch."""
 
     @property
     def is_on(self):
@@ -50,7 +50,7 @@ class LitterRobotPanelLockoutSwitch(LitterRobotEntity, ToggleEntity):
 
 
 ROBOT_SWITCHES = {
-    "Night Light": LitterRobotNightLightSwitch,
+    "Night Light Mode": LitterRobotNightLightModeSwitch,
     "Panel Lockout": LitterRobotPanelLockoutSwitch,
 }
 

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -14,6 +14,7 @@ from homeassistant.components.vacuum import (
     VacuumEntity,
 )
 from homeassistant.const import STATE_OFF
+import homeassistant.util.dt as dt_util
 
 from .const import DOMAIN
 from .hub import LitterRobotEntity
@@ -118,9 +119,21 @@ class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
     @property
     def device_state_attributes(self):
         """Return device specific state attributes."""
+        [sleep_mode_start_time, sleep_mode_end_time] = [None, None]
+
+        if self.robot.sleep_mode_active:
+            sleep_mode_start_time = dt_util.as_local(
+                self.robot.sleep_mode_start_time
+            ).strftime("%H:%M:00")
+            sleep_mode_end_time = dt_util.as_local(
+                self.robot.sleep_mode_end_time
+            ).strftime("%H:%M:00")
+
         return {
             "clean_cycle_wait_time_minutes": self.robot.clean_cycle_wait_time_minutes,
             "is_sleeping": self.robot.is_sleeping,
+            "sleep_mode_start_time": sleep_mode_start_time,
+            "sleep_mode_end_time": sleep_mode_end_time,
             "power_status": self.robot.power_status,
             "unit_status_code": self.robot.unit_status.name,
             "last_seen": self.robot.last_seen,

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -17,6 +17,8 @@ def create_mock_robot(hass):
     robot.set_power_status = AsyncMock()
     robot.reset_waste_drawer = AsyncMock()
     robot.set_sleep_mode = AsyncMock()
+    robot.set_night_light = AsyncMock()
+    robot.set_panel_lockout = AsyncMock()
     return robot
 
 

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -46,8 +46,10 @@ async def setup_hub(hass, mock_hub, platform_domain):
         data=CONFIG[litterrobot.DOMAIN],
     )
     entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(entry.entry_id)
 
-    with patch.dict(hass.data, {litterrobot.DOMAIN: {entry.entry_id: mock_hub}}):
+    with patch(
+        "homeassistant.components.litterrobot.LitterRobotHub",
+        return_value=mock_hub,
+    ):
         await hass.config_entries.async_forward_entry_setup(entry, platform_domain)
         await hass.async_block_till_done()

--- a/tests/components/litterrobot/test_sensor.py
+++ b/tests/components/litterrobot/test_sensor.py
@@ -1,36 +1,18 @@
 """Test the Litter-Robot sensor entity."""
-from unittest.mock import patch
-
-from homeassistant.components import litterrobot
 from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
 from homeassistant.const import PERCENTAGE
 
-from .common import CONFIG
-
-from tests.common import MockConfigEntry
+from .conftest import setup_hub
 
 ENTITY_ID = "sensor.test_waste_drawer"
 
 
-async def setup_hub(hass, mock_hub):
-    """Load the Litter-Robot sensor platform with the provided hub."""
-    hass.config.components.add(litterrobot.DOMAIN)
-    entry = MockConfigEntry(
-        domain=litterrobot.DOMAIN,
-        data=CONFIG[litterrobot.DOMAIN],
-    )
-
-    with patch.dict(hass.data, {litterrobot.DOMAIN: {entry.entry_id: mock_hub}}):
-        await hass.config_entries.async_forward_entry_setup(entry, PLATFORM_DOMAIN)
-        await hass.async_block_till_done()
-
-
 async def test_sensor(hass, mock_hub):
     """Tests the sensor entity was set up."""
-    await setup_hub(hass, mock_hub)
+    await setup_hub(hass, mock_hub, PLATFORM_DOMAIN)
 
     sensor = hass.states.get(ENTITY_ID)
-    assert sensor is not None
+    assert sensor
     assert sensor.state == "50"
     assert sensor.attributes["cycle_count"] == 15
     assert sensor.attributes["cycle_capacity"] == 30

--- a/tests/components/litterrobot/test_sensor.py
+++ b/tests/components/litterrobot/test_sensor.py
@@ -1,0 +1,38 @@
+"""Test the Litter-Robot sensor entity."""
+from unittest.mock import patch
+
+from homeassistant.components import litterrobot
+from homeassistant.components.sensor import DOMAIN as PLATFORM_DOMAIN
+from homeassistant.const import PERCENTAGE
+
+from .common import CONFIG
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "sensor.test_waste_drawer"
+
+
+async def setup_hub(hass, mock_hub):
+    """Load the Litter-Robot sensor platform with the provided hub."""
+    hass.config.components.add(litterrobot.DOMAIN)
+    entry = MockConfigEntry(
+        domain=litterrobot.DOMAIN,
+        data=CONFIG[litterrobot.DOMAIN],
+    )
+
+    with patch.dict(hass.data, {litterrobot.DOMAIN: {entry.entry_id: mock_hub}}):
+        await hass.config_entries.async_forward_entry_setup(entry, PLATFORM_DOMAIN)
+        await hass.async_block_till_done()
+
+
+async def test_sensor(hass, mock_hub):
+    """Tests the sensor entity was set up."""
+    await setup_hub(hass, mock_hub)
+
+    sensor = hass.states.get(ENTITY_ID)
+    assert sensor is not None
+    assert sensor.state == "50"
+    assert sensor.attributes["cycle_count"] == 15
+    assert sensor.attributes["cycle_capacity"] == 30
+    assert sensor.attributes["cycles_after_drawer_full"] == 0
+    assert sensor.attributes["unit_of_measurement"] == PERCENTAGE

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -1,10 +1,8 @@
 """Test the Litter-Robot switch entity."""
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import litterrobot
 from homeassistant.components.litterrobot.hub import REFRESH_WAIT_TIME
 from homeassistant.components.switch import (
     DOMAIN as PLATFORM_DOMAIN,
@@ -14,30 +12,17 @@ from homeassistant.components.switch import (
 from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
 from homeassistant.util.dt import utcnow
 
-from .common import CONFIG
+from .conftest import setup_hub
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import async_fire_time_changed
 
 NIGHT_LIGHT_MODE_ENTITY_ID = "switch.test_night_light_mode"
 PANEL_LOCKOUT_ENTITY_ID = "switch.test_panel_lockout"
 
 
-async def setup_hub(hass, mock_hub):
-    """Load the Litter-Robot switch platform with the provided hub."""
-    hass.config.components.add(litterrobot.DOMAIN)
-    entry = MockConfigEntry(
-        domain=litterrobot.DOMAIN,
-        data=CONFIG[litterrobot.DOMAIN],
-    )
-
-    with patch.dict(hass.data, {litterrobot.DOMAIN: {entry.entry_id: mock_hub}}):
-        await hass.config_entries.async_forward_entry_setup(entry, PLATFORM_DOMAIN)
-        await hass.async_block_till_done()
-
-
 async def test_switch(hass, mock_hub):
     """Tests the switch entity was set up."""
-    await setup_hub(hass, mock_hub)
+    await setup_hub(hass, mock_hub, PLATFORM_DOMAIN)
 
     switch = hass.states.get(NIGHT_LIGHT_MODE_ENTITY_ID)
     assert switch
@@ -53,7 +38,7 @@ async def test_switch(hass, mock_hub):
 )
 async def test_on_off_commands(hass, mock_hub, entity_id, robot_command):
     """Test sending commands to the switch."""
-    await setup_hub(hass, mock_hub)
+    await setup_hub(hass, mock_hub, PLATFORM_DOMAIN)
 
     switch = hass.states.get(entity_id)
     assert switch

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -18,9 +18,8 @@ from .common import CONFIG
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
-NIGHT_LIGHT_ENTITY_ID = "switch.test_night_light"
+NIGHT_LIGHT_MODE_ENTITY_ID = "switch.test_night_light_mode"
 PANEL_LOCKOUT_ENTITY_ID = "switch.test_panel_lockout"
-SLEEP_MODE_ENTITY_ID = "switch.test_sleep_mode"
 
 
 async def setup_hub(hass, mock_hub):
@@ -40,7 +39,7 @@ async def test_switch(hass, mock_hub):
     """Tests the switch entity was set up."""
     await setup_hub(hass, mock_hub)
 
-    switch = hass.states.get(NIGHT_LIGHT_ENTITY_ID)
+    switch = hass.states.get(NIGHT_LIGHT_MODE_ENTITY_ID)
     assert switch
     assert switch.state == STATE_ON
 
@@ -48,7 +47,7 @@ async def test_switch(hass, mock_hub):
 @pytest.mark.parametrize(
     "entity_id,robot_command",
     [
-        (NIGHT_LIGHT_ENTITY_ID, "set_night_light"),
+        (NIGHT_LIGHT_MODE_ENTITY_ID, "set_night_light"),
         (PANEL_LOCKOUT_ENTITY_ID, "set_panel_lockout"),
     ],
 )

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -50,7 +50,6 @@ async def test_switch(hass, mock_hub):
     [
         (NIGHT_LIGHT_ENTITY_ID, "set_night_light"),
         (PANEL_LOCKOUT_ENTITY_ID, "set_panel_lockout"),
-        (SLEEP_MODE_ENTITY_ID, "set_sleep_mode"),
     ],
 )
 async def test_on_off_commands(hass, mock_hub, entity_id, robot_command):

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -1,0 +1,76 @@
+"""Test the Litter-Robot switch entity."""
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components import litterrobot
+from homeassistant.components.litterrobot.hub import REFRESH_WAIT_TIME
+from homeassistant.components.switch import (
+    DOMAIN as PLATFORM_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_ON
+from homeassistant.util.dt import utcnow
+
+from .common import CONFIG
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+NIGHT_LIGHT_ENTITY_ID = "switch.test_night_light"
+PANEL_LOCKOUT_ENTITY_ID = "switch.test_panel_lockout"
+SLEEP_MODE_ENTITY_ID = "switch.test_sleep_mode"
+
+
+async def setup_hub(hass, mock_hub):
+    """Load the Litter-Robot switch platform with the provided hub."""
+    hass.config.components.add(litterrobot.DOMAIN)
+    entry = MockConfigEntry(
+        domain=litterrobot.DOMAIN,
+        data=CONFIG[litterrobot.DOMAIN],
+    )
+
+    with patch.dict(hass.data, {litterrobot.DOMAIN: {entry.entry_id: mock_hub}}):
+        await hass.config_entries.async_forward_entry_setup(entry, PLATFORM_DOMAIN)
+        await hass.async_block_till_done()
+
+
+async def test_switch(hass, mock_hub):
+    """Tests the switch entity was set up."""
+    await setup_hub(hass, mock_hub)
+
+    switch = hass.states.get(NIGHT_LIGHT_ENTITY_ID)
+    assert switch
+    assert switch.state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    "entity_id,robot_command",
+    [
+        (NIGHT_LIGHT_ENTITY_ID, "set_night_light"),
+        (PANEL_LOCKOUT_ENTITY_ID, "set_panel_lockout"),
+        (SLEEP_MODE_ENTITY_ID, "set_sleep_mode"),
+    ],
+)
+async def test_on_off_commands(hass, mock_hub, entity_id, robot_command):
+    """Test sending commands to the switch."""
+    await setup_hub(hass, mock_hub)
+
+    switch = hass.states.get(entity_id)
+    assert switch
+
+    data = {ATTR_ENTITY_ID: entity_id}
+
+    count = 0
+    for service in [SERVICE_TURN_ON, SERVICE_TURN_OFF]:
+        count += 1
+        await hass.services.async_call(
+            PLATFORM_DOMAIN,
+            service,
+            data,
+            blocking=True,
+        )
+        future = utcnow() + timedelta(seconds=REFRESH_WAIT_TIME)
+        async_fire_time_changed(hass, future)
+        assert getattr(mock_hub.account.robots[0], robot_command).call_count == count

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -43,7 +43,7 @@ async def test_vacuum(hass, mock_hub):
     await setup_hub(hass, mock_hub)
 
     vacuum = hass.states.get(ENTITY_ID)
-    assert vacuum is not None
+    assert vacuum
     assert vacuum.state == STATE_DOCKED
     assert vacuum.attributes["is_sleeping"] is False
 

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -1,10 +1,8 @@
 """Test the Litter-Robot vacuum entity."""
 from datetime import timedelta
-from unittest.mock import patch
 
 import pytest
 
-from homeassistant.components import litterrobot
 from homeassistant.components.litterrobot.hub import REFRESH_WAIT_TIME
 from homeassistant.components.vacuum import (
     ATTR_PARAMS,
@@ -18,29 +16,16 @@ from homeassistant.components.vacuum import (
 from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID
 from homeassistant.util.dt import utcnow
 
-from .common import CONFIG
+from .conftest import setup_hub
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import async_fire_time_changed
 
 ENTITY_ID = "vacuum.test_litter_box"
 
 
-async def setup_hub(hass, mock_hub):
-    """Load the Litter-Robot vacuum platform with the provided hub."""
-    hass.config.components.add(litterrobot.DOMAIN)
-    entry = MockConfigEntry(
-        domain=litterrobot.DOMAIN,
-        data=CONFIG[litterrobot.DOMAIN],
-    )
-
-    with patch.dict(hass.data, {litterrobot.DOMAIN: {entry.entry_id: mock_hub}}):
-        await hass.config_entries.async_forward_entry_setup(entry, PLATFORM_DOMAIN)
-        await hass.async_block_till_done()
-
-
 async def test_vacuum(hass, mock_hub):
     """Tests the vacuum entity was set up."""
-    await setup_hub(hass, mock_hub)
+    await setup_hub(hass, mock_hub, PLATFORM_DOMAIN)
 
     vacuum = hass.states.get(ENTITY_ID)
     assert vacuum
@@ -71,7 +56,7 @@ async def test_vacuum(hass, mock_hub):
 )
 async def test_commands(hass, mock_hub, service, command, extra):
     """Test sending commands to the vacuum."""
-    await setup_hub(hass, mock_hub)
+    await setup_hub(hass, mock_hub, PLATFORM_DOMAIN)
 
     vacuum = hass.states.get(ENTITY_ID)
     assert vacuum is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds switches and sensors to the Litter-Robot platform for a better end user experience.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16702

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
