### PR TITLE
Migrate zwave_js entities to use new unique ID format

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -43,7 +43,7 @@ from .const import (
     ZWAVE_JS_EVENT,
 )
 from .discovery import async_discover_values
-from .helpers import get_device_id
+from .helpers import get_device_id, get_old_value_id, get_unique_id
 from .services import ZWaveServices
 
 LOGGER = logging.getLogger(__package__)
@@ -83,6 +83,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Z-Wave JS from a config entry."""
     client = ZwaveClient(entry.data[CONF_URL], async_get_clientsession(hass))
     dev_reg = await device_registry.async_get_registry(hass)
+    ent_reg = entity_registry.async_get(hass)
 
     @callback
     def async_on_node_ready(node: ZwaveNode) -> None:
@@ -95,6 +96,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # run discovery on all node values and create/update entities
         for disc_info in async_discover_values(node):
             LOGGER.debug("Discovered entity: %s", disc_info)
+
+            old_value_id = get_old_value_id(node, disc_info.primary_value)
+            old_unique_id = get_unique_id(
+                client.driver.controller.home_id, old_value_id
+            )
+            if entity_id := ent_reg.async_get_entity_id(
+                disc_info.platform, DOMAIN, old_unique_id
+            ):
+                LOGGER.debug(
+                    "Entity %s is using old unique ID, migrating to new one", entity_id
+                )
+                ent_reg.async_update_entity(
+                    entity_id,
+                    new_unique_id=get_unique_id(
+                        client.driver.controller.home_id,
+                        disc_info.primary_value.value_id,
+                    ),
+                )
+
             async_dispatcher_send(
                 hass, f"{DOMAIN}_{entry.entry_id}_add_{disc_info.platform}", disc_info
             )
@@ -193,7 +213,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DATA_UNSUBSCRIBE: unsubscribe_callbacks,
     }
 
-    services = ZWaveServices(hass, entity_registry.async_get(hass))
+    services = ZWaveServices(hass, ent_reg)
     services.async_register()
 
     # Set up websocket API

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -97,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for disc_info in async_discover_values(node):
             LOGGER.debug("Discovered entity: %s", disc_info)
 
-            old_value_id = get_old_value_id(node, disc_info.primary_value)
+            old_value_id = get_old_value_id(disc_info.primary_value)
             old_unique_id = get_unique_id(
                 client.driver.controller.home_id, old_value_id
             )

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -97,7 +97,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for disc_info in async_discover_values(node):
             LOGGER.debug("Discovered entity: %s", disc_info)
 
-            # TODO: Migration logic added in 2021.3 to handle breaking change to
+            # This migration logic was added in 2021.3 to handle breaking change to
             # value_id format. Some time in the future, this code block
             # (and get_old_value_id helper) can be removed.
             old_value_id = get_old_value_id(disc_info.primary_value)

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -97,6 +97,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for disc_info in async_discover_values(node):
             LOGGER.debug("Discovered entity: %s", disc_info)
 
+            # TODO: Migration logic added in 2021.3 to handle breaking change to
+            # value_id format. Some time in the future, this code block
+            # (and get_old_value_id helper) can be removed.
             old_value_id = get_old_value_id(disc_info.primary_value)
             old_unique_id = get_unique_id(
                 client.driver.controller.home_id, old_value_id

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -31,6 +31,9 @@ class ZWaveBaseEntity(Entity):
         self.client = client
         self.info = info
         self._name = self.generate_name()
+        self._unique_id = get_unique_id(
+            self.client.driver.controller.home_id, self.info.value_id
+        )
         # entities requiring additional values, can add extra ids to this list
         self.watched_value_ids = {self.info.primary_value.value_id}
 
@@ -128,7 +131,7 @@ class ZWaveBaseEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return the unique_id of the entity."""
-        return get_unique_id(self.client.driver.controller.home_id, self.info.value_id)
+        return self._unique_id
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 from .discovery import ZwaveDiscoveryInfo
-from .helpers import get_device_id
+from .helpers import get_device_id, get_unique_id
 
 LOGGER = logging.getLogger(__name__)
 
@@ -128,7 +128,7 @@ class ZWaveBaseEntity(Entity):
     @property
     def unique_id(self) -> str:
         """Return the unique_id of the entity."""
-        return f"{self.client.driver.controller.home_id}.{self.info.value_id}"
+        return get_unique_id(self.client.driver.controller.home_id, self.info.value_id)
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -3,6 +3,7 @@ from typing import List, Tuple, cast
 
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.node import Node as ZwaveNode
+from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
@@ -10,6 +11,22 @@ from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
 from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
 
 from .const import DATA_CLIENT, DOMAIN
+
+
+@callback
+def get_old_value_id(node: ZwaveNode, value: ZwaveValue) -> str:
+    """Get old value ID so we can migrate entity unique ID."""
+    command_class = value.command_class
+    endpoint = value.endpoint or "00"
+    property_ = value.property_
+    property_key_name = value.property_key_name or "00"
+    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key_name}"
+
+
+@callback
+def get_unique_id(home_id: str, value_id: str) -> str:
+    """Get unique ID from home ID and value ID."""
+    return f"{home_id}.{value_id}"
 
 
 @callback

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -14,13 +14,13 @@ from .const import DATA_CLIENT, DOMAIN
 
 
 @callback
-def get_old_value_id(node: ZwaveNode, value: ZwaveValue) -> str:
+def get_old_value_id(value: ZwaveValue) -> str:
     """Get old value ID so we can migrate entity unique ID."""
     command_class = value.command_class
     endpoint = value.endpoint or "00"
     property_ = value.property_
     property_key_name = value.property_key_name or "00"
-    return f"{node.node_id}-{command_class}-{endpoint}-{property_}-{property_key_name}"
+    return f"{value.node.node_id}-{command_class}-{endpoint}-{property_}-{property_key_name}"
 
 
 @callback


### PR DESCRIPTION
## Proposed change
As @MartinHjelmare mentioned [here](https://discord.com/channels/330944238910963714/800356888827002880/813935056547872828), when we changed the value ID format, we introduced a breaking change that would cause all previously created entities to be "detached". The suggestion was to use `entity_registry.async_migrate_entries` to migrate entities to use the new value ID in the unique ID, but the problem with this approach is we need to be able to convert the old value ID format to the new value ID format without having access to the value itself. Since the new format adds new properties to the value ID string, it's safer to perform this action when a node is added and entities are discovered, because at that point we have the `ZwaveValue`, and we can use that to get both the old and new unique ID.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
