### PR TITLE
Support Wolflink reconnection after unexpected failure

### DIFF
--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -90,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         except InvalidAuth as exception:
             raise UpdateFailed("Invalid authentication during update.") from exception
 
-    coordinator: DataUpdateCoordinator = DataUpdateCoordinator(
+    coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name=DOMAIN,

--- a/homeassistant/components/wolflink/manifest.json
+++ b/homeassistant/components/wolflink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Wolf SmartSet Service",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wolflink",
-  "requirements": ["wolf_smartset==0.1.8"],
+  "requirements": ["wolf_smartset==0.1.10"],
   "codeowners": ["@adamkrol93"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/wolflink/manifest.json
+++ b/homeassistant/components/wolflink/manifest.json
@@ -3,7 +3,7 @@
   "name": "Wolf SmartSet Service",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wolflink",
-  "requirements": ["wolf_smartset==0.1.10"],
+  "requirements": ["wolf_smartset==0.1.11"],
   "codeowners": ["@adamkrol93"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/wolflink/sensor.py
+++ b/homeassistant/components/wolflink/sensor.py
@@ -65,8 +65,10 @@ class WolfLinkSensor(CoordinatorEntity, SensorEntity):
     @property
     def state(self):
         """Return the state. Wolf Client is returning only changed values so we need to store old value here."""
-        if self.wolf_object.value_id in self.coordinator.data:
-            self._state = self.coordinator.data[self.wolf_object.value_id]
+        if self.wolf_object.parameter_id in self.coordinator.data:
+            new_state = self.coordinator.data[self.wolf_object.parameter_id]
+            self.wolf_object.value_id = new_state[0]
+            self._state = new_state[1]
         return self._state
 
     @property

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2356,7 +2356,7 @@ withings-api==2.3.2
 wled==0.4.4
 
 # homeassistant.components.wolflink
-wolf_smartset==0.1.8
+wolf_smartset==0.1.10
 
 # homeassistant.components.xbee
 xbee-helper==0.0.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2356,7 +2356,7 @@ withings-api==2.3.2
 wled==0.4.4
 
 # homeassistant.components.wolflink
-wolf_smartset==0.1.10
+wolf_smartset==0.1.11
 
 # homeassistant.components.xbee
 xbee-helper==0.0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1265,7 +1265,7 @@ withings-api==2.3.2
 wled==0.4.4
 
 # homeassistant.components.wolflink
-wolf_smartset==0.1.8
+wolf_smartset==0.1.10
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1265,7 +1265,7 @@ withings-api==2.3.2
 wled==0.4.4
 
 # homeassistant.components.wolflink
-wolf_smartset==0.1.10
+wolf_smartset==0.1.11
 
 # homeassistant.components.xbox
 xbox-webapi==2.0.11


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
There was an issue with setting up the whole integration after some internet loss or similar. When wolf gateway is back on-line then theirs system is changing value ids which this integration based on.
Now after some specific error integration will try to connect again and recreate the whole session with fetching new value ids.  
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44453
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
