### PR TITLE
Deep copy zwave_js state in test fixtures

### DIFF
--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -1,5 +1,6 @@
 """Provide common Z-Wave JS fixtures."""
 import asyncio
+import copy
 import json
 from unittest.mock import AsyncMock, patch
 
@@ -188,7 +189,7 @@ def mock_client_fixture(controller_state, version_state):
 @pytest.fixture(name="multisensor_6")
 def multisensor_6_fixture(client, multisensor_6_state):
     """Mock a multisensor 6 node."""
-    node = Node(client, multisensor_6_state)
+    node = Node(client, copy.deepcopy(multisensor_6_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -196,7 +197,7 @@ def multisensor_6_fixture(client, multisensor_6_state):
 @pytest.fixture(name="ecolink_door_sensor")
 def legacy_binary_sensor_fixture(client, ecolink_door_sensor_state):
     """Mock a legacy_binary_sensor node."""
-    node = Node(client, ecolink_door_sensor_state)
+    node = Node(client, copy.deepcopy(ecolink_door_sensor_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -204,7 +205,7 @@ def legacy_binary_sensor_fixture(client, ecolink_door_sensor_state):
 @pytest.fixture(name="hank_binary_switch")
 def hank_binary_switch_fixture(client, hank_binary_switch_state):
     """Mock a binary switch node."""
-    node = Node(client, hank_binary_switch_state)
+    node = Node(client, copy.deepcopy(hank_binary_switch_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -212,7 +213,7 @@ def hank_binary_switch_fixture(client, hank_binary_switch_state):
 @pytest.fixture(name="bulb_6_multi_color")
 def bulb_6_multi_color_fixture(client, bulb_6_multi_color_state):
     """Mock a bulb 6 multi-color node."""
-    node = Node(client, bulb_6_multi_color_state)
+    node = Node(client, copy.deepcopy(bulb_6_multi_color_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -220,7 +221,7 @@ def bulb_6_multi_color_fixture(client, bulb_6_multi_color_state):
 @pytest.fixture(name="eaton_rf9640_dimmer")
 def eaton_rf9640_dimmer_fixture(client, eaton_rf9640_dimmer_state):
     """Mock a Eaton RF9640 (V4 compatible) dimmer node."""
-    node = Node(client, eaton_rf9640_dimmer_state)
+    node = Node(client, copy.deepcopy(eaton_rf9640_dimmer_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -228,7 +229,7 @@ def eaton_rf9640_dimmer_fixture(client, eaton_rf9640_dimmer_state):
 @pytest.fixture(name="lock_schlage_be469")
 def lock_schlage_be469_fixture(client, lock_schlage_be469_state):
     """Mock a schlage lock node."""
-    node = Node(client, lock_schlage_be469_state)
+    node = Node(client, copy.deepcopy(lock_schlage_be469_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -236,7 +237,7 @@ def lock_schlage_be469_fixture(client, lock_schlage_be469_state):
 @pytest.fixture(name="lock_august_pro")
 def lock_august_asl03_fixture(client, lock_august_asl03_state):
     """Mock a August Pro lock node."""
-    node = Node(client, lock_august_asl03_state)
+    node = Node(client, copy.deepcopy(lock_august_asl03_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -246,7 +247,7 @@ def climate_radio_thermostat_ct100_plus_fixture(
     client, climate_radio_thermostat_ct100_plus_state
 ):
     """Mock a climate radio thermostat ct100 plus node."""
-    node = Node(client, climate_radio_thermostat_ct100_plus_state)
+    node = Node(client, copy.deepcopy(climate_radio_thermostat_ct100_plus_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -256,7 +257,10 @@ def climate_radio_thermostat_ct100_plus_different_endpoints_fixture(
     client, climate_radio_thermostat_ct100_plus_different_endpoints_state
 ):
     """Mock a climate radio thermostat ct100 plus node with values on different endpoints."""
-    node = Node(client, climate_radio_thermostat_ct100_plus_different_endpoints_state)
+    node = Node(
+        client,
+        copy.deepcopy(climate_radio_thermostat_ct100_plus_different_endpoints_state),
+    )
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -264,7 +268,7 @@ def climate_radio_thermostat_ct100_plus_different_endpoints_fixture(
 @pytest.fixture(name="climate_danfoss_lc_13")
 def climate_danfoss_lc_13_fixture(client, climate_danfoss_lc_13_state):
     """Mock a climate radio danfoss LC-13 node."""
-    node = Node(client, climate_danfoss_lc_13_state)
+    node = Node(client, copy.deepcopy(climate_danfoss_lc_13_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -272,7 +276,7 @@ def climate_danfoss_lc_13_fixture(client, climate_danfoss_lc_13_state):
 @pytest.fixture(name="climate_heatit_z_trm3")
 def climate_heatit_z_trm3_fixture(client, climate_heatit_z_trm3_state):
     """Mock a climate radio HEATIT Z-TRM3 node."""
-    node = Node(client, climate_heatit_z_trm3_state)
+    node = Node(client, copy.deepcopy(climate_heatit_z_trm3_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -280,7 +284,7 @@ def climate_heatit_z_trm3_fixture(client, climate_heatit_z_trm3_state):
 @pytest.fixture(name="nortek_thermostat")
 def nortek_thermostat_fixture(client, nortek_thermostat_state):
     """Mock a nortek thermostat node."""
-    node = Node(client, nortek_thermostat_state)
+    node = Node(client, copy.deepcopy(nortek_thermostat_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -317,7 +321,7 @@ async def integration_fixture(hass, client):
 @pytest.fixture(name="chain_actuator_zws12")
 def window_cover_fixture(client, chain_actuator_zws12_state):
     """Mock a window cover node."""
-    node = Node(client, chain_actuator_zws12_state)
+    node = Node(client, copy.deepcopy(chain_actuator_zws12_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -325,7 +329,7 @@ def window_cover_fixture(client, chain_actuator_zws12_state):
 @pytest.fixture(name="in_wall_smart_fan_control")
 def in_wall_smart_fan_control_fixture(client, in_wall_smart_fan_control_state):
     """Mock a fan node."""
-    node = Node(client, in_wall_smart_fan_control_state)
+    node = Node(client, copy.deepcopy(in_wall_smart_fan_control_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -335,9 +339,9 @@ def multiple_devices_fixture(
     client, climate_radio_thermostat_ct100_plus_state, lock_schlage_be469_state
 ):
     """Mock a client with multiple devices."""
-    node = Node(client, climate_radio_thermostat_ct100_plus_state)
+    node = Node(client, copy.deepcopy(climate_radio_thermostat_ct100_plus_state))
     client.driver.controller.nodes[node.node_id] = node
-    node = Node(client, lock_schlage_be469_state)
+    node = Node(client, copy.deepcopy(lock_schlage_be469_state))
     client.driver.controller.nodes[node.node_id] = node
     return client.driver.controller.nodes
 
@@ -345,7 +349,7 @@ def multiple_devices_fixture(
 @pytest.fixture(name="gdc_zw062")
 def motorized_barrier_cover_fixture(client, gdc_zw062_state):
     """Mock a motorized barrier node."""
-    node = Node(client, gdc_zw062_state)
+    node = Node(client, copy.deepcopy(gdc_zw062_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -353,7 +357,7 @@ def motorized_barrier_cover_fixture(client, gdc_zw062_state):
 @pytest.fixture(name="iblinds_v2")
 def iblinds_cover_fixture(client, iblinds_v2_state):
     """Mock an iBlinds v2.0 window cover node."""
-    node = Node(client, iblinds_v2_state)
+    node = Node(client, copy.deepcopy(iblinds_v2_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 
@@ -361,6 +365,6 @@ def iblinds_cover_fixture(client, iblinds_v2_state):
 @pytest.fixture(name="ge_12730")
 def ge_12730_fixture(client, ge_12730_state):
     """Mock a GE 12730 fan controller node."""
-    node = Node(client, ge_12730_state)
+    node = Node(client, copy.deepcopy(ge_12730_state))
     client.driver.controller.nodes[node.node_id] = node
     return node


### PR DESCRIPTION
## Proposed change
Before this change, a test that changed the state of one of the `zwave_js` fixture nodes would cause other tests to see that new state. This change makes it such that each test can be run isolated from the rest, i.e. state changes in one test don't impact another


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
