### PR TITLE
Add zeroconf discovery to Freebox

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -22,7 +22,6 @@ SERVICE_APPLE_TV = "apple_tv"
 SERVICE_DAIKIN = "daikin"
 SERVICE_DLNA_DMR = "dlna_dmr"
 SERVICE_ENIGMA2 = "enigma2"
-SERVICE_FREEBOX = "freebox"
 SERVICE_HASS_IOS_APP = "hass_ios"
 SERVICE_HASSIO = "hassio"
 SERVICE_HEOS = "heos"
@@ -67,7 +66,6 @@ MIGRATED_SERVICE_HANDLERS = [
     SERVICE_DAIKIN,
     "denonavr",
     "esphome",
-    SERVICE_FREEBOX,
     "google_cast",
     SERVICE_HASS_IOS_APP,
     SERVICE_HASSIO,

--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -25,26 +25,20 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass, config):
-    """Set up the Freebox component."""
-    conf = config.get(DOMAIN)
-
-    if conf is None:
-        return True
-
-    for freebox_conf in conf:
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=freebox_conf,
+    """Set up the Freebox integration."""
+    if DOMAIN in config:
+        for entry_config in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry_config
+                )
             )
-        )
 
     return True
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
-    """Set up Freebox component."""
+    """Set up Freebox entry."""
     router = FreeboxRouter(hass, entry)
     await router.setup()
 

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -105,3 +105,9 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, user_input=None):
         """Import a config entry."""
         return await self.async_step_user(user_input)
+
+    async def async_step_zeroconf(self, discovery_info: dict):
+        """Initialize flow from zeroconf."""
+        host = discovery_info.get("properties", {}).get("api_domain")
+        port = discovery_info.get("properties", {}).get("https_port")
+        return await self.async_step_user({CONF_HOST: host, CONF_PORT: port})

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -108,6 +108,6 @@ class FreeboxFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf(self, discovery_info: dict):
         """Initialize flow from zeroconf."""
-        host = discovery_info.get("properties", {}).get("api_domain")
-        port = discovery_info.get("properties", {}).get("https_port")
+        host = discovery_info["properties"]["api_domain"]
+        port = discovery_info["properties"]["https_port"]
         return await self.async_step_user({CONF_HOST: host, CONF_PORT: port})

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -31,6 +31,16 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
+async def get_api(hass: HomeAssistantType, host: str) -> Freepybox:
+    """Get the Freebox API."""
+    freebox_path = Path(hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY).path)
+    freebox_path.mkdir(exist_ok=True)
+
+    token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
+
+    return Freepybox(APP_DESC, token_file, API_VERSION)
+
+
 class FreeboxRouter:
     """Representation of a Freebox router."""
 
@@ -188,13 +198,3 @@ class FreeboxRouter:
     def wifi(self) -> Wifi:
         """Return the wifi."""
         return self._api.wifi
-
-
-async def get_api(hass: HomeAssistantType, host: str) -> Freepybox:
-    """Get the Freebox API."""
-    freebox_path = Path(hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY).path)
-    freebox_path.mkdir(exist_ok=True)
-
-    token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
-
-    return Freepybox(APP_DESC, token_file, API_VERSION)

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -31,16 +31,6 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(seconds=30)
 
 
-async def get_api(hass: HomeAssistantType, host: str) -> Freepybox:
-    """Get the Freebox API."""
-    freebox_path = Path(hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY).path)
-    freebox_path.mkdir(exist_ok=True)
-
-    token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
-
-    return Freepybox(APP_DESC, token_file, API_VERSION)
-
-
 class FreeboxRouter:
     """Representation of a Freebox router."""
 
@@ -198,3 +188,13 @@ class FreeboxRouter:
     def wifi(self) -> Wifi:
         """Return the wifi."""
         return self._api.wifi
+
+
+async def get_api(hass: HomeAssistantType, host: str) -> Freepybox:
+    """Get the Freebox API."""
+    freebox_path = Path(hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY).path)
+    freebox_path.mkdir(exist_ok=True)
+
+    token_file = Path(f"{freebox_path}/{slugify(host)}.conf")
+
+    return Freepybox(APP_DESC, token_file, API_VERSION)

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -10,13 +10,32 @@ import pytest
 
 from homeassistant import data_entry_flow
 from homeassistant.components.freebox.const import DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT
 
 from tests.common import MockConfigEntry
 
 HOST = "myrouter.freeboxos.fr"
 PORT = 1234
+
+MOCK_ZEROCONF_DATA = {
+    "host": "192.168.0.254",
+    "port": 80,
+    "hostname": "Freebox-Server.local.",
+    "type": "_fbx-api._tcp.local.",
+    "name": "Freebox Server._fbx-api._tcp.local.",
+    "properties": {
+        "api_version": "8.0",
+        "device_type": "FreeboxServer1,2",
+        "api_base_url": "/api/",
+        "uid": "b15ab20debb399f95001a9ca207d2777",
+        "https_available": "1",
+        "https_port": f"{PORT}",
+        "box_model": "fbxgw-r2/full",
+        "box_model_name": "Freebox Server (r2)",
+        "api_domain": HOST,
+    },
+}
 
 
 @pytest.fixture(name="connect")
@@ -61,6 +80,17 @@ async def test_import(hass):
         DOMAIN,
         context={"source": SOURCE_IMPORT},
         data={CONF_HOST: HOST, CONF_PORT: PORT},
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "link"
+
+
+async def test_zeroconf(hass):
+    """Test zeroconf step."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=MOCK_ZEROCONF_DATA,
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "link"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use `zeroconf` to discover a Freebox, not `discovery`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to PR: #47022

- remove deprecated discovery
- tried with SSDP too but the presentation URL is not the same (*.fbxos.fr for zeroconf, http://mafreebox.freebox.fr/ for SSDP)
- so config entry unique_id should be the MAC (included into SSDP, but not zeroconf, can be retrieve from `fbx.system.get_config()`)
- DHCP discovery might be added in the future too

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
