### PR TITLE
Fix harmony failing to switch activities when a switch is in progress

### DIFF
--- a/homeassistant/components/harmony/data.py
+++ b/homeassistant/components/harmony/data.py
@@ -22,17 +22,8 @@ class HarmonyData(HarmonySubscriberMixin):
         self._name = name
         self._unique_id = unique_id
         self._available = False
-
-        callbacks = {
-            "config_updated": self._config_updated,
-            "connect": self._connected,
-            "disconnect": self._disconnected,
-            "new_activity_starting": self._activity_starting,
-            "new_activity": self._activity_started,
-        }
-        self._client = HarmonyClient(
-            ip_address=address, callbacks=ClientCallbackType(**callbacks)
-        )
+        self._client = None
+        self._address = address
 
     @property
     def activities(self):
@@ -105,6 +96,18 @@ class HarmonyData(HarmonySubscriberMixin):
     async def connect(self) -> bool:
         """Connect to the Harmony Hub."""
         _LOGGER.debug("%s: Connecting", self._name)
+
+        callbacks = {
+            "config_updated": self._config_updated,
+            "connect": self._connected,
+            "disconnect": self._disconnected,
+            "new_activity_starting": self._activity_starting,
+            "new_activity": self._activity_started,
+        }
+        self._client = HarmonyClient(
+            ip_address=self._address, callbacks=ClientCallbackType(**callbacks)
+        )
+
         try:
             if not await self._client.connect():
                 _LOGGER.warning("%s: Unable to connect to HUB", self._name)
@@ -113,6 +116,7 @@ class HarmonyData(HarmonySubscriberMixin):
         except aioexc.TimeOut:
             _LOGGER.warning("%s: Connection timed-out", self._name)
             return False
+
         return True
 
     async def shutdown(self):
@@ -159,10 +163,12 @@ class HarmonyData(HarmonySubscriberMixin):
             )
             return
 
+        await self.async_lock_start_activity()
         try:
             await self._client.start_activity(activity_id)
         except aioexc.TimeOut:
             _LOGGER.error("%s: Starting activity %s timed-out", self.name, activity)
+            self.async_unlock_start_activity()
 
     async def async_power_off(self):
         """Start the PowerOff activity."""

--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -1,5 +1,6 @@
 """Mixin class for handling harmony callback subscriptions."""
 
+import asyncio
 import logging
 from typing import Any, Callable, NamedTuple, Optional
 
@@ -29,6 +30,16 @@ class HarmonySubscriberMixin:
         super().__init__()
         self._hass = hass
         self._subscriptions = []
+        self._activity_lock = asyncio.Lock()
+
+    async def async_lock_start_activity(self):
+        """Acquire the lock."""
+        await self._activity_lock.acquire()
+
+    def async_unlock_start_activity(self):
+        """Release the lock."""
+        if self._activity_lock.locked():
+            self._activity_lock.release()
 
     @callback
     def async_subscribe(self, update_callbacks: HarmonyCallback) -> Callable:
@@ -51,11 +62,13 @@ class HarmonySubscriberMixin:
 
     def _connected(self, _=None) -> None:
         _LOGGER.debug("connected")
+        self.async_unlock_start_activity()
         self._available = True
         self._call_callbacks("connected")
 
     def _disconnected(self, _=None) -> None:
         _LOGGER.debug("disconnected")
+        self.async_unlock_start_activity()
         self._available = False
         self._call_callbacks("disconnected")
 
@@ -65,6 +78,7 @@ class HarmonySubscriberMixin:
 
     def _activity_started(self, activity_info: tuple) -> None:
         _LOGGER.debug("activity %s started", activity_info)
+        self.async_unlock_start_activity()
         self._call_callbacks("activity_started", activity_info)
 
     def _call_callbacks(self, callback_func_name: str, argument: tuple = None):

--- a/homeassistant/components/harmony/subscriber.py
+++ b/homeassistant/components/harmony/subscriber.py
@@ -36,6 +36,7 @@ class HarmonySubscriberMixin:
         """Acquire the lock."""
         await self._activity_lock.acquire()
 
+    @callback
     def async_unlock_start_activity(self):
         """Release the lock."""
         if self._activity_lock.locked():


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix harmony failing to switch activities when a switch is in progress

If an activity switch was in progress and another one is asked for, the
second switch would be dropped.  This is most apparent when switching with
HomeKit since HomeKit restores the last activity, and then its impossible to
switch to another one because the switch is in progress already.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
