### PR TITLE
Guard zwave_js missing nodes in websocket api

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -106,7 +106,12 @@ def websocket_node_status(
     entry_id = msg[ENTRY_ID]
     client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
     node_id = msg[NODE_ID]
-    node = client.driver.controller.nodes[node_id]
+    node = client.driver.controller.nodes.get(node_id)
+
+    if node is None:
+        connection.send_error(msg[ID], ERR_NOT_FOUND, f"Node {node_id} not found")
+        return
+
     data = {
         "node_id": node.node_id,
         "is_routing": node.is_routing,
@@ -354,7 +359,12 @@ def websocket_get_config_parameters(
     entry_id = msg[ENTRY_ID]
     node_id = msg[NODE_ID]
     client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
-    node = client.driver.controller.nodes[node_id]
+    node = client.driver.controller.nodes.get(node_id)
+
+    if node is None:
+        connection.send_error(msg[ID], ERR_NOT_FOUND, f"Node {node_id} not found")
+        return
+
     values = node.get_configuration_values()
     result = {}
     for value_id, zwave_value in values.items():

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -76,6 +76,30 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     assert result[key]["configuration_value_type"] == "enumerated"
     assert result[key]["metadata"]["states"]
 
+    # Test getting non-existent node fails
+    await ws_client.send_json(
+        {
+            ID: 5,
+            TYPE: "zwave_js/node_status",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 99999,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
+    # Test getting non-existent node config params fails
+    await ws_client.send_json(
+        {
+            ID: 5,
+            TYPE: "zwave_js/get_config_parameters",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 99999,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+
 
 async def test_add_node(
     hass, integration, client, hass_ws_client, nortek_thermostat_added_event

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -6,6 +6,7 @@ from zwave_js_server.const import LogLevel
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import InvalidNewValue, NotFoundError, SetValueFailed
 
+from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 from homeassistant.components.zwave_js.api import (
     CONFIG,
     ENABLED,
@@ -87,11 +88,12 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     )
     msg = await ws_client.receive_json()
     assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
 
     # Test getting non-existent node config params fails
     await ws_client.send_json(
         {
-            ID: 5,
+            ID: 6,
             TYPE: "zwave_js/get_config_parameters",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 99999,
@@ -99,6 +101,7 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     )
     msg = await ws_client.receive_json()
     assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
 
 
 async def test_add_node(


### PR DESCRIPTION
## Proposed change
Guard for nonexistent nodes and send an error code back in the node_status and get_config_parameters websocket api functions for zwave_js


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
