### PR TITLE
Use Plex server URL as config entry title

### DIFF
--- a/homeassistant/components/plex/config_flow.py
+++ b/homeassistant/components/plex/config_flow.py
@@ -240,7 +240,7 @@ class PlexFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         _LOGGER.debug("Valid config created for %s", plex_server.friendly_name)
 
-        return self.async_create_entry(title=plex_server.friendly_name, data=data)
+        return self.async_create_entry(title=url, data=data)
 
     async def async_step_select_server(self, user_input=None):
         """Use selected Plex server."""

--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -203,7 +203,7 @@ async def test_single_available_server(hass, mock_plex_calls):
         server_id = result["data"][CONF_SERVER_IDENTIFIER]
         mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-        assert result["title"] == mock_plex_server.friendly_name
+        assert result["title"] == mock_plex_server.url_in_use
         assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
         assert (
             result["data"][CONF_SERVER_IDENTIFIER]
@@ -259,7 +259,7 @@ async def test_multiple_servers_with_selection(
         server_id = result["data"][CONF_SERVER_IDENTIFIER]
         mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-        assert result["title"] == mock_plex_server.friendly_name
+        assert result["title"] == mock_plex_server.url_in_use
         assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
         assert (
             result["data"][CONF_SERVER_IDENTIFIER]
@@ -317,7 +317,7 @@ async def test_adding_last_unconfigured_server(
         server_id = result["data"][CONF_SERVER_IDENTIFIER]
         mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-        assert result["title"] == mock_plex_server.friendly_name
+        assert result["title"] == mock_plex_server.url_in_use
         assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
         assert (
             result["data"][CONF_SERVER_IDENTIFIER]
@@ -656,7 +656,7 @@ async def test_manual_config(hass, mock_plex_calls):
     server_id = result["data"][CONF_SERVER_IDENTIFIER]
     mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-    assert result["title"] == mock_plex_server.friendly_name
+    assert result["title"] == mock_plex_server.url_in_use
     assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
     assert result["data"][CONF_SERVER_IDENTIFIER] == mock_plex_server.machine_identifier
     assert result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_plex_server.url_in_use
@@ -692,7 +692,7 @@ async def test_manual_config_with_token(hass, mock_plex_calls):
     server_id = result["data"][CONF_SERVER_IDENTIFIER]
     mock_plex_server = hass.data[DOMAIN][SERVERS][server_id]
 
-    assert result["title"] == mock_plex_server.friendly_name
+    assert result["title"] == mock_plex_server.url_in_use
     assert result["data"][CONF_SERVER] == mock_plex_server.friendly_name
     assert result["data"][CONF_SERVER_IDENTIFIER] == mock_plex_server.machine_identifier
     assert result["data"][PLEX_SERVER_CONFIG][CONF_URL] == mock_plex_server.url_in_use


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The config entry title is currently the "friendly" name of the Plex server. However, it seems more useful to show the user the URL used to connect to their Plex server as it is commonly used in troubleshooting. Currently the user would need to go into `.storage` to know for certain which URL was used.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #45419
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
