### PR TITLE
Replace wrong domain returned from xbox api 2.0

### DIFF
--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -51,12 +51,12 @@ class XboxBaseSensorEntity(CoordinatorEntity):
         # The correct domain is images-eds-ssl which can just be replaced
         # to point to the correct image, with the correct domain and certificate.
         # Using YARL URL lib, we can replace the domain part of an url and remove
-        # the padding query.
+        # the mode=padding query.
         url = URL(self.data.display_pic)
         if url.host == "images-eds.xboxlive.com":
             url = url.with_host("images-eds-ssl.xboxlive.com")
         query = dict(url.query)
-        query.pop("padding", None)
+        query.pop("mode", None)
         return str(url.with_query(query))
 
     @property

--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -52,12 +52,10 @@ class XboxBaseSensorEntity(CoordinatorEntity):
         # to point to the correct image, with the correct domain and certificate
         # using YARL URL lib, we can replace the domain part of a url and append
         # only the queries we need (url and format) and omit unnecessary ones (padding)
-        original_url = URL(self.data.display_pic)
-        return str(
-            original_url.with_host("images-eds-ssl.xboxlive.com").with_query(
-                url=original_url.query["url"], format=original_url.query["format"]
-            )
-        )
+        url = URL(self.data.display_pic)
+        if url.host == "images-eds.xboxlive.com":
+            url = url.with_host("images-eds-ssl.xboxlive.com")
+        return str(url.with_query(url=url.query["url"], format=url.query["format"]))
 
     @property
     def entity_registry_enabled_default(self) -> bool:

--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -50,8 +50,7 @@ class XboxBaseSensorEntity(CoordinatorEntity):
         # with loading the image.
         # The correct domain is images-eds-ssl which can just be replaced
         # to point to the correct image, with the correct domain and certificate.
-        # Using YARL URL lib, we can replace the domain part of an url and remove
-        # the mode=padding query.
+        # We need to also remove the 'mode=Padding' query because with it, it results in an error 400.
         url = URL(self.data.display_pic)
         if url.host == "images-eds.xboxlive.com":
             url = url.with_host("images-eds-ssl.xboxlive.com")

--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -49,13 +49,15 @@ class XboxBaseSensorEntity(CoordinatorEntity):
         # Xbox sometimes returns a domain that uses a wrong certificate which creates issues
         # with loading the image.
         # The correct domain is images-eds-ssl which can just be replaced
-        # to point to the correct image, with the correct domain and certificate
-        # using YARL URL lib, we can replace the domain part of a url and append
-        # only the queries we need (url and format) and omit unnecessary ones (padding)
+        # to point to the correct image, with the correct domain and certificate.
+        # Using YARL URL lib, we can replace the domain part of an url and remove
+        # the padding query.
         url = URL(self.data.display_pic)
         if url.host == "images-eds.xboxlive.com":
             url = url.with_host("images-eds-ssl.xboxlive.com")
-        return str(url.with_query(url=url.query["url"], format=url.query["format"]))
+        query = dict(url.query)
+        query.pop("padding", None)
+        return str(url.with_query(query))
 
     @property
     def entity_registry_enabled_default(self) -> bool:


### PR DESCRIPTION
**Somehow after setting up the dev environment, i couldn't commit/push to my original fork, thus i needed to create a seperate branch and push it into that. As far as i know i can't merge that branch with the original pull request #46723, if that's somehow possible, please let me know**

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As explained in [this issue-807727457](https://github.com/home-assistant/core/issues/46486#issue-807727457) the xbox api somehow returns a wrong domain sometimes. The wrong url is: "https://images-eds.xboxlive.com/" and it contains a wrong certificate (common name invalid). However, if you replace the domain with: "https://images-eds-ssl.xboxlive.com/" there is no certificate error and the correct image is loaded. 

To fix this, the base_sensor can do a string replace. if the wrong url is returned, it is replaced with the correct one. If the xbox api returns the correct one already, nothing is replaced. 

**I don't have the means or knowhow to test this, as its a simple change, i'm hoping someone can test this or help me test this **


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46486 
- This PR is related to issue: #46486
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:
**[N/A]**
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:
**[N/A]**
- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
