### PR TITLE
Check template cover state when calling close/open

### DIFF
--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -365,24 +365,26 @@ class CoverTemplate(TemplateEntity, CoverEntity):
 
     async def async_open_cover(self, **kwargs):
         """Move the cover up."""
-        if self._open_script:
-            await self._open_script.async_run(context=self._context)
-        elif self._position_script:
-            await self._position_script.async_run(
-                {"position": 100}, context=self._context
-            )
+        if self._optimistic or (not self._optimistic and self._position != 0):
+            if self._open_script:
+                await self._open_script.async_run(context=self._context)
+            elif self._position_script:
+                await self._position_script.async_run(
+                    {"position": 100}, context=self._context
+                )
         if self._optimistic:
             self._position = 100
             self.async_write_ha_state()
 
     async def async_close_cover(self, **kwargs):
         """Move the cover down."""
-        if self._close_script:
-            await self._close_script.async_run(context=self._context)
-        elif self._position_script:
-            await self._position_script.async_run(
-                {"position": 0}, context=self._context
-            )
+        if self._optimistic or (not self._optimistic and self._position != 100):
+            if self._close_script:
+                await self._close_script.async_run(context=self._context)
+            elif self._position_script:
+                await self._position_script.async_run(
+                    {"position": 0}, context=self._context
+                )
         if self._optimistic:
             self._position = 0
             self.async_write_ha_state()


### PR DESCRIPTION
For templated sensors that report value state prevents letting
Google Assistant (or any service for that matter) call open/close
when the door is in the opposite state.

See https://github.com/home-assistant/core/pull/46088 for more
context.
Fixes: #35317

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Template covers with a value template set will now check current state on open/close requests.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevents Google Assistant from calling "Close" on a cover subverting pin security that is normally present on "Open" only.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
# Example configuration.yaml
google_assistant:
  project_id: foo
  service_account: !include google_account.json
  report_state: true
  secure_devices_pin: "1234"
  exposed_domains:
    - cover

cover:                         
  - platform: template                                                    
    covers:                                                    
      garage_door:                                           
        device_class: garage                                               
        friendly_name: "Garage Door"                                     
        value_template: "{{ states('switch.garagedoor_sensor') == 'off' }}"
        open_cover:                                                         
          service: switch.toggle           
          data:                                                                           
            entity_id: switch.garagedoor                                             
        close_cover:                         
          service: switch.toggle        
          data:                                                                  
            entity_id: switch.garagedoor                    
        stop_cover:                       
          service: switch.toggle                       
          data:
            entity_id: switch.garagedoor
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #35317
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
