### PR TITLE
Fix Z-Wave JS discovery schema for thermostat devices

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -75,6 +75,8 @@ class ZWaveDiscoverySchema:
     device_class_specific: Optional[Set[Union[str, int]]] = None
     # [optional] additional values that ALL need to be present on the node for this scheme to pass
     required_values: Optional[List[ZWaveValueDiscoverySchema]] = None
+    # [optional] additional values that MAY NOT be present on the node for this scheme to pass
+    absent_values: Optional[List[ZWaveValueDiscoverySchema]] = None
     # [optional] bool to specify if this primary value may be discovered by multiple platforms
     allow_multi: bool = False
 
@@ -186,6 +188,7 @@ DISCOVERY_SCHEMAS = [
         ),
     ),
     # climate
+    # thermostats supporting mode (and optional setpoint)
     ZWaveDiscoverySchema(
         platform="climate",
         primary_value=ZWaveValueDiscoverySchema(
@@ -194,8 +197,7 @@ DISCOVERY_SCHEMAS = [
             type={"number"},
         ),
     ),
-    # climate
-    # setpoint thermostats
+    # thermostats supporting setpoint only (and thus not mode)
     ZWaveDiscoverySchema(
         platform="climate",
         primary_value=ZWaveValueDiscoverySchema(
@@ -203,6 +205,13 @@ DISCOVERY_SCHEMAS = [
             property={"setpoint"},
             type={"number"},
         ),
+        absent_values=[  # mode may not be present to prevent dupes
+            ZWaveValueDiscoverySchema(
+                command_class={CommandClass.THERMOSTAT_MODE},
+                property={"mode"},
+                type={"number"},
+            ),
+        ],
     ),
     # binary sensors
     ZWaveDiscoverySchema(
@@ -421,6 +430,13 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
                 if not all(
                     any(check_value(val, val_scheme) for val in node.values.values())
                     for val_scheme in schema.required_values
+                ):
+                    continue
+            # check for values that may not be present
+            if schema.absent_values is not None:
+                if any(
+                    any(check_value(val, val_scheme) for val in node.values.values())
+                    for val_scheme in schema.absent_values
                 ):
                     continue
             # all checks passed, this value belongs to an entity

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -188,14 +188,6 @@ DISCOVERY_SCHEMAS = [
     # climate
     ZWaveDiscoverySchema(
         platform="climate",
-        device_class_generic={"Thermostat"},
-        device_class_specific={
-            "Setback Thermostat",
-            "Thermostat General",
-            "Thermostat General V2",
-            "General Thermostat",
-            "General Thermostat V2",
-        },
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.THERMOSTAT_MODE},
             property={"mode"},
@@ -206,11 +198,6 @@ DISCOVERY_SCHEMAS = [
     # setpoint thermostats
     ZWaveDiscoverySchema(
         platform="climate",
-        device_class_generic={"Thermostat"},
-        device_class_specific={
-            "Setpoint Thermostat",
-            "Unused",
-        },
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.THERMOSTAT_SETPOINT},
             property={"setpoint"},

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -205,7 +205,7 @@ DISCOVERY_SCHEMAS = [
             property={"setpoint"},
             type={"number"},
         ),
-        absent_values=[  # mode may not be present to prevent dupes
+        absent_values=[  # mode must not be present to prevent dupes
             ZWaveValueDiscoverySchema(
                 command_class={CommandClass.THERMOSTAT_MODE},
                 property={"mode"},

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -449,7 +449,7 @@ async def test_removed_device(hass, client, multiple_devices, integration):
     entity_entries = entity_registry.async_entries_for_config_entry(
         ent_reg, integration.entry_id
     )
-    assert len(entity_entries) == 26
+    assert len(entity_entries) == 24
 
     # Remove a node and reload the entry
     old_node = nodes.pop(13)

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -449,7 +449,7 @@ async def test_removed_device(hass, client, multiple_devices, integration):
     entity_entries = entity_registry.async_entries_for_config_entry(
         ent_reg, integration.entry_id
     )
-    assert len(entity_entries) == 24
+    assert len(entity_entries) == 26
 
     # Remove a node and reload the entry
     old_node = nodes.pop(13)


### PR DESCRIPTION
## Breaking change

## Proposed change
This removes the deviceclass checks from the thermostat discovery as it is redundant with the checks on CommandClass.
This will fix situations where a thermostat device reports itself as sensor.
Only checking for the correct commandclass on primary value is sufficient.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

## Additional information

- This PR fixes or closes issue: fixes #46643 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
