### PR TITLE
Convert climacell forecast timestamp to isoformat so that UI shows the right times

### DIFF
--- a/homeassistant/components/climacell/weather.py
+++ b/homeassistant/components/climacell/weather.py
@@ -1,4 +1,5 @@
 """Weather component that handles meteorological data for your location."""
+from datetime import datetime
 import logging
 from typing import Any, Callable, Dict, List, Optional
 
@@ -80,7 +81,7 @@ def _translate_condition(
 
 def _forecast_dict(
     hass: HomeAssistantType,
-    time: str,
+    time: datetime,
     use_datetime: bool,
     condition: str,
     precipitation: Optional[float],
@@ -92,10 +93,7 @@ def _forecast_dict(
 ) -> Dict[str, Any]:
     """Return formatted Forecast dict from ClimaCell forecast data."""
     if use_datetime:
-        translated_condition = _translate_condition(
-            condition,
-            is_up(hass, dt_util.as_utc(dt_util.parse_datetime(time))),
-        )
+        translated_condition = _translate_condition(condition, is_up(hass, time))
     else:
         translated_condition = _translate_condition(condition, True)
 
@@ -112,7 +110,7 @@ def _forecast_dict(
             wind_speed = distance_convert(wind_speed, LENGTH_MILES, LENGTH_KILOMETERS)
 
     data = {
-        ATTR_FORECAST_TIME: time,
+        ATTR_FORECAST_TIME: time.isoformat(),
         ATTR_FORECAST_CONDITION: translated_condition,
         ATTR_FORECAST_PRECIPITATION: precipitation,
         ATTR_FORECAST_PRECIPITATION_PROBABILITY: precipitation_probability,
@@ -246,7 +244,9 @@ class ClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
         # Set default values (in cases where keys don't exist), None will be
         # returned. Override properties per forecast type as needed
         for forecast in self.coordinator.data[FORECASTS][self.forecast_type]:
-            timestamp = self._get_cc_value(forecast, CC_ATTR_TIMESTAMP)
+            timestamp = dt_util.parse_datetime(
+                self._get_cc_value(forecast, CC_ATTR_TIMESTAMP)
+            )
             use_datetime = True
             condition = self._get_cc_value(forecast, CC_ATTR_CONDITION)
             precipitation = self._get_cc_value(forecast, CC_ATTR_PRECIPITATION)

--- a/homeassistant/components/climacell/weather.py
+++ b/homeassistant/components/climacell/weather.py
@@ -81,7 +81,7 @@ def _translate_condition(
 
 def _forecast_dict(
     hass: HomeAssistantType,
-    time: datetime,
+    forecast_dt: datetime,
     use_datetime: bool,
     condition: str,
     precipitation: Optional[float],
@@ -93,7 +93,7 @@ def _forecast_dict(
 ) -> Dict[str, Any]:
     """Return formatted Forecast dict from ClimaCell forecast data."""
     if use_datetime:
-        translated_condition = _translate_condition(condition, is_up(hass, time))
+        translated_condition = _translate_condition(condition, is_up(hass, forecast_dt))
     else:
         translated_condition = _translate_condition(condition, True)
 
@@ -110,7 +110,7 @@ def _forecast_dict(
             wind_speed = distance_convert(wind_speed, LENGTH_MILES, LENGTH_KILOMETERS)
 
     data = {
-        ATTR_FORECAST_TIME: time.isoformat(),
+        ATTR_FORECAST_TIME: forecast_dt.isoformat(),
         ATTR_FORECAST_CONDITION: translated_condition,
         ATTR_FORECAST_PRECIPITATION: precipitation,
         ATTR_FORECAST_PRECIPITATION_PROBABILITY: precipitation_probability,
@@ -244,7 +244,7 @@ class ClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
         # Set default values (in cases where keys don't exist), None will be
         # returned. Override properties per forecast type as needed
         for forecast in self.coordinator.data[FORECASTS][self.forecast_type]:
-            timestamp = dt_util.parse_datetime(
+            forecast_dt = dt_util.parse_datetime(
                 self._get_cc_value(forecast, CC_ATTR_TIMESTAMP)
             )
             use_datetime = True
@@ -290,7 +290,7 @@ class ClimaCellWeatherEntity(ClimaCellEntity, WeatherEntity):
             forecasts.append(
                 _forecast_dict(
                     self.hass,
-                    timestamp,
+                    forecast_dt,
                     use_datetime,
                     condition,
                     precipitation,


### PR DESCRIPTION
## Proposed change
I thought I was passing the timestamp in as an ISO8601 compliant string, but it appears that I need to convert it to a `datetime` and use `isoformat` to get the correct string. This should show the correct info in the UI whereas now the daily data may appear to start on the previous day.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47283
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
