### PR TITLE
Add suggested area for zwave_js devices

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -67,14 +67,17 @@ def register_node_in_dev_reg(
     node: ZwaveNode,
 ) -> None:
     """Register node in dev reg."""
-    device = dev_reg.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={get_device_id(client, node)},
-        sw_version=node.firmware_version,
-        name=node.name or node.device_config.description or f"Node {node.node_id}",
-        model=node.device_config.label,
-        manufacturer=node.device_config.manufacturer,
-    )
+    params = {
+        "config_entry_id": entry.entry_id,
+        "identifiers": {get_device_id(client, node)},
+        "sw_version": node.firmware_version,
+        "name": node.name or node.device_config.description or f"Node {node.node_id}",
+        "model": node.device_config.label,
+        "manufacturer": node.device_config.manufacturer,
+    }
+    if node.location:
+        params["suggested_area"] = node.location
+    device = dev_reg.async_get_or_create(**params)
 
     async_dispatcher_send(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device)
 

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -16,3 +16,6 @@ PROPERTY_DOOR_STATUS_BINARY_SENSOR = (
 CLIMATE_RADIO_THERMOSTAT_ENTITY = "climate.z_wave_thermostat"
 CLIMATE_DANFOSS_LC13_ENTITY = "climate.living_connect_z_thermostat"
 CLIMATE_FLOOR_THERMOSTAT_ENTITY = "climate.floor_thermostat"
+BULB_6_MULTI_COLOR_LIGHT_ENTITY = "light.bulb_6_multi_color"
+EATON_RF9640_ENTITY = "light.allloaddimmer"
+AEON_SMART_SWITCH_LIGHT_ENTITY = "light.smart_switch_6"

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -10,9 +10,7 @@ from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
 
-from homeassistant.helpers.device_registry import (
-    async_get_registry as async_get_device_registry,
-)
+from homeassistant.helpers.device_registry import async_get as async_get_device_registry
 
 from tests.common import MockConfigEntry, load_fixture
 
@@ -20,7 +18,7 @@ from tests.common import MockConfigEntry, load_fixture
 @pytest.fixture(name="device_registry")
 async def device_registry_fixture(hass):
     """Return the device registry."""
-    return await async_get_device_registry(hass)
+    return async_get_device_registry(hass)
 
 
 @pytest.fixture(name="controller_state", scope="session")

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -18,7 +18,11 @@ from homeassistant.config_entries import (
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.helpers import device_registry, entity_registry
 
-from .common import AIR_TEMPERATURE_SENSOR, NOTIFICATION_MOTION_BINARY_SENSOR
+from .common import (
+    AIR_TEMPERATURE_SENSOR,
+    EATON_RF9640_ENTITY,
+    NOTIFICATION_MOTION_BINARY_SENSOR,
+)
 
 from tests.common import MockConfigEntry
 
@@ -467,3 +471,17 @@ async def test_removed_device(hass, client, multiple_devices, integration):
     )
     assert len(entity_entries) == 15
     assert dev_reg.async_get_device({get_device_id(client, old_node)}) is None
+
+
+async def test_suggested_area(hass, client, eaton_rf9640_dimmer):
+    """Test that suggested area works."""
+    dev_reg = device_registry.async_get(hass)
+    ent_reg = entity_registry.async_get(hass)
+
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity = ent_reg.async_get(EATON_RF9640_ENTITY)
+    assert dev_reg.async_get(entity.device_id).area_id is not None

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -12,9 +12,11 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, STATE_OFF, STATE_ON
 
-BULB_6_MULTI_COLOR_LIGHT_ENTITY = "light.bulb_6_multi_color"
-EATON_RF9640_ENTITY = "light.allloaddimmer"
-AEON_SMART_SWITCH_LIGHT_ENTITY = "light.smart_switch_6"
+from .common import (
+    AEON_SMART_SWITCH_LIGHT_ENTITY,
+    BULB_6_MULTI_COLOR_LIGHT_ENTITY,
+    EATON_RF9640_ENTITY,
+)
 
 
 async def test_light(hass, client, bulb_6_multi_color, integration):

--- a/tests/fixtures/zwave_js/eaton_rf9640_dimmer_state.json
+++ b/tests/fixtures/zwave_js/eaton_rf9640_dimmer_state.json
@@ -27,7 +27,7 @@
     "nodeType": 0,
     "roleType": 5,
     "name": "AllLoadDimmer",
-    "location": "",
+    "location": "LivingRoom",
     "deviceConfig": {
         "manufacturerId": 26,
         "manufacturer": "Eaton",


### PR DESCRIPTION
## Proposed change
Adding suggested area support for `zwave_js` now that we can get the location attribute of a node from zwavejs2mqtt. I saw some previous PRs related to this (https://github.com/home-assistant/core/pull/47056) that were cherry picked for the next release so setting the milestone accordingly.

I also made some small tweaks to tests so that they are more future proof


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
