### PR TITLE
Add OPENING & CLOSING state to MySensors cover

### DIFF
--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -1,5 +1,6 @@
 """Support for MySensors covers."""
 import logging
+from enum import Enum
 from typing import Callable
 
 from homeassistant.components import mysensors
@@ -13,10 +14,17 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
+class CoverState(Enum):
+    """
+    An enumeration of the standard cover states.
+    """
+    OPEN = 0
+    OPENING = 1
+    CLOSED = 2
+    CLOSING = 3
 
 async def async_setup_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities: Callable
-):
+        hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities: Callable):
     """Set up this platform for a specific ConfigEntry(==Gateway)."""
 
     async def async_discover(discovery_info):
@@ -43,13 +51,45 @@ async def async_setup_entry(
 class MySensorsCover(mysensors.device.MySensorsEntity, CoverEntity):
     """Representation of the value of a MySensors Cover child node."""
 
+    def get_cover_state(self):
+        """Returns a CoverState enum representing the state of the cover
+           as determined by the current state of each required V_"""
+        set_req = self.gateway.const.SetReq
+        v_up = self._values.get(set_req.V_UP) == STATE_ON
+        v_down = self._values.get(set_req.V_DOWN) == STATE_ON
+        v_stop = self._values.get(set_req.V_STOP) == STATE_ON
+
+        # If a V_DIMMER or V_PERCENTAGE is available, that is the amount
+        # the cover is open. Otherwise, use 0 or 100 based on the V_LIGHT
+        # or V_STATUS.
+        amount = 100
+        if set_req.V_DIMMER in self._values:
+            amount = self._values.get(set_req.V_DIMMER)
+        else:
+            amount = 100 if self._values.get(set_req.V_LIGHT) == STATE_ON else 0
+
+        if v_up and (not v_down) and (not v_stop):
+            return CoverState.OPENING
+        if (not v_up) and v_down and (not v_stop):
+            return CoverState.CLOSING
+        if (not v_up) and (not v_down) and v_stop and amount == 0:
+            return CoverState.CLOSED
+        return CoverState.OPEN
+
     @property
     def is_closed(self):
-        """Return True if cover is closed."""
-        set_req = self.gateway.const.SetReq
-        if set_req.V_DIMMER in self._values:
-            return self._values.get(set_req.V_DIMMER) == 0
-        return self._values.get(set_req.V_LIGHT) == STATE_OFF
+        """Return True if the cover is closed."""
+        return self.get_cover_state() == CoverState.CLOSED
+
+    @property
+    def is_closing(self):
+        """Return True if the cover is closing."""
+        return self.get_cover_state() == CoverState.CLOSING
+
+    @property
+    def is_opening(self):
+        """Return True if the cover is opening."""
+        return self.get_cover_state() == CoverState.OPENING
 
     @property
     def current_cover_position(self):

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -1,6 +1,6 @@
 """Support for MySensors covers."""
-import logging
 from enum import Enum
+import logging
 from typing import Callable
 
 from homeassistant.components import mysensors
@@ -14,17 +14,19 @@ from homeassistant.helpers.typing import HomeAssistantType
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class CoverState(Enum):
-    """
-    An enumeration of the standard cover states.
-    """
+    """An enumeration of the standard cover states."""
+
     OPEN = 0
     OPENING = 1
     CLOSED = 2
     CLOSING = 3
 
+
 async def async_setup_entry(
-        hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities: Callable):
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities: Callable
+):
     """Set up this platform for a specific ConfigEntry(==Gateway)."""
 
     async def async_discover(discovery_info):
@@ -52,8 +54,7 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverEntity):
     """Representation of the value of a MySensors Cover child node."""
 
     def get_cover_state(self):
-        """Returns a CoverState enum representing the state of the cover
-           as determined by the current state of each required V_"""
+        """Return a CoverState enum representing the state of the cover."""
         set_req = self.gateway.const.SetReq
         v_up = self._values.get(set_req.V_UP) == STATE_ON
         v_down = self._values.get(set_req.V_DOWN) == STATE_ON

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -1,5 +1,5 @@
 """Support for MySensors covers."""
-from enum import Enum
+from enum import Enum, unique
 import logging
 from typing import Callable
 
@@ -15,13 +15,14 @@ from homeassistant.helpers.typing import HomeAssistantType
 _LOGGER = logging.getLogger(__name__)
 
 
+@unique
 class CoverState(Enum):
     """An enumeration of the standard cover states."""
 
     OPEN = 0
     OPENING = 1
-    CLOSED = 2
-    CLOSING = 3
+    CLOSING = 2
+    CLOSED = 3
 
 
 async def async_setup_entry(
@@ -69,11 +70,11 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverEntity):
         else:
             amount = 100 if self._values.get(set_req.V_LIGHT) == STATE_ON else 0
 
-        if v_up and (not v_down) and (not v_stop):
+        if v_up and not v_down and not v_stop:
             return CoverState.OPENING
-        if (not v_up) and v_down and (not v_stop):
+        if not v_up and v_down and not v_stop:
             return CoverState.CLOSING
-        if (not v_up) and (not v_down) and v_stop and amount == 0:
+        if not v_up and not v_down and v_stop and amount == 0:
             return CoverState.CLOSED
         return CoverState.OPEN
 

--- a/homeassistant/components/mysensors/device.py
+++ b/homeassistant/components/mysensors/device.py
@@ -162,6 +162,9 @@ class MySensorsDevice:
                 set_req.V_LIGHT,
                 set_req.V_LOCK_STATUS,
                 set_req.V_TRIPPED,
+                set_req.V_UP,
+                set_req.V_DOWN,
+                set_req.V_STOP
             ):
                 self._values[value_type] = STATE_ON if int(value) == 1 else STATE_OFF
             elif value_type == set_req.V_DIMMER:

--- a/homeassistant/components/mysensors/device.py
+++ b/homeassistant/components/mysensors/device.py
@@ -164,7 +164,7 @@ class MySensorsDevice:
                 set_req.V_TRIPPED,
                 set_req.V_UP,
                 set_req.V_DOWN,
-                set_req.V_STOP
+                set_req.V_STOP,
             ):
                 self._values[value_type] = STATE_ON if int(value) == 1 else STATE_OFF
             elif value_type == set_req.V_DIMMER:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added support for OPENING and CLOSING states to cover devices using a combination of the required mysensor V_ variables according to the existing documentation.

Simplified the determination of the cover's state by use of a new enumeration and single method allowing the state to be used by all three HomeAssistant query methods.

Minor change to devices.py to allow V_UP, V_DOWN, and V_STOP to be converted to STATE_ON and STATE_OFF.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
