### PR TITLE
Fix Plex showing removed shared users

### DIFF
--- a/tests/components/plex/conftest.py
+++ b/tests/components/plex/conftest.py
@@ -218,6 +218,12 @@ def plextv_resources_fixture(plextv_resources_base):
     return plextv_resources_base.format(second_server_enabled=0)
 
 
+@pytest.fixture(name="plextv_shared_users", scope="session")
+def plextv_shared_users_fixture(plextv_resources_base):
+    """Load payload for plex.tv shared users and return it."""
+    return load_fixture("plex/plextv_shared_users.xml")
+
+
 @pytest.fixture(name="session_base", scope="session")
 def session_base_fixture():
     """Load the base session payload and return it."""
@@ -293,6 +299,7 @@ def mock_plex_calls(
     children_200,
     children_300,
     empty_library,
+    empty_payload,
     grandchildren_300,
     library,
     library_sections,
@@ -310,12 +317,15 @@ def mock_plex_calls(
     playlist_500,
     plextv_account,
     plextv_resources,
+    plextv_shared_users,
     plex_server_accounts,
     plex_server_clients,
     plex_server_default,
     security_token,
 ):
     """Mock Plex API calls."""
+    requests_mock.get("https://plex.tv/api/users/", text=plextv_shared_users)
+    requests_mock.get("https://plex.tv/api/invites/requested", text=empty_payload)
     requests_mock.get("https://plex.tv/users/account", text=plextv_account)
     requests_mock.get("https://plex.tv/api/resources", text=plextv_resources)
 

--- a/tests/components/plex/test_init.py
+++ b/tests/components/plex/test_init.py
@@ -116,6 +116,7 @@ async def test_setup_when_certificate_changed(
     plex_server_default,
     plextv_account,
     plextv_resources,
+    plextv_shared_users,
 ):
     """Test setup component when the Plex certificate has changed."""
     await async_setup_component(hass, "persistent_notification", {})
@@ -140,6 +141,9 @@ async def test_setup_when_certificate_changed(
         options=DEFAULT_OPTIONS,
         unique_id=DEFAULT_DATA["server_id"],
     )
+
+    requests_mock.get("https://plex.tv/api/users/", text=plextv_shared_users)
+    requests_mock.get("https://plex.tv/api/invites/requested", text=empty_payload)
 
     requests_mock.get("https://plex.tv/users/account", text=plextv_account)
     requests_mock.get("https://plex.tv/api/resources", text=plextv_resources)

--- a/tests/fixtures/plex/plextv_shared_users.xml
+++ b/tests/fixtures/plex/plextv_shared_users.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MediaContainer friendlyName="myPlex" identifier="com.plexapp.plugins.myplex" machineIdentifier="85a28b6ea2b35c1a10cbdd967b74117a45e8694f" totalSize="3" size="3">
+<User id="1000" title="User 1000" username="User 1000" email="user_1000@email.com" recommendationsPlaylistId="" thumb="https://plex.tv/users/0000000000000000/avatar?c=1467656888" protected="0" home="0" allowTuners="0" allowSync="0" allowCameraUpload="0" allowChannels="0" allowSubtitleAdmin="0" filterAll="" filterMovies="" filterMusic="" filterPhotos="" filterTelevision="" restricted="0">
+  <Server id="7654321" serverId="000001" machineIdentifier="unique_id_123" name="plex" lastSeenAt="1614072646" numLibraries="4" allLibraries="0" owned="1" pending="0"/>
+</User>
+<User id="1001" title="User 1001" username="User 1001" email="user_1001@email.com" recommendationsPlaylistId="" thumb="https://plex.tv/users/0000000000000001/avatar?c=1599008193" protected="0" home="0" allowTuners="0" allowSync="0" allowCameraUpload="0" allowChannels="0" allowSubtitleAdmin="0" filterAll="" filterMovies="" filterMusic="" filterPhotos="" filterTelevision="" restricted="0">
+  <Server id="1234567" serverId="000001" machineIdentifier="unique_id_123" name="plex" lastSeenAt="1614072646" numLibraries="5" allLibraries="0" owned="1" pending="0"/>
+</User>
+</MediaContainer>


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The local API endpoint would return all shared users, even if they had been previously unshared or deleted. This will query plex.tv on startup to ensure the shared user list is accurate.

As discussed in https://community.home-assistant.io/t/plex-integration-returns-deleted-users-within-monitored-users/283654.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
