### PR TITLE
Use async_capture_events to avoid running in executor

### DIFF
--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -26,7 +26,7 @@ from homeassistant.components.media_player.const import (
 import homeassistant.components.vacuum as vacuum
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import TEMP_CELSIUS, TEMP_FAHRENHEIT
-from homeassistant.core import Context, callback
+from homeassistant.core import Context
 from homeassistant.helpers import entityfilter
 from homeassistant.setup import async_setup_component
 
@@ -42,17 +42,13 @@ from . import (
     reported_properties,
 )
 
-from tests.common import async_mock_service
+from tests.common import async_capture_events, async_mock_service
 
 
 @pytest.fixture
 def events(hass):
     """Fixture that catches alexa events."""
-    events = []
-    hass.bus.async_listen(
-        smart_home.EVENT_ALEXA_SMART_HOME, callback(lambda e: events.append(e))
-    )
-    yield events
+    return async_capture_events(hass, smart_home.EVENT_ALEXA_SMART_HOME)
 
 
 @pytest.fixture

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -30,7 +30,12 @@ from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import assert_setup_component, async_mock_service, mock_restore_cache
+from tests.common import (
+    assert_setup_component,
+    async_capture_events,
+    async_mock_service,
+    mock_restore_cache,
+)
 from tests.components.logbook.test_init import MockLazyEventPartialState
 
 
@@ -496,10 +501,7 @@ async def test_reload_config_service(hass, calls, hass_admin_user, hass_read_onl
     assert len(calls) == 1
     assert calls[0].data.get("event") == "test_event"
 
-    test_reload_event = []
-    hass.bus.async_listen(
-        EVENT_AUTOMATION_RELOADED, lambda event: test_reload_event.append(event)
-    )
+    test_reload_event = async_capture_events(hass, EVENT_AUTOMATION_RELOADED)
 
     with patch(
         "homeassistant.config.load_yaml_config_file",

--- a/tests/components/demo/test_notify.py
+++ b/tests/components/demo/test_notify.py
@@ -12,7 +12,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import discovery
 from homeassistant.setup import async_setup_component
 
-from tests.common import assert_setup_component
+from tests.common import assert_setup_component, async_capture_events
 
 CONFIG = {notify.DOMAIN: {"platform": "demo"}}
 
@@ -20,9 +20,7 @@ CONFIG = {notify.DOMAIN: {"platform": "demo"}}
 @pytest.fixture
 def events(hass):
     """Fixture that catches notify events."""
-    events = []
-    hass.bus.async_listen(demo.EVENT_NOTIFY, callback(lambda e: events.append(e)))
-    yield events
+    return async_capture_events(hass, demo.EVENT_NOTIFY)
 
 
 @pytest.fixture

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -30,7 +30,12 @@ from homeassistant.setup import async_setup_component
 
 from . import BASIC_CONFIG, MockConfig
 
-from tests.common import mock_area_registry, mock_device_registry, mock_registry
+from tests.common import (
+    async_capture_events,
+    mock_area_registry,
+    mock_device_registry,
+    mock_registry,
+)
 
 REQ_ID = "ff36a3cc-ec34-11e6-b1a0-64510650abcf"
 
@@ -77,8 +82,7 @@ async def test_sync_message(hass):
         },
     )
 
-    events = []
-    hass.bus.async_listen(EVENT_SYNC_RECEIVED, events.append)
+    events = async_capture_events(hass, EVENT_SYNC_RECEIVED)
 
     result = await sh.async_handle_message(
         hass,
@@ -192,8 +196,7 @@ async def test_sync_in_area(area_on_device, hass, registries):
 
     config = MockConfig(should_expose=lambda _: True, entity_config={})
 
-    events = []
-    hass.bus.async_listen(EVENT_SYNC_RECEIVED, events.append)
+    events = async_capture_events(hass, EVENT_SYNC_RECEIVED)
 
     result = await sh.async_handle_message(
         hass,
@@ -295,8 +298,7 @@ async def test_query_message(hass):
     light3.entity_id = "light.color_temp_light"
     await light3.async_update_ha_state()
 
-    events = []
-    hass.bus.async_listen(EVENT_QUERY_RECEIVED, events.append)
+    events = async_capture_events(hass, EVENT_QUERY_RECEIVED)
 
     result = await sh.async_handle_message(
         hass,
@@ -387,11 +389,8 @@ async def test_execute(hass):
         "light", "turn_off", {"entity_id": "light.ceiling_lights"}, blocking=True
     )
 
-    events = []
-    hass.bus.async_listen(EVENT_COMMAND_RECEIVED, events.append)
-
-    service_events = []
-    hass.bus.async_listen(EVENT_CALL_SERVICE, service_events.append)
+    events = async_capture_events(hass, EVENT_COMMAND_RECEIVED)
+    service_events = async_capture_events(hass, EVENT_CALL_SERVICE)
 
     result = await sh.async_handle_message(
         hass,
@@ -570,8 +569,7 @@ async def test_raising_error_trait(hass):
         {ATTR_MIN_TEMP: 15, ATTR_MAX_TEMP: 30, ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS},
     )
 
-    events = []
-    hass.bus.async_listen(EVENT_COMMAND_RECEIVED, events.append)
+    events = async_capture_events(hass, EVENT_COMMAND_RECEIVED)
     await hass.async_block_till_done()
 
     result = await sh.async_handle_message(
@@ -660,8 +658,7 @@ async def test_unavailable_state_does_sync(hass):
     light._available = False  # pylint: disable=protected-access
     await light.async_update_ha_state()
 
-    events = []
-    hass.bus.async_listen(EVENT_SYNC_RECEIVED, events.append)
+    events = async_capture_events(hass, EVENT_SYNC_RECEIVED)
 
     result = await sh.async_handle_message(
         hass,

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -54,7 +54,7 @@ from homeassistant.util import color
 
 from . import BASIC_CONFIG, MockConfig
 
-from tests.common import async_mock_service
+from tests.common import async_capture_events, async_mock_service
 
 REQ_ID = "ff36a3cc-ec34-11e6-b1a0-64510650abcf"
 
@@ -84,8 +84,7 @@ async def test_brightness_light(hass):
 
     assert trt.query_attributes() == {"brightness": 95}
 
-    events = []
-    hass.bus.async_listen(EVENT_CALL_SERVICE, events.append)
+    events = async_capture_events(hass, EVENT_CALL_SERVICE)
 
     calls = async_mock_service(hass, light.DOMAIN, light.SERVICE_TURN_ON)
     await trt.execute(

--- a/tests/components/homeassistant/test_scene.py
+++ b/tests/components/homeassistant/test_scene.py
@@ -8,17 +8,14 @@ from homeassistant.components.homeassistant import scene as ha_scene
 from homeassistant.components.homeassistant.scene import EVENT_SCENE_RELOADED
 from homeassistant.setup import async_setup_component
 
-from tests.common import async_mock_service
+from tests.common import async_capture_events, async_mock_service
 
 
 async def test_reload_config_service(hass):
     """Test the reload config service."""
     assert await async_setup_component(hass, "scene", {})
 
-    test_reloaded_event = []
-    hass.bus.async_listen(
-        EVENT_SCENE_RELOADED, lambda event: test_reloaded_event.append(event)
-    )
+    test_reloaded_event = async_capture_events(hass, EVENT_SCENE_RELOADED)
 
     with patch(
         "homeassistant.config.load_yaml_config_file",

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -5,7 +5,8 @@ from pyhap.accessory_driver import AccessoryDriver
 import pytest
 
 from homeassistant.components.homekit.const import EVENT_HOMEKIT_CHANGED
-from homeassistant.core import callback as ha_callback
+
+from tests.common import async_capture_events
 
 
 @pytest.fixture
@@ -24,8 +25,4 @@ def hk_driver(loop):
 @pytest.fixture
 def events(hass):
     """Yield caught homekit_changed events."""
-    events = []
-    hass.bus.async_listen(
-        EVENT_HOMEKIT_CHANGED, ha_callback(lambda e: events.append(e))
-    )
-    yield events
+    return async_capture_events(hass, EVENT_HOMEKIT_CHANGED)

--- a/tests/components/shelly/conftest.py
+++ b/tests/components/shelly/conftest.py
@@ -10,10 +10,14 @@ from homeassistant.components.shelly.const import (
     DOMAIN,
     EVENT_SHELLY_CLICK,
 )
-from homeassistant.core import callback as ha_callback
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry, async_mock_service, mock_device_registry
+from tests.common import (
+    MockConfigEntry,
+    async_capture_events,
+    async_mock_service,
+    mock_device_registry,
+)
 
 MOCK_SETTINGS = {
     "name": "Test name",
@@ -81,9 +85,7 @@ def calls(hass):
 @pytest.fixture
 def events(hass):
     """Yield caught shelly_click events."""
-    ha_events = []
-    hass.bus.async_listen(EVENT_SHELLY_CLICK, ha_callback(ha_events.append))
-    yield ha_events
+    return async_capture_events(hass, EVENT_SHELLY_CLICK)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Found a couple of places in tests that passed the `append` function as an event listener. Since it's not annotated as a callback, it will run that callback in the executor. This PR uses `async_capture_events` to ensure it runs inside the event loop.

This should remove flakiness in tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
