### PR TITLE
Add location details to deprecation warning

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -746,15 +746,21 @@ def deprecated(
     def validator(config: Dict) -> Dict:
         """Check if key is in config and log warning."""
         if key in config:
-            KeywordStyleAdapter(logging.getLogger(module_name)).warning(
-                warning.replace(
-                    "'{key}' option",
-                    f"'{key}' option near {config.__config_file__}:{config.__line__}",  # type: ignore
-                ),
-                key=key,
-                replacement_key=replacement_key,
-            )
-
+            try:
+                KeywordStyleAdapter(logging.getLogger(module_name)).warning(
+                    warning.replace(
+                        "'{key}' option",
+                        f"'{key}' option near {config.__config_file__}:{config.__line__}",  # type: ignore
+                    ),
+                    key=key,
+                    replacement_key=replacement_key,
+                )
+            except AttributeError:
+                KeywordStyleAdapter(logging.getLogger(module_name)).warning(
+                    warning,
+                    key=key,
+                    replacement_key=replacement_key,
+                )
             value = config[key]
             if replacement_key:
                 config.pop(key)

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -747,7 +747,10 @@ def deprecated(
         """Check if key is in config and log warning."""
         if key in config:
             KeywordStyleAdapter(logging.getLogger(module_name)).warning(
-                warning,
+                warning.replace(
+                    "'{key}' option",
+                    f"'{key}' option near {config.__config_file__}:{config.__line__}",  # type: ignore
+                ),
                 key=key,
                 replacement_key=replacement_key,
             )

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -818,6 +818,40 @@ def test_deprecated_logger_with_config_attributes(caplog):
     assert len(caplog.records) == 0
 
 
+def test_deprecated_logger_with_one_config_attribute(caplog):
+    """Test if the logger outputs the correct message if only one of line and file attribute is available in config."""
+    file: str = "configuration.yaml"
+    line: int = 54
+    replacement = f"'mars' option near {file}:{line} is deprecated"
+    config = OrderedDict([("mars", "blah")])
+    setattr(config, "__config_file__", file)
+
+    cv.deprecated("mars", replacement_key="jupiter", default=False)(config)
+
+    assert len(caplog.records) == 1
+    assert replacement not in caplog.text
+    assert (
+        "The 'mars' option is deprecated, please replace it with 'jupiter'"
+    ) in caplog.text
+
+    caplog.clear()
+    assert len(caplog.records) == 0
+
+    config = OrderedDict([("mars", "blah")])
+    setattr(config, "__line__", line)
+
+    cv.deprecated("mars", replacement_key="jupiter", default=False)(config)
+
+    assert len(caplog.records) == 1
+    assert replacement not in caplog.text
+    assert (
+        "The 'mars' option is deprecated, please replace it with 'jupiter'"
+    ) in caplog.text
+
+    caplog.clear()
+    assert len(caplog.records) == 0
+
+
 def test_deprecated_logger_without_config_attributes(caplog):
     """Test if the logger outputs the correct message if the line and file attribute is not available in config."""
     file: str = "configuration.yaml"

--- a/tests/helpers/test_config_validation.py
+++ b/tests/helpers/test_config_validation.py
@@ -1,4 +1,5 @@
 """Test config validators."""
+from collections import OrderedDict
 from datetime import date, datetime, timedelta
 import enum
 import os
@@ -797,6 +798,43 @@ def test_deprecated_cant_find_module():
             replacement_key="jupiter",
             default=False,
         )
+
+
+def test_deprecated_logger_with_config_attributes(caplog):
+    """Test if the logger outputs the correct message if the line and file attribute is available in config."""
+    file: str = "configuration.yaml"
+    line: int = 54
+    replacement = f"'mars' option near {file}:{line} is deprecated"
+    config = OrderedDict([("mars", "blah")])
+    setattr(config, "__config_file__", file)
+    setattr(config, "__line__", line)
+
+    cv.deprecated("mars", replacement_key="jupiter", default=False)(config)
+
+    assert len(caplog.records) == 1
+    assert replacement in caplog.text
+
+    caplog.clear()
+    assert len(caplog.records) == 0
+
+
+def test_deprecated_logger_without_config_attributes(caplog):
+    """Test if the logger outputs the correct message if the line and file attribute is not available in config."""
+    file: str = "configuration.yaml"
+    line: int = 54
+    replacement = f"'mars' option near {file}:{line} is deprecated"
+    config = OrderedDict([("mars", "blah")])
+
+    cv.deprecated("mars", replacement_key="jupiter", default=False)(config)
+
+    assert len(caplog.records) == 1
+    assert replacement not in caplog.text
+    assert (
+        "The 'mars' option is deprecated, please replace it with 'jupiter'"
+    ) in caplog.text
+
+    caplog.clear()
+    assert len(caplog.records) == 0
 
 
 def test_key_dependency():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add file and line information for deprecation warnings. This will help users find where deprecated options are. For users using packages or large configuration.yaml files, this will help in finding what needs to be changed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
