### PR TITLE
Mullvad integration improvements

### DIFF
--- a/homeassistant/components/mullvad/binary_sensor.py
+++ b/homeassistant/components/mullvad/binary_sensor.py
@@ -47,6 +47,6 @@ class MullvadBinarySensor(CoordinatorEntity, BinarySensorEntity):
         return self._name
 
     @property
-    def state(self):
+    def is_on(self):
         """Return the state for this binary sensor."""
         return self.coordinator.data[self.id]

--- a/homeassistant/components/mullvad/strings.json
+++ b/homeassistant/components/mullvad/strings.json
@@ -5,17 +5,11 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
       "user": {
-        "description": "Set up the Mullvad VPN integration?",
-        "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "password": "[%key:common::config_flow::data::password%]",
-          "username": "[%key:common::config_flow::data::username%]"
-        }
+        "description": "Set up the Mullvad VPN integration?"
       }
     }
   }

--- a/homeassistant/components/mullvad/translations/en.json
+++ b/homeassistant/components/mullvad/translations/en.json
@@ -3,6 +3,10 @@
         "abort": {
             "already_configured": "Device is already configured"
         },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
         "step": {
             "user": {
                 "description": "Set up the Mullvad VPN integration?"

--- a/homeassistant/components/mullvad/translations/en.json
+++ b/homeassistant/components/mullvad/translations/en.json
@@ -3,18 +3,8 @@
         "abort": {
             "already_configured": "Device is already configured"
         },
-        "error": {
-            "cannot_connect": "Failed to connect",
-            "invalid_auth": "Invalid authentication",
-            "unknown": "Unexpected error"
-        },
         "step": {
             "user": {
-                "data": {
-                    "host": "Host",
-                    "password": "Password",
-                    "username": "Username"
-                },
                 "description": "Set up the Mullvad VPN integration?"
             }
         }

--- a/tests/components/mullvad/test_config_flow.py
+++ b/tests/components/mullvad/test_config_flow.py
@@ -1,8 +1,11 @@
 """Test the Mullvad config flow."""
 from unittest.mock import patch
 
+from mullvad_api import MullvadAPIError
+
 from homeassistant import config_entries, setup
 from homeassistant.components.mullvad.const import DOMAIN
+from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
 
 from tests.common import MockConfigEntry
 
@@ -13,15 +16,17 @@ async def test_form_user(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == "form"
-    assert result["errors"] is None
+    assert result["type"] == RESULT_TYPE_FORM
+    assert not result["errors"]
 
     with patch(
         "homeassistant.components.mullvad.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.mullvad.async_setup_entry",
         return_value=True,
-    ) as mock_setup_entry:
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.mullvad.config_flow.MullvadAPI"
+    ) as mock_mullvad_api:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},
@@ -33,6 +38,7 @@ async def test_form_user(hass):
     assert result2["data"] == {}
     assert len(mock_setup.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 1
+    assert len(mock_mullvad_api.mock_calls) == 1
 
 
 async def test_form_user_only_once(hass):
@@ -42,5 +48,47 @@ async def test_form_user_only_once(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == "abort"
+    assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_connection_error(hass):
+    """Test we show an error when we have trouble connecting."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.mullvad.config_flow.MullvadAPI",
+        side_effect=MullvadAPIError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_unknown_error(hass):
+    """Test we show an error when an unknown error occurs."""
+    await setup.async_setup_component(hass, DOMAIN, {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.mullvad.config_flow.MullvadAPI",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "unknown"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Several improvements to the Mullvad integration, based on review comments in #44189 by @MartinHjelmare, and some additionally added robustness.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
