### PR TITLE
Catch ValueError when unique ID update fails because its taken and remove the duplicate entity

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -95,10 +95,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 old_unique_id,
                 new_unique_id,
             )
-            ent_reg.async_update_entity(
-                entity_id,
-                new_unique_id=new_unique_id,
-            )
+            try:
+                ent_reg.async_update_entity(
+                    entity_id,
+                    new_unique_id=new_unique_id,
+                )
+            except ValueError:
+                LOGGER.debug(
+                    (
+                        "Entity %s can't be migrated because the unique ID is taken. "
+                        "Cleaning it up since it is likely no longer valid."
+                    ),
+                    entity_id,
+                )
+                ent_reg.async_remove(entity_id)
 
     @callback
     def async_on_node_ready(node: ZwaveNode) -> None:

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -124,6 +124,59 @@ async def test_on_node_added_ready(
     )
 
 
+async def test_unique_id_migration_dupes(
+    hass, multisensor_6_state, client, integration
+):
+    """Test we remove an entity when ."""
+    ent_reg = entity_registry.async_get(hass)
+
+    entity_name = AIR_TEMPERATURE_SENSOR.split(".")[1]
+
+    # Create entity RegistryEntry using old unique ID format
+    old_unique_id_1 = (
+        f"{client.driver.controller.home_id}.52.52-49-00-Air temperature-00"
+    )
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id_1,
+        suggested_object_id=entity_name,
+        config_entry=integration,
+        original_name=entity_name,
+    )
+    assert entity_entry.entity_id == AIR_TEMPERATURE_SENSOR
+    assert entity_entry.unique_id == old_unique_id_1
+
+    # Create entity RegistryEntry using b0 unique ID format
+    old_unique_id_2 = (
+        f"{client.driver.controller.home_id}.52.52-49-0-Air temperature-00-00"
+    )
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id_2,
+        suggested_object_id=f"{entity_name}_1",
+        config_entry=integration,
+        original_name=entity_name,
+    )
+    assert entity_entry.entity_id == f"{AIR_TEMPERATURE_SENSOR}_1"
+    assert entity_entry.unique_id == old_unique_id_2
+
+    # Add a ready node, unique ID should be migrated
+    node = Node(client, multisensor_6_state)
+    event = {"node": node}
+
+    client.driver.controller.emit("node added", event)
+    await hass.async_block_till_done()
+
+    # Check that new RegistryEntry is using new unique ID format
+    entity_entry = ent_reg.async_get(AIR_TEMPERATURE_SENSOR)
+    new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Air temperature-00-00"
+    assert entity_entry.unique_id == new_unique_id
+
+    assert ent_reg.async_get(f"{AIR_TEMPERATURE_SENSOR}_1") is None
+
+
 async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integration):
     """Test unique ID is migrated from old format to new (version 1)."""
     ent_reg = entity_registry.async_get(hass)


### PR DESCRIPTION
## Proposed change
In the `zwave_js` unique ID migration logic, we were assuming that the user cleaned up the entity registry before upgrading from b0. Some users didn't and the update call raised an exception that wasn't being caught. In this PR we are:
- Catching the exception so the function will continue to run
- Removing entities that cause the exception because they are duplicates


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
