### PR TITLE
Update tests to use async_get() instead of async_get_registry()

### DIFF
--- a/tests/components/abode/test_alarm_control_panel.py
+++ b/tests/components/abode/test_alarm_control_panel.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -25,7 +26,7 @@ DEVICE_ID = "alarm_control_panel.abode_alarm"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, ALARM_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     # Abode alarm device unique_id is the MAC address

--- a/tests/components/abode/test_binary_sensor.py
+++ b/tests/components/abode/test_binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     STATE_OFF,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -18,7 +19,7 @@ from .common import setup_platform
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, BINARY_SENSOR_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("binary_sensor.front_door")
     assert entry.unique_id == "2834013428b6035fba7d4054aa7b25a3"

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from homeassistant.components.abode.const import DOMAIN as ABODE_DOMAIN
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_IDLE
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -11,7 +12,7 @@ from .common import setup_platform
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, CAMERA_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("camera.test_cam")
     assert entry.unique_id == "d0a3a1c316891ceb00c20118aae2a133"

--- a/tests/components/abode/test_cover.py
+++ b/tests/components/abode/test_cover.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER,
     STATE_CLOSED,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -19,7 +20,7 @@ DEVICE_ID = "cover.garage_door"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, COVER_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry.unique_id == "61cbz3b542d2o33ed2fz02721bda3324"

--- a/tests/components/abode/test_light.py
+++ b/tests/components/abode/test_light.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -25,7 +26,7 @@ DEVICE_ID = "light.living_room_lamp"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, LIGHT_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry.unique_id == "741385f4388b2637df4c6b398fe50581"

--- a/tests/components/abode/test_lock.py
+++ b/tests/components/abode/test_lock.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     SERVICE_UNLOCK,
     STATE_LOCKED,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -19,7 +20,7 @@ DEVICE_ID = "lock.test_lock"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, LOCK_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry.unique_id == "51cab3b545d2o34ed7fz02731bda5324"

--- a/tests/components/abode/test_sensor.py
+++ b/tests/components/abode/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     PERCENTAGE,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -16,7 +17,7 @@ from .common import setup_platform
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, SENSOR_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("sensor.environment_sensor_humidity")
     assert entry.unique_id == "13545b21f4bdcd33d9abd461f8443e65-humidity"

--- a/tests/components/abode/test_switch.py
+++ b/tests/components/abode/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -25,7 +26,7 @@ DEVICE_UID = "0012a4d3614cb7e2b8c9abea31d2fb2a"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, SWITCH_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(AUTOMATION_ID)
     assert entry.unique_id == AUTOMATION_UID

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     TIME_HOURS,
     UV_INDEX,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -32,7 +33,7 @@ from tests.components.accuweather import init_integration
 async def test_sensor_without_forecast(hass):
     """Test states of the sensor without forecast."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_cloud_ceiling")
     assert state
@@ -94,7 +95,7 @@ async def test_sensor_without_forecast(hass):
 async def test_sensor_with_forecast(hass):
     """Test states of the sensor with forecast."""
     await init_integration(hass, forecast=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_hours_of_sun_0d")
     assert state
@@ -166,7 +167,7 @@ async def test_sensor_with_forecast(hass):
 async def test_sensor_disabled(hass):
     """Test sensor disabled by default."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get("sensor.home_apparent_temperature")
     assert entry
@@ -185,7 +186,7 @@ async def test_sensor_disabled(hass):
 
 async def test_sensor_enabled_without_forecast(hass):
     """Test enabling an advanced sensor."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         SENSOR_DOMAIN,

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -23,6 +23,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -33,7 +34,7 @@ from tests.components.accuweather import init_integration
 async def test_weather_without_forecast(hass):
     """Test states of the weather without forecast."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("weather.home")
     assert state
@@ -56,7 +57,7 @@ async def test_weather_without_forecast(hass):
 async def test_weather_with_forecast(hass):
     """Test states of the weather with forecast."""
     await init_integration(hass, forecast=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("weather.home")
     assert state

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -1,6 +1,7 @@
 """Test the Advantage Air Binary Sensor Platform."""
 
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -24,7 +25,7 @@ async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
     )
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_climate.py
+++ b/tests/components/advantage_air/test_climate.py
@@ -22,6 +22,7 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -45,7 +46,7 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
     )
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_cover.py
+++ b/tests/components/advantage_air/test_cover.py
@@ -15,6 +15,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OPEN
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -39,7 +40,7 @@ async def test_cover_async_setup_entry(hass, aioclient_mock):
 
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.advantage_air.sensor import (
     ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
 )
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -31,7 +32,7 @@ async def test_sensor_platform(hass, aioclient_mock):
     )
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_switch.py
+++ b/tests/components/advantage_air/test_switch.py
@@ -1,5 +1,4 @@
 """Test the Advantage Air Switch Platform."""
-
 from json import loads
 
 from homeassistant.components.advantage_air.const import (
@@ -12,6 +11,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -36,7 +36,7 @@ async def test_cover_async_setup_entry(hass, aioclient_mock):
 
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/airly/test_air_quality.py
+++ b/tests/components/airly/test_air_quality.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     HTTP_INTERNAL_SERVER_ERROR,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -35,7 +36,7 @@ from tests.components.airly import init_integration
 async def test_air_quality(hass, aioclient_mock):
     """Test states of the air_quality."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("air_quality.home")
     assert state

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -29,7 +30,7 @@ from tests.components.airly import init_integration
 async def test_sensor(hass, aioclient_mock):
     """Test states of the sensor."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_humidity")
     assert state

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -64,7 +65,7 @@ def mock_controller_connect():
 
 async def test_sensors(hass, connect):
     """Test creating an AsusWRT sensor."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(

--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -1,5 +1,4 @@
 """Tests for the Atag climate platform."""
-
 from unittest.mock import PropertyMock, patch
 
 from homeassistant.components.atag import CLIMATE, DOMAIN
@@ -19,6 +18,7 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.components.atag import UID, init_integration
@@ -33,7 +33,7 @@ async def test_climate(
     """Test the creation and values of Atag climate device."""
     with patch("pyatag.entities.Climate.status"):
         entry = await init_integration(hass, aioclient_mock)
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
 
         assert registry.async_is_registered(CLIMATE_ID)
         entry = registry.async_get(CLIMATE_ID)

--- a/tests/components/atag/test_sensors.py
+++ b/tests/components/atag/test_sensors.py
@@ -1,7 +1,7 @@
 """Tests for the Atag sensor platform."""
-
 from homeassistant.components.atag.sensor import SENSORS
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -12,7 +12,7 @@ async def test_sensors(
 ) -> None:
     """Test the creation of ATAG sensors."""
     entry = await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     for item in SENSORS:
         sensor_id = "_".join(f"sensor.{item}".lower().split())

--- a/tests/components/atag/test_water_heater.py
+++ b/tests/components/atag/test_water_heater.py
@@ -1,11 +1,11 @@
 """Tests for the Atag water heater platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.atag import DOMAIN, WATER_HEATER
 from homeassistant.components.water_heater import SERVICE_SET_TEMPERATURE
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -19,7 +19,7 @@ async def test_water_heater(
     """Test the creation of Atag water heater."""
     with patch("pyatag.entities.DHW.status"):
         entry = await init_integration(hass, aioclient_mock)
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
 
         assert registry.async_is_registered(WATER_HEATER_ID)
         entry = registry.async_get(WATER_HEATER_ID)

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -1,5 +1,4 @@
 """The binary_sensor tests for the august platform."""
-
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -9,6 +8,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -119,7 +119,7 @@ async def test_doorbell_device_registry(hass):
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     reg_device = device_registry.async_get_device(identifiers={("august", "tmt100")})
     assert reg_device.model == "hydra1"

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -1,5 +1,4 @@
 """The lock tests for the august platform."""
-
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -9,6 +8,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -23,7 +23,7 @@ async def test_lock_device_registry(hass):
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     await _create_august_with_devices(hass, [lock_one])
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     reg_device = device_registry.async_get_device(
         identifiers={("august", "online_with_doorsense")}
@@ -90,7 +90,7 @@ async def test_one_lock_operation(hass):
     assert lock_online_with_doorsense_name.state == STATE_LOCKED
 
     # No activity means it will be unavailable until the activity feed has data
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )

--- a/tests/components/august/test_sensor.py
+++ b/tests/components/august/test_sensor.py
@@ -1,6 +1,6 @@
 """The sensor tests for the august platform."""
-
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, STATE_UNKNOWN
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -29,7 +29,7 @@ async def test_create_doorbell_offline(hass):
     """Test creation of a doorbell that is offline."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor_tmt100_name_battery = hass.states.get("sensor.tmt100_name_battery")
     assert sensor_tmt100_name_battery.state == "81"
@@ -55,7 +55,7 @@ async def test_create_lock_with_linked_keypad(hass):
     """Test creation of a lock with a linked keypad that both have a battery."""
     lock_one = await _mock_lock_from_fixture(hass, "get_lock.doorsense_init.json")
     await _create_august_with_devices(hass, [lock_one])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor_a6697750d607098bae8d6baa11ef8063_name_battery = hass.states.get(
         "sensor.a6697750d607098bae8d6baa11ef8063_name_battery"
@@ -85,7 +85,7 @@ async def test_create_lock_with_low_battery_linked_keypad(hass):
     """Test creation of a lock with a linked keypad that both have a battery."""
     lock_one = await _mock_lock_from_fixture(hass, "get_lock.low_keypad_battery.json")
     await _create_august_with_devices(hass, [lock_one])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor_a6697750d607098bae8d6baa11ef8063_name_battery = hass.states.get(
         "sensor.a6697750d607098bae8d6baa11ef8063_name_battery"
@@ -133,7 +133,7 @@ async def test_lock_operator_bluetooth(hass):
     )
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )
@@ -177,7 +177,7 @@ async def test_lock_operator_keypad(hass):
     )
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )
@@ -219,7 +219,7 @@ async def test_lock_operator_remote(hass):
     activities = await _mock_activities_from_fixture(hass, "get_activity.lock.json")
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )
@@ -263,7 +263,7 @@ async def test_lock_operator_autorelock(hass):
     )
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -1,5 +1,4 @@
 """Tests for the Awair sensor platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.awair.const import (
@@ -27,6 +26,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     AWAIR_UUID,
@@ -74,7 +74,7 @@ async def test_awair_gen1_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GEN1_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -170,7 +170,7 @@ async def test_awair_gen2_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GEN2_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -204,7 +204,7 @@ async def test_awair_mint_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, MINT_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -246,7 +246,7 @@ async def test_awair_glow_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GLOW_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -266,7 +266,7 @@ async def test_awair_omni_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, OMNI_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -319,7 +319,7 @@ async def test_awair_unavailable(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GEN1_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
 )
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.setup import async_setup_component
 
@@ -83,7 +83,7 @@ async def test_migrate_entry(hass):
     assert not entry.unique_id
 
     # Create entity entry to migrate to new unique ID
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         BINARY_SENSOR_DOMAIN,
         AXIS_DOMAIN,

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.blebox.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -84,7 +85,7 @@ async def async_setup_entities(hass, config, entity_ids):
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     return [entity_registry.async_get(entity_id) for entity_id in entity_ids]
 
 

--- a/tests/components/blebox/test_air_quality.py
+++ b/tests/components/blebox/test_air_quality.py
@@ -1,5 +1,4 @@
 """Blebox air_quality tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -8,6 +7,7 @@ import pytest
 
 from homeassistant.components.air_quality import ATTR_PM_0_1, ATTR_PM_2_5, ATTR_PM_10
 from homeassistant.const import ATTR_ICON, STATE_UNKNOWN
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -49,7 +49,7 @@ async def test_init(airsensor, hass, config):
 
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My air sensor"

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -1,5 +1,4 @@
 """BleBox climate entities tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -28,6 +27,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -79,7 +79,7 @@ async def test_init(saunabox, hass, config):
 
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My sauna"

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -1,5 +1,4 @@
 """BleBox cover entities tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -30,6 +29,7 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -117,7 +117,7 @@ async def test_init_gatecontroller(gatecontroller, hass, config):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My gate controller"
@@ -147,7 +147,7 @@ async def test_init_shutterbox(shutterbox, hass, config):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My shutter"
@@ -179,7 +179,7 @@ async def test_init_gatebox(gatebox, hass, config):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My gatebox"

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -1,5 +1,4 @@
 """BleBox light entities tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -21,6 +20,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.util import color
 
 from .conftest import async_setup_entity, mock_feature
@@ -65,7 +65,7 @@ async def test_dimmer_init(dimmer, hass, config):
     assert state.attributes[ATTR_BRIGHTNESS] == 65
     assert state.state == STATE_ON
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My dimmer"
@@ -236,7 +236,7 @@ async def test_wlightbox_s_init(wlightbox_s, hass, config):
     assert ATTR_BRIGHTNESS not in state.attributes
     assert state.state == STATE_OFF
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My wLightBoxS"
@@ -339,7 +339,7 @@ async def test_wlightbox_init(wlightbox, hass, config):
     assert ATTR_BRIGHTNESS not in state.attributes
     assert state.state == STATE_OFF
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My wLightBox"

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -1,5 +1,4 @@
 """Blebox sensors tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -13,6 +12,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -49,7 +49,7 @@ async def test_init(tempsensor, hass, config):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My temperature sensor"

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -1,5 +1,4 @@
 """Blebox switch tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -14,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import (
     async_setup_entities,
@@ -58,7 +58,7 @@ async def test_switchbox_init(switchbox, hass, config):
 
     assert state.state == STATE_OFF
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My switch box"
@@ -204,7 +204,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_SWITCH
     assert state.state == STATE_OFF  # NOTE: should instead be STATE_UNKNOWN?
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My relays"
@@ -221,7 +221,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_SWITCH
     assert state.state == STATE_OFF  # NOTE: should instead be STATE_UNKNOWN?
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My relays"

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -39,7 +40,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["cover.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -18,6 +18,7 @@ from homeassistant.components.fan import (
     SPEED_OFF,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -71,7 +72,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["fan.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -79,7 +79,7 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
     assert config_entry.unique_id == "test-bond-id"
 
     # verify hub device is registered correctly
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     hub = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert hub.name == "bond-name"
     assert hub.manufacturer == "Olibra"
@@ -127,7 +127,7 @@ async def test_old_identifiers_are_removed(hass: HomeAssistant):
 
     old_identifers = (DOMAIN, "device_id")
     new_identifiers = (DOMAIN, "test-bond-id", "device_id")
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={old_identifers},
@@ -204,7 +204,7 @@ async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant):
     assert config_entry.state == ENTRY_STATE_LOADED
     assert config_entry.unique_id == "test-bond-id"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert device is not None
     assert device.suggested_area == "Den"
@@ -250,7 +250,7 @@ async def test_bridge_device_suggested_area(hass: HomeAssistant):
     assert config_entry.state == ENTRY_STATE_LOADED
     assert config_entry.unique_id == "test-bond-id"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert device is not None
     assert device.suggested_area == "Office"

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -107,7 +108,7 @@ async def test_fan_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fan_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
@@ -122,7 +123,7 @@ async def test_fan_up_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fan_name_up_light"]
     assert entity.unique_id == "test-hub-id_test-device-id_up_light"
 
@@ -137,7 +138,7 @@ async def test_fan_down_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fan_name_down_light"]
     assert entity.unique_id == "test-hub-id_test-device-id_down_light"
 
@@ -152,7 +153,7 @@ async def test_fireplace_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fireplace_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
@@ -167,7 +168,7 @@ async def test_fireplace_with_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity_flame = registry.entities["light.fireplace_name"]
     assert entity_flame.unique_id == "test-hub-id_test-device-id"
     entity_light = registry.entities["light.fireplace_name_light"]
@@ -184,7 +185,7 @@ async def test_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.light_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -6,6 +6,7 @@ from bond_api import Action, DeviceType
 from homeassistant import core
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -34,7 +35,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["switch.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     PERCENTAGE,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import UTC, utcnow
 
@@ -28,7 +29,7 @@ async def test_sensors(hass):
     """Test states of the sensors."""
     entry = await init_integration(hass, skip_setup=True)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
@@ -241,7 +242,7 @@ async def test_disabled_by_default_sensors(hass):
     """Test the disabled by default Brother sensors."""
     await init_integration(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     state = hass.states.get("sensor.hl_l2340dw_uptime")
     assert state is None
 

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -28,6 +28,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import PlatformNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
@@ -489,7 +490,7 @@ async def test_discover_dynamic_group(hass, dial_mock, pycast_mock, caplog):
     zconf_1 = get_fake_zconf(host="host_1", port=23456)
     zconf_2 = get_fake_zconf(host="host_2", port=34567)
 
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     # Fake dynamic group info
     tmp1 = MagicMock()
@@ -613,7 +614,7 @@ async def test_entity_availability(hass: HomeAssistantType):
 async def test_entity_cast_status(hass: HomeAssistantType):
     """Test handling of cast status."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -682,7 +683,7 @@ async def test_entity_cast_status(hass: HomeAssistantType):
 async def test_entity_play_media(hass: HomeAssistantType):
     """Test playing media."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -711,7 +712,7 @@ async def test_entity_play_media(hass: HomeAssistantType):
 async def test_entity_play_media_cast(hass: HomeAssistantType, quick_play_mock):
     """Test playing media with cast special features."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -744,7 +745,7 @@ async def test_entity_play_media_cast(hass: HomeAssistantType, quick_play_mock):
 async def test_entity_play_media_cast_invalid(hass, caplog, quick_play_mock):
     """Test playing media."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -817,7 +818,7 @@ async def test_entity_play_media_sign_URL(hass: HomeAssistantType):
 async def test_entity_media_content_type(hass: HomeAssistantType):
     """Test various content types."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -871,7 +872,7 @@ async def test_entity_media_content_type(hass: HomeAssistantType):
 async def test_entity_control(hass: HomeAssistantType):
     """Test various device and media controls."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -980,7 +981,7 @@ async def test_entity_control(hass: HomeAssistantType):
 async def test_entity_media_states(hass: HomeAssistantType):
     """Test various entity media states."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -1039,7 +1040,7 @@ async def test_entity_media_states(hass: HomeAssistantType):
 async def test_group_media_states(hass, mz_mock):
     """Test media states are read from group if entity has no state."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(
@@ -1092,7 +1093,7 @@ async def test_group_media_states(hass, mz_mock):
 async def test_group_media_control(hass, mz_mock):
     """Test media controls are handled by group if entity has no state."""
     entity_id = "media_player.speaker"
-    reg = await hass.helpers.entity_registry.async_get_registry()
+    reg = er.async_get(hass)
 
     info = get_fake_chromecast_info()
     full_info = attr.evolve(

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa
 
@@ -110,7 +111,7 @@ async def test_bad_formatted_automations(hass, hass_client):
 
 async def test_delete_automation(hass, hass_client):
     """Test deleting an automation."""
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,

--- a/tests/components/config/test_scene.py
+++ b/tests/components/config/test_scene.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import config
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.yaml import dump
 
 
@@ -114,7 +115,7 @@ async def test_bad_formatted_scene(hass, hass_client):
 
 async def test_delete_scene(hass, hass_client):
     """Test deleting a scene."""
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,

--- a/tests/components/coronavirus/test_init.py
+++ b/tests/components/coronavirus/test_init.py
@@ -1,6 +1,6 @@
 """Test init of Coronavirus integration."""
 from homeassistant.components.coronavirus.const import DOMAIN, OPTION_WORLDWIDE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, mock_registry
@@ -17,13 +17,13 @@ async def test_migration(hass):
     mock_registry(
         hass,
         {
-            "sensor.netherlands_confirmed": entity_registry.RegistryEntry(
+            "sensor.netherlands_confirmed": er.RegistryEntry(
                 entity_id="sensor.netherlands_confirmed",
                 unique_id="34-confirmed",
                 platform="coronavirus",
                 config_entry_id=nl_entry.entry_id,
             ),
-            "sensor.worldwide_confirmed": entity_registry.RegistryEntry(
+            "sensor.worldwide_confirmed": er.RegistryEntry(
                 entity_id="sensor.worldwide_confirmed",
                 unique_id="__worldwide-confirmed",
                 platform="coronavirus",
@@ -34,7 +34,7 @@ async def test_migration(hass):
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     sensor_nl = ent_reg.async_get("sensor.netherlands_confirmed")
     assert sensor_nl.unique_id == "Netherlands-confirmed"

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.components.counter import (
 )
 from homeassistant.const import ATTR_FRIENDLY_NAME, ATTR_ICON, ATTR_NAME
 from homeassistant.core import Context, CoreState, State
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache
@@ -569,7 +569,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -606,7 +606,7 @@ async def test_update_min_max(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -683,7 +683,7 @@ async def test_create(hass, hass_ws_client, storage_setup):
 
     counter_id = "new_counter"
     input_entity_id = f"{DOMAIN}.{counter_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -1,5 +1,4 @@
 """deCONZ binary sensor platform tests."""
-
 from copy import deepcopy
 
 from homeassistant.components.binary_sensor import (
@@ -15,6 +14,7 @@ from homeassistant.components.deconz.const import (
 from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.deconz.services import SERVICE_DEVICE_REFRESH
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 
 from .test_gateway import (
@@ -191,7 +191,7 @@ async def test_add_new_binary_sensor_ignored(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
     assert not hass.states.get("binary_sensor.presence_sensor")
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     assert (
         len(async_entries_for_config_entry(entity_registry, config_entry.entry_id)) == 0
     )

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.components.deconz.const import (
 )
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
@@ -133,7 +133,7 @@ async def test_update_group_unique_id(hass):
         },
     )
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     # Create entity entry to migrate to new unique ID
     registry.async_get_or_create(
         LIGHT_DOMAIN,
@@ -172,7 +172,7 @@ async def test_update_group_unique_id_no_legacy_group_id(hass):
         data={},
     )
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     # Create entity entry to migrate to new unique ID
     registry.async_get_or_create(
         LIGHT_DOMAIN,

--- a/tests/components/deconz/test_services.py
+++ b/tests/components/deconz/test_services.py
@@ -1,5 +1,4 @@
 """deCONZ service tests."""
-
 from copy import deepcopy
 from unittest.mock import Mock, patch
 
@@ -23,6 +22,7 @@ from homeassistant.components.deconz.services import (
     async_unload_services,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 
 from .test_gateway import (
@@ -245,7 +245,7 @@ async def test_remove_orphaned_entries_service(hass, aioclient_mock):
 
     data = {CONF_BRIDGE_ID: BRIDGEID}
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id, identifiers={("mac", "123")}
     )
@@ -261,7 +261,7 @@ async def test_remove_orphaned_entries_service(hass, aioclient_mock):
         == 5  # Host, gateway, light, switch and orphan
     )
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entity_registry.async_get_or_create(
         SENSOR_DOMAIN,
         DECONZ_DOMAIN,

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -53,6 +53,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import dt as dt_util
 
@@ -167,7 +168,7 @@ async def test_unique_id(
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     main = entity_registry.async_get(MAIN_ENTITY_ID)
     assert main.device_class == DEVICE_CLASS_RECEIVER

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -7,6 +7,7 @@ from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.directv import setup_integration
@@ -36,7 +37,7 @@ async def test_unique_id(
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     main = entity_registry.async_get(MAIN_ENTITY_ID)
     assert main.unique_id == "028877455858"

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     VOLUME_CUBIC_METERS,
     VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, patch
@@ -107,7 +108,7 @@ async def test_default_setup(hass, dsmr_connection_fixture):
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get("sensor.power_consumption")
     assert entry
@@ -167,7 +168,7 @@ async def test_setup_only_energy(hass, dsmr_connection_fixture):
     await hass.config_entries.async_setup(mock_entry.entry_id)
     await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get("sensor.power_consumption")
     assert entry

--- a/tests/components/dynalite/common.py
+++ b/tests/components/dynalite/common.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, Mock, call, patch
 
 from homeassistant.components import dynalite
 from homeassistant.const import ATTR_SERVICE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -23,7 +23,7 @@ def create_mock_device(platform, spec):
 
 async def get_entry_id_from_hass(hass):
     """Get the config entry id from hass."""
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
     assert ent_reg
     conf_entries = hass.config_entries.async_entries(dynalite.DOMAIN)
     assert len(conf_entries) == 1

--- a/tests/components/dyson/test_climate.py
+++ b/tests/components/dyson/test_climate.py
@@ -60,7 +60,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .common import (
     ENTITY_NAME,
@@ -99,8 +99,8 @@ def async_get_device(spec: Type[DysonDevice]) -> DysonDevice:
 )
 async def test_state_common(hass: HomeAssistant, device: DysonDevice) -> None:
     """Test common state and attributes of two types of climate entities."""
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(ENTITY_ID).unique_id == SERIAL
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(ENTITY_ID).unique_id == SERIAL
 
     state = hass.states.get(ENTITY_ID)
     assert state.name == NAME

--- a/tests/components/dyson/test_fan.py
+++ b/tests/components/dyson/test_fan.py
@@ -52,7 +52,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .common import (
     ENTITY_NAME,
@@ -79,8 +79,8 @@ async def test_state_purecoollink(
     hass: HomeAssistant, device: DysonPureCoolLink
 ) -> None:
     """Test the state of a PureCoolLink fan."""
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(ENTITY_ID).unique_id == SERIAL
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(ENTITY_ID).unique_id == SERIAL
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON
@@ -128,8 +128,8 @@ async def test_state_purecoollink(
 @pytest.mark.parametrize("device", [DysonPureCool], indirect=True)
 async def test_state_purecool(hass: HomeAssistant, device: DysonPureCool) -> None:
     """Test the state of a PureCool fan."""
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(ENTITY_ID).unique_id == SERIAL
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(ENTITY_ID).unique_id == SERIAL
 
     state = hass.states.get(ENTITY_ID)
     assert state.state == STATE_ON

--- a/tests/components/dyson/test_sensor.py
+++ b/tests/components/dyson/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM, UnitSystem
 
 from .common import (
@@ -120,12 +120,12 @@ async def test_sensors(
     # Make sure no other sensors are set up
     assert len(hass.states.async_all()) == len(sensors)
 
-    er = await entity_registry.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     for sensor in sensors:
         entity_id = _async_get_entity_id(sensor)
 
         # Test unique id
-        assert er.async_get(entity_id).unique_id == f"{SERIAL}-{sensor}"
+        assert entity_registry.async_get(entity_id).unique_id == f"{SERIAL}-{sensor}"
 
         # Test state
         state = hass.states.get(entity_id)

--- a/tests/components/dyson/test_vacuum.py
+++ b/tests/components/dyson/test_vacuum.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .common import (
     ENTITY_NAME,
@@ -45,8 +45,8 @@ def async_get_device(state=Dyson360EyeMode.FULL_CLEAN_RUNNING) -> Dyson360Eye:
 
 async def test_state(hass: HomeAssistant, device: Dyson360Eye) -> None:
     """Test the state of the vacuum."""
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(ENTITY_ID).unique_id == SERIAL
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(ENTITY_ID).unique_id == SERIAL
 
     state = hass.states.get(ENTITY_ID)
     assert state.name == NAME

--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import mock_coro
 from tests.components.elgato import init_integration
@@ -28,7 +29,7 @@ async def test_light_state(
     """Test the creation and values of the Elgato Key Lights."""
     await init_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("light.frenck")

--- a/tests/components/gdacs/test_geo_location.py
+++ b/tests/components/gdacs/test_geo_location.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     LENGTH_KILOMETERS,
 )
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
@@ -99,7 +99,7 @@ async def test_setup(hass, legacy_patchable_time):
         all_states = hass.states.async_all()
         # 3 geolocation and 1 sensor entities
         assert len(all_states) == 4
-        entity_registry = await async_get_registry(hass)
+        entity_registry = er.async_get(hass)
         assert len(entity_registry.entities) == 4
 
         state = hass.states.get("geo_location.drought_name_1")

--- a/tests/components/generic_thermostat/test_climate.py
+++ b/tests/components/generic_thermostat/test_climate.py
@@ -35,6 +35,7 @@ from homeassistant.const import (
 )
 import homeassistant.core as ha
 from homeassistant.core import DOMAIN as HASS_DOMAIN, CoreState, State, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.unit_system import METRIC_SYSTEM
 
@@ -179,7 +180,7 @@ async def test_unique_id(hass, setup_comp_1):
     )
     await hass.async_block_till_done()
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(ENTITY)
     assert entry

--- a/tests/components/geofency/test_init.py
+++ b/tests/components/geofency/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
 
@@ -223,10 +224,10 @@ async def test_gps_enter_and_exit_home(hass, geofency_client, webhook_id):
     ]
     assert NOT_HOME_LONGITUDE == current_longitude
 
-    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == 1
 
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 1
 
 

--- a/tests/components/geonetnz_quakes/test_geo_location.py
+++ b/tests/components/geonetnz_quakes/test_geo_location.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_START,
     LENGTH_KILOMETERS,
 )
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
@@ -75,7 +75,7 @@ async def test_setup(hass):
         all_states = hass.states.async_all()
         # 3 geolocation and 1 sensor entities
         assert len(all_states) == 4
-        entity_registry = await async_get_registry(hass)
+        entity_registry = er.async_get(hass)
         assert len(entity_registry.entities) == 4
 
         state = hass.states.get("geo_location.title_1")

--- a/tests/components/gios/test_air_quality.py
+++ b/tests/components/gios/test_air_quality.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from tests.common import async_fire_time_changed, load_fixture
@@ -32,7 +33,7 @@ from tests.components.gios import init_integration
 async def test_air_quality(hass):
     """Test states of the air_quality."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("air_quality.home")
     assert state
@@ -60,7 +61,7 @@ async def test_air_quality(hass):
 async def test_air_quality_with_incomplete_data(hass):
     """Test states of the air_quality with incomplete data from measuring station."""
     await init_integration(hass, incomplete_data=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("air_quality.home")
     assert state

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
@@ -135,10 +136,10 @@ async def test_enter_and_exit(hass, gpslogger_client, webhook_id):
     state_name = hass.states.get(f"{DEVICE_TRACKER_DOMAIN}.{data['device']}").state
     assert STATE_NOT_HOME == state_name
 
-    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == 1
 
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 1
 
 

--- a/tests/components/harmony/test_init.py
+++ b/tests/components/harmony/test_init.py
@@ -1,7 +1,7 @@
 """Test init of Logitch Harmony Hub integration."""
 from homeassistant.components.harmony.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_NAME
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .const import (
@@ -28,28 +28,28 @@ async def test_unique_id_migration(mock_hc, hass, mock_write_config):
         hass,
         {
             # old format
-            ENTITY_WATCH_TV: entity_registry.RegistryEntry(
+            ENTITY_WATCH_TV: er.RegistryEntry(
                 entity_id=ENTITY_WATCH_TV,
                 unique_id="123443-Watch TV",
                 platform="harmony",
                 config_entry_id=entry.entry_id,
             ),
             # old format, activity name with -
-            ENTITY_NILE_TV: entity_registry.RegistryEntry(
+            ENTITY_NILE_TV: er.RegistryEntry(
                 entity_id=ENTITY_NILE_TV,
                 unique_id="123443-Nile-TV",
                 platform="harmony",
                 config_entry_id=entry.entry_id,
             ),
             # new format
-            ENTITY_PLAY_MUSIC: entity_registry.RegistryEntry(
+            ENTITY_PLAY_MUSIC: er.RegistryEntry(
                 entity_id=ENTITY_PLAY_MUSIC,
                 unique_id=f"activity_{PLAY_MUSIC_ACTIVITY_ID}",
                 platform="harmony",
                 config_entry_id=entry.entry_id,
             ),
             # old entity which no longer has a matching activity on the hub. skipped.
-            "switch.some_other_activity": entity_registry.RegistryEntry(
+            "switch.some_other_activity": er.RegistryEntry(
                 entity_id="switch.some_other_activity",
                 unique_id="123443-Some Other Activity",
                 platform="harmony",
@@ -60,7 +60,7 @@ async def test_unique_id_migration(mock_hc, hass, mock_write_config):
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
 
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     switch_tv = ent_reg.async_get(ENTITY_WATCH_TV)
     assert switch_tv.unique_id == f"activity_{WATCH_TV_ACTIVITY_ID}"

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -53,6 +53,7 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 
@@ -237,8 +238,8 @@ async def test_updates_from_players_changed_new_ids(
 ):
     """Test player updates from changes to available players."""
     await setup_platform(hass, config_entry, config)
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
     player = controller.players[1]
     event = asyncio.Event()
 

--- a/tests/components/homekit/test_type_covers.py
+++ b/tests/components/homekit/test_type_covers.py
@@ -40,7 +40,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import CoreState
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
@@ -446,7 +446,7 @@ async def test_windowcovering_basic_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "cover",
@@ -484,7 +484,7 @@ async def test_windowcovering_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "cover",

--- a/tests/components/homekit/test_type_fans.py
+++ b/tests/components/homekit/test_type_fans.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import CoreState
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
@@ -526,7 +526,7 @@ async def test_fan_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "fan",

--- a/tests/components/homekit/test_type_lights.py
+++ b/tests/components/homekit/test_type_lights.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import CoreState
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
@@ -354,7 +354,7 @@ async def test_light_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create("light", "hue", "1234", suggested_object_id="simple")
     registry.async_get_or_create(

--- a/tests/components/homekit/test_type_media_players.py
+++ b/tests/components/homekit/test_type_media_players.py
@@ -37,7 +37,7 @@ from homeassistant.const import (
     STATE_STANDBY,
 )
 from homeassistant.core import CoreState
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
@@ -421,7 +421,7 @@ async def test_tv_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "media_player",

--- a/tests/components/homekit/test_type_sensors.py
+++ b/tests/components/homekit/test_type_sensors.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import CoreState
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 
 async def test_temperature(hass, hk_driver):
@@ -326,7 +326,7 @@ async def test_sensor_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "sensor",

--- a/tests/components/homekit/test_type_thermostats.py
+++ b/tests/components/homekit/test_type_thermostats.py
@@ -61,7 +61,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import CoreState
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import async_mock_service
 
@@ -889,7 +889,7 @@ async def test_thermostat_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "climate", "generic", "1234", suggested_object_id="simple"
@@ -1705,7 +1705,7 @@ async def test_water_heater_restore(hass, hk_driver, events):
     """Test setting up an entity from state in the event registry."""
     hass.state = CoreState.not_running
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         "water_heater", "generic", "1234", suggested_object_id="simple"

--- a/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
+++ b/tests/components/homekit_controller/specific_devices/test_anker_eufycam.py
@@ -1,4 +1,5 @@
 """Test against characteristics captured from a eufycam."""
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -12,7 +13,7 @@ async def test_eufycam_setup(hass):
     accessories = await setup_accessories_from_file(hass, "anker_eufycam.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Check that the camera is correctly found and set up
     camera_id = "camera.eufycam2_0000"
@@ -32,7 +33,7 @@ async def test_eufycam_setup(hass):
     assert camera_state.state == "idle"
     assert camera_state.attributes["supported_features"] == 0
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(camera.device_id)
     assert device.manufacturer == "Anker"

--- a/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_gateway.py
@@ -5,6 +5,7 @@ https://github.com/home-assistant/core/issues/20957
 """
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -18,7 +19,7 @@ async def test_aqara_gateway_setup(hass):
     accessories = await setup_accessories_from_file(hass, "aqara_gateway.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Check that the light is correctly found and set up
     alarm_id = "alarm_control_panel.aqara_hub_1563"
@@ -48,7 +49,7 @@ async def test_aqara_gateway_setup(hass):
         SUPPORT_BRIGHTNESS | SUPPORT_COLOR
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     # All the entities are services of the same accessory
     # So it looks at the protocol like a single physical device

--- a/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
+++ b/tests/components/homekit_controller/specific_devices/test_aqara_switch.py
@@ -7,6 +7,8 @@ service-label-index despite not being linked to a service-label.
 https://github.com/home-assistant/core/pull/39090
 """
 
+from homeassistant.helpers import entity_registry as er
+
 from tests.common import assert_lists_same, async_get_device_automations
 from tests.components.homekit_controller.common import (
     setup_accessories_from_file,
@@ -19,7 +21,7 @@ async def test_aqara_switch_setup(hass):
     accessories = await setup_accessories_from_file(hass, "aqara_switch.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     battery_id = "sensor.programmable_switch_battery"
     battery = entity_registry.async_get(battery_id)

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -15,6 +15,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -30,7 +31,7 @@ async def test_ecobee3_setup(hass):
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     climate = entity_registry.async_get("climate.homew")
     assert climate.unique_id == "homekit-123456789012-16"
@@ -73,7 +74,7 @@ async def test_ecobee3_setup(hass):
     occ3 = entity_registry.async_get("binary_sensor.basement")
     assert occ3.unique_id == "homekit-AB3C-56"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     climate_device = device_registry.async_get(climate.device_id)
     assert climate_device.manufacturer == "ecobee Inc."
@@ -112,7 +113,7 @@ async def test_ecobee3_setup_from_cache(hass, hass_storage):
 
     await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     climate = entity_registry.async_get("climate.homew")
     assert climate.unique_id == "homekit-123456789012-16"
@@ -131,7 +132,7 @@ async def test_ecobee3_setup_connection_failure(hass):
     """Test that Ecbobee can be correctly setup from its cached entity map."""
     accessories = await setup_accessories_from_file(hass, "ecobee3.json")
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Test that the connection fails during initial setup.
     # No entities should be created.
@@ -170,7 +171,7 @@ async def test_ecobee3_setup_connection_failure(hass):
 
 async def test_ecobee3_add_sensors_at_runtime(hass):
     """Test that new sensors are automatically added."""
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Set up a base Ecobee 3 with no additional sensors.
     # There shouldn't be any entities but climate visible.

--- a/tests/components/homekit_controller/specific_devices/test_ecobee_occupancy.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee_occupancy.py
@@ -4,6 +4,8 @@ Regression tests for Ecobee occupancy.
 https://github.com/home-assistant/core/issues/31827
 """
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
 from tests.components.homekit_controller.common import (
     Helper,
     setup_accessories_from_file,
@@ -16,7 +18,7 @@ async def test_ecobee_occupancy_setup(hass):
     accessories = await setup_accessories_from_file(hass, "ecobee_occupancy.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor = entity_registry.async_get("binary_sensor.master_fan")
     assert sensor.unique_id == "homekit-111111111111-56"
@@ -27,7 +29,7 @@ async def test_ecobee_occupancy_setup(hass):
     sensor_state = await sensor_helper.poll_and_get_state()
     assert sensor_state.attributes["friendly_name"] == "Master Fan"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(sensor.device_id)
     assert device.manufacturer == "ecobee Inc."

--- a/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_homeassistant_bridge.py
@@ -5,6 +5,7 @@ from homeassistant.components.fan import (
     SUPPORT_OSCILLATE,
     SUPPORT_SET_SPEED,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -20,7 +21,7 @@ async def test_homeassistant_bridge_fan_setup(hass):
     )
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Check that the fan is correctly found and set up
     fan_id = "fan.living_room_fan"
@@ -42,7 +43,7 @@ async def test_homeassistant_bridge_fan_setup(hass):
         SUPPORT_DIRECTION | SUPPORT_SET_SPEED | SUPPORT_OSCILLATE
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(fan.device_id)
     assert device.manufacturer == "Home Assistant"

--- a/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
+++ b/tests/components/homekit_controller/specific_devices/test_hue_bridge.py
@@ -1,5 +1,7 @@
 """Tests for handling accessories on a Hue bridge via HomeKit."""
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
 from tests.common import assert_lists_same, async_get_device_automations
 from tests.components.homekit_controller.common import (
     Helper,
@@ -13,7 +15,7 @@ async def test_hue_bridge_setup(hass):
     accessories = await setup_accessories_from_file(hass, "hue_bridge.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Check that the battery is correctly found and set up
     battery_id = "sensor.hue_dimmer_switch_battery"
@@ -28,7 +30,7 @@ async def test_hue_bridge_setup(hass):
     assert battery_state.attributes["icon"] == "mdi:battery"
     assert battery_state.state == "100"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(battery.device_id)
     assert device.manufacturer == "Philips"

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_ls1.py
@@ -8,6 +8,7 @@ from aiohomekit.testing import FakePairing
 import pytest
 
 from homeassistant.components.light import SUPPORT_BRIGHTNESS, SUPPORT_COLOR
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
@@ -25,7 +26,7 @@ async def test_koogeek_ls1_setup(hass):
     accessories = await setup_accessories_from_file(hass, "koogeek_ls1.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Assert that the entity is correctly added to the entity registry
     entry = entity_registry.async_get("light.koogeek_ls1_20833f")
@@ -44,7 +45,7 @@ async def test_koogeek_ls1_setup(hass):
         SUPPORT_BRIGHTNESS | SUPPORT_COLOR
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(entry.device_id)
     assert device.manufacturer == "Koogeek"

--- a/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
+++ b/tests/components/homekit_controller/specific_devices/test_koogeek_p1eu.py
@@ -1,5 +1,7 @@
 """Make sure that existing Koogeek P1EU support isn't broken."""
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
 from tests.components.homekit_controller.common import (
     Helper,
     setup_accessories_from_file,
@@ -12,8 +14,8 @@ async def test_koogeek_p1eu_setup(hass):
     accessories = await setup_accessories_from_file(hass, "koogeek_p1eu.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
 
     # Check that the switch entity is handled correctly
 

--- a/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
+++ b/tests/components/homekit_controller/specific_devices/test_lennox_e30.py
@@ -8,6 +8,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -21,7 +22,7 @@ async def test_lennox_e30_setup(hass):
     accessories = await setup_accessories_from_file(hass, "lennox_e30.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     climate = entity_registry.async_get("climate.lennox")
     assert climate.unique_id == "homekit-XXXXXXXX-100"
@@ -35,7 +36,7 @@ async def test_lennox_e30_setup(hass):
         SUPPORT_TARGET_TEMPERATURE | SUPPORT_TARGET_TEMPERATURE_RANGE
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(climate.device_id)
     assert device.manufacturer == "Lennox"

--- a/tests/components/homekit_controller/specific_devices/test_lg_tv.py
+++ b/tests/components/homekit_controller/specific_devices/test_lg_tv.py
@@ -5,6 +5,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_SELECT_SOURCE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import async_get_device_automations
 from tests.components.homekit_controller.common import (
@@ -19,7 +20,7 @@ async def test_lg_tv(hass):
     accessories = await setup_accessories_from_file(hass, "lg_tv.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Assert that the entity is correctly added to the entity registry
     entry = entity_registry.async_get("media_player.lg_webos_tv_af80")
@@ -54,7 +55,7 @@ async def test_lg_tv(hass):
     # CURRENT_MEDIA_STATE. Therefore "ok" is the best we can say.
     assert state.state == "ok"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(entry.device_id)
     assert device.manufacturer == "LG Electronics"

--- a/tests/components/homekit_controller/specific_devices/test_rainmachine_pro_8.py
+++ b/tests/components/homekit_controller/specific_devices/test_rainmachine_pro_8.py
@@ -4,6 +4,8 @@ Make sure that existing RainMachine support isn't broken.
 https://github.com/home-assistant/core/issues/31745
 """
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
 from tests.components.homekit_controller.common import (
     Helper,
     setup_accessories_from_file,
@@ -16,7 +18,7 @@ async def test_rainmachine_pro_8_setup(hass):
     accessories = await setup_accessories_from_file(hass, "rainmachine-pro-8.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Assert that the entity is correctly added to the entity registry
     entry = entity_registry.async_get("switch.rainmachine_00ce4a")
@@ -30,7 +32,7 @@ async def test_rainmachine_pro_8_setup(hass):
     # Assert that the friendly name is detected correctly
     assert state.attributes["friendly_name"] == "RainMachine-00ce4a"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(entry.device_id)
     assert device.manufacturer == "Green Electronics LLC"

--- a/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
+++ b/tests/components/homekit_controller/specific_devices/test_simpleconnect_fan.py
@@ -5,6 +5,7 @@ https://github.com/home-assistant/core/issues/26180
 """
 
 from homeassistant.components.fan import SUPPORT_DIRECTION, SUPPORT_SET_SPEED
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -18,7 +19,7 @@ async def test_simpleconnect_fan_setup(hass):
     accessories = await setup_accessories_from_file(hass, "simpleconnect_fan.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Check that the fan is correctly found and set up
     fan_id = "fan.simpleconnect_fan_06f674"
@@ -40,7 +41,7 @@ async def test_simpleconnect_fan_setup(hass):
         SUPPORT_DIRECTION | SUPPORT_SET_SPEED
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(fan.device_id)
     assert device.manufacturer == "Hunter Fan"

--- a/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
+++ b/tests/components/homekit_controller/specific_devices/test_velux_gateway.py
@@ -9,6 +9,7 @@ from homeassistant.components.cover import (
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.homekit_controller.common import (
     Helper,
@@ -22,7 +23,7 @@ async def test_simpleconnect_cover_setup(hass):
     accessories = await setup_accessories_from_file(hass, "velux_gateway.json")
     config_entry, pairing = await setup_test_accessories(hass, accessories)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Check that the cover is correctly found and set up
     cover_id = "cover.velux_window"
@@ -64,7 +65,7 @@ async def test_simpleconnect_cover_setup(hass):
     # The cover and sensor are different devices (accessories) attached to the same bridge
     assert cover.device_id != sensor.device_id
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     device = device_registry.async_get(cover.device_id)
     assert device.manufacturer == "VELUX"

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -5,6 +5,7 @@ import pytest
 
 import homeassistant.components.automation as automation
 from homeassistant.components.homekit_controller.const import DOMAIN
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -82,10 +83,10 @@ async def test_enumerate_remote(hass, utcnow):
     """Test that remote is correctly enumerated."""
     await setup_test_component(hass, create_remote)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     expected = [
@@ -118,10 +119,10 @@ async def test_enumerate_button(hass, utcnow):
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_button)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     expected = [
@@ -153,10 +154,10 @@ async def test_enumerate_doorbell(hass, utcnow):
     """Test that a button is correctly enumerated."""
     await setup_test_component(hass, create_doorbell)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     expected = [
@@ -188,10 +189,10 @@ async def test_handle_events(hass, utcnow, calls):
     """Test that events are handled."""
     helper = await setup_test_component(hass, create_remote)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("sensor.testdevice_battery")
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert await async_setup_component(

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -41,8 +41,8 @@ async def test_hmip_remove_device(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
     assert hmip_device
 
-    device_registry = await dr.async_get_registry(hass)
-    entity_registry = await er.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
@@ -73,8 +73,8 @@ async def test_hmip_add_device(hass, default_mock_hap_factory, hmip_config_entry
     assert ha_state.state == STATE_ON
     assert hmip_device
 
-    device_registry = await dr.async_get_registry(hass)
-    entity_registry = await er.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
@@ -119,8 +119,8 @@ async def test_hmip_remove_group(hass, default_mock_hap_factory):
     assert ha_state.state == STATE_ON
     assert hmip_device
 
-    device_registry = await dr.async_get_registry(hass)
-    entity_registry = await er.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     pre_device_count = len(device_registry.devices)
     pre_entity_count = len(entity_registry.entities)
@@ -257,12 +257,12 @@ async def test_hmip_multi_area_device(hass, default_mock_hap_factory):
     assert ha_state
 
     # get the entity
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(ha_state.entity_id)
     assert entity
 
     # get the device
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entity.device_id)
     assert device.name == "Wired Eingangsmodul – 32-fach"
 

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -7,12 +7,7 @@ import aiohue
 from homeassistant import config_entries
 from homeassistant.components import hue
 from homeassistant.components.hue import light as hue_light
-from homeassistant.helpers.device_registry import (
-    async_get_registry as async_get_device_registry,
-)
-from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import color
 
 HUE_LIGHT_NS = "homeassistant.components.light.hue."
@@ -937,8 +932,8 @@ async def test_group_features(hass, mock_bridge):
     group_3 = hass.states.get("light.dining_room")
     assert group_3.attributes["supported_features"] == extended_color_feature
 
-    entity_registry = await async_get_entity_registry(hass)
-    device_registry = await async_get_device_registry(hass)
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
 
     entry = entity_registry.async_get("light.hue_lamp_1")
     device_entry = device_registry.async_get(entry.device_id)

--- a/tests/components/hyperion/test_light.py
+++ b/tests/components/hyperion/test_light.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
 
@@ -109,7 +109,7 @@ async def test_setup_config_entry_not_ready_load_state_fail(
 
 async def test_setup_config_entry_dynamic_instances(hass: HomeAssistantType) -> None:
     """Test dynamic changes in the instance configuration."""
-    registry = await async_get_registry(hass)
+    registry = er.async_get(hass)
 
     config_entry = add_test_config_entry(hass)
 

--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import Context, CoreState, State
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_restore_cache
@@ -192,7 +192,7 @@ async def test_input_boolean_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -313,7 +313,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -28,7 +28,7 @@ from homeassistant.components.input_datetime import (
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_NAME
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -415,7 +415,7 @@ async def test_input_datetime_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -544,7 +544,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.datetime_from_storage"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -570,7 +570,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.datetime_from_storage"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "datetime from storage"
@@ -602,7 +602,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_datetime"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache
@@ -300,7 +300,7 @@ async def test_input_number_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -442,7 +442,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -478,7 +478,7 @@ async def test_update_min_max(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -518,7 +518,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
@@ -425,7 +425,7 @@ async def test_input_select_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -559,7 +559,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -592,7 +592,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
@@ -633,7 +633,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
@@ -393,7 +393,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -419,7 +419,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
@@ -457,7 +457,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 from homeassistant.components.ipma import DOMAIN, config_flow
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .test_weather import MockLocation
@@ -143,13 +143,13 @@ async def test_config_entry_migration(hass):
     mock_registry(
         hass,
         {
-            "weather.hometown": entity_registry.RegistryEntry(
+            "weather.hometown": er.RegistryEntry(
                 entity_id="weather.hometown",
                 unique_id="0, 0",
                 platform="ipma",
                 config_entry_id=ipma_entry.entry_id,
             ),
-            "weather.hometown_2": entity_registry.RegistryEntry(
+            "weather.hometown_2": er.RegistryEntry(
                 entity_id="weather.hometown_2",
                 unique_id="0, 0, hourly",
                 platform="ipma",
@@ -165,7 +165,7 @@ async def test_config_entry_migration(hass):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
-        ent_reg = await entity_registry.async_get_registry(hass)
+        ent_reg = er.async_get(hass)
 
         weather_home = ent_reg.async_get("weather.hometown")
         assert weather_home.unique_id == "0, 0, daily"

--- a/tests/components/ipp/test_sensor.py
+++ b/tests/components/ipp/test_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.ipp.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ICON, ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from tests.components.ipp import init_integration, mock_connection
@@ -19,7 +20,7 @@ async def test_sensors(
     mock_connection(aioclient_mock)
 
     entry = await init_integration(hass, aioclient_mock, skip_setup=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
@@ -86,7 +87,7 @@ async def test_disabled_by_default_sensors(
 ) -> None:
     """Test the disabled by default IPP sensors."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.epson_xp_6000_series_uptime")
     assert state is None
@@ -102,7 +103,7 @@ async def test_missing_entry_unique_id(
 ) -> None:
     """Test the unique_id of IPP sensor when printer is missing identifiers."""
     entry = await init_integration(hass, aioclient_mock, uuid=None, unique_id=None)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entity = registry.async_get("sensor.epson_xp_6000_series")
     assert entity

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components import jewish_calendar
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -84,7 +85,7 @@ async def test_issur_melacha_sensor(
     hass.config.latitude = latitude
     hass.config.longitude = longitude
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     with alter_time(test_time):
         assert await async_setup_component(

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -4,6 +4,7 @@ from datetime import datetime as dt, timedelta
 import pytest
 
 from homeassistant.components import jewish_calendar
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -511,7 +512,7 @@ async def test_shabbat_times_sensor(
     hass.config.latitude = latitude
     hass.config.longitude = longitude
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     with alter_time(test_time):
         assert await async_setup_component(

--- a/tests/components/litejet/__init__.py
+++ b/tests/components/litejet/__init__.py
@@ -2,6 +2,7 @@
 from homeassistant.components import scene, switch
 from homeassistant.components.litejet import DOMAIN
 from homeassistant.const import CONF_PORT
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -11,7 +12,7 @@ async def async_init_integration(
 ) -> MockConfigEntry:
     """Set up the LiteJet integration in Home Assistant."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry_data = {CONF_PORT: "/dev/mock"}
 

--- a/tests/components/litejet/test_scene.py
+++ b/tests/components/litejet/test_scene.py
@@ -1,6 +1,7 @@
 """The tests for the litejet component."""
 from homeassistant.components import scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 
 from . import async_init_integration
 
@@ -14,7 +15,7 @@ async def test_disabled_by_default(hass, mock_litejet):
     """Test the scene is disabled by default."""
     await async_init_integration(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get(ENTITY_SCENE)
     assert state is None

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     PERCENTAGE,
     PRESSURE_PSI,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.components.mazda import init_integration
@@ -19,7 +20,7 @@ async def test_device_nickname(hass):
     """Test creation of the device when vehicle has a nickname."""
     await init_integration(hass, use_nickname=True)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={(DOMAIN, "JM000000000000000")},
     )
@@ -33,7 +34,7 @@ async def test_device_no_nickname(hass):
     """Test creation of the device when vehicle has no nickname."""
     await init_integration(hass, use_nickname=False)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={(DOMAIN, "JM000000000000000")},
     )
@@ -47,7 +48,7 @@ async def test_sensors(hass):
     """Test creation of the sensors."""
     await init_integration(hass)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Fuel Remaining Percentage
     state = hass.states.get("sensor.my_mazda3_fuel_remaining_percentage")

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.met import DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 
 async def test_tracking_home(hass, mock_weather):
@@ -12,7 +13,7 @@ async def test_tracking_home(hass, mock_weather):
     assert len(mock_weather.mock_calls) == 4
 
     # Test the hourly sensor is disabled by default
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("weather.test_home_hourly")
     assert state is None
@@ -38,7 +39,7 @@ async def test_not_tracking_home(hass, mock_weather):
     """Test when we not track home."""
 
     # Pre-create registry entry for disabled by default hourly weather
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from homeassistant.components import mikrotik
 import homeassistant.components.device_tracker as device_tracker
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -101,7 +101,7 @@ async def test_restoring_devices(hass):
     )
     config_entry.add_to_hass(hass)
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         device_tracker.DOMAIN,
         mikrotik.DOMAIN,

--- a/tests/components/mobile_app/test_binary_sensor.py
+++ b/tests/components/mobile_app/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Entity tests for mobile_app."""
 from homeassistant.const import STATE_OFF
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 
 
 async def test_sensor(hass, create_registrations, webhook_client):
@@ -70,7 +70,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert updated_entity.state == "off"
     assert "foo" not in updated_entity.attributes
 
-    dev_reg = await device_registry.async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == len(create_registrations)
 
     # Reload to verify state is restored

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the mobile app integration."""
 from homeassistant.components.mobile_app.const import DATA_DELETED_IDS, DOMAIN
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CALL_SERVICE
 
@@ -30,8 +31,8 @@ async def test_remove_entry(hass, create_registrations):
         await hass.config_entries.async_remove(config_entry.entry_id)
         assert config_entry.data["webhook_id"] in hass.data[DOMAIN][DATA_DELETED_IDS]
 
-    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == 0
 
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 0

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -1,6 +1,6 @@
 """Entity tests for mobile_app."""
 from homeassistant.const import PERCENTAGE, STATE_UNKNOWN
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 
 
 async def test_sensor(hass, create_registrations, webhook_client):
@@ -68,7 +68,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert updated_entity.state == "123"
     assert "foo" not in updated_entity.attributes
 
-    dev_reg = await device_registry.async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == len(create_registrations)
 
     # Reload to verify state is restored

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from tests.common import MockConfigEntry
@@ -497,7 +498,7 @@ async def test_first_run_with_available_zones(hass):
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get(ZONE_7_ID)
     assert not entry.disabled
@@ -510,7 +511,7 @@ async def test_first_run_with_failing_zones(hass):
     with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
         await _setup_monoprice(hass, monoprice)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get(ZONE_1_ID)
     assert not entry.disabled
@@ -527,7 +528,7 @@ async def test_not_first_run_with_failing_zone(hass):
     with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
         await _setup_monoprice_not_first_run(hass, monoprice)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get(ZONE_1_ID)
     assert not entry.disabled

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -8,6 +8,7 @@ from homeassistant.components import mqtt
 from homeassistant.components.mqtt import debug_info
 from homeassistant.components.mqtt.const import MQTT_DISCONNECTED
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
@@ -725,7 +726,7 @@ async def help_test_entity_device_info_with_identifier(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -750,7 +751,7 @@ async def help_test_entity_device_info_with_connection(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_MAC)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -772,8 +773,8 @@ async def help_test_entity_device_info_remove(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    dev_registry = await hass.helpers.device_registry.async_get_registry()
-    ent_registry = await hass.helpers.entity_registry.async_get_registry()
+    dev_registry = dr.async_get(hass)
+    ent_registry = er.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -801,7 +802,7 @@ async def help_test_entity_device_info_update(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -913,7 +914,7 @@ async def help_test_entity_debug_info(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -946,7 +947,7 @@ async def help_test_entity_debug_info_max_messages(hass, mqtt_mock, domain, conf
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -1008,7 +1009,7 @@ async def help_test_entity_debug_info_message(
     if payload is None:
         payload = "ON"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -1054,7 +1055,7 @@ async def help_test_entity_debug_info_remove(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -1097,7 +1098,7 @@ async def help_test_entity_debug_info_update_entity_id(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    dev_registry = await hass.helpers.device_registry.async_get_registry()
+    dev_registry = dr.async_get(hass)
     ent_registry = mock_registry(hass, {})
 
     data = json.dumps(config)

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -6,6 +6,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.mqtt import DOMAIN, debug_info
 from homeassistant.components.mqtt.device_trigger import async_attach_trigger
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -836,7 +837,7 @@ async def test_attach_remove_late2(hass, device_reg, mqtt_mock):
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -867,7 +868,7 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock):
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -898,7 +899,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
 
 async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     config = {
         "automation_type": "trigger",
@@ -1159,7 +1160,7 @@ async def test_trigger_debug_info(hass, mqtt_mock):
 
     This is a test helper for MQTT debug_info.
     """
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     config = {
         "platform": "mqtt",

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -1058,7 +1058,7 @@ async def test_mqtt_ws_remove_non_mqtt_device(
 
     device_entry = device_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     assert device_entry is not None
 
@@ -1157,7 +1157,7 @@ async def test_debug_info_multiple_devices(hass, mqtt_mock):
         },
     ]
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     for d in devices:
         data = json.dumps(d["config"])
@@ -1236,7 +1236,7 @@ async def test_debug_info_multiple_entities_triggers(hass, mqtt_mock):
         },
     ]
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     for c in config:
         data = json.dumps(c["config"])
@@ -1284,7 +1284,7 @@ async def test_debug_info_non_mqtt(hass, device_reg, entity_reg):
     config_entry.add_to_hass(hass)
     device_entry = device_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for device_class in DEVICE_CLASSES:
         entity_reg.async_get_or_create(
@@ -1311,7 +1311,7 @@ async def test_debug_info_wildcard(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
@@ -1357,7 +1357,7 @@ async def test_debug_info_filter_same(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
@@ -1416,7 +1416,7 @@ async def test_debug_info_same_topic(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
@@ -1467,7 +1467,7 @@ async def test_debug_info_qos_retain(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -9,6 +9,7 @@ import pytest
 import homeassistant.components.sensor as sensor
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
 import homeassistant.core as ha
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -574,7 +575,7 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock):
 
 async def test_entity_device_info_with_hub(hass, mqtt_mock):
     """Test MQTT sensor device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     hub = registry.async_get_or_create(
         config_entry_id="123",
         connections=set(),

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -5,6 +5,8 @@ from unittest.mock import ANY, patch
 
 import pytest
 
+from homeassistant.helpers import device_registry as dr
+
 from tests.common import (
     async_fire_mqtt_message,
     async_get_device_automations,
@@ -378,7 +380,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -406,7 +408,7 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock):
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -434,7 +436,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
 
 async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     config = {
         "topic": "test-topic",

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -16,6 +16,7 @@ import pytest
 from homeassistant.components import camera
 from homeassistant.components.camera import STATE_IDLE
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -168,13 +169,13 @@ async def test_camera_device(hass):
     assert camera is not None
     assert camera.state == STATE_IDLE
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.my_camera")
     assert entry.unique_id == "some-device-id-camera"
     assert entry.original_name == "My Camera"
     assert entry.domain == "camera"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Camera"
     assert device.model == "Camera"

--- a/tests/components/nest/sensor_sdm_test.py
+++ b/tests/components/nest/sensor_sdm_test.py
@@ -8,6 +8,8 @@ pubsub subscriber.
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
 from .common import async_setup_sdm_platform
 
 PLATFORM = "sensor"
@@ -52,13 +54,13 @@ async def test_thermostat_device(hass):
     assert humidity is not None
     assert humidity.state == "35.0"
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.my_sensor_temperature")
     assert entry.unique_id == "some-device-id-temperature"
     assert entry.original_name == "My Sensor Temperature"
     assert entry.domain == "sensor"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Sensor"
     assert device.model == "Thermostat"
@@ -197,13 +199,13 @@ async def test_device_with_unknown_type(hass):
     assert temperature is not None
     assert temperature.state == "25.1"
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.my_sensor_temperature")
     assert entry.unique_id == "some-device-id-temperature"
     assert entry.original_name == "My Sensor Temperature"
     assert entry.domain == "sensor"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Sensor"
     assert device.model is None

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.nest import DOMAIN
 from homeassistant.components.nest.events import NEST_EVENT
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -101,7 +102,7 @@ async def test_get_triggers(hass):
     )
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
 
     expected_triggers = [
@@ -140,7 +141,7 @@ async def test_multiple_devices(hass):
     )
     await async_setup_camera(hass, {"device-id-1": camera1, "device-id-2": camera2})
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry1 = registry.async_get("camera.camera_1")
     assert entry1.unique_id == "device-id-1-camera"
     entry2 = registry.async_get("camera.camera_2")
@@ -176,7 +177,7 @@ async def test_triggers_for_invalid_device_id(hass):
     )
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
     assert device_entry is not None
 
@@ -198,7 +199,7 @@ async def test_no_triggers(hass):
     camera = make_camera(device_id=DEVICE_ID, traits={})
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.my_camera")
     assert entry.unique_id == "some-device-id-camera"
 
@@ -288,7 +289,7 @@ async def test_subscriber_automation(hass, calls):
     )
     subscriber = await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -7,6 +7,7 @@ pubsub subscriber.
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from .common import async_setup_sdm_platform
@@ -91,14 +92,14 @@ async def test_doorbell_chime_event(hass):
         create_device_traits("sdm.devices.traits.DoorbellChime"),
     )
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
     assert entry.unique_id == "some-device-id-camera"
     assert entry.original_name == "Front"
     assert entry.domain == "camera"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "Front"
     assert device.model == "Doorbell"
@@ -127,7 +128,7 @@ async def test_camera_motion_event(hass):
         "sdm.devices.types.CAMERA",
         create_device_traits("sdm.devices.traits.CameraMotion"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 
@@ -154,7 +155,7 @@ async def test_camera_sound_event(hass):
         "sdm.devices.types.CAMERA",
         create_device_traits("sdm.devices.traits.CameraSound"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 
@@ -181,7 +182,7 @@ async def test_camera_person_event(hass):
         "sdm.devices.types.DOORBELL",
         create_device_traits("sdm.devices.traits.CameraEventImage"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 
@@ -208,7 +209,7 @@ async def test_camera_multiple_event(hass):
         "sdm.devices.types.DOORBELL",
         create_device_traits("sdm.devices.traits.CameraEventImage"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -1,6 +1,7 @@
 """The sensor tests for the nut platform."""
 
 from homeassistant.const import PERCENTAGE
+from homeassistant.helpers import entity_registry as er
 
 from .util import async_init_integration
 
@@ -9,7 +10,7 @@ async def test_pr3000rt2u(hass):
     """Test creation of PR3000RT2U sensors."""
 
     await async_init_integration(hass, "PR3000RT2U", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == "CPS_PR3000RT2U_PYVJO2000034_battery.charge"
@@ -35,7 +36,7 @@ async def test_cp1350c(hass):
 
     config_entry = await async_init_integration(hass, "CP1350C", ["battery.charge"])
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -60,7 +61,7 @@ async def test_5e850i(hass):
     """Test creation of 5E850I sensors."""
 
     config_entry = await async_init_integration(hass, "5E850I", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -85,7 +86,7 @@ async def test_5e650i(hass):
     """Test creation of 5E650I sensors."""
 
     config_entry = await async_init_integration(hass, "5E650I", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -110,7 +111,7 @@ async def test_backupsses600m1(hass):
     """Test creation of BACKUPSES600M1 sensors."""
 
     await async_init_integration(hass, "BACKUPSES600M1", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert (
@@ -140,7 +141,7 @@ async def test_cp1500pfclcd(hass):
     config_entry = await async_init_integration(
         hass, "CP1500PFCLCD", ["battery.charge"]
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -165,7 +166,7 @@ async def test_dl650elcd(hass):
     """Test creation of DL650ELCD sensors."""
 
     config_entry = await async_init_integration(hass, "DL650ELCD", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -190,7 +191,7 @@ async def test_blazer_usb(hass):
     """Test creation of blazer_usb sensors."""
 
     config_entry = await async_init_integration(hass, "blazer_usb", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -12,6 +12,7 @@ from homeassistant.components.weather import (
     DOMAIN as WEATHER_DOMAIN,
 )
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
@@ -40,7 +41,7 @@ async def test_imperial_metric(
 ):
     """Test with imperial and metric units."""
     # enable the hourly entity
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         WEATHER_DOMAIN,
         nws.DOMAIN,
@@ -284,7 +285,7 @@ async def test_error_forecast_hourly(hass, mock_simple_nws):
     instance.update_forecast_hourly.side_effect = aiohttp.ClientError
 
     # enable the hourly entity
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         WEATHER_DOMAIN,
         nws.DOMAIN,
@@ -330,7 +331,7 @@ async def test_forecast_hourly_disable_enable(hass, mock_simple_nws):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get_or_create(
         WEATHER_DOMAIN,
         nws.DOMAIN,

--- a/tests/components/nzbget/test_sensor.py
+++ b/tests/components/nzbget/test_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     DATA_RATE_MEGABYTES_PER_SECOND,
     DEVICE_CLASS_TIMESTAMP,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import init_integration
@@ -19,7 +20,7 @@ async def test_sensors(hass, nzbget_api) -> None:
     with patch("homeassistant.components.nzbget.sensor.utcnow", return_value=now):
         entry = await init_integration(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     uptime = now - timedelta(seconds=600)
 

--- a/tests/components/nzbget/test_switch.py
+++ b/tests/components/nzbget/test_switch.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
@@ -18,7 +19,7 @@ async def test_download_switch(hass, nzbget_api) -> None:
     entry = await init_integration(hass)
     assert entry
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = "switch.nzbgettest_download"
     entity_entry = registry.async_get(entity_id)
     assert entity_entry

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components import onboarding
 from homeassistant.components.onboarding import const, views
 from homeassistant.const import HTTP_FORBIDDEN
+from homeassistant.helpers import area_registry as ar
 from homeassistant.setup import async_setup_component
 
 from . import mock_storage
@@ -181,7 +182,7 @@ async def test_onboarding_user(hass, hass_storage, aiohttp_client):
     )
 
     # Validate created areas
-    area_registry = await hass.helpers.area_registry.async_get_registry()
+    area_registry = ar.async_get(hass)
     assert len(area_registry.areas) == 3
     assert sorted([area.name for area in area_registry.async_list_areas()]) == [
         "Bedroom",

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -6,6 +6,7 @@ from pyotgw.vars import OTGW, OTGW_ABOUT
 from homeassistant import setup
 from homeassistant.components.opentherm_gw.const import DOMAIN
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_NAME
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry, mock_device_registry
 
@@ -38,7 +39,7 @@ async def test_device_registry_insert(hass):
 
     await hass.async_block_till_done()
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     gw_dev = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_GATEWAY_ID)})
     assert gw_dev.sw_version == VERSION_OLD

--- a/tests/components/ozw/test_binary_sensor.py
+++ b/tests/components/ozw/test_binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.components.ozw.const import DOMAIN
 from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_ozw
 
@@ -14,7 +15,7 @@ async def test_binary_sensor(hass, generic_data, binary_sensor_msg):
     receive_msg = await setup_ozw(hass, fixture=generic_data)
 
     # Test Legacy sensor (disabled by default)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = "binary_sensor.trisensor_sensor"
     state = hass.states.get(entity_id)
     assert state is None
@@ -46,7 +47,7 @@ async def test_binary_sensor(hass, generic_data, binary_sensor_msg):
 async def test_sensor_enabled(hass, generic_data, binary_sensor_alt_msg):
     """Test enabling a legacy binary_sensor."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get_or_create(
         BINARY_SENSOR_DOMAIN,

--- a/tests/components/ozw/test_migration.py
+++ b/tests/components/ozw/test_migration.py
@@ -4,14 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.ozw.websocket_api import ID, TYPE
-from homeassistant.helpers.device_registry import (
-    DeviceEntry,
-    async_get_registry as async_get_device_registry,
-)
-from homeassistant.helpers.entity_registry import (
-    RegistryEntry,
-    async_get_registry as async_get_entity_registry,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import setup_ozw
 
@@ -41,35 +34,35 @@ ZWAVE_POWER_ICON = "mdi:zwave-test-power"
 @pytest.fixture(name="zwave_migration_data")
 def zwave_migration_data_fixture(hass):
     """Return mock zwave migration data."""
-    zwave_source_node_device = DeviceEntry(
+    zwave_source_node_device = dr.DeviceEntry(
         id=ZWAVE_SOURCE_NODE_DEVICE_ID,
         name_by_user=ZWAVE_SOURCE_NODE_DEVICE_NAME,
         area_id=ZWAVE_SOURCE_NODE_DEVICE_AREA,
     )
-    zwave_source_node_entry = RegistryEntry(
+    zwave_source_node_entry = er.RegistryEntry(
         entity_id=ZWAVE_SOURCE_ENTITY,
         unique_id=ZWAVE_SOURCE_NODE_UNIQUE_ID,
         platform="zwave",
         name="Z-Wave Source Node",
     )
-    zwave_battery_device = DeviceEntry(
+    zwave_battery_device = dr.DeviceEntry(
         id=ZWAVE_BATTERY_DEVICE_ID,
         name_by_user=ZWAVE_BATTERY_DEVICE_NAME,
         area_id=ZWAVE_BATTERY_DEVICE_AREA,
     )
-    zwave_battery_entry = RegistryEntry(
+    zwave_battery_entry = er.RegistryEntry(
         entity_id=ZWAVE_BATTERY_ENTITY,
         unique_id=ZWAVE_BATTERY_UNIQUE_ID,
         platform="zwave",
         name=ZWAVE_BATTERY_NAME,
         icon=ZWAVE_BATTERY_ICON,
     )
-    zwave_power_device = DeviceEntry(
+    zwave_power_device = dr.DeviceEntry(
         id=ZWAVE_POWER_DEVICE_ID,
         name_by_user=ZWAVE_POWER_DEVICE_NAME,
         area_id=ZWAVE_POWER_DEVICE_AREA,
     )
-    zwave_power_entry = RegistryEntry(
+    zwave_power_entry = er.RegistryEntry(
         entity_id=ZWAVE_POWER_ENTITY,
         unique_id=ZWAVE_POWER_UNIQUE_ID,
         platform="zwave",
@@ -169,8 +162,8 @@ async def test_migrate_zwave(hass, migration_data, hass_ws_client, zwave_integra
     assert result["migration_entity_map"] == migration_entity_map
     assert result["migrated"] is True
 
-    dev_reg = await async_get_device_registry(hass)
-    ent_reg = await async_get_entity_registry(hass)
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
 
     # check the device registry migration
 
@@ -252,7 +245,7 @@ async def test_migrate_zwave_dry_run(
     assert result["migration_entity_map"] == migration_entity_map
     assert result["migrated"] is False
 
-    ent_reg = await async_get_entity_registry(hass)
+    ent_reg = er.async_get(hass)
 
     # no real migration should have been done
     assert ent_reg.async_is_registered("sensor.water_sensor_6_battery_level")

--- a/tests/components/ozw/test_sensor.py
+++ b/tests/components/ozw/test_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
 )
 from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_ozw
 
@@ -34,7 +35,7 @@ async def test_sensor(hass, generic_data):
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_POWER
 
     # Test ZWaveListSensor disabled by default
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = "sensor.water_sensor_6_instance_1_water"
     state = hass.states.get(entity_id)
     assert state is None
@@ -55,7 +56,7 @@ async def test_sensor(hass, generic_data):
 async def test_sensor_enabled(hass, generic_data, sensor_msg):
     """Test enabling an advanced sensor."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get_or_create(
         SENSOR_DOMAIN,
@@ -79,7 +80,7 @@ async def test_sensor_enabled(hass, generic_data, sensor_msg):
 async def test_string_sensor(hass, string_sensor_data):
     """Test so the returned type is a string sensor."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get_or_create(
         SENSOR_DOMAIN,

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, CoreState, State
-from homeassistant.helpers import collection, entity_registry
+from homeassistant.helpers import collection, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_restore_cache
@@ -589,7 +589,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     assert resp["success"]
     assert len(hass.states.async_entity_ids("person")) == 0
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert not ent_reg.async_is_registered("person.tracked_person")
 
 
@@ -681,7 +681,7 @@ async def test_update_person_when_user_removed(
 async def test_removing_device_tracker(hass, storage_setup):
     """Test we automatically remove removed device trackers."""
     storage_collection = hass.data[DOMAIN][1]
-    reg = await entity_registry.async_get_registry(hass)
+    reg = er.async_get(hass)
     entry = reg.async_get_or_create(
         "device_tracker", "mobile_app", "bla", suggested_object_id="pixel"
     )

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -1,9 +1,9 @@
 """The sensor tests for the powerwall platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, PERCENTAGE
+from homeassistant.helpers import device_registry as dr
 
 from .mocks import _mock_powerwall_with_fixtures
 
@@ -26,7 +26,7 @@ async def test_sensors(hass):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={("powerwall", "TG0123456789AB_TG9876543210BA")},
     )

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -7,7 +7,7 @@ from pytz import timezone
 from homeassistant import data_entry_flow
 from homeassistant.components.pvpc_hourly_pricing import ATTR_TARIFF, DOMAIN
 from homeassistant.const import CONF_NAME
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import check_valid_state
 
@@ -60,7 +60,7 @@ async def test_config_flow(
         assert pvpc_aioclient_mock.call_count == 1
 
         # Check removal
-        registry = await entity_registry.async_get_registry(hass)
+        registry = er.async_get(hass)
         registry_entity = registry.async_get("sensor.test")
         assert await hass.config_entries.async_remove(registry_entity.config_entry_id)
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -6,13 +6,7 @@ import serial.tools.list_ports
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.rfxtrx import DOMAIN, config_flow
-from homeassistant.helpers.device_registry import (
-    async_entries_for_config_entry,
-    async_get_registry as async_get_device_registry,
-)
-from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -610,8 +604,8 @@ async def test_options_add_remove_device(hass):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
 
@@ -704,8 +698,8 @@ async def test_options_replace_sensor_device(hass):
     )
     assert state
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     old_device = next(
         (
@@ -751,7 +745,7 @@ async def test_options_replace_sensor_device(hass):
 
     await hass.async_block_till_done()
 
-    entity_registry = await async_get_entity_registry(hass)
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
@@ -843,8 +837,8 @@ async def test_options_replace_control_device(hass):
     state = hass.states.get("switch.ac_1118cdea_2")
     assert state
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     old_device = next(
         (
@@ -890,7 +884,7 @@ async def test_options_replace_control_device(hass):
 
     await hass.async_block_till_done()
 
-    entity_registry = await async_get_entity_registry(hass)
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("binary_sensor.ac_118cdea_2")
     assert entry
@@ -941,8 +935,8 @@ async def test_options_remove_multiple_devices(hass):
     state = hass.states.get("binary_sensor.ac_1118cdea_2")
     assert state
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert len(device_entries) == 3
 
@@ -1061,8 +1055,8 @@ async def test_options_add_and_configure_device(hass):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "PT2262 22670e"
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
 
@@ -1151,8 +1145,8 @@ async def test_options_configure_rfy_cover_device(hass):
 
     assert entry.data["devices"]["071a000001020301"]["venetian_blind_mode"] == "EU"
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
 

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -5,10 +5,7 @@ from unittest.mock import call
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import (
-    DeviceRegistry,
-    async_get_registry as async_get_device_registry,
-)
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -79,7 +76,7 @@ async def test_fire_event(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
-    device_registry: DeviceRegistry = await async_get_device_registry(hass)
+    device_registry: dr.DeviceRegistry = dr.async_get(hass)
 
     calls = []
 

--- a/tests/components/ring/test_light.py
+++ b/tests/components/ring/test_light.py
@@ -1,5 +1,6 @@
 """The tests for the Ring light platform."""
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -9,7 +10,7 @@ from tests.common import load_fixture
 async def test_entity_registry(hass, requests_mock):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, LIGHT_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("light.front_light")
     assert entry.unique_id == 765432

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -1,5 +1,6 @@
 """The tests for the Ring switch platform."""
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -9,7 +10,7 @@ from tests.common import load_fixture
 async def test_entity_registry(hass, requests_mock):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, SWITCH_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("switch.front_siren")
     assert entry.unique_id == "765432-siren"

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from .util import TEST_CONFIG, TEST_SITE_UUID, setup_risco
@@ -114,7 +115,7 @@ async def test_cannot_connect(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
@@ -130,14 +131,14 @@ async def test_unauthorized(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
 async def test_setup(hass, two_part_alarm):
     """Test entity setup."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert not registry.async_is_registered(FIRST_ENTITY_ID)
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
@@ -147,7 +148,7 @@ async def test_setup(hass, two_part_alarm):
     assert registry.async_is_registered(FIRST_ENTITY_ID)
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_0")})
     assert device is not None
     assert device.manufacturer == "Risco"
@@ -251,7 +252,7 @@ async def test_sets_custom_mapping(hass, two_part_alarm):
     """Test settings the various modes when mapping some states."""
     await setup_risco(hass, [], CUSTOM_MAPPING_OPTIONS)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity = registry.async_get(FIRST_ENTITY_ID)
     assert entity.supported_features == EXPECTED_FEATURES
 
@@ -277,7 +278,7 @@ async def test_sets_full_custom_mapping(hass, two_part_alarm):
     """Test settings the various modes when mapping all states."""
     await setup_risco(hass, [], FULL_CUSTOM_MAPPING)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity = registry.async_get(FIRST_ENTITY_ID)
     assert (
         entity.supported_features == EXPECTED_FEATURES | SUPPORT_ALARM_ARM_CUSTOM_BYPASS

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import PropertyMock, patch
 from homeassistant.components.risco import CannotConnectError, UnauthorizedError
 from homeassistant.components.risco.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from .util import TEST_CONFIG, TEST_SITE_UUID, setup_risco
@@ -26,7 +27,7 @@ async def test_cannot_connect(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
@@ -42,14 +43,14 @@ async def test_unauthorized(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
 async def test_setup(hass, two_zone_alarm):  # noqa: F811
     """Test entity setup."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert not registry.async_is_registered(FIRST_ENTITY_ID)
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
@@ -59,7 +60,7 @@ async def test_setup(hass, two_zone_alarm):  # noqa: F811
     assert registry.async_is_registered(FIRST_ENTITY_ID)
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0")})
     assert device is not None
     assert device.manufacturer == "Risco"

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.risco import (
     UnauthorizedError,
 )
 from homeassistant.components.risco.const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
 from .util import TEST_CONFIG, TEST_SITE_UUID, setup_risco
@@ -120,7 +121,7 @@ async def test_cannot_connect(hass):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)
 
@@ -137,7 +138,7 @@ async def test_unauthorized(hass):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)
 
@@ -167,7 +168,7 @@ def _check_state(hass, category, entity_id):
 
 async def test_setup(hass, two_zone_alarm):  # noqa: F811
     """Test entity setup."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -61,6 +61,7 @@ from homeassistant.const import (
     STATE_STANDBY,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import dt as dt_util
 
@@ -85,7 +86,7 @@ async def test_setup(
     """Test setup with basic config."""
     await setup_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     main = entity_registry.async_get(MAIN_ENTITY_ID)
 
     assert hass.states.get(MAIN_ENTITY_ID)
@@ -117,7 +118,7 @@ async def test_tv_setup(
         unique_id=TV_SERIAL,
     )
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     tv = entity_registry.async_get(TV_ENTITY_ID)
 
     assert hass.states.get(TV_ENTITY_ID)
@@ -321,7 +322,7 @@ async def test_tv_device_registry(
         unique_id=TV_SERIAL,
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(identifiers={(DOMAIN, TV_SERIAL)})
 
     assert reg_device.model == TV_MODEL

--- a/tests/components/roku/test_remote.py
+++ b/tests/components/roku/test_remote.py
@@ -7,6 +7,7 @@ from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.roku import UPNP_SERIAL, setup_integration
@@ -31,7 +32,7 @@ async def test_unique_id(
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     main = entity_registry.async_get(MAIN_ENTITY_ID)
     assert main.unique_id == UPNP_SERIAL

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from homeassistant.components.ruckus_unleashed import API_MAC, DOMAIN
 from homeassistant.components.ruckus_unleashed.const import API_AP, API_ID, API_NAME
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.util import utcnow
 
@@ -80,7 +80,7 @@ async def test_restoring_clients(hass):
     entry = mock_config_entry()
     entry.add_to_hass(hass)
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         "device_tracker",
         DOMAIN,
@@ -120,7 +120,7 @@ async def test_client_device_setup(hass):
 
     router_info = DEFAULT_AP_INFO[API_AP][API_ID]["1"]
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     client_device = device_registry.async_get_device(
         identifiers={},
         connections={(CONNECTION_NETWORK_MAC, TEST_CLIENT[API_MAC])},

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_RETRY,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from tests.components.ruckus_unleashed import (
@@ -64,7 +65,7 @@ async def test_router_device_setup(hass):
 
     device_info = DEFAULT_AP_INFO[API_AP][API_ID]["1"]
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={(CONNECTION_NETWORK_MAC, device_info[API_MAC])},
         connections={(CONNECTION_NETWORK_MAC, device_info[API_MAC])},

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -1,5 +1,10 @@
 """Tests for Search integration."""
 from homeassistant.components import search
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -8,9 +13,9 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa
 
 async def test_search(hass):
     """Test that search works."""
-    area_reg = await hass.helpers.area_registry.async_get_registry()
-    device_reg = await hass.helpers.device_registry.async_get_registry()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    area_reg = ar.async_get(hass)
+    device_reg = dr.async_get(hass)
+    entity_reg = er.async_get(hass)
 
     living_room_area = area_reg.async_create("Living Room")
 
@@ -275,8 +280,8 @@ async def test_ws_api(hass, hass_ws_client):
     """Test WS API."""
     assert await async_setup_component(hass, "search", {})
 
-    area_reg = await hass.helpers.area_registry.async_get_registry()
-    device_reg = await hass.helpers.device_registry.async_get_registry()
+    area_reg = ar.async_get(hass)
+    device_reg = dr.async_get(hass)
 
     kitchen_area = area_reg.async_create("Kitchen")
 

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -46,6 +46,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .const import (
@@ -128,7 +129,7 @@ async def setup_integration(hass):
 async def test_simple_properties(hass: HomeAssistant):
     """Test that simple properties work as intended."""
     state = hass.states.get(VAC_ENTITY_ID)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity = registry.async_get(VAC_ENTITY_ID)
 
     assert entity
@@ -199,7 +200,7 @@ async def test_device_properties(
     hass: HomeAssistant, device_property: str, target_value: str
 ):
     """Test device properties."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, "AC000Wxxxxxxxxx")})
     assert getattr(device, device_property) == target_value
 

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.smartthings import binary_sensor
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -49,8 +50,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     device = device_factory(
         "Motion Sensor 1", [Capability.motion_sensor], {Attribute.motion: "inactive"}
     )
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, BINARY_SENSOR_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -44,6 +44,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import setup_platform
 
@@ -569,8 +570,8 @@ async def test_set_turn_on(hass, air_conditioner):
 async def test_entity_and_device_attributes(hass, thermostat):
     """Test the attributes of the entries are correct."""
     await setup_platform(hass, CLIMATE_DOMAIN, devices=[thermostat])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
 
     entry = entity_registry.async_get("climate.thermostat")
     assert entry

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -20,6 +20,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -31,8 +32,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     device = device_factory(
         "Garage", [Capability.garage_door_control], {Attribute.door: "open"}
     )
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, COVER_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -59,8 +60,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     )
     # Act
     await setup_platform(hass, FAN_DOMAIN, devices=[device])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Assert
     entry = entity_registry.async_get("fan.fan_1")
     assert entry

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -110,8 +111,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Light 1", [Capability.switch, Capability.switch_level])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, LIGHT_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -10,6 +10,7 @@ from pysmartthings.device import Status
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -19,8 +20,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Lock_1", [Capability.lock], {Attribute.lock: "unlocked"})
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, LOCK_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_scene.py
+++ b/tests/components/smartthings/test_scene.py
@@ -6,6 +6,7 @@ real HTTP calls are not initiated during testing.
 """
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_platform
 
@@ -13,7 +14,7 @@ from .conftest import setup_platform
 async def test_entity_and_device_attributes(hass, scene):
     """Test the attributes of the entity are correct."""
     # Arrange
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     # Act
     await setup_platform(hass, SCENE_DOMAIN, scenes=[scene])
     # Assert

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -78,8 +79,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Sensor 1", [Capability.battery], {Attribute.battery: 100})
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
 )
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -22,8 +23,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Switch_1", [Capability.switch], {Attribute.switch: "on"})
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, SWITCH_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     DATA_GIGABYTES,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import dt as dt_util
 
@@ -27,7 +28,7 @@ async def test_sensors(
 ) -> None:
     """Test the creation and values of the sensors."""
     entry = await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     sensors = {
@@ -107,7 +108,7 @@ async def test_disabled_by_default_sensors(
 ) -> None:
     """Test the disabled by default sensors."""
     await setup_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     print(registry.entities)
 
     state = hass.states.get(entity_id)

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -113,7 +113,7 @@ async def test_state(hass):
     assert attributes["source"] == "title2"
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
     assert device.manufacturer == "Sony Corporation"
@@ -121,7 +121,7 @@ async def test_state(hass):
     assert device.sw_version == SW_VERSION
     assert device.model == MODEL
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(ENTITY_ID)
     assert entity.unique_id == MAC
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant.components.sonos import DOMAIN, media_player
 from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 
@@ -48,7 +49,7 @@ async def test_device_registry(hass, config_entry, config, soco):
     """Test sonos device registered in the device registry."""
     await setup_platform(hass, config_entry, config)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={("sonos", "RINCON_test")}
     )

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -2,6 +2,7 @@
 from surepy import MESTART_RESOURCE
 
 from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import MOCK_API_DATA, MOCK_CONFIG, _patch_sensor_setup
@@ -24,7 +25,7 @@ async def test_binary_sensors(hass, surepetcare) -> None:
         assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
         await hass.async_block_till_done()
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     state_entity_ids = hass.states.async_entity_ids()
 
     for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():

--- a/tests/components/tasmota/test_common.py
+++ b/tests/components/tasmota/test_common.py
@@ -20,6 +20,7 @@ from hatasmota.utils import (
 
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import async_fire_mqtt_message
 
@@ -363,8 +364,8 @@ async def help_test_discovery_removal(
     name="Test",
 ):
     """Test removal of discovered entity."""
-    device_reg = await hass.helpers.device_registry.async_get_registry()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    device_reg = dr.async_get(hass)
+    entity_reg = er.async_get(hass)
 
     data1 = json.dumps(config1)
     data2 = json.dumps(config2)
@@ -470,8 +471,8 @@ async def help_test_discovery_device_remove(
     hass, mqtt_mock, domain, unique_id, config, sensor_config=None
 ):
     """Test domain entity is removed when device is removed."""
-    device_reg = await hass.helpers.device_registry.async_get_registry()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    device_reg = dr.async_get(hass)
+    entity_reg = er.async_get(hass)
 
     config = copy.deepcopy(config)
 
@@ -502,7 +503,7 @@ async def help_test_entity_id_update_subscriptions(
     hass, mqtt_mock, domain, config, topics=None, sensor_config=None, entity_id="test"
 ):
     """Test MQTT subscriptions are managed when entity_id is updated."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     config = copy.deepcopy(config)
     data = json.dumps(config)
@@ -548,7 +549,7 @@ async def help_test_entity_id_update_discovery_update(
     hass, mqtt_mock, domain, config, sensor_config=None, entity_id="test"
 ):
     """Test MQTT discovery update after entity_id is updated."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     config = copy.deepcopy(config)
     data = json.dumps(config)

--- a/tests/components/tasmota/test_sensor.py
+++ b/tests/components/tasmota/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant import config_entries
 from homeassistant.components import sensor
 from homeassistant.components.tasmota.const import DEFAULT_PREFIX
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNKNOWN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
 from .test_common import (
@@ -226,7 +227,7 @@ async def test_indexed_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 @pytest.mark.parametrize("status_sensor_disabled", [False])
 async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
@@ -279,7 +280,7 @@ async def test_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
 @pytest.mark.parametrize("status_sensor_disabled", [False])
 async def test_single_shot_status_sensor_state_via_mqtt(hass, mqtt_mock, setup_tasmota):
     """Test state update via MQTT."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
@@ -363,7 +364,7 @@ async def test_restart_time_status_sensor_state_via_mqtt(
     hass, mqtt_mock, setup_tasmota
 ):
     """Test state update via MQTT."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     # Pre-enable the status sensor
     entity_reg.async_get_or_create(
@@ -518,7 +519,7 @@ async def test_indexed_sensor_attributes(hass, mqtt_mock, setup_tasmota):
 @pytest.mark.parametrize("status_sensor_disabled", [False])
 async def test_enable_status_sensor(hass, mqtt_mock, setup_tasmota):
     """Test enabling status sensor."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     config = copy.deepcopy(DEFAULT_CONFIG)
     mac = config["mac"]

--- a/tests/components/timer/test_init.py
+++ b/tests/components/timer/test_init.py
@@ -39,7 +39,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, CoreState
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -248,7 +248,7 @@ async def test_no_initial_state_and_no_restore_state(hass):
 async def test_config_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -498,7 +498,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     timer_id = "from_storage"
     timer_entity_id = f"{DOMAIN}.{DOMAIN}_{timer_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(timer_entity_id)
     assert state is not None
@@ -525,7 +525,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     timer_id = "from_storage"
     timer_entity_id = f"{DOMAIN}.{DOMAIN}_{timer_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(timer_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "timer from storage"
@@ -554,7 +554,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     timer_id = "new_timer"
     timer_entity_id = f"{DOMAIN}.{timer_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(timer_entity_id)
     assert state is None

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import DATA_DISPATCHER
 from homeassistant.setup import async_setup_component
 
@@ -136,10 +137,10 @@ async def test_enter_and_exit(hass, client, webhook_id):
     ).state
     assert STATE_NOT_HOME == state_name
 
-    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == 1
 
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 1
 
 

--- a/tests/components/tradfri/test_init.py
+++ b/tests/components/tradfri/test_init.py
@@ -2,10 +2,7 @@
 from unittest.mock import patch
 
 from homeassistant.components import tradfri
-from homeassistant.helpers.device_registry import (
-    async_entries_for_config_entry,
-    async_get_registry as async_get_device_registry,
-)
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -99,8 +96,8 @@ async def test_entry_setup_unload(hass, api_factory, gateway_id):
         await hass.async_block_till_done()
         assert setup.call_count == len(tradfri.PLATFORMS)
 
-    dev_reg = await async_get_device_registry(hass)
-    dev_entries = async_entries_for_config_entry(dev_reg, entry.entry_id)
+    dev_reg = dr.async_get(hass)
+    dev_entries = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
 
     assert dev_entries
     dev_entry = dev_entries[0]

--- a/tests/components/twinkly/test_twinkly.py
+++ b/tests/components/twinkly/test_twinkly.py
@@ -1,5 +1,4 @@
 """Tests for the integration of a twinly device."""
-
 from typing import Tuple
 from unittest.mock import patch
 
@@ -12,6 +11,7 @@ from homeassistant.components.twinkly.const import (
 )
 from homeassistant.components.twinkly.light import TwinklyLight
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_registry import RegistryEntry
 
@@ -211,8 +211,8 @@ async def _create_entries(
         assert await hass.config_entries.async_setup(client.id)
         await hass.async_block_till_done()
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
 
     entity_id = entity_registry.async_get_entity_id("light", TWINKLY_DOMAIN, client.id)
     entity = entity_registry.async_get(entity_id)

--- a/tests/components/unifi/test_device_tracker.py
+++ b/tests/components/unifi/test_device_tracker.py
@@ -24,7 +24,7 @@ from homeassistant.components.unifi.const import (
     DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from .test_controller import ENTRY_CONFIG, setup_unifi_integration
@@ -326,9 +326,9 @@ async def test_tracked_devices(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     # Verify device registry has been updated
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry = entity_registry.async_get("device_tracker.device_2")
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.sw_version == EVENT_DEVICE_2_UPGRADED["version_to"]
 
@@ -801,7 +801,7 @@ async def test_restoring_client(hass, aioclient_mock):
         entry_id=1,
     )
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         TRACKER_DOMAIN,
         UNIFI_DOMAIN,

--- a/tests/components/unifi/test_switch.py
+++ b/tests/components/unifi/test_switch.py
@@ -16,7 +16,7 @@ from homeassistant.components.unifi.const import (
     DOMAIN as UNIFI_DOMAIN,
 )
 from homeassistant.components.unifi.switch import POE_SWITCH
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .test_controller import (
     CONTROLLER_HOST,
@@ -724,7 +724,7 @@ async def test_restoring_client(hass, aioclient_mock):
         entry_id=1,
     )
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         SWITCH_DOMAIN,
         UNIFI_DOMAIN,

--- a/tests/components/vera/test_init.py
+++ b/tests/components/vera/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.components.vera import (
 )
 from homeassistant.config_entries import ENTRY_STATE_NOT_LOADED
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .common import ComponentFactory, ConfigSource, new_simple_controller_config
 
@@ -40,7 +41,7 @@ async def test_init(
         ),
     )
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1
     assert entry1.unique_id == "vera_first_serial_1"
@@ -67,7 +68,7 @@ async def test_init_from_file(
         ),
     )
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1
     assert entry1.unique_id == "vera_first_serial_1"
@@ -117,7 +118,7 @@ async def test_multiple_controllers_with_legacy_one(
         ),
     )
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry1 = entity_registry.async_get(entity1_id)
     assert entry1

--- a/tests/components/wemo/conftest.py
+++ b/tests/components/wemo/conftest.py
@@ -7,6 +7,7 @@ import pywemo
 
 from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC
 from homeassistant.components.wemo.const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 MOCK_HOST = "127.0.0.1"
@@ -72,7 +73,7 @@ async def async_wemo_entity_fixture(hass, pywemo_device):
     )
     await hass.async_block_till_done()
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     entity_entries = list(entity_registry.entities.values())
     assert len(entity_entries) == 1
 

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -6,6 +6,7 @@ import pywemo
 
 from homeassistant.components.wemo import CONF_DISCOVERY, CONF_STATIC, WemoDiscovery
 from homeassistant.components.wemo.const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -41,7 +42,7 @@ async def test_static_duplicate_static_entry(hass, pywemo_device):
         },
     )
     await hass.async_block_till_done()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
     entity_entries = list(entity_reg.entities.values())
     assert len(entity_entries) == 1
 
@@ -59,7 +60,7 @@ async def test_static_config_with_port(hass, pywemo_device):
         },
     )
     await hass.async_block_till_done()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
     entity_entries = list(entity_reg.entities.values())
     assert len(entity_entries) == 1
 
@@ -77,7 +78,7 @@ async def test_static_config_without_port(hass, pywemo_device):
         },
     )
     await hass.async_block_till_done()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
     entity_entries = list(entity_reg.entities.values())
     assert len(entity_entries) == 1
 
@@ -145,7 +146,7 @@ async def test_discovery(hass, pywemo_registry):
         await hass.async_block_till_done()
 
     # Verify that the expected number of devices were setup.
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
     entity_entries = list(entity_reg.entities.values())
     assert len(entity_entries) == 3
 

--- a/tests/components/wilight/test_cover.py
+++ b/tests/components/wilight/test_cover.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
@@ -64,7 +65,7 @@ async def test_loading_cover(
     assert entry
     assert entry.unique_id == WILIGHT_ID
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("cover.wl000000000099_1")

--- a/tests/components/wilight/test_fan.py
+++ b/tests/components/wilight/test_fan.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
@@ -64,7 +65,7 @@ async def test_loading_light_fan(
     assert entry
     assert entry.unique_id == WILIGHT_ID
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("fan.wl000000000099_2")

--- a/tests/components/wilight/test_light.py
+++ b/tests/components/wilight/test_light.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.wilight import (
@@ -140,7 +141,7 @@ async def test_loading_light(
     assert entry
     assert entry.unique_id == WILIGHT_ID
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("light.wl000000000099_1")

--- a/tests/components/withings/test_binary_sensor.py
+++ b/tests/components/withings/test_binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.withings.common import (
 from homeassistant.components.withings.const import Measurement
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .common import ComponentFactory, new_profile_config
@@ -21,9 +22,7 @@ async def test_binary_sensor(
     person0 = new_profile_config("person0", 0)
     person1 = new_profile_config("person1", 1)
 
-    entity_registry: EntityRegistry = (
-        await hass.helpers.entity_registry.async_get_registry()
-    )
+    entity_registry: EntityRegistry = er.async_get(hass)
 
     await component_factory.configure_component(profile_configs=(person0, person1))
     assert not await async_get_entity_id(hass, in_bed_attribute, person0.user_id)

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -27,6 +27,7 @@ from homeassistant.components.withings.common import (
 )
 from homeassistant.components.withings.const import Measurement
 from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 
 from .common import ComponentFactory, new_profile_config
@@ -304,9 +305,7 @@ async def test_sensor_default_enabled_entities(
     hass: HomeAssistant, component_factory: ComponentFactory
 ) -> None:
     """Test entities enabled by default."""
-    entity_registry: EntityRegistry = (
-        await hass.helpers.entity_registry.async_get_registry()
-    )
+    entity_registry: EntityRegistry = er.async_get(hass)
 
     await component_factory.configure_component(profile_configs=(PERSON0,))
 
@@ -347,9 +346,7 @@ async def test_all_entities(
     hass: HomeAssistant, component_factory: ComponentFactory
 ) -> None:
     """Test all entities."""
-    entity_registry: EntityRegistry = (
-        await hass.helpers.entity_registry.async_get_registry()
-    )
+    entity_registry: EntityRegistry = er.async_get(hass)
 
     with patch(
         "homeassistant.components.withings.sensor.BaseWithingsSensor.entity_registry_enabled_default"

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed, load_fixture
@@ -49,7 +50,7 @@ async def test_rgb_light_state(
     """Test the creation and values of the WLED lights."""
     await init_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # First segment of the strip
     state = hass.states.get("light.wled_rgb_light_segment_0")

--- a/tests/components/wled/test_sensor.py
+++ b/tests/components/wled/test_sensor.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from tests.components.wled import init_integration
@@ -35,7 +36,7 @@ async def test_sensors(
     """Test the creation and values of the WLED sensors."""
 
     entry = await init_integration(hass, aioclient_mock, skip_setup=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
@@ -185,7 +186,7 @@ async def test_disabled_by_default_sensors(
 ) -> None:
     """Test the disabled by default WLED sensors."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get(entity_id)
     assert state is None

--- a/tests/components/wled/test_switch.py
+++ b/tests/components/wled/test_switch.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.wled import init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -31,7 +32,7 @@ async def test_switch_state(
     """Test the creation and values of the WLED switches."""
     await init_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     state = hass.states.get("switch.wled_rgb_light_nightlight")
     assert state

--- a/tests/components/yeelight/test_init.py
+++ b/tests/components/yeelight/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.components.yeelight import (
 )
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_NAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import (
@@ -106,11 +106,14 @@ async def test_unique_ids_device(hass: HomeAssistant):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(ENTITY_BINARY_SENSOR).unique_id == f"{ID}-nightlight_sensor"
-    assert er.async_get(ENTITY_LIGHT).unique_id == ID
-    assert er.async_get(ENTITY_NIGHTLIGHT).unique_id == f"{ID}-nightlight"
-    assert er.async_get(ENTITY_AMBILIGHT).unique_id == f"{ID}-ambilight"
+    entity_registry = er.async_get(hass)
+    assert (
+        entity_registry.async_get(ENTITY_BINARY_SENSOR).unique_id
+        == f"{ID}-nightlight_sensor"
+    )
+    assert entity_registry.async_get(ENTITY_LIGHT).unique_id == ID
+    assert entity_registry.async_get(ENTITY_NIGHTLIGHT).unique_id == f"{ID}-nightlight"
+    assert entity_registry.async_get(ENTITY_AMBILIGHT).unique_id == f"{ID}-ambilight"
 
 
 async def test_unique_ids_entry(hass: HomeAssistant):
@@ -131,18 +134,19 @@ async def test_unique_ids_entry(hass: HomeAssistant):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    er = await entity_registry.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     assert (
-        er.async_get(ENTITY_BINARY_SENSOR).unique_id
+        entity_registry.async_get(ENTITY_BINARY_SENSOR).unique_id
         == f"{config_entry.entry_id}-nightlight_sensor"
     )
-    assert er.async_get(ENTITY_LIGHT).unique_id == config_entry.entry_id
+    assert entity_registry.async_get(ENTITY_LIGHT).unique_id == config_entry.entry_id
     assert (
-        er.async_get(ENTITY_NIGHTLIGHT).unique_id
+        entity_registry.async_get(ENTITY_NIGHTLIGHT).unique_id
         == f"{config_entry.entry_id}-nightlight"
     )
     assert (
-        er.async_get(ENTITY_AMBILIGHT).unique_id == f"{config_entry.entry_id}-ambilight"
+        entity_registry.async_get(ENTITY_AMBILIGHT).unique_id
+        == f"{config_entry.entry_id}-ambilight"
     )
 
 
@@ -170,8 +174,8 @@ async def test_bulb_off_while_adding_in_ha(hass: HomeAssistant):
     binary_sensor_entity_id = ENTITY_BINARY_SENSOR_TEMPLATE.format(
         IP_ADDRESS.replace(".", "_")
     )
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(binary_sensor_entity_id) is None
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(binary_sensor_entity_id) is None
 
     type(mocked_bulb).get_capabilities = MagicMock(CAPABILITIES)
     type(mocked_bulb).get_properties = MagicMock(None)
@@ -179,5 +183,5 @@ async def test_bulb_off_while_adding_in_ha(hass: HomeAssistant):
     hass.data[DOMAIN][DATA_CONFIG_ENTRIES][config_entry.entry_id][DATA_DEVICE].update()
     await hass.async_block_till_done()
 
-    er = await entity_registry.async_get_registry(hass)
-    assert er.async_get(binary_sensor_entity_id) is not None
+    entity_registry = er.async_get(hass)
+    assert entity_registry.async_get(binary_sensor_entity_id) is not None

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -85,7 +85,7 @@ from homeassistant.components.yeelight.light import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.color import (
     color_hs_to_RGB,
@@ -376,7 +376,7 @@ async def test_device_types(hass: HomeAssistant):
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await config_entry.async_remove(hass)
-        registry = await entity_registry.async_get_registry(hass)
+        registry = er.async_get(hass)
         registry.async_clear_config_entry(config_entry.entry_id)
 
         # nightlight

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -10,7 +10,7 @@ import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.zha.core.device as zha_core_device
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
-import homeassistant.helpers.device_registry as ha_dev_reg
+import homeassistant.helpers.device_registry as dr
 import homeassistant.util.dt as dt_util
 
 from .common import async_enable_traffic, make_zcl_header
@@ -227,7 +227,7 @@ async def test_ota_sw_version(hass, ota_zha_device):
     """Test device entry gets sw_version updated via OTA channel."""
 
     ota_ch = ota_zha_device.channels.pools[0].client_channels["1:0x0019"]
-    dev_registry = await ha_dev_reg.async_get_registry(hass)
+    dev_registry = dr.async_get(hass)
     entry = dev_registry.async_get(ota_zha_device.device_id)
     assert entry.sw_version is None
 

--- a/tests/components/zha/test_device_action.py
+++ b/tests/components/zha/test_device_action.py
@@ -12,7 +12,7 @@ from homeassistant.components.device_automation import (
     _async_get_device_automations as async_get_device_automations,
 )
 from homeassistant.components.zha import DOMAIN
-from homeassistant.helpers.device_registry import async_get_registry
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_mock_service, mock_coro
@@ -49,7 +49,7 @@ async def test_get_actions(hass, device_ias):
 
     ieee_address = str(device_ias[0].ieee)
 
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
 
     actions = await async_get_device_automations(hass, "action", reg_device.id)
@@ -72,7 +72,7 @@ async def test_action(hass, device_ias):
 
     ieee_address = str(zha_device.ieee)
 
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({(DOMAIN, ieee_address)})
 
     with patch(

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -8,7 +8,7 @@ import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.automation as automation
 import homeassistant.components.zha.core.device as zha_core_device
-from homeassistant.helpers.device_registry import async_get_registry
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -86,7 +86,7 @@ async def test_triggers(hass, mock_devices):
 
     ieee_address = str(zha_device.ieee)
 
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
@@ -144,7 +144,7 @@ async def test_no_triggers(hass, mock_devices):
     _, zha_device = mock_devices
     ieee_address = str(zha_device.ieee)
 
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     triggers = await async_get_device_automations(hass, "trigger", reg_device.id)
@@ -173,7 +173,7 @@ async def test_if_fires_on_event(hass, mock_devices, calls):
     }
 
     ieee_address = str(zha_device.ieee)
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     assert await async_setup_component(
@@ -282,7 +282,7 @@ async def test_exception_no_triggers(hass, mock_devices, calls, caplog):
     _, zha_device = mock_devices
 
     ieee_address = str(zha_device.ieee)
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     await async_setup_component(
@@ -324,7 +324,7 @@ async def test_exception_bad_trigger(hass, mock_devices, calls, caplog):
     }
 
     ieee_address = str(zha_device.ieee)
-    ha_device_registry = await async_get_registry(hass)
+    ha_device_registry = dr.async_get(hass)
     reg_device = ha_device_registry.async_get_device({("zha", ieee_address)})
 
     await async_setup_component(

--- a/tests/components/zha/test_discover.py
+++ b/tests/components/zha/test_discover.py
@@ -67,7 +67,7 @@ async def test_devices(
     zha_device_joined_restored,
 ):
     """Test device discovery."""
-    entity_registry = await homeassistant.helpers.entity_registry.async_get_registry(
+    entity_registry = homeassistant.helpers.entity_registry.async_get(
         hass_disable_services
     )
 

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -244,7 +244,7 @@ async def test_core_config_update(hass):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await setup.async_setup_component(
         hass,
@@ -365,7 +365,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -401,7 +401,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes["latitude"] == 1
@@ -435,7 +435,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/zwave/test_init.py
+++ b/tests/components/zwave/test_init.py
@@ -18,8 +18,7 @@ from homeassistant.components.zwave import (
 )
 from homeassistant.components.zwave.binary_sensor import get_device
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
-from homeassistant.helpers.entity_registry import async_get_registry
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import async_fire_time_changed, mock_registry
 from tests.mock.zwave import MockEntityValues, MockNetwork, MockNode, MockValue
@@ -472,8 +471,8 @@ async def test_value_entities(hass, mock_openzwave):
     assert hass.states.get("binary_sensor.mock_node_mock_value").state == "off"
     assert hass.states.get("binary_sensor.mock_node_mock_value_b").state == "off"
 
-    ent_reg = await async_get_registry(hass)
-    dev_reg = await get_dev_reg(hass)
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
 
     entry = ent_reg.async_get("zwave.mock_node")
     assert entry is not None

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -23,7 +23,7 @@ from homeassistant.components.zwave_js.api import (
     VALUE,
 )
 from homeassistant.components.zwave_js.const import DOMAIN
-from homeassistant.helpers.device_registry import async_get_registry
+from homeassistant.helpers import device_registry as dr
 
 
 async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
@@ -197,7 +197,7 @@ async def test_remove_node(
     # Add mock node to controller
     client.driver.controller.nodes[67] = nortek_thermostat
 
-    dev_reg = await async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
 
     # Create device registry entry for mock node
     device = dev_reg.async_get_or_create(

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -3,6 +3,7 @@ from zwave_js_server.event import Event
 
 from homeassistant.components.binary_sensor import DEVICE_CLASS_MOTION
 from homeassistant.const import DEVICE_CLASS_BATTERY, STATE_OFF, STATE_ON
+from homeassistant.helpers import entity_registry as er
 
 from .common import (
     DISABLED_LEGACY_BINARY_SENSOR,
@@ -61,7 +62,7 @@ async def test_disabled_legacy_sensor(hass, multisensor_6, integration):
     """Test disabled legacy boolean binary sensor."""
     # this node has Notification CC implemented so legacy binary sensor should be disabled
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = DISABLED_LEGACY_BINARY_SENSOR
     state = hass.states.get(entity_id)
     assert state is None

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -16,7 +16,7 @@ from homeassistant.config_entries import (
     ENTRY_STATE_SETUP_RETRY,
 )
 from homeassistant.const import STATE_UNAVAILABLE
-from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import (
     AIR_TEMPERATURE_SENSOR,
@@ -132,7 +132,7 @@ async def test_unique_id_migration_dupes(
     hass, multisensor_6_state, client, integration
 ):
     """Test we remove an entity when ."""
-    ent_reg = entity_registry.async_get(hass)
+    ent_reg = er.async_get(hass)
 
     entity_name = AIR_TEMPERATURE_SENSOR.split(".")[1]
 
@@ -183,7 +183,7 @@ async def test_unique_id_migration_dupes(
 
 async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integration):
     """Test unique ID is migrated from old format to new (version 1)."""
-    ent_reg = entity_registry.async_get(hass)
+    ent_reg = er.async_get(hass)
 
     # Migrate version 1
     entity_name = AIR_TEMPERATURE_SENSOR.split(".")[1]
@@ -216,7 +216,7 @@ async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integra
 
 async def test_unique_id_migration_v2(hass, multisensor_6_state, client, integration):
     """Test unique ID is migrated from old format to new (version 2)."""
-    ent_reg = entity_registry.async_get(hass)
+    ent_reg = er.async_get(hass)
     # Migrate version 2
     ILLUMINANCE_SENSOR = "sensor.multisensor_6_illuminance"
     entity_name = ILLUMINANCE_SENSOR.split(".")[1]
@@ -251,7 +251,7 @@ async def test_unique_id_migration_notification_binary_sensor(
     hass, multisensor_6_state, client, integration
 ):
     """Test unique ID is migrated from old format to new for a notification binary sensor."""
-    ent_reg = entity_registry.async_get(hass)
+    ent_reg = er.async_get(hass)
 
     entity_name = NOTIFICATION_MOTION_BINARY_SENSOR.split(".")[1]
 
@@ -442,17 +442,13 @@ async def test_removed_device(hass, client, multiple_devices, integration):
     assert len(client.driver.controller.nodes) == 2
 
     # Make sure there are the same number of devices
-    dev_reg = await device_registry.async_get_registry(hass)
-    device_entries = device_registry.async_entries_for_config_entry(
-        dev_reg, integration.entry_id
-    )
+    dev_reg = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(dev_reg, integration.entry_id)
     assert len(device_entries) == 2
 
     # Check how many entities there are
-    ent_reg = await entity_registry.async_get_registry(hass)
-    entity_entries = entity_registry.async_entries_for_config_entry(
-        ent_reg, integration.entry_id
-    )
+    ent_reg = er.async_get(hass)
+    entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
     assert len(entity_entries) == 24
 
     # Remove a node and reload the entry
@@ -462,21 +458,17 @@ async def test_removed_device(hass, client, multiple_devices, integration):
 
     # Assert that the node and all of it's entities were removed from the device and
     # entity registry
-    device_entries = device_registry.async_entries_for_config_entry(
-        dev_reg, integration.entry_id
-    )
+    device_entries = dr.async_entries_for_config_entry(dev_reg, integration.entry_id)
     assert len(device_entries) == 1
-    entity_entries = entity_registry.async_entries_for_config_entry(
-        ent_reg, integration.entry_id
-    )
+    entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
     assert len(entity_entries) == 15
     assert dev_reg.async_get_device({get_device_id(client, old_node)}) is None
 
 
 async def test_suggested_area(hass, client, eaton_rf9640_dimmer):
     """Test that suggested area works."""
-    dev_reg = device_registry.async_get(hass)
-    ent_reg = entity_registry.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
 
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -7,10 +7,7 @@ from homeassistant.const import (
     POWER_WATT,
     TEMP_CELSIUS,
 )
-from homeassistant.helpers.entity_registry import (
-    DISABLED_INTEGRATION,
-    async_get_registry,
-)
+from homeassistant.helpers import entity_registry as er
 
 from .common import (
     AIR_TEMPERATURE_SENSOR,
@@ -49,12 +46,12 @@ async def test_energy_sensors(hass, hank_binary_switch, integration):
 
 async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     """Test sensor is created from Notification CC and is disabled."""
-    ent_reg = await async_get_registry(hass)
+    ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_SENSOR)
 
     assert entity_entry
     assert entity_entry.disabled
-    assert entity_entry.disabled_by == DISABLED_INTEGRATION
+    assert entity_entry.disabled_by == er.DISABLED_INTEGRATION
 
     # Test enabling entity
     updated_entry = ent_reg.async_update_entity(

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -797,7 +797,7 @@ async def test_cleanup_device_registry(hass, registry):
         identifiers={("something", "d4")}, config_entry_id="non_existing"
     )
 
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = entity_registry.async_get(hass)
     ent_reg.async_get_or_create("light", "hue", "e1", device_id=d1.id)
     ent_reg.async_get_or_create("light", "hue", "e2", device_id=d1.id)
     ent_reg.async_get_or_create("light", "hue", "e3", device_id=d3.id)
@@ -829,7 +829,7 @@ async def test_cleanup_device_registry_removes_expired_orphaned_devices(hass, re
     assert len(registry.devices) == 0
     assert len(registry.deleted_devices) == 3
 
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = entity_registry.async_get(hass)
     device_registry.async_cleanup(hass, registry, ent_reg)
 
     assert len(registry.devices) == 0
@@ -847,7 +847,6 @@ async def test_cleanup_device_registry_removes_expired_orphaned_devices(hass, re
 async def test_cleanup_startup(hass):
     """Test we run a cleanup on startup."""
     hass.state = CoreState.not_running
-    await device_registry.async_get_registry(hass)
 
     with patch(
         "homeassistant.helpers.device_registry.Debouncer.async_call"

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -9,7 +9,11 @@ import pytest
 from homeassistant.const import PERCENTAGE
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
-from homeassistant.helpers import entity_platform, entity_registry
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_platform,
+    entity_registry as er,
+)
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.entity_component import (
     DEFAULT_SCAN_INTERVAL,
@@ -467,7 +471,7 @@ async def test_overriding_name_from_registry(hass):
     mock_registry(
         hass,
         {
-            "test_domain.world": entity_registry.RegistryEntry(
+            "test_domain.world": er.RegistryEntry(
                 entity_id="test_domain.world",
                 unique_id="1234",
                 # Using component.async_add_entities is equal to platform "domain"
@@ -499,12 +503,12 @@ async def test_registry_respect_entity_disabled(hass):
     mock_registry(
         hass,
         {
-            "test_domain.world": entity_registry.RegistryEntry(
+            "test_domain.world": er.RegistryEntry(
                 entity_id="test_domain.world",
                 unique_id="1234",
                 # Using component.async_add_entities is equal to platform "domain"
                 platform="test_platform",
-                disabled_by=entity_registry.DISABLED_USER,
+                disabled_by=er.DISABLED_USER,
             )
         },
     )
@@ -520,7 +524,7 @@ async def test_entity_registry_updates_name(hass):
     registry = mock_registry(
         hass,
         {
-            "test_domain.world": entity_registry.RegistryEntry(
+            "test_domain.world": er.RegistryEntry(
                 entity_id="test_domain.world",
                 unique_id="1234",
                 # Using component.async_add_entities is equal to platform "domain"
@@ -624,7 +628,7 @@ async def test_entity_registry_updates_entity_id(hass):
     registry = mock_registry(
         hass,
         {
-            "test_domain.world": entity_registry.RegistryEntry(
+            "test_domain.world": er.RegistryEntry(
                 entity_id="test_domain.world",
                 unique_id="1234",
                 # Using component.async_add_entities is equal to platform "domain"
@@ -656,14 +660,14 @@ async def test_entity_registry_updates_invalid_entity_id(hass):
     registry = mock_registry(
         hass,
         {
-            "test_domain.world": entity_registry.RegistryEntry(
+            "test_domain.world": er.RegistryEntry(
                 entity_id="test_domain.world",
                 unique_id="1234",
                 # Using component.async_add_entities is equal to platform "domain"
                 platform="test_platform",
                 name="Some name",
             ),
-            "test_domain.existing": entity_registry.RegistryEntry(
+            "test_domain.existing": er.RegistryEntry(
                 entity_id="test_domain.existing",
                 unique_id="5678",
                 platform="test_platform",
@@ -703,7 +707,7 @@ async def test_entity_registry_updates_invalid_entity_id(hass):
 
 async def test_device_info_called(hass):
     """Test device info is forwarded correctly."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     via = registry.async_get_or_create(
         config_entry_id="123",
         connections=set(),
@@ -763,7 +767,7 @@ async def test_device_info_called(hass):
 
 async def test_device_info_not_overrides(hass):
     """Test device info is forwarded correctly."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_or_create(
         config_entry_id="bla",
         connections={("mac", "abcd")},
@@ -823,7 +827,7 @@ async def test_entity_disabled_by_integration(hass):
     assert entity_disabled.hass is None
     assert entity_disabled.platform is None
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry_default = registry.async_get_or_create(DOMAIN, DOMAIN, "default")
     assert entry_default.disabled_by is None
@@ -845,7 +849,7 @@ async def test_entity_info_added_to_entity_registry(hass):
 
     await component.async_add_entities([entity_default])
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry_default = registry.async_get_or_create(DOMAIN, DOMAIN, "default")
     print(entry_default)

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -299,7 +300,7 @@ async def test_remove_entry(hass, manager):
     assert len(hass.states.async_all()) == 1
 
     # Check entity got added to entity registry
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 1
     entity_entry = list(ent_reg.entities.values())[0]
     assert entity_entry.config_entry_id == entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update tests to use `*_registry.async_get()` instead of deprecated `*_registry.depreceated async_get_registry()`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
