### PR TITLE
Add zwave-js api to return device info from node and config entry id

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -134,6 +134,7 @@ def websocket_node_status(
         vol.Required(NODE_ID): int,
     }
 )
+@callback
 def websocket_get_device_from_node(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict
 ) -> None:

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -151,20 +151,24 @@ def websocket_get_device_from_node(
     registry = device_registry.async_get(hass)
     device_id = get_device_id(client, node)
     entry = registry.async_get_device({device_id})
-    result = {}
 
-    if entry is not None:
-        result = {
-            "manufacturer": entry.manufacturer,
-            "model": entry.model,
-            "name": entry.name,
-            "sw_version": entry.sw_version,
-            "id": entry.id,
-            "via_device_id": entry.via_device_id,
-            "area_id": entry.area_id,
-            "name_by_user": entry.name_by_user,
-            "disabled_by": entry.disabled_by,
-        }
+    if entry is None:
+        connection.send_error(
+            msg[ID], ERR_NOT_FOUND, f"No device found for node {node_id}"
+        )
+        return
+
+    result = {
+        "manufacturer": entry.manufacturer,
+        "model": entry.model,
+        "name": entry.name,
+        "sw_version": entry.sw_version,
+        "id": entry.id,
+        "via_device_id": entry.via_device_id,
+        "area_id": entry.area_id,
+        "name_by_user": entry.name_by_user,
+        "disabled_by": entry.disabled_by,
+    }
 
     connection.send_result(
         msg[ID],

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -23,6 +23,7 @@ from homeassistant.components.zwave_js.api import (
     VALUE,
 )
 from homeassistant.components.zwave_js.const import DOMAIN
+from homeassistant.helpers import device_registry
 from homeassistant.helpers.device_registry import async_get_registry
 
 
@@ -95,6 +96,41 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
         {
             ID: 6,
             TYPE: "zwave_js/get_config_parameters",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 99999,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test getting device registry entry for a node
+    dev_reg = device_registry.async_get(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "3245146787-52")},
+        name="Node 52",
+        model="Mock Multisensor 6",
+    )
+    await ws_client.send_json(
+        {
+            ID: 7,
+            TYPE: "zwave_js/get_device_from_node",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 52,
+        }
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+    print(result)
+    assert result["name"] == "Node 52"
+    assert result["model"] == "Mock Multisensor 6"
+
+    # Test getting device for non-existent fails
+    await ws_client.send_json(
+        {
+            ID: 8,
+            TYPE: "zwave_js/get_device_from_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 99999,
         }


### PR DESCRIPTION
## Proposed change
Add a websocket API command to return a device registry entry from a given Z-Wave JS config entry and node ID.
Will be used for the frontend Z-Wave JS config panel to more closely tie devices to nodes

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.