### PR TITLE
Remove flaky climacell test

### DIFF
--- a/tests/components/climacell/test_init.py
+++ b/tests/components/climacell/test_init.py
@@ -1,7 +1,5 @@
 """Tests for Climacell init."""
-from datetime import timedelta
 import logging
-from unittest.mock import patch
 
 import pytest
 
@@ -12,11 +10,10 @@ from homeassistant.components.climacell.config_flow import (
 from homeassistant.components.climacell.const import DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.helpers.typing import HomeAssistantType
-from homeassistant.util import dt as dt_util
 
 from .const import MIN_CONFIG
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,44 +36,3 @@ async def test_load_and_unload(
     assert await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_entity_ids(WEATHER_DOMAIN)) == 0
-
-
-async def test_update_interval(
-    hass: HomeAssistantType,
-    climacell_config_entry_update: pytest.fixture,
-) -> None:
-    """Test that update_interval changes based on number of entries."""
-    now = dt_util.utcnow()
-    async_fire_time_changed(hass, now)
-    config = _get_config_schema(hass)(MIN_CONFIG)
-    for i in range(1, 3):
-        config_entry = MockConfigEntry(
-            domain=DOMAIN, data=config, unique_id=_get_unique_id(hass, config) + str(i)
-        )
-        config_entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(config_entry.entry_id)
-        await hass.async_block_till_done()
-
-    with patch("homeassistant.components.climacell.ClimaCell.realtime") as mock_api:
-        # First entry refresh will happen in 7 minutes due to original update interval.
-        # Next refresh for this entry will happen at 20 minutes due to the update interval
-        # change.
-        mock_api.return_value = {}
-        async_fire_time_changed(hass, now + timedelta(minutes=7))
-        await hass.async_block_till_done()
-        assert mock_api.call_count == 1
-
-        # Second entry refresh will happen in 13 minutes due to the update interval set
-        # when it was set up. Next refresh for this entry will happen at 26 minutes due to the
-        # update interval change.
-        mock_api.reset_mock()
-        async_fire_time_changed(hass, now + timedelta(minutes=13))
-        await hass.async_block_till_done()
-        assert not mock_api.call_count == 1
-
-        # 19 minutes should be after the first update for each config entry and before the
-        # second update for the first config entry
-        mock_api.reset_mock()
-        async_fire_time_changed(hass, now + timedelta(minutes=19))
-        await hass.async_block_till_done()
-        assert not mock_api.call_count == 0


### PR DESCRIPTION
## Proposed change
I had a failure for the test I'm removing in an unrelated PR that passed when I re-ran checks. @elupus reported the same:  https://discord.com/channels/330944238910963714/330990195199442944/814617291076665445

Removing this will reduce coverage slightly but we're still above 90%. I will re-add these tests once I've figured out a more stable way to test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
