### PR TITLE
Fix zwave_js unique ID migration logic

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -117,17 +117,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # (and get_old_value_id helper) can be removed.
             # Beta users may have a different unique ID from what we expect, so let's
             # make all entities have the same format
-            old_unique_ids = [
+            value_ids = [
                 # 2021.2.* format
-                get_unique_id(
-                    client.driver.controller.home_id,
-                    get_old_value_id(disc_info.primary_value),
-                ),
+                get_old_value_id(disc_info.primary_value),
                 # 2021.3.0b0 format
-                get_unique_id(
-                    client.driver.controller.home_id,
-                    f"{disc_info.primary_value.node.node_id}.{disc_info.primary_value.value_id}",
-                ),
+                disc_info.primary_value.value_id,
             ]
 
             new_unique_id = get_unique_id(
@@ -135,7 +129,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 disc_info.primary_value.value_id,
             )
 
-            for unique_id in old_unique_ids:
+            for value_id in value_ids:
+                old_unique_id = (
+                    get_unique_id(
+                        client.driver.controller.home_id,
+                        f"{disc_info.primary_value.node.node_id}.{value_id}",
+                    ),
+                )
                 # Most entities have the same ID format, but notification binary sensors
                 # have a state key in their ID
                 if (
@@ -143,7 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     or disc_info.platform_hint != "notification"
                 ):
                     check_and_migrate_entity(
-                        disc_info.platform, f"{unique_id}", f"{new_unique_id}"
+                        disc_info.platform, f"{old_unique_id}", f"{new_unique_id}"
                     )
                     continue
 
@@ -154,7 +154,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
                     check_and_migrate_entity(
                         disc_info.platform,
-                        f"{unique_id}.{state_key}",
+                        f"{old_unique_id}.{state_key}",
                         f"{new_unique_id}.{state_key}",
                     )
 

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -112,11 +112,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         for disc_info in async_discover_values(node):
             LOGGER.debug("Discovered entity: %s", disc_info)
 
-            # This migration logic was added in 2021.3 to handle breaking change to
-            # value_id format. Some time in the future, this code block
-            # (and get_old_value_id helper) can be removed.
-            # Beta users may have a different unique ID from what we expect, so let's
-            # make all entities have the same format
+            # This migration logic was added in 2021.3 to handle a breaking change to
+            # the value_id format. Some time in the future, this code block
+            # (as well as get_old_value_id helper and migrate_entity closure) can be
+            # removed.
             value_ids = [
                 # 2021.2.* format
                 get_old_value_id(disc_info.primary_value),

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -129,11 +129,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
             for value_id in value_ids:
-                old_unique_id = (
-                    get_unique_id(
-                        client.driver.controller.home_id,
-                        f"{disc_info.primary_value.node.node_id}.{value_id}",
-                    ),
+                old_unique_id = get_unique_id(
+                    client.driver.controller.home_id,
+                    f"{disc_info.primary_value.node.node_id}.{value_id}",
                 )
                 # Most entities have the same ID format, but notification binary sensors
                 # have a state key in their ID so we need to handle them differently
@@ -156,9 +154,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     # next item
                     continue
 
-                migrate_entity(
-                    disc_info.platform, f"{old_unique_id}", f"{new_unique_id}"
-                )
+                migrate_entity(disc_info.platform, old_unique_id, new_unique_id)
 
             async_dispatcher_send(
                 hass, f"{DOMAIN}_{entry.entry_id}_add_{disc_info.platform}", disc_info

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -86,14 +86,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ent_reg = entity_registry.async_get(hass)
 
     @callback
-    def check_and_migrate_entity(
-        platform: str, old_unique_id: str, new_unique_id: str
-    ) -> None:
+    def migrate_entity(platform: str, old_unique_id: str, new_unique_id: str) -> None:
         """Check if entity with old unique ID exists, and if so migrate it to new ID."""
         if entity_id := ent_reg.async_get_entity_id(platform, DOMAIN, old_unique_id):
             LOGGER.debug(
-                "Entity %s is using old unique ID, migrating to new one",
+                "Migrating entity %s from old unique ID '%s' to new unique ID '%s'",
                 entity_id,
+                old_unique_id,
+                new_unique_id,
             )
             ent_reg.async_update_entity(
                 entity_id,
@@ -142,7 +142,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     disc_info.platform != "binary_sensor"
                     or disc_info.platform_hint != "notification"
                 ):
-                    check_and_migrate_entity(
+                    migrate_entity(
                         disc_info.platform, f"{old_unique_id}", f"{new_unique_id}"
                     )
                     continue
@@ -152,7 +152,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     if state_key == "0":
                         continue
 
-                    check_and_migrate_entity(
+                    migrate_entity(
                         disc_info.platform,
                         f"{old_unique_id}.{state_key}",
                         f"{new_unique_id}.{state_key}",

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -24,11 +24,6 @@ class ZwaveDiscoveryInfo:
     # hint for the platform about this discovered entity
     platform_hint: Optional[str] = ""
 
-    @property
-    def value_id(self) -> str:
-        """Return the unique value_id belonging to primary value."""
-        return f"{self.node.node_id}.{self.primary_value.value_id}"
-
 
 @dataclass
 class ZWaveValueDiscoverySchema:

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -32,7 +32,7 @@ class ZWaveBaseEntity(Entity):
         self.info = info
         self._name = self.generate_name()
         self._unique_id = get_unique_id(
-            self.client.driver.controller.home_id, self.info.value_id
+            self.client.driver.controller.home_id, self.info.primary_value.value_id
         )
         # entities requiring additional values, can add extra ids to this list
         self.watched_value_ids = {self.info.primary_value.value_id}

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -20,7 +20,10 @@ def get_old_value_id(value: ZwaveValue) -> str:
     endpoint = value.endpoint or "00"
     property_ = value.property_
     property_key_name = value.property_key_name or "00"
-    return f"{value.node.node_id}-{command_class}-{endpoint}-{property_}-{property_key_name}"
+    return (
+        f"{value.node.node_id}.{value.node.node_id}-{command_class}-{endpoint}-"
+        f"{property_}-{property_key_name}"
+    )
 
 
 @callback

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -20,10 +20,7 @@ def get_old_value_id(value: ZwaveValue) -> str:
     endpoint = value.endpoint or "00"
     property_ = value.property_
     property_key_name = value.property_key_name or "00"
-    return (
-        f"{value.node.node_id}.{value.node.node_id}-{command_class}-{endpoint}-"
-        f"{property_}-{property_key_name}"
-    )
+    return f"{value.node.node_id}-{command_class}-{endpoint}-{property_}-{property_key_name}"
 
 
 @callback

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -201,7 +201,7 @@ async def test_unique_id_migration_notification_binary_sensor(
     # Create entity RegistryEntry using old unique ID format
     old_unique_id = f"{client.driver.controller.home_id}.52.52-113-00-Home Security-Motion sensor status.8"
     entity_entry = ent_reg.async_get_or_create(
-        "sensor",
+        "binary_sensor",
         DOMAIN,
         old_unique_id,
         suggested_object_id=entity_name,

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -18,7 +18,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry, entity_registry
 
-from .common import AIR_TEMPERATURE_SENSOR
+from .common import AIR_TEMPERATURE_SENSOR, NOTIFICATION_MOTION_BINARY_SENSOR
 
 from tests.common import MockConfigEntry
 
@@ -124,7 +124,7 @@ async def test_on_node_added_ready(
     )
 
 
-async def test_unique_id_migration_1(hass, multisensor_6_state, client, integration):
+async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integration):
     """Test unique ID is migrated from old format to new (version 1)."""
     ent_reg = entity_registry.async_get(hass)
 
@@ -157,7 +157,7 @@ async def test_unique_id_migration_1(hass, multisensor_6_state, client, integrat
     assert entity_entry.unique_id == new_unique_id
 
 
-async def test_unique_id_migration_2(hass, multisensor_6_state, client, integration):
+async def test_unique_id_migration_v2(hass, multisensor_6_state, client, integration):
     """Test unique ID is migrated from old format to new (version 2)."""
     ent_reg = entity_registry.async_get(hass)
     # Migrate version 2
@@ -187,6 +187,40 @@ async def test_unique_id_migration_2(hass, multisensor_6_state, client, integrat
     # Check that new RegistryEntry is using new unique ID format
     entity_entry = ent_reg.async_get(ILLUMINANCE_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance-00-00"
+    assert entity_entry.unique_id == new_unique_id
+
+
+async def test_unique_id_migration_notification_binary_sensor(
+    hass, multisensor_6_state, client, integration
+):
+    """Test unique ID is migrated from old format to new for a notification binary sensor."""
+    ent_reg = entity_registry.async_get(hass)
+
+    entity_name = NOTIFICATION_MOTION_BINARY_SENSOR.split(".")[1]
+
+    # Create entity RegistryEntry using old unique ID format
+    old_unique_id = f"{client.driver.controller.home_id}.52.52-113-00-Home Security-Motion sensor status.8"
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id,
+        suggested_object_id=entity_name,
+        config_entry=integration,
+        original_name=entity_name,
+    )
+    assert entity_entry.entity_id == NOTIFICATION_MOTION_BINARY_SENSOR
+    assert entity_entry.unique_id == old_unique_id
+
+    # Add a ready node, unique ID should be migrated
+    node = Node(client, multisensor_6_state)
+    event = {"node": node}
+
+    client.driver.controller.emit("node added", event)
+    await hass.async_block_till_done()
+
+    # Check that new RegistryEntry is using new unique ID format
+    entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_BINARY_SENSOR)
+    new_unique_id = f"{client.driver.controller.home_id}.52-113-0-Home Security-Motion sensor status-Motion sensor status.8"
     assert entity_entry.unique_id == new_unique_id
 
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -124,9 +124,11 @@ async def test_on_node_added_ready(
     )
 
 
-async def test_unique_id_migration(hass, multisensor_6_state, client, integration):
-    """Test unique ID is migrated from old format to new."""
+async def test_unique_id_migration_1(hass, multisensor_6_state, client, integration):
+    """Test unique ID is migrated from old format to new (version 1)."""
     ent_reg = entity_registry.async_get(hass)
+
+    # Migrate version 1
     entity_name = AIR_TEMPERATURE_SENSOR.split(".")[1]
 
     # Create entity RegistryEntry using old unique ID format
@@ -152,6 +154,39 @@ async def test_unique_id_migration(hass, multisensor_6_state, client, integratio
     # Check that new RegistryEntry is using new unique ID format
     entity_entry = ent_reg.async_get(AIR_TEMPERATURE_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Air temperature-00-00"
+    assert entity_entry.unique_id == new_unique_id
+
+
+async def test_unique_id_migration_2(hass, multisensor_6_state, client, integration):
+    """Test unique ID is migrated from old format to new (version 2)."""
+    ent_reg = entity_registry.async_get(hass)
+    # Migrate version 2
+    ILLUMINANCE_SENSOR = "sensor.multisensor_6_illuminance"
+    entity_name = ILLUMINANCE_SENSOR.split(".")[1]
+
+    # Create entity RegistryEntry using old unique ID format
+    old_unique_id = f"{client.driver.controller.home_id}.52.52-49-0-Illuminance-00-00"
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id,
+        suggested_object_id=entity_name,
+        config_entry=integration,
+        original_name=entity_name,
+    )
+    assert entity_entry.entity_id == ILLUMINANCE_SENSOR
+    assert entity_entry.unique_id == old_unique_id
+
+    # Add a ready node, unique ID should be migrated
+    node = Node(client, multisensor_6_state)
+    event = {"node": node}
+
+    client.driver.controller.emit("node added", event)
+    await hass.async_block_till_done()
+
+    # Check that new RegistryEntry is using new unique ID format
+    entity_entry = ent_reg.async_get(ILLUMINANCE_SENSOR)
+    new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance-00-00"
     assert entity_entry.unique_id == new_unique_id
 
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -130,7 +130,7 @@ async def test_unique_id_migration(hass, multisensor_6_state, client, integratio
     entity_name = AIR_TEMPERATURE_SENSOR.split(".")[1]
 
     # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.52-49-00-Air temperature-00"
+    old_unique_id = f"{client.driver.controller.home_id}.52.52-49-00-Air temperature-00"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,


### PR DESCRIPTION
## Proposed change
There are two things we want to fix from https://github.com/home-assistant/core/pull/46979:
1. The migration logic looked for a unique ID of `<home_id>.<old_value_id>` but we should have been looking for `<home_id>.<node_id>.<old_value_id>`. This is because the `unique_id` used `ZwaveDiscoveryInfo.value_id` which confusingly uses the `<node_id>.<value_id>` format. Because this logic was wrong, b0 users had entities duplicated.
2. In the entity instance, we were still using `ZwaveDiscoveryInfo.value_id`, so the unique ID was set to`<home_id>.<node_id>.<new_value_id>`. Even if the migration logic had worked, it would have still resulted in duplicates because we were migrating to `<home_id>.<new_value_id>` but the new entities are using this same `ZwaveDiscoveryInfo.value_id` format for unique ID except with the new value ID (`ZwaveValue.value_id`) format, so we would have successfully migrated the existing entities but they would still be orphaned.

`ZwaveDiscoveryInfo.value_id` is clearly a source of confusion (at least it was for me), it's only being used for unique IDs, and it doesn't add any uniqueness to the ID since node ID is already in the value ID, so I got rid of it entirely. I also updated the migration logic to look for both `<home_id>.<node_id>.<OLD_value_id>` (from 2021.2) and `<home_id>.<node_id>.<NEW_value_id>` from (2021.3.0b0) and 
to change them to `<home_id>.<NEW_value_id>`. This is less confusing as there is no duplicate information and the code is easier to read as a result.

Notification binary sensors have a unique ID that also includes the state key so there is additional logic added to handle that scenario.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
