### PR TITLE
Add force_update to tasmota sensors

### DIFF
--- a/homeassistant/components/tasmota/sensor.py
+++ b/homeassistant/components/tasmota/sensor.py
@@ -193,6 +193,11 @@ class TasmotaSensor(TasmotaAvailability, TasmotaDiscoveryUpdate, Entity):
         return self._state
 
     @property
+    def force_update(self):
+        """Force update."""
+        return True
+
+    @property
     def unit_of_measurement(self):
         """Return the unit this state is expressed in."""
         return SENSOR_UNIT_MAP.get(self._tasmota_entity.unit, self._tasmota_entity.unit)

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -100,6 +100,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     entry = entity_registry.async_get("binary_sensor.tasmota_binary_sensor_1")
     assert entry.force_update
 
+
 async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""
     config = copy.deepcopy(DEFAULT_CONFIG)

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -78,9 +78,6 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
 
-    # Test force update flag
-    assert state.force_update
-
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Switch1":"OFF"}')
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
@@ -98,6 +95,10 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF
 
+    # Test force update flag
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entry = entity_registry.async_get("binary_sensor.tasmota_binary_sensor_1")
+    assert entry.force_update
 
 async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -78,6 +78,9 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_ON
 
+    # Test force update flag
+    assert state.force_update == True
+
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Switch1":"OFF"}')
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")
     assert state.state == STATE_OFF

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -79,7 +79,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_ON
 
     # Test force update flag
-    assert state.force_update == True
+    assert state.force_update
 
     async_fire_mqtt_message(hass, "tasmota_49A3BC/tele/SENSOR", '{"Switch1":"OFF"}')
     state = hass.states.get("binary_sensor.tasmota_binary_sensor_1")

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -96,8 +96,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
     # Test force update flag
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    entry = entity_registry.async_get("binary_sensor.tasmota_binary_sensor_1")
+    entity = hass.data["entity_components"]["binary_sensor"].get_entity("binary_sensor.tasmota_binary_sensor_1")
     assert entry.force_update
 
 

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -97,7 +97,7 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 
     # Test force update flag
     entity = hass.data["entity_components"]["binary_sensor"].get_entity("binary_sensor.tasmota_binary_sensor_1")
-    assert entry.force_update
+    assert entity.force_update
 
 
 async def test_controlling_state_via_mqtt_switchname(hass, mqtt_mock, setup_tasmota):

--- a/tests/components/tasmota/test_binary_sensor.py
+++ b/tests/components/tasmota/test_binary_sensor.py
@@ -96,7 +96,9 @@ async def test_controlling_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == STATE_OFF
 
     # Test force update flag
-    entity = hass.data["entity_components"]["binary_sensor"].get_entity("binary_sensor.tasmota_binary_sensor_1")
+    entity = hass.data["entity_components"]["binary_sensor"].get_entity(
+        "binary_sensor.tasmota_binary_sensor_1"
+    )
     assert entity.force_update
 
 

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -266,7 +266,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == "20.5"
 
     # Test force update flag
-    assert state.force_update == True
+    assert state.force_update
 
     # Test polled state update
     async_fire_mqtt_message(

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -276,8 +276,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == "20.0"
 
     # Test force update flag
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    entry = entity_registry.async_get("sensor.tasmota_status")
+    entity = hass.data["entity_components"]["sensor"].get_entity("sensor.tasmota_status")
     assert entry.force_update
 
 

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -265,9 +265,6 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("sensor.tasmota_status")
     assert state.state == "20.5"
 
-    # Test force update flag
-    assert state.force_update
-
     # Test polled state update
     async_fire_mqtt_message(
         hass,
@@ -278,6 +275,10 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("sensor.tasmota_status")
     assert state.state == "20.0"
 
+    # Test force update flag
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entry = entity_registry.async_get("sensor.tasmota_status")
+    assert entry.force_update
 
 @pytest.mark.parametrize("status_sensor_disabled", [False])
 async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -276,7 +276,9 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     assert state.state == "20.0"
 
     # Test force update flag
-    entity = hass.data["entity_components"]["sensor"].get_entity("sensor.tasmota_status")
+    entity = hass.data["entity_components"]["sensor"].get_entity(
+        "sensor.tasmota_status"
+    )
     assert entity.force_update
 
 

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -277,7 +277,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 
     # Test force update flag
     entity = hass.data["entity_components"]["sensor"].get_entity("sensor.tasmota_status")
-    assert entry.force_update
+    assert entity.force_update
 
 
 @pytest.mark.parametrize("status_sensor_disabled", [False])

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -265,6 +265,9 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     state = hass.states.get("sensor.tasmota_status")
     assert state.state == "20.5"
 
+    # Test force update flag
+    assert state.force_update == True
+
     # Test polled state update
     async_fire_mqtt_message(
         hass,

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -280,6 +280,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     entry = entity_registry.async_get("sensor.tasmota_status")
     assert entry.force_update
 
+
 @pytest.mark.parametrize("status_sensor_disabled", [False])
 async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds `force_update` property with value `True` for Tasmota sensors as already done for Tasmota binary sensors. This makes it possible to calculate properly mean average values e.g. of POWER Measurement. This is by the way the same behaviour as set with the obsolete tasmota MQTT discovery (`setoption19 1`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
 