### PR TITLE
Keeps MagicHome RGB strips from automatically turning off

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -276,8 +276,6 @@ class FluxLight(LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
-        if not self.is_on:
-            self._bulb.turnOn()
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
 
@@ -332,6 +330,13 @@ class FluxLight(LightEntity):
         # Preserve current brightness on color/white level change
         if brightness is None:
             brightness = self.brightness
+
+        # If these are 0 then bulb.isOn will return false, not what we want
+        if hs_color is None or (hs_color[0] == 0 and hs_color[1] == 0):
+            hs_color = (1, 1, 1)
+        
+        if brightness is None or brightness == 0:
+            brightness = 100
 
         # Preserve color on brightness/white level change
         if rgb is None:

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -1,6 +1,7 @@
 """Support for Flux lights."""
 import logging
 import random
+import socket
 
 from flux_led import BulbScanner, WifiLedBulb
 import voluptuous as vol
@@ -166,7 +167,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         ipaddr = device["ipaddr"]
         if ipaddr in light_ips:
             continue
-        device["name"] = f"{device['id']} {ipaddr}"
+        device["name"] = "{} {}".format(device["id"], ipaddr)
         device[ATTR_MODE] = None
         device[CONF_PROTOCOL] = None
         device[CONF_CUSTOM_EFFECT] = None
@@ -276,6 +277,8 @@ class FluxLight(LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn the specified or all lights on."""
+#        if not self.is_on:
+#            self._bulb.turnOn()
 
         hs_color = kwargs.get(ATTR_HS_COLOR)
 
@@ -337,7 +340,7 @@ class FluxLight(LightEntity):
         
         if brightness is None or brightness == 0:
             brightness = 100
-
+        
         # Preserve color on brightness/white level change
         if rgb is None:
             rgb = self._bulb.getRgb()
@@ -367,7 +370,7 @@ class FluxLight(LightEntity):
             try:
                 self._connect()
                 self._error_reported = False
-            except OSError:
+            except socket.error:
                 self._disconnect()
                 if not self._error_reported:
                     _LOGGER.warning(


### PR DESCRIPTION
## Proposed change
This fixes the current MagicHome error where when you turned on a light it turns itself off.


## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml
light:
  - platform: flux_led
    automatic_add: true
    scan_interval: 0.5
    devices:
      192.168.21.55:
        name: Kitchen Counter Lights
        mode: rgb

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- This PR includes code from the following links, which was contributed by the community but has not been merged to HASS core.
https://community.home-assistant.io/t/fixed-flux-led-does-not-set-brightness-or-color-correctly-when-device-is-initially-off/157578/2
https://community.home-assistant.io/t/flux-led-magiclight-dont-work-since-few-updated/145179/70

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
