### PR TITLE
Handle stream failures in recorder

### DIFF
--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -21,6 +21,11 @@ def async_setup_recorder(hass):
 
 def recorder_save_worker(file_out: str, segments: Deque[Segment]):
     """Handle saving stream."""
+
+    if not segments:
+        _LOGGER.error("Recording failed to capture anything.")
+        return
+
     if not os.path.exists(os.path.dirname(file_out)):
         os.makedirs(os.path.dirname(file_out), exist_ok=True)
 

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -23,7 +23,7 @@ def recorder_save_worker(file_out: str, segments: Deque[Segment]):
     """Handle saving stream."""
 
     if not segments:
-        _LOGGER.error("Recording failed to capture anything.")
+        _LOGGER.error("Recording failed to capture anything")
         return
 
     if not os.path.exists(os.path.dirname(file_out)):

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -193,6 +193,18 @@ async def test_recorder_discontinuity(tmpdir):
     assert os.path.exists(filename)
 
 
+async def test_recorder_no_segements(tmpdir):
+    """Test recorder behavior with a stream failure which causes no segments."""
+    # Setup
+    filename = f"{tmpdir}/test.mp4"
+
+    # Run
+    recorder_save_worker("unused-file", [])
+
+    # Assert
+    assert not os.path.exists(filename)
+
+
 async def test_record_stream_audio(
     hass, hass_client, stream_worker_sync, record_worker_sync
 ):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fail gracefully with an error message when the recorder is invoked with no segments due to a stream failure.

I previously observed this failure mode when an rtsp stream failed for an unknown reason:

```
2021-02-27 08:10:35 ERROR (stream_worker) [homeassistant.components.stream.worker] Stream has no video
2021-02-27 08:10:35 DEBUG (MainThread) [homeassistant.components.stream.recorder] Starting recorder worker thread
2021-02-27 08:10:35 INFO (MainThread) [homeassistant.components.stream] Stopped stream: rtsps://....
2021-02-27 08:10:35 ERROR (recorder_save_worker) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/home/allen/home-assistant-core/homeassistant/components/stream/recorder.py", line 96, in recorder_save_worker
    output.close()
AttributeError: 'NoneType' object has no attribute 'close'
```

An alternative could be to handle this explicitly upstream, however this was the easiest approach to test.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
