### PR TITLE
Update color logic for zwave_js light platform

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -233,7 +233,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             value_property_key=None,
             value_property_key_name=None,
         )
-        if combined_color_val and combined_color_val.property_key is None:
+        if combined_color_val and isinstance(combined_color_val.value, dict):
             colors_dict = {}
             for color, value in colors.items():
                 color_name = MULTI_COLOR_MAP[color]

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -289,6 +289,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
     @callback
     def _calculate_color_values(self) -> None:
         """Calculate light colors."""
+        # NOTE: We lookup all values here (instead of relying on the multicolor one)
+        # to find out what colors are supported
+        # as this is a simple lookup by key, this not heavy
         red_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
@@ -298,14 +301,14 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         green_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.RED.value.key,
-            value_property_key_name=ColorComponent.RED.value.name,
+            value_property_key=ColorComponent.GREEN.value.key,
+            value_property_key_name=ColorComponent.GREEN.value.name,
         )
         blue_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.RED.value.key,
-            value_property_key_name=ColorComponent.RED.value.name,
+            value_property_key=ColorComponent.BLUE.value.key,
+            value_property_key_name=ColorComponent.BLUE.value.name,
         )
         cw_val = self.get_zwave_value(
             "currentColor",

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -316,7 +316,7 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         if red is not None and green is not None and blue is not None:
             self._supports_color = True
             # convert to HS
-            self._hs_color = color_util.color_RGB_to_hs(red, green, blue.value)
+            self._hs_color = color_util.color_RGB_to_hs(red, green, blue)
 
         # color temperature support
         if warm_white is not None and cold_white is not None:

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -190,15 +190,12 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             warm = 255 - cold
             await self._async_set_colors(
                 {
-                    ColorComponent.WARM_WHITE: warm,
-                    ColorComponent.COLD_WHITE: cold,
                     # turn off color leds when setting color temperature
                     ColorComponent.RED: 0,
                     ColorComponent.GREEN: 0,
                     ColorComponent.BLUE: 0,
-                    ColorComponent.AMBER: 0,
-                    ColorComponent.CYAN: 0,
-                    ColorComponent.PURPLE: 0,
+                    ColorComponent.WARM_WHITE: warm,
+                    ColorComponent.COLD_WHITE: cold,
                 }
             )
 

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -310,12 +310,6 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             value_property_key=ColorComponent.BLUE.value.key,
             value_property_key_name=ColorComponent.BLUE.value.name,
         )
-        cw_val = self.get_zwave_value(
-            "currentColor",
-            CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.COLD_WHITE.value.key,
-            value_property_key_name=ColorComponent.COLD_WHITE.value.name,
-        )
         ww_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -137,62 +137,62 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 5
-    warm_args = client.async_send_command_no_wait.call_args_list[0][0][
-        0
-    ]  # warm white 0
+    assert len(client.async_send_command_no_wait.call_args_list) == 6
+    warm_args = client.async_send_command_no_wait.call_args_list[0][0][0]  # red 255
     assert warm_args["command"] == "node.set_value"
     assert warm_args["nodeId"] == 39
     assert warm_args["valueId"]["commandClassName"] == "Color Switch"
     assert warm_args["valueId"]["commandClass"] == 51
     assert warm_args["valueId"]["endpoint"] == 0
-    assert warm_args["valueId"]["metadata"]["label"] == "Target value (Warm White)"
+    assert warm_args["valueId"]["metadata"]["label"] == "Target value (Red)"
     assert warm_args["valueId"]["property"] == "targetColor"
     assert warm_args["valueId"]["propertyName"] == "targetColor"
-    assert warm_args["value"] == 0
+    assert warm_args["value"] == 255
 
-    cold_args = client.async_send_command_no_wait.call_args_list[1][0][
-        0
-    ]  # cold white 0
+    cold_args = client.async_send_command_no_wait.call_args_list[1][0][0]  # green 76
     assert cold_args["command"] == "node.set_value"
     assert cold_args["nodeId"] == 39
     assert cold_args["valueId"]["commandClassName"] == "Color Switch"
     assert cold_args["valueId"]["commandClass"] == 51
     assert cold_args["valueId"]["endpoint"] == 0
-    assert cold_args["valueId"]["metadata"]["label"] == "Target value (Cold White)"
+    assert cold_args["valueId"]["metadata"]["label"] == "Target value (Green)"
     assert cold_args["valueId"]["property"] == "targetColor"
     assert cold_args["valueId"]["propertyName"] == "targetColor"
-    assert cold_args["value"] == 0
-    red_args = client.async_send_command_no_wait.call_args_list[2][0][0]  # red 255
+    assert cold_args["value"] == 76
+    red_args = client.async_send_command_no_wait.call_args_list[2][0][0]  # blue 255
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
     assert red_args["valueId"]["commandClass"] == 51
     assert red_args["valueId"]["endpoint"] == 0
-    assert red_args["valueId"]["metadata"]["label"] == "Target value (Red)"
+    assert red_args["valueId"]["metadata"]["label"] == "Target value (Blue)"
     assert red_args["valueId"]["property"] == "targetColor"
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 255
-    green_args = client.async_send_command_no_wait.call_args_list[3][0][0]  # green 76
+    green_args = client.async_send_command_no_wait.call_args_list[3][0][
+        0
+    ]  # warm white 0
     assert green_args["command"] == "node.set_value"
     assert green_args["nodeId"] == 39
     assert green_args["valueId"]["commandClassName"] == "Color Switch"
     assert green_args["valueId"]["commandClass"] == 51
     assert green_args["valueId"]["endpoint"] == 0
-    assert green_args["valueId"]["metadata"]["label"] == "Target value (Green)"
+    assert green_args["valueId"]["metadata"]["label"] == "Target value (Warm White)"
     assert green_args["valueId"]["property"] == "targetColor"
     assert green_args["valueId"]["propertyName"] == "targetColor"
-    assert green_args["value"] == 76
-    blue_args = client.async_send_command_no_wait.call_args_list[4][0][0]  # blue 255
+    assert green_args["value"] == 0
+    blue_args = client.async_send_command_no_wait.call_args_list[4][0][
+        0
+    ]  # cold white 0
     assert blue_args["command"] == "node.set_value"
     assert blue_args["nodeId"] == 39
     assert blue_args["valueId"]["commandClassName"] == "Color Switch"
     assert blue_args["valueId"]["commandClass"] == 51
     assert blue_args["valueId"]["endpoint"] == 0
-    assert blue_args["valueId"]["metadata"]["label"] == "Target value (Blue)"
+    assert blue_args["valueId"]["metadata"]["label"] == "Target value (Cold White)"
     assert blue_args["valueId"]["property"] == "targetColor"
     assert blue_args["valueId"]["propertyName"] == "targetColor"
-    assert blue_args["value"] == 255
+    assert blue_args["value"] == 0
 
     # Test rgb color update from value updated event
     red_event = Event(
@@ -232,7 +232,6 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     state = hass.states.get(BULB_6_MULTI_COLOR_LIGHT_ENTITY)
     assert state.state == STATE_ON
     assert state.attributes[ATTR_BRIGHTNESS] == 255
-    assert state.attributes[ATTR_COLOR_TEMP] == 370
     assert state.attributes[ATTR_RGB_COLOR] == (255, 76, 255)
 
     client.async_send_command_no_wait.reset_mock()
@@ -245,7 +244,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 5
+    assert len(client.async_send_command_no_wait.call_args_list) == 6
 
     client.async_send_command_no_wait.reset_mock()
 
@@ -257,7 +256,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 5
+    assert len(client.async_send_command_no_wait.call_args_list) == 6
     red_args = client.async_send_command_no_wait.call_args_list[0][0][0]  # red 0
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
@@ -367,7 +366,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 5
+    assert len(client.async_send_command_no_wait.call_args_list) == 6
 
     client.async_send_command_no_wait.reset_mock()
 


### PR DESCRIPTION
## Breaking change

## Proposed change
- Prefer setting color change in one set (if supported)
- Allow white level control for RGBW lights

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:


## Additional information

- This PR fixes or closes issue: fixes #46229 fixes #47073
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
