### PR TITLE
Fix Xiaomi Miio discovery

### DIFF
--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -88,7 +88,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
                 self.context.update(
-                    {"title_placeholders": {"name": f"Miio {device_model} {self.host}"}}
+                    {"title_placeholders": {"name": f"{device_model} {self.host}"}}
                 )
 
                 return await self.async_step_device()

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -57,6 +57,11 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         name = discovery_info.get("name")
         self.host = discovery_info.get("host")
         self.mac = discovery_info.get("properties", {}).get("mac")
+        if self.mac is None:
+            poch = discovery_info.get("properties", {}).get("poch", "")
+            result = re.search("mac=\w+", poch)
+            if result is not None:
+                self.mac = result.group(0).split("=")[1]
 
         if not name or not self.host or not self.mac:
             return self.async_abort(reason="not_xiaomi_miio")
@@ -81,7 +86,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
                 self.context.update(
-                    {"title_placeholders": {"name": f"Miio Device {self.host}"}}
+                    {"title_placeholders": {"name": f"Miio {device_model} {self.host}"}}
                 )
 
                 return await self.async_step_device()

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -3,6 +3,7 @@ import logging
 
 import voluptuous as vol
 
+from re import search
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.helpers.device_registry import format_mac
@@ -59,7 +60,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.mac = discovery_info.get("properties", {}).get("mac")
         if self.mac is None:
             poch = discovery_info.get("properties", {}).get("poch", "")
-            result = re.search("mac=\w+", poch)
+            result = search("mac=\w+", poch)
             if result is not None:
                 self.mac = result.group(0).split("=")[1]
 

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -67,10 +67,12 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if not name or not self.host or not self.mac:
             return self.async_abort(reason="not_xiaomi_miio")
 
+        self.mac = format_mac(self.mac)
+
         # Check which device is discovered.
         for gateway_model in MODELS_GATEWAY:
             if name.startswith(gateway_model.replace(".", "-")):
-                unique_id = format_mac(self.mac)
+                unique_id = self.mac
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
 
@@ -82,7 +84,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         for device_model in MODELS_ALL_DEVICES:
             if name.startswith(device_model.replace(".", "-")):
-                unique_id = format_mac(self.mac)
+                unique_id = self.mac
                 await self.async_set_unique_id(unique_id)
                 self._abort_if_unique_id_configured({CONF_HOST: self.host})
 

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -25,7 +25,6 @@ from .device import ConnectXiaomiDevice
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_GATEWAY_NAME = "Xiaomi Gateway"
-DEFAULT_DEVICE_NAME = "Xiaomi Device"
 
 DEVICE_SETTINGS = {
     vol.Required(CONF_TOKEN): vol.All(str, vol.Length(min=32, max=32)),
@@ -141,7 +140,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                         )
 
                 # Setup all other Miio Devices
-                name = user_input.get(CONF_NAME, DEFAULT_DEVICE_NAME)
+                name = user_input.get(CONF_NAME, model)
 
                 for device_model in MODELS_ALL_DEVICES:
                     if model.startswith(device_model):

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -1,9 +1,9 @@
 """Config flow to configure Xiaomi Miio."""
 import logging
+from re import search
 
 import voluptuous as vol
 
-from re import search
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.helpers.device_registry import format_mac
@@ -60,7 +60,7 @@ class XiaomiMiioFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.mac = discovery_info.get("properties", {}).get("mac")
         if self.mac is None:
             poch = discovery_info.get("properties", {}).get("poch", "")
-            result = search("mac=\w+", poch)
+            result = search(r"mac=\w+", poch)
             if result is not None:
                 self.mac = result.group(0).split("=")[1]
 

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -4,7 +4,7 @@
     "step": {
       "device": {
         "title": "Connect to a Xiaomi Miio Device or Xiaomi Gateway",
-        "description": "You will need the 32 character [%key:common::config_flow::data::api_token%], see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Please note, that this [%key:common::config_flow::data::api_token%] is different from the key used by the Xiaomi Aqara integration.",
+        "description": "You will need the 32 character [%key:common::config_flow::data::api_token%], see https://www.home-assistant.io/integrations/xiaomi_miio#retrieving-the-access-token for instructions. Please note, that this [%key:common::config_flow::data::api_token%] is different from the key used by the Xiaomi Aqara integration.",
         "data": {
           "host": "[%key:common::config_flow::data::ip%]",
           "token": "[%key:common::config_flow::data::api_token%]",

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -1,24 +1,24 @@
 {
   "config": {
-    "flow_title": "Xiaomi Miio: {name}",
-    "step": {
-      "device": {
-        "title": "Connect to a Xiaomi Miio Device or Xiaomi Gateway",
-        "description": "You will need the 32 character [%key:common::config_flow::data::api_token%], see https://www.home-assistant.io/integrations/xiaomi_miio#retrieving-the-access-token for instructions. Please note, that this [%key:common::config_flow::data::api_token%] is different from the key used by the Xiaomi Aqara integration.",
-        "data": {
-          "host": "[%key:common::config_flow::data::ip%]",
-          "token": "[%key:common::config_flow::data::api_token%]",
-          "model": "Device model (Optional)"
-        }
-      }
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown_device": "The device model is not known, not able to setup the device using config flow."
     },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]"
+    "flow_title": "Xiaomi Miio: {name}",
+    "step": {
+      "device": {
+        "data": {
+          "host": "[%key:common::config_flow::data::ip%]",
+          "model": "Device model (Optional)",
+          "token": "[%key:common::config_flow::data::api_token%]"
+        },
+        "description": "You will need the 32 character [%key:common::config_flow::data::api_token%], see https://www.home-assistant.io/integrations/xiaomi_miio#retrieving-the-access-token for instructions. Please note, that this [%key:common::config_flow::data::api_token%] is different from the key used by the Xiaomi Aqara integration.",
+        "title": "Connect to a Xiaomi Miio Device or Xiaomi Gateway"
+      }
     }
   }
 }

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -7,7 +7,6 @@ from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.xiaomi_miio import const
 from homeassistant.components.xiaomi_miio.config_flow import (
-    DEFAULT_DEVICE_NAME,
     DEFAULT_GATEWAY_NAME,
 )
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
@@ -295,7 +294,7 @@ async def test_config_flow_step_device_manual_model_succes(hass):
         )
 
     assert result["type"] == "create_entry"
-    assert result["title"] == DEFAULT_DEVICE_NAME
+    assert result["title"] == overwrite_model
     assert result["data"] == {
         const.CONF_FLOW_TYPE: const.CONF_DEVICE,
         CONF_HOST: TEST_HOST,
@@ -329,7 +328,7 @@ async def config_flow_device_success(hass, model_to_test):
         )
 
     assert result["type"] == "create_entry"
-    assert result["title"] == DEFAULT_DEVICE_NAME
+    assert result["title"] == model_to_test
     assert result["data"] == {
         const.CONF_FLOW_TYPE: const.CONF_DEVICE,
         CONF_HOST: TEST_HOST,
@@ -369,7 +368,7 @@ async def zeroconf_device_success(hass, zeroconf_name_to_test, model_to_test):
         )
 
     assert result["type"] == "create_entry"
-    assert result["title"] == DEFAULT_DEVICE_NAME
+    assert result["title"] == model_to_test
     assert result["data"] == {
         const.CONF_FLOW_TYPE: const.CONF_DEVICE,
         CONF_HOST: TEST_HOST,

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -21,6 +21,7 @@ TEST_TOKEN = "12345678901234567890123456789012"
 TEST_NAME = "Test_Gateway"
 TEST_MODEL = const.MODELS_GATEWAY[0]
 TEST_MAC = "ab:cd:ef:gh:ij:kl"
+TEST_MAC_DEVICE = "abcdefghijkl"
 TEST_GATEWAY_ID = TEST_MAC
 TEST_HARDWARE_VERSION = "AB123"
 TEST_FIRMWARE_VERSION = "1.2.3_456"
@@ -346,7 +347,7 @@ async def zeroconf_device_success(hass, zeroconf_name_to_test, model_to_test):
         data={
             zeroconf.ATTR_HOST: TEST_HOST,
             ZEROCONF_NAME: zeroconf_name_to_test,
-            ZEROCONF_PROP: {ZEROCONF_MAC: TEST_MAC},
+            ZEROCONF_PROP: {"poch": f"0:mac={TEST_MAC_DEVICE}\x00"},
         },
     )
 

--- a/tests/components/xiaomi_miio/test_config_flow.py
+++ b/tests/components/xiaomi_miio/test_config_flow.py
@@ -6,9 +6,7 @@ from miio import DeviceException
 from homeassistant import config_entries
 from homeassistant.components import zeroconf
 from homeassistant.components.xiaomi_miio import const
-from homeassistant.components.xiaomi_miio.config_flow import (
-    DEFAULT_GATEWAY_NAME,
-)
+from homeassistant.components.xiaomi_miio.config_flow import DEFAULT_GATEWAY_NAME
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 
 ZEROCONF_NAME = "name"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix discovery for xioami miio devices that do not properly show their mac in the discovery_info (extract the mac from the raw info).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Config flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47006
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
