### PR TITLE
Add battery support for Sonos Move

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -1,12 +1,26 @@
 """Support to embed Sonos."""
+import asyncio
+import logging
+import socket
+
+import pysonos
+from pysonos.exceptions import SoCoException
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
-from homeassistant.const import CONF_HOSTS
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import CONF_HOSTS, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN
+from .const import (
+    DATA_SONOS,
+    DISCOVERY_INTERVAL,
+    DOMAIN,
+    SONOS_DISCOVERY_UPDATE,
+)
+
+_LOGGER = logging.getLogger(__name__)
 
 CONF_ADVERTISE_ADDR = "advertise_addr"
 CONF_INTERFACE_ADDR = "interface_addr"
@@ -31,6 +45,21 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
+class SonosData:
+    """Storage class for platform global data."""
+
+    def __init__(self):
+        """Initialize the data."""
+        self.discovered = {}
+        self.speaker_info = {}
+        self.battery_entities = {}
+        self.media_player_entities = {}
+        self.topology_condition = asyncio.Condition()
+        self.discovery_thread = None
+        self.hosts_heartbeat = None
+        self.seen_timers = {}
+
+
 async def async_setup(hass, config):
     """Set up the Sonos component."""
     conf = config.get(DOMAIN)
@@ -49,7 +78,109 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass, entry):
     """Set up Sonos from a config entry."""
+    if DATA_SONOS not in hass.data:
+        hass.data[DATA_SONOS] = SonosData()
+
+    config = hass.data[DOMAIN].get("media_player", {})
+    _LOGGER.debug("Reached async_setup_entry, config=%s", config)
+
+    advertise_addr = config.get(CONF_ADVERTISE_ADDR)
+    if advertise_addr:
+        pysonos.config.EVENT_ADVERTISE_IP = advertise_addr
+
+    def _stop_discovery(event):
+        data = hass.data[DATA_SONOS]
+        if data.discovery_thread:
+            data.discovery_thread.stop()
+            data.discovery_thread = None
+        if data.hosts_heartbeat:
+            data.hosts_heartbeat()
+            data.hosts_heartbeat = None
+
+    def _discovery(now=None):
+        """Discover players from network or configuration."""
+        hosts = config.get(CONF_HOSTS)
+
+        def _discovered_player(soco):
+            """Handle a (re)discovered player."""
+            try:
+
+                data = hass.data[DATA_SONOS]
+
+                if soco.uid not in data.discovered:
+                    data.discovered[soco.uid] = soco
+                    # Set these early since device_info() needs them
+                    data.speaker_info[soco.uid] = soco.get_speaker_info(True)
+
+                    hass.bus.fire(SONOS_DISCOVERY_UPDATE, {"soco": soco})
+                else:
+                    entity = data.media_player_entities.get(soco.uid)
+                    if entity and (entity.soco == soco or not entity.available):
+                        hass.add_job(entity.async_seen(soco))
+
+                    entity = data.battery_entities.get(soco.uid)
+                    if entity and (entity.soco == soco or not entity.available):
+                        hass.add_job(entity.async_seen(soco))
+
+                # watch for this soco to become unavailable
+                seen_timers = data.seen_timers
+                if soco.uid in seen_timers:
+                    seen_timers[soco.uid]()
+                seen_timers[soco.uid] = hass.helpers.event.async_call_later(
+                    2.5 * DISCOVERY_INTERVAL.seconds, lambda: _disappeared_player(soco)
+                )
+
+            except SoCoException as ex:
+                _LOGGER.debug("SoCoException, ex=%s", ex)
+
+        def _disappeared_player(soco):
+            """Handle a player that has disappeared."""
+            data = hass.data[DATA_SONOS]
+            del data.seen_timers[soco.uid]
+            entity = data.media_player_entities.get(soco.uid)
+            if entity:
+                entity.async_unseen()
+            entity = data.battery_entities.get(soco.uid)
+            if entity:
+                entity.async_unseen()
+
+        if hosts:
+            for host in hosts:
+                try:
+                    _LOGGER.debug("Testing %s", host)
+                    player = pysonos.SoCo(socket.gethostbyname(host))
+                    if player.is_visible:
+                        # Make sure that the player is available
+                        _ = player.volume
+
+                        _discovered_player(player)
+                except (OSError, SoCoException) as ex:
+                    _LOGGER.debug("Exception %s", ex)
+                    if now is None:
+                        _LOGGER.warning("Failed to initialize '%s'", host)
+
+            _LOGGER.debug("Tested all hosts")
+            hass.data[DATA_SONOS].hosts_heartbeat = hass.helpers.event.call_later(
+                DISCOVERY_INTERVAL.seconds, _discovery
+            )
+        else:
+            _LOGGER.debug("Starting discovery thread")
+            hass.data[DATA_SONOS].discovery_thread = pysonos.discover_thread(
+                _discovered_player,
+                interval=DISCOVERY_INTERVAL.seconds,
+                interface_addr=config.get(CONF_INTERFACE_ADDR),
+            )
+
+    # register the entity classes
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, MP_DOMAIN)
     )
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, SENSOR_DOMAIN)
+    )
+
+    _LOGGER.debug("Adding discovery job")
+    hass.async_add_executor_job(_discovery)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop_discovery)
+
     return True

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -13,12 +13,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import CONF_HOSTS, EVENT_HOMEASSISTANT_STOP
 from homeassistant.helpers import config_validation as cv
 
-from .const import (
-    DATA_SONOS,
-    DISCOVERY_INTERVAL,
-    DOMAIN,
-    SONOS_DISCOVERY_UPDATE,
-)
+from .const import DATA_SONOS, DISCOVERY_INTERVAL, DOMAIN, SONOS_DISCOVERY_UPDATE
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -1,4 +1,6 @@
 """Const for Sonos."""
+import datetime
+
 from homeassistant.components.media_player.const import (
     MEDIA_CLASS_ALBUM,
     MEDIA_CLASS_ARTIST,
@@ -121,3 +123,8 @@ PLAYABLE_MEDIA_TYPES = [
     MEDIA_TYPE_PLAYLIST,
     MEDIA_TYPE_TRACK,
 ]
+
+SONOS_DISCOVERY_UPDATE = "sonos_discovery_update"
+
+SCAN_INTERVAL = datetime.timedelta(seconds=10)
+DISCOVERY_INTERVAL = datetime.timedelta(seconds=60)

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -176,6 +176,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.bus.async_listen(SONOS_DISCOVERY_UPDATE, async_create_entities)
 
+    # create any entities for devices that exist already
+    for uid, soco in hass.data[DATA_SONOS].discovered.items():
+        if uid not in hass.data[DATA_SONOS].media_player_entities:
+            hass.data[DATA_SONOS].media_player_entities[soco.uid] = None
+            hass.add_job(async_add_entities, [SonosMediaPlayerEntity(soco)])
+
     hass.services.async_register(
         SONOS_DOMAIN,
         SERVICE_JOIN,

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -49,12 +49,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.components.media_player.errors import BrowseError
 from homeassistant.components.plex.const import PLEX_URI_SCHEME
 from homeassistant.components.plex.services import play_on_sonos
-from homeassistant.const import (
-    ATTR_TIME,
-    STATE_IDLE,
-    STATE_PAUSED,
-    STATE_PLAYING,
-)
+from homeassistant.const import ATTR_TIME, STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import Event, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv, entity_platform, service
 import homeassistant.helpers.device_registry as dr

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -5,11 +5,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 from pysonos.core import SoCo
 from pysonos.exceptions import SoCoException
 
-from homeassistant.const import (
-    DEVICE_CLASS_BATTERY,
-    PERCENTAGE,
-    STATE_UNKNOWN,
-)
+from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE, STATE_UNKNOWN
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -1,0 +1,130 @@
+"""Entity representing a Sonos Move battery level."""
+import datetime
+import logging
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from pysonos.core import SoCo
+from pysonos.exceptions import SoCoException
+
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.icon import icon_for_battery_level
+
+if TYPE_CHECKING:  # Avoid recursive import loops
+    from .media_player import SonosEntity
+
+_LOGGER = logging.getLogger(__name__)
+SCAN_INTERVAL = datetime.timedelta(seconds=10)
+
+ATTR_BATTERY_LEVEL = "battery_level"
+ATTR_BATTERY_CHARGING = "charging"
+ATTR_BATTERY_POWERSOURCE = "power_source"
+
+
+class SonosBatteryEntity(Entity):
+    """Representation of a Sonos Battery entity.
+
+    Defers connection status to parent SonosEntity.
+    """
+
+    def __init__(self, parent: "SonosEntity", soco: SoCo, battery_info: Dict[str, Any]):
+        """Initialize a SonosBatteryEntity from a parent SonosEntity."""
+        self._parent = parent
+        self._soco = soco
+        self._battery_info = battery_info
+        self._timer = None
+
+    @staticmethod
+    def fetch(soco: SoCo) -> Optional[Dict[str, Any]]:
+        """Fetch battery_info from the given SoCo object.
+
+        Returns None if the device doesn't support battery info
+        or if the device is offline.
+        """
+        try:
+            return soco.get_battery_info()
+        except (ConnectionError, TimeoutError, SoCoException):
+            pass
+        return None
+
+    async def async_added_to_hass(self) -> None:
+        """Register polling callback when added to hass."""
+        if self._timer is None:
+            self._timer = self._parent.hass.helpers.event.async_track_time_interval(
+                self.update, SCAN_INTERVAL
+            )
+
+    # Identification of this Entity
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID of the sensor."""
+        return self._parent.unique_id + "-battery"
+
+    @property
+    def name(self) -> str:
+        """Return the name of the sensor."""
+        return self._parent.name + " Battery"
+
+    @property
+    def device_info(self) -> Dict[str, Any]:
+        """Return information about the device."""
+        return self._parent.device_info
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Get the unit of measurement."""
+        return "%"
+
+    # Update the current state
+    def update(self, event=None):
+        """Poll the device for the current state."""
+        if self.available:
+            # only poll if the Sonos device is online
+            _LOGGER.debug("Starting to check battery_info on %s", self._soco)
+            battery_info = SonosBatteryEntity.fetch(self._soco)
+            if battery_info is not None:
+                self._battery_info = battery_info
+                self.schedule_update_ha_state()
+
+    # Current state
+    @property
+    def available(self) -> bool:
+        """Return whether this device is available."""
+        return self._parent.available
+
+    @property
+    def battery_level(self) -> int:
+        """Return the battery level."""
+        return self._battery_info.get("Level", 0)
+
+    @property
+    def power_source(self) -> str:
+        """Return the name of the power source.
+
+        Observed to be either BATTERY or SONOS_CHARGING_RING or USB_POWER.
+        """
+        return self._battery_info.get("PowerSource", "Unknown")
+
+    @property
+    def charging(self) -> bool:
+        """Return the charging status of this battery."""
+        return self.power_source != "BATTERY"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon of the sensor."""
+        return icon_for_battery_level(self.battery_level, self.charging)
+
+    @property
+    def state(self) -> int:
+        """Return the state of the sensor."""
+        return self._battery_info.get("Level")
+
+    @property
+    def device_state_attributes(self) -> Dict[str, Any]:
+        """Return entity specific state attributes."""
+        attributes = {
+            ATTR_BATTERY_CHARGING: self.charging,
+            ATTR_BATTERY_LEVEL: self.battery_level,
+            ATTR_BATTERY_POWERSOURCE: self.power_source,
+        }
+        return attributes

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -1,18 +1,21 @@
 """Entity representing a Sonos Move battery level."""
 import datetime
-import logging
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from pysonos.core import SoCo
 from pysonos.exceptions import SoCoException
 
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY,
+    PERCENTAGE,
+    STATE_UNKNOWN,
+)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.icon import icon_for_battery_level
 
 if TYPE_CHECKING:  # Avoid recursive import loops
     from .media_player import SonosEntity
 
-_LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = datetime.timedelta(seconds=10)
 
 ATTR_BATTERY_LEVEL = "battery_level"
@@ -31,7 +34,6 @@ class SonosBatteryEntity(Entity):
         self._parent = parent
         self._soco = soco
         self._battery_info = battery_info
-        self._timer = None
 
     @staticmethod
     def fetch(soco: SoCo) -> Optional[Dict[str, Any]]:
@@ -48,21 +50,21 @@ class SonosBatteryEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Register polling callback when added to hass."""
-        if self._timer is None:
-            self._timer = self._parent.hass.helpers.event.async_track_time_interval(
-                self.update, SCAN_INTERVAL
-            )
+        cancel_timer = self._parent.hass.helpers.event.async_track_time_interval(
+            self.update, SCAN_INTERVAL
+        )
+        self.async_on_remove(cancel_timer)
 
     # Identification of this Entity
     @property
     def unique_id(self) -> str:
         """Return the unique ID of the sensor."""
-        return self._parent.unique_id + "-battery"
+        return f"{self._parent.unique_id}-battery"
 
     @property
     def name(self) -> str:
         """Return the name of the sensor."""
-        return self._parent.name + " Battery"
+        return f"{self._parent.name} Battery"
 
     @property
     def device_info(self) -> Dict[str, Any]:
@@ -70,20 +72,25 @@ class SonosBatteryEntity(Entity):
         return self._parent.device_info
 
     @property
+    def device_class(self) -> str:
+        """Return the entity's device class."""
+        return DEVICE_CLASS_BATTERY
+
+    @property
     def unit_of_measurement(self) -> str:
         """Get the unit of measurement."""
-        return "%"
+        return PERCENTAGE
 
     # Update the current state
     def update(self, event=None):
         """Poll the device for the current state."""
-        if self.available:
-            # only poll if the Sonos device is online
-            _LOGGER.debug("Starting to check battery_info on %s", self._soco)
-            battery_info = SonosBatteryEntity.fetch(self._soco)
-            if battery_info is not None:
-                self._battery_info = battery_info
-                self.schedule_update_ha_state()
+        if not self.available:
+            # wait for the Sonos device to come back online
+            return
+        battery_info = SonosBatteryEntity.fetch(self._soco)
+        if battery_info is not None:
+            self._battery_info = battery_info
+            self.schedule_update_ha_state()
 
     # Current state
     @property
@@ -102,12 +109,12 @@ class SonosBatteryEntity(Entity):
 
         Observed to be either BATTERY or SONOS_CHARGING_RING or USB_POWER.
         """
-        return self._battery_info.get("PowerSource", "Unknown")
+        return self._battery_info.get("PowerSource", STATE_UNKNOWN)
 
     @property
     def charging(self) -> bool:
         """Return the charging status of this battery."""
-        return self.power_source != "BATTERY"
+        return self.power_source not in ("BATTERY", STATE_UNKNOWN)
 
     @property
     def icon(self) -> str:
@@ -115,16 +122,14 @@ class SonosBatteryEntity(Entity):
         return icon_for_battery_level(self.battery_level, self.charging)
 
     @property
-    def state(self) -> int:
+    def state(self) -> Optional[int]:
         """Return the state of the sensor."""
         return self._battery_info.get("Level")
 
     @property
     def device_state_attributes(self) -> Dict[str, Any]:
         """Return entity specific state attributes."""
-        attributes = {
+        return {
             ATTR_BATTERY_CHARGING: self.charging,
-            ATTR_BATTERY_LEVEL: self.battery_level,
             ATTR_BATTERY_POWERSOURCE: self.power_source,
         }
-        return attributes

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -41,6 +41,12 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     hass.bus.async_listen(SONOS_DISCOVERY_UPDATE, _async_create_entities)
 
+    # create any entities for devices that exist already
+    for uid, soco in hass.data[DATA_SONOS].discovered.items():
+        if uid not in hass.data[DATA_SONOS].battery_entities:
+            hass.data[DATA_SONOS].battery_entities[soco.uid] = None
+            hass.async_add_executor_job(_discover_battery, hass, soco)
+
 
 class SonosBatteryEntity(Entity):
     """Representation of a Sonos Battery entity."""
@@ -49,6 +55,7 @@ class SonosBatteryEntity(Entity):
         """Initialize a SonosBatteryEntity."""
         self._soco = soco
         self._battery_info = battery_info
+        self._available = True
 
     @staticmethod
     def fetch(soco: SoCo) -> Optional[Dict[str, Any]]:

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -37,9 +37,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     def _discover_battery(hass, soco):
         battery_info = SonosBatteryEntity.fetch(soco)
         if battery_info is not None:
-            hass.add_job(
-                async_add_entities, [SonosBatteryEntity(soco, battery_info)]
-            )
+            hass.add_job(async_add_entities, [SonosBatteryEntity(soco, battery_info)])
 
     hass.bus.async_listen(SONOS_DISCOVERY_UPDATE, _async_create_entities)
 
@@ -51,9 +49,6 @@ class SonosBatteryEntity(Entity):
         """Initialize a SonosBatteryEntity."""
         self._soco = soco
         self._battery_info = battery_info
-
-        self._available = True
-        self._timer = None
 
     @staticmethod
     def fetch(soco: SoCo) -> Optional[Dict[str, Any]]:
@@ -74,12 +69,11 @@ class SonosBatteryEntity(Entity):
             self.update, SCAN_INTERVAL
         )
         self.async_on_remove(cancel_timer)
-        """Record that this entity is added to hass."""
+
         self.hass.data[DATA_SONOS].battery_entities[self.unique_id] = self
 
     async def async_seen(self, soco) -> None:
         """Record that this player was seen right now."""
-        self._available = True
         self._soco = soco
 
         self.async_write_ha_state()
@@ -88,10 +82,6 @@ class SonosBatteryEntity(Entity):
     def async_unseen(self, now=None):
         """Make this player unavailable when it was not seen recently."""
         self._available = False
-
-        if self._timer is not None:
-            self._timer()
-            self._timer = None
 
         self.async_write_ha_state()
 

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -17,7 +17,7 @@ def config_entry_fixture():
 
 
 @pytest.fixture(name="soco")
-def soco_fixture(music_library, speaker_info, dummy_soco_service):
+def soco_fixture(music_library, speaker_info, battery_info, dummy_soco_service):
     """Create a mock pysonos SoCo fixture."""
     with patch("pysonos.SoCo", autospec=True) as mock, patch(
         "socket.gethostbyname", return_value="192.168.42.2"
@@ -31,6 +31,7 @@ def soco_fixture(music_library, speaker_info, dummy_soco_service):
         mock_soco.renderingControl = dummy_soco_service
         mock_soco.zoneGroupTopology = dummy_soco_service
         mock_soco.contentDirectory = dummy_soco_service
+        mock_soco.get_battery_info.return_value = battery_info
 
         yield mock_soco
 
@@ -76,4 +77,15 @@ def speaker_info_fixture():
         "model_name": "Model Name",
         "software_version": "49.2-64250",
         "mac_address": "00-11-22-33-44-55",
+    }
+
+
+@pytest.fixture(name="battery_info")
+def battery_info_fixture():
+    """Create battery_info fixture."""
+    return {
+        "Health": "GREEN",
+        "Level": 100,
+        "Temperature": "NORMAL",
+        "PowerSource": "SONOS_CHARGING_RING",
     }

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -18,7 +18,8 @@ async def test_async_setup_entry_hosts(hass, config_entry, config, soco):
     """Test static setup."""
     await setup_platform(hass, config_entry, config)
 
-    entity = hass.data[media_player.DATA_SONOS].entities[0]
+    entities = list(hass.data[media_player.DATA_SONOS].media_player_entities.values())
+    entity = entities[0]
     assert entity.soco == soco
 
 
@@ -26,7 +27,8 @@ async def test_async_setup_entry_discover(hass, config_entry, discover):
     """Test discovery setup."""
     await setup_platform(hass, config_entry, {})
 
-    entity = hass.data[media_player.DATA_SONOS].entities[0]
+    entities = list(hass.data[media_player.DATA_SONOS].media_player_entities.values())
+    entity = entities[0]
     assert entity.unique_id == "RINCON_test"
 
 

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -49,7 +49,6 @@ async def test_battery_missing_attributes(hass, config_entry, config, soco):
     assert battery_state.state == "unknown"
     assert battery_state.attributes.get("unit_of_measurement") == "%"
     assert battery_state.attributes.get("icon") == "mdi:battery-alert"
-    assert battery_state.attributes.get("battery_level") == 0
     assert not battery_state.attributes.get("charging")
     assert battery_state.attributes.get("power_source") == "unknown"
 
@@ -67,6 +66,5 @@ async def test_battery_attributes(hass, config_entry, config, soco):
     assert battery_state.state == "100"
     assert battery_state.attributes.get("unit_of_measurement") == "%"
     assert battery_state.attributes.get("icon") == "mdi:battery-charging-100"
-    assert battery_state.attributes.get("battery_level") == 100
     assert battery_state.attributes.get("charging")
     assert battery_state.attributes.get("power_source") == "SONOS_CHARGING_RING"

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -1,0 +1,56 @@
+"""Tests for the Sonos battery sensor platform."""
+from pysonos.exceptions import NotSupportedException
+
+from homeassistant.components.sonos import DOMAIN
+from homeassistant.setup import async_setup_component
+
+
+async def setup_platform(hass, config_entry, config):
+    """Set up the media player platform for testing."""
+    config_entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+
+async def test_entity_registry_unsupported(hass, config_entry, config, soco):
+    """Test sonos device without battery registered in the device registry."""
+    soco.get_battery_info.side_effect = NotSupportedException
+
+    await setup_platform(hass, config_entry, config)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    assert "media_player.zone_a" in entity_registry.entities
+    assert "media_player.zone_a_battery" not in entity_registry.entities
+
+
+async def test_entity_registry_supported(hass, config_entry, config, soco):
+    """Test sonos device with battery registered in the device registry."""
+    await setup_platform(hass, config_entry, config)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    print("Finding")
+    for e in entity_registry.entities.values():
+        print("Found entity " + str(e.entity_id))
+
+    assert "media_player.zone_a" in entity_registry.entities
+    assert "media_player.zone_a_battery" in entity_registry.entities
+
+
+async def test_battery_attributes(hass, config_entry, config, soco):
+    """Test sonos device with battery updates state."""
+    await setup_platform(hass, config_entry, config)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    battery = entity_registry.entities["media_player.zone_a_battery"]
+    battery_state = hass.states.get(battery.entity_id)
+
+    # confirm initial state from conftest
+    assert battery_state.state == "100"
+    assert battery_state.attributes.get("unit_of_measurement") == "%"
+    assert battery_state.attributes.get("icon") == "mdi:battery-charging-100"
+    assert battery_state.attributes.get("battery_level") == 100
+    assert battery_state.attributes.get("charging")
+    assert battery_state.attributes.get("power_source") == "SONOS_CHARGING_RING"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I would like to trigger an automation to remind me to charge my Sonos Move, and so this change will add the new pysonos' battery information as attributes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
sonos:
  media_player:
    hosts:
      - 192.168.1.128
      - 192.168.1.160
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Example additional attributes: 
```
battery_level: 100
power_source: SONOS_CHARGING_RING
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
