### PR TITLE
Add type hints to LightEntity

### DIFF
--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -88,8 +88,8 @@ class LightGroup(GroupEntity, light.LightEntity):
         self._brightness: Optional[int] = None
         self._hs_color: Optional[Tuple[float, float]] = None
         self._color_temp: Optional[int] = None
-        self._min_mireds: Optional[int] = 154
-        self._max_mireds: Optional[int] = 500
+        self._min_mireds: int = 154
+        self._max_mireds: int = 500
         self._white_value: Optional[int] = None
         self._effect_list: Optional[List[str]] = None
         self._effect: Optional[str] = None
@@ -152,12 +152,12 @@ class LightGroup(GroupEntity, light.LightEntity):
         return self._color_temp
 
     @property
-    def min_mireds(self) -> Optional[int]:
+    def min_mireds(self) -> int:
         """Return the coldest color_temp that this light group supports."""
         return self._min_mireds
 
     @property
-    def max_mireds(self) -> Optional[int]:
+    def max_mireds(self) -> int:
         """Return the warmest color_temp that this light group supports."""
         return self._max_mireds
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -407,46 +407,46 @@ class LightEntity(ToggleEntity):
     """Representation of a light."""
 
     @property
-    def brightness(self):
+    def brightness(self) -> Optional[int]:
         """Return the brightness of this light between 0..255."""
         return None
 
     @property
-    def hs_color(self):
+    def hs_color(self) -> Optional[Tuple[float, float]]:
         """Return the hue and saturation color value [float, float]."""
         return None
 
     @property
-    def color_temp(self):
+    def color_temp(self) -> Optional[int]:
         """Return the CT color value in mireds."""
         return None
 
     @property
-    def min_mireds(self):
+    def min_mireds(self) -> int:
         """Return the coldest color_temp that this light supports."""
         # Default to the Philips Hue value that HA has always assumed
         # https://developers.meethue.com/documentation/core-concepts
         return 153
 
     @property
-    def max_mireds(self):
+    def max_mireds(self) -> int:
         """Return the warmest color_temp that this light supports."""
         # Default to the Philips Hue value that HA has always assumed
         # https://developers.meethue.com/documentation/core-concepts
         return 500
 
     @property
-    def white_value(self):
+    def white_value(self) -> Optional[int]:
         """Return the white value of this light between 0..255."""
         return None
 
     @property
-    def effect_list(self):
+    def effect_list(self) -> Optional[List[str]]:
         """Return the list of supported effects."""
         return None
 
     @property
-    def effect(self):
+    def effect(self) -> Optional[str]:
         """Return the current effect."""
         return None
 
@@ -495,7 +495,7 @@ class LightEntity(ToggleEntity):
         return {key: val for key, val in data.items() if val is not None}
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> int:
         """Flag supported features."""
         return 0
 

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -140,7 +140,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         return self._max_mireds
 
     @property
-    def supported_features(self) -> Optional[int]:
+    def supported_features(self) -> int:
         """Flag supported features."""
         return self._supported_features
 

--- a/homeassistant/util/color.py
+++ b/homeassistant/util/color.py
@@ -507,12 +507,12 @@ def _get_blue(temperature: float) -> float:
     return _bound(blue)
 
 
-def color_temperature_mired_to_kelvin(mired_temperature: float) -> float:
+def color_temperature_mired_to_kelvin(mired_temperature: float) -> int:
     """Convert absolute mired shift to degrees kelvin."""
     return math.floor(1000000 / mired_temperature)
 
 
-def color_temperature_kelvin_to_mired(kelvin_temperature: float) -> float:
+def color_temperature_kelvin_to_mired(kelvin_temperature: float) -> int:
     """Convert degrees kelvin to mired shift."""
     return math.floor(1000000 / kelvin_temperature)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add type hints to `LightEntity` as described in the documentation: [Light Entity Docs](https://developers.home-assistant.io/docs/core/entity/light/) 

Fix the following functions:
- `color_temperature_mired_to_kelvin`
- `color_temperature_kelvin_to_mired`

Which returns `int` but type hints is incorrectly set to `float`. This causes some integrations using `LightEntity` to return wrong types which eventually mess the frontend.

Background can be found here: https://github.com/home-assistant/core/issues/44822
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
