### PR TITLE
ZHA lock code services and events

### DIFF
--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -62,7 +62,7 @@ class DoorLockChannel(ZigbeeChannel):
         set_pin_code = self.__getattr__("set_pin_code")
         await set_pin_code(
             *(
-                code_slot - 1,  # start code slots at 1
+                code_slot - 1,  # start code slots at 1, Zigbee internals use 0
                 closures.DoorLock.UserStatus.Enabled,
                 closures.DoorLock.UserType.Unrestricted,
                 user_code,

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -59,58 +59,48 @@ class DoorLockChannel(ZigbeeChannel):
     async def async_set_user_code(self, code_slot: int, user_code: str) -> None:
         """Set the user code for the code slot."""
 
-        set_pin_code = self.__getattr__("set_pin_code")
-        await set_pin_code(
-            *(
-                code_slot - 1,  # start code slots at 1, Zigbee internals use 0
-                closures.DoorLock.UserStatus.Enabled,
-                closures.DoorLock.UserType.Unrestricted,
-                user_code,
-            ),
+        await self.set_pin_code(
+            code_slot - 1,  # start code slots at 1, Zigbee internals use 0
+            closures.DoorLock.UserStatus.Enabled,
+            closures.DoorLock.UserType.Unrestricted,
+            user_code,
         )
 
     async def async_enable_user_code(self, code_slot: int) -> None:
         """Enable the code slot."""
 
-        set_user_status = self.__getattr__("set_user_status")
-        await set_user_status(*(code_slot - 1, closures.DoorLock.UserStatus.Enabled))
+        await self.set_user_status(code_slot - 1, closures.DoorLock.UserStatus.Enabled)
 
     async def async_disable_user_code(self, code_slot: int) -> None:
         """Disable the code slot."""
 
-        set_user_status = self.__getattr__("set_user_status")
-        await set_user_status(*(code_slot - 1, closures.DoorLock.UserStatus.Disabled))
+        await self.set_user_status(code_slot - 1, closures.DoorLock.UserStatus.Disabled)
 
     async def async_get_user_code(self, code_slot: int) -> int:
         """Get the user code from the code slot."""
 
-        get_pin_code = self.__getattr__("get_pin_code")
-        result = await get_pin_code(*(code_slot - 1,))
+        result = await self.get_pin_code(code_slot - 1)
         return result
 
     async def async_clear_user_code(self, code_slot: int) -> None:
         """Clear the code slot."""
 
-        clear_pin_code = self.__getattr__("clear_pin_code")
-        await clear_pin_code(*(code_slot - 1,))
+        await self.clear_pin_code(code_slot - 1)
 
     async def async_clear_all_user_codes(self) -> None:
         """Clear all code slots."""
 
-        clear_all_pin_codes = self.__getattr__("clear_all_pin_codes")
-        await clear_all_pin_codes(*())
+        await self.clear_all_pin_codes()
 
     async def async_set_user_type(self, code_slot: int, user_type: str) -> None:
         """Set user type."""
 
-        set_user_type = self.__getattr__("set_user_type")
-        await set_user_type(*(code_slot - 1, user_type))
+        await self.set_user_type(code_slot - 1, user_type)
 
     async def async_get_user_type(self, code_slot: int) -> str:
         """Get user type."""
 
-        get_user_type = self.__getattr__("get_user_type")
-        result = await get_user_type(*(code_slot - 1))
+        result = await self.get_user_type(code_slot - 1)
         return result
 
 

--- a/homeassistant/components/zha/core/channels/closures.py
+++ b/homeassistant/components/zha/core/channels/closures.py
@@ -27,7 +27,10 @@ class DoorLockChannel(ZigbeeChannel):
     def cluster_command(self, tsn, command_id, args):
         """Handle a cluster command received on this cluster."""
 
-        if self._cluster.client_commands is None:
+        if (
+            self._cluster.client_commands is None
+            or self._cluster.client_commands.get(command_id) is None
+        ):
             return
 
         command_name = self._cluster.client_commands.get(command_id, [command_id])[0]

--- a/homeassistant/components/zha/lock.py
+++ b/homeassistant/components/zha/lock.py
@@ -32,6 +32,8 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, DOMAIN)
 VALUE_TO_STATE = dict(enumerate(STATE_LIST))
 
 SERVICE_SET_LOCK_USER_CODE = "set_lock_user_code"
+SERVICE_ENABLE_LOCK_USER_CODE = "enable_lock_user_code"
+SERVICE_DISABLE_LOCK_USER_CODE = "disable_lock_user_code"
 SERVICE_CLEAR_LOCK_USER_CODE = "clear_lock_user_code"
 
 
@@ -58,6 +60,22 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             vol.Required("user_code"): cv.string,
         },
         "async_set_lock_user_code",
+    )
+
+    platform.async_register_entity_service(  # type: ignore
+        SERVICE_ENABLE_LOCK_USER_CODE,
+        {
+            vol.Required("code_slot"): vol.Coerce(int),
+        },
+        "async_enable_lock_user_code",
+    )
+
+    platform.async_register_entity_service(  # type: ignore
+        SERVICE_DISABLE_LOCK_USER_CODE,
+        {
+            vol.Required("code_slot"): vol.Coerce(int),
+        },
+        "async_disable_lock_user_code",
     )
 
     platform.async_register_entity_service(  # type: ignore
@@ -147,6 +165,18 @@ class ZhaDoorLock(ZhaEntity, LockEntity):
         if self._doorlock_channel:
             await self._doorlock_channel.async_set_user_code(code_slot, user_code)
             self.debug("User code at slot %s set", code_slot)
+
+    async def async_enable_lock_user_code(self, code_slot: int) -> None:
+        """Enable user_code at index X on the lock."""
+        if self._doorlock_channel:
+            await self._doorlock_channel.async_enable_user_code(code_slot)
+            self.debug("User code at slot %s enabled", code_slot)
+
+    async def async_disable_lock_user_code(self, code_slot: int) -> None:
+        """Disable user_code at index X on the lock."""
+        if self._doorlock_channel:
+            await self._doorlock_channel.async_disable_user_code(code_slot)
+            self.debug("User code at slot %s disabled", code_slot)
 
     async def async_clear_lock_user_code(self, code_slot: int) -> None:
         """Clear the user_code at index X on the lock."""

--- a/homeassistant/components/zha/lock.py
+++ b/homeassistant/components/zha/lock.py
@@ -1,6 +1,7 @@
 """Locks on Zigbee Home Automation networks."""
 import functools
 
+import voluptuous as vol
 from zigpy.zcl.foundation import Status
 
 from homeassistant.components.lock import (
@@ -10,6 +11,7 @@ from homeassistant.components.lock import (
     LockEntity,
 )
 from homeassistant.core import callback
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .core import discovery
@@ -29,6 +31,9 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, DOMAIN)
 
 VALUE_TO_STATE = dict(enumerate(STATE_LIST))
 
+SERVICE_SET_LOCK_USER_CODE = "set_lock_user_code"
+SERVICE_CLEAR_LOCK_USER_CODE = "clear_lock_user_code"
+
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Zigbee Home Automation Door Lock from config entry."""
@@ -42,6 +47,26 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         ),
     )
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
+
+    platform = entity_platform.current_platform.get()
+    assert platform
+
+    platform.async_register_entity_service(  # type: ignore
+        SERVICE_SET_LOCK_USER_CODE,
+        {
+            vol.Required("code_slot"): vol.Coerce(int),
+            vol.Required("user_code"): cv.string,
+        },
+        "async_set_lock_user_code",
+    )
+
+    platform.async_register_entity_service(  # type: ignore
+        SERVICE_CLEAR_LOCK_USER_CODE,
+        {
+            vol.Required("code_slot"): vol.Coerce(int),
+        },
+        "async_clear_lock_user_code",
+    )
 
 
 @STRICT_MATCH(channel_names=CHANNEL_DOORLOCK)
@@ -116,3 +141,15 @@ class ZhaDoorLock(ZhaEntity, LockEntity):
     async def refresh(self, time):
         """Call async_get_state at an interval."""
         await self.async_get_state(from_cache=False)
+
+    async def async_set_lock_user_code(self, code_slot: int, user_code: str) -> None:
+        """Set the user_code to index X on the lock."""
+        if self._doorlock_channel:
+            await self._doorlock_channel.async_set_user_code(code_slot, user_code)
+            self.debug("User code at slot %s set", code_slot)
+
+    async def async_clear_lock_user_code(self, code_slot: int) -> None:
+        """Clear the user_code at index X on the lock."""
+        if self._doorlock_channel:
+            await self._doorlock_channel.async_clear_user_code(code_slot)
+            self.debug("User code at slot %s cleared", code_slot)

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -163,3 +163,42 @@ warning_device_warn:
       description: >-
         Indicates the intensity of the strobe as shown in Table 8-23 of the ZCL spec. This attribute is designed to vary the output of the strobe (i.e., brightness) and not its frequency, which is detailed in section 8.4.2.3.1.6 of the ZCL spec.
       example: 2
+
+clear_lock_user_code:
+  name: Clear a user code from a lock
+  description: Clear a user code from a lock
+  target:
+    entity:
+      domain: lock
+      integration: zha
+  fields:
+    code_slot:
+      name: Code slot
+      description: Code slot to clear code from
+      required: true
+      example: 1
+      selector:
+        text:
+
+set_lock_user_code:
+  name: Set a user code on a lock
+  description: Set a user code on a lock
+  target:
+    entity:
+      domain: lock
+      integration: zha
+  fields:
+    code_slot:
+      name: Code slot
+      description: Code slot to set the code.
+      required: true
+      example: 1
+      selector:
+        text:
+    user_code:
+      name: Code
+      description: Code to set.
+      required: true
+      example: 1234
+      selector:
+        text:

--- a/homeassistant/components/zha/services.yaml
+++ b/homeassistant/components/zha/services.yaml
@@ -165,7 +165,7 @@ warning_device_warn:
       example: 2
 
 clear_lock_user_code:
-  name: Clear a user code from a lock
+  name: Clear lock user
   description: Clear a user code from a lock
   target:
     entity:
@@ -180,8 +180,40 @@ clear_lock_user_code:
       selector:
         text:
 
+enable_lock_user_code:
+  name: Enable lock user
+  description: Enable a user code on a lock
+  target:
+    entity:
+      domain: lock
+      integration: zha
+  fields:
+    code_slot:
+      name: Code slot
+      description: Code slot to enable
+      required: true
+      example: 1
+      selector:
+        text:
+
+disable_lock_user_code:
+  name: Disable lock user
+  description: Disable a user code on a lock
+  target:
+    entity:
+      domain: lock
+      integration: zha
+  fields:
+    code_slot:
+      name: Code slot
+      description: Code slot to disable
+      required: true
+      example: 1
+      selector:
+        text:
+
 set_lock_user_code:
-  name: Set a user code on a lock
+  name: Set lock user code
   description: Set a user code on a lock
   target:
     entity:
@@ -190,14 +222,14 @@ set_lock_user_code:
   fields:
     code_slot:
       name: Code slot
-      description: Code slot to set the code.
+      description: Code slot to set the code in
       required: true
       example: 1
       selector:
         text:
     user_code:
       name: Code
-      description: Code to set.
+      description: Code to set
       required: true
       example: 1234
       selector:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Add zha_events for zigbee lock notifications (including the sending device and user slot)
- Add set_user_code and clear_user_code services to zigbee locks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://community.home-assistant.io/t/zha-user-code-management-on-zigbee-door-locks/225594
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16947

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
