### PR TITLE
Use dispatch instead of eventbus for supervisor events

### DIFF
--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -33,7 +33,8 @@ X_HASS_IS_ADMIN = "X-Hass-Is-Admin"
 WS_TYPE = "type"
 WS_ID = "id"
 
-WS_TYPE_EVENT = "supervisor/event"
 WS_TYPE_API = "supervisor/api"
+WS_TYPE_EVENT = "supervisor/event"
+WS_TYPE_SUBSCRIBE = "supervisor/subscribe"
 
 EVENT_SUPERVISOR_EVENT = "supervisor_event"

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -7,7 +7,10 @@ from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
+from homeassistant.helpers.dispatcher import (
+    async_dispatcher_connect,
+    async_dispatcher_send,
+)
 
 from .const import (
     ATTR_DATA,

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -52,21 +52,14 @@ async def websocket_subscribe(
 ):
     """Subscribe to supervisor events."""
 
-    async def forward_messages(data):
+    @callback
+    def forward_messages(data):
         """Forward events to websocket."""
         connection.send_message(websocket_api.event_message(msg[WS_ID], data))
 
-    subscriptions = {
-        EVENT_SUPERVISOR_EVENT: async_dispatcher_connect(
-            hass, EVENT_SUPERVISOR_EVENT, forward_messages
-        ),
-    }
-
-    @callback
-    def unsubscribe():
-        subscriptions[EVENT_SUPERVISOR_EVENT]()
-
-    connection.subscriptions[msg[WS_ID]] = unsubscribe
+    connection.subscriptions[msg[WS_ID]] = async_dispatcher_connect(
+        hass, EVENT_SUPERVISOR_EVENT, forward_messages
+    )
     connection.send_message(websocket_api.result_message(msg[WS_ID]))
 
 

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -7,7 +7,7 @@ from homeassistant.components import websocket_api
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_connect, async_dispatcher_send
 
 from .const import (
     ATTR_DATA,
@@ -77,7 +77,7 @@ async def websocket_supervisor_event(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ):
     """Publish events from the Supervisor."""
-    dispatcher_send(hass, EVENT_SUPERVISOR_EVENT, msg[ATTR_DATA])
+    async_dispatcher_send(hass, EVENT_SUPERVISOR_EVENT, msg[ATTR_DATA])
     connection.send_result(msg[WS_ID])
 
 

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -24,6 +24,7 @@ from .const import (
     WS_TYPE,
     WS_TYPE_API,
     WS_TYPE_EVENT,
+    WS_TYPE_SUBSCRIBE,
 )
 from .handler import HassIO
 
@@ -45,7 +46,7 @@ def async_load_websocket_api(hass: HomeAssistant):
 
 @websocket_api.require_admin
 @websocket_api.async_response
-@websocket_api.websocket_command({vol.Required("type"): "supervisor/subscribe"})
+@websocket_api.websocket_command({vol.Required(WS_TYPE): WS_TYPE_SUBSCRIBE})
 async def websocket_subscribe(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ):
@@ -53,7 +54,7 @@ async def websocket_subscribe(
 
     async def forward_messages(data):
         """Forward events to websocket."""
-        connection.send_message(websocket_api.event_message(msg["id"], data))
+        connection.send_message(websocket_api.event_message(msg[WS_ID], data))
 
     subscriptions = {
         EVENT_SUPERVISOR_EVENT: async_dispatcher_connect(
@@ -65,8 +66,8 @@ async def websocket_subscribe(
     def unsubscribe():
         subscriptions[EVENT_SUPERVISOR_EVENT]()
 
-    connection.subscriptions[msg["id"]] = unsubscribe
-    connection.send_message(websocket_api.result_message(msg["id"]))
+    connection.subscriptions[msg[WS_ID]] = unsubscribe
+    connection.send_message(websocket_api.result_message(msg[WS_ID]))
 
 
 @websocket_api.async_response

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -63,6 +63,7 @@ async def websocket_subscribe(
         subscriptions[EVENT_SUPERVISOR_EVENT]()
 
     connection.subscriptions[msg["id"]] = unsubscribe
+    connection.send_message(websocket_api.result_message(msg["id"]))
 
 
 @websocket_api.async_response

--- a/tests/components/hassio/__init__.py
+++ b/tests/components/hassio/__init__.py
@@ -1,3 +1,48 @@
 """Tests for Hass.io component."""
+import pytest
 
 HASSIO_TOKEN = "123456"
+
+
+@pytest.fixture(autouse=True)
+def mock_all(aioclient_mock):
+    """Mock all setup requests."""
+    aioclient_mock.post("http://127.0.0.1/homeassistant/options", json={"result": "ok"})
+    aioclient_mock.get("http://127.0.0.1/supervisor/ping", json={"result": "ok"})
+    aioclient_mock.post("http://127.0.0.1/supervisor/options", json={"result": "ok"})
+    aioclient_mock.get(
+        "http://127.0.0.1/info",
+        json={
+            "result": "ok",
+            "data": {"supervisor": "222", "homeassistant": "0.110.0", "hassos": None},
+        },
+    )
+    aioclient_mock.get(
+        "http://127.0.0.1/host/info",
+        json={
+            "result": "ok",
+            "data": {
+                "result": "ok",
+                "data": {
+                    "chassis": "vm",
+                    "operating_system": "Debian GNU/Linux 10 (buster)",
+                    "kernel": "4.19.0-6-amd64",
+                },
+            },
+        },
+    )
+    aioclient_mock.get(
+        "http://127.0.0.1/core/info",
+        json={"result": "ok", "data": {"version_latest": "1.0.0"}},
+    )
+    aioclient_mock.get(
+        "http://127.0.0.1/os/info",
+        json={"result": "ok", "data": {"version_latest": "1.0.0"}},
+    )
+    aioclient_mock.get(
+        "http://127.0.0.1/supervisor/info",
+        json={"result": "ok", "data": {"version_latest": "1.0.0"}},
+    )
+    aioclient_mock.get(
+        "http://127.0.0.1/ingress/panels", json={"result": "ok", "data": {"panels": {}}}
+    )

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -2,73 +2,14 @@
 import os
 from unittest.mock import patch
 
-import pytest
-
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components import frontend
 from homeassistant.components.hassio import STORAGE_KEY
-from homeassistant.components.hassio.const import (
-    ATTR_DATA,
-    ATTR_ENDPOINT,
-    ATTR_METHOD,
-    ATTR_WS_EVENT,
-    EVENT_SUPERVISOR_EVENT,
-    WS_ID,
-    WS_TYPE,
-    WS_TYPE_API,
-    WS_TYPE_SUBSCRIBE,
-)
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_mock_signal
+from . import mock_all  # noqa
 
 MOCK_ENVIRON = {"HASSIO": "127.0.0.1", "HASSIO_TOKEN": "abcdefgh"}
-
-
-@pytest.fixture(autouse=True)
-def mock_all(aioclient_mock):
-    """Mock all setup requests."""
-    aioclient_mock.post("http://127.0.0.1/homeassistant/options", json={"result": "ok"})
-    aioclient_mock.get("http://127.0.0.1/supervisor/ping", json={"result": "ok"})
-    aioclient_mock.post("http://127.0.0.1/supervisor/options", json={"result": "ok"})
-    aioclient_mock.get(
-        "http://127.0.0.1/info",
-        json={
-            "result": "ok",
-            "data": {"supervisor": "222", "homeassistant": "0.110.0", "hassos": None},
-        },
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/host/info",
-        json={
-            "result": "ok",
-            "data": {
-                "result": "ok",
-                "data": {
-                    "chassis": "vm",
-                    "operating_system": "Debian GNU/Linux 10 (buster)",
-                    "kernel": "4.19.0-6-amd64",
-                },
-            },
-        },
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/core/info",
-        json={"result": "ok", "data": {"version_latest": "1.0.0"}},
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/os/info",
-        json={"result": "ok", "data": {"version_latest": "1.0.0"}},
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/supervisor/info",
-        json={"result": "ok", "data": {"version_latest": "1.0.0"}},
-    )
-    aioclient_mock.get(
-        "http://127.0.0.1/ingress/panels", json={"result": "ok", "data": {"panels": {}}}
-    )
 
 
 async def test_setup_api_ping(hass, aioclient_mock):
@@ -361,74 +302,3 @@ async def test_service_calls_core(hassio_env, hass, aioclient_mock):
         assert mock_check_config.called
 
     assert aioclient_mock.call_count == 5
-
-
-async def test_ws_subscription(hassio_env, hass: HomeAssistant, hass_ws_client):
-    """Test websocket subscription."""
-    assert await async_setup_component(hass, "hassio", {})
-    client = await hass_ws_client(hass)
-    await client.send_json({WS_ID: 5, WS_TYPE: WS_TYPE_SUBSCRIBE})
-    response = await client.receive_json()
-    assert response["success"]
-
-    calls = async_mock_signal(hass, EVENT_SUPERVISOR_EVENT)
-    async_dispatcher_send(hass, EVENT_SUPERVISOR_EVENT, {"lorem": "ipsum"})
-
-    response = await client.receive_json()
-    assert response["event"]["lorem"] == "ipsum"
-    assert len(calls) == 1
-
-    await client.send_json(
-        {
-            WS_ID: 6,
-            WS_TYPE: "supervisor/event",
-            ATTR_DATA: {ATTR_WS_EVENT: "test", "lorem": "ipsum"},
-        }
-    )
-    response = await client.receive_json()
-    assert response["success"]
-    assert len(calls) == 2
-
-    response = await client.receive_json()
-    assert response["event"]["lorem"] == "ipsum"
-
-    # Unsubscribe
-    await client.send_json({WS_ID: 7, WS_TYPE: "unsubscribe_events", "subscription": 5})
-    response = await client.receive_json()
-    assert response["success"]
-
-
-async def test_websocket_supervisor_api(
-    hassio_env, hass: HomeAssistant, hass_ws_client, aioclient_mock
-):
-    """Test Supervisor websocket api."""
-    assert await async_setup_component(hass, "hassio", {})
-    websocket_client = await hass_ws_client(hass)
-    aioclient_mock.post(
-        "http://127.0.0.1/snapshots/new/partial",
-        json={"result": "ok", "data": {"slug": "sn_slug"}},
-    )
-
-    await websocket_client.send_json(
-        {
-            WS_ID: 1,
-            WS_TYPE: WS_TYPE_API,
-            ATTR_ENDPOINT: "/snapshots/new/partial",
-            ATTR_METHOD: "post",
-        }
-    )
-
-    msg = await websocket_client.receive_json()
-    assert msg["result"]["slug"] == "sn_slug"
-
-    await websocket_client.send_json(
-        {
-            WS_ID: 2,
-            WS_TYPE: WS_TYPE_API,
-            ATTR_ENDPOINT: "/supervisor/info",
-            ATTR_METHOD: "get",
-        }
-    )
-
-    msg = await websocket_client.receive_json()
-    assert msg["result"]["version_latest"] == "1.0.0"

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.components.hassio.const import (
     WS_TYPE_API,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_signal
@@ -368,7 +368,7 @@ async def test_ws_subscription(hassio_env, hass: HomeAssistant, hass_ws_client):
     response = await client.receive_json()
     assert response["success"]
 
-    dispatcher_send(hass, EVENT_SUPERVISOR_EVENT, {"lorem": "ipsum"})
+    async_dispatcher_send(hass, EVENT_SUPERVISOR_EVENT, {"lorem": "ipsum"})
     calls = async_mock_signal(hass, EVENT_SUPERVISOR_EVENT)
 
     response = await client.receive_json()

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -1,0 +1,90 @@
+"""Test websocket API."""
+from homeassistant.components.hassio.const import (
+    ATTR_DATA,
+    ATTR_ENDPOINT,
+    ATTR_METHOD,
+    ATTR_WS_EVENT,
+    EVENT_SUPERVISOR_EVENT,
+    WS_ID,
+    WS_TYPE,
+    WS_TYPE_API,
+    WS_TYPE_SUBSCRIBE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.setup import async_setup_component
+
+from . import mock_all  # noqa
+
+from tests.common import async_mock_signal
+
+
+async def test_ws_subscription(hassio_env, hass: HomeAssistant, hass_ws_client):
+    """Test websocket subscription."""
+    assert await async_setup_component(hass, "hassio", {})
+    client = await hass_ws_client(hass)
+    await client.send_json({WS_ID: 5, WS_TYPE: WS_TYPE_SUBSCRIBE})
+    response = await client.receive_json()
+    assert response["success"]
+
+    calls = async_mock_signal(hass, EVENT_SUPERVISOR_EVENT)
+    async_dispatcher_send(hass, EVENT_SUPERVISOR_EVENT, {"lorem": "ipsum"})
+
+    response = await client.receive_json()
+    assert response["event"]["lorem"] == "ipsum"
+    assert len(calls) == 1
+
+    await client.send_json(
+        {
+            WS_ID: 6,
+            WS_TYPE: "supervisor/event",
+            ATTR_DATA: {ATTR_WS_EVENT: "test", "lorem": "ipsum"},
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert len(calls) == 2
+
+    response = await client.receive_json()
+    assert response["event"]["lorem"] == "ipsum"
+
+    # Unsubscribe
+    await client.send_json({WS_ID: 7, WS_TYPE: "unsubscribe_events", "subscription": 5})
+    response = await client.receive_json()
+    assert response["success"]
+
+
+async def test_websocket_supervisor_api(
+    hassio_env, hass: HomeAssistant, hass_ws_client, aioclient_mock
+):
+    """Test Supervisor websocket api."""
+    assert await async_setup_component(hass, "hassio", {})
+    websocket_client = await hass_ws_client(hass)
+    aioclient_mock.post(
+        "http://127.0.0.1/snapshots/new/partial",
+        json={"result": "ok", "data": {"slug": "sn_slug"}},
+    )
+
+    await websocket_client.send_json(
+        {
+            WS_ID: 1,
+            WS_TYPE: WS_TYPE_API,
+            ATTR_ENDPOINT: "/snapshots/new/partial",
+            ATTR_METHOD: "post",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["result"]["slug"] == "sn_slug"
+
+    await websocket_client.send_json(
+        {
+            WS_ID: 2,
+            WS_TYPE: WS_TYPE_API,
+            ATTR_ENDPOINT: "/supervisor/info",
+            ATTR_METHOD: "get",
+        }
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["result"]["version_latest"] == "1.0.0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use a subscription model to publish events from the supervisor instead of the eventbus.
Frontend: https://github.com/home-assistant/frontend/pull/8443

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
