### PR TITLE
Improve behaviour when disabling or enabling config entries

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -11,10 +11,9 @@ import weakref
 import attr
 
 from homeassistant import data_entry_flow, loader
-from homeassistant.const import EVENT_CONFIG_ENTRY_DISABLED_BY_UPDATED
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.event import Event
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 from homeassistant.setup import async_process_deps_reqs, async_setup_component
@@ -807,12 +806,21 @@ class ConfigEntries:
         entry.disabled_by = disabled_by
         self._async_schedule_save()
 
+        dev_reg = device_registry.async_get(self.hass)
+        ent_reg = entity_registry.async_get(self.hass)
+
+        if not entry.disabled_by:
+            # The config entry is no longer disabled, enable devices and entities
+            device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
+            entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)
+
         # Unload the config entry, then fire an event
         reload_result = await self.async_reload(entry_id)
 
-        self.hass.bus.async_fire(
-            EVENT_CONFIG_ENTRY_DISABLED_BY_UPDATED, {"config_entry_id": entry_id}
-        )
+        if entry.disabled_by:
+            # The config entry is disabled, disable devices and entities
+            device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
+            entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)
 
         return reload_result
 
@@ -1250,8 +1258,16 @@ class EntityRegistryDisabledHandler:
 
 @callback
 def _handle_entry_updated_filter(event: Event) -> bool:
-    """Handle entity registry entry update filter."""
-    if event.data["action"] != "update" or "disabled_by" not in event.data["changes"]:
+    """Handle entity registry entry update filter.
+
+    Only handle changes to "disabled_by".
+    If "disabled_by" was DISABLED_CONFIG_ENTRY, reload is not needed.
+    """
+    if (
+        event.data["action"] != "update"
+        or "disabled_by" not in event.data["changes"]
+        or event.data["changes"]["disabled_by"] == entity_registry.DISABLED_CONFIG_ENTRY
+    ):
         return False
     return True
 

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -810,15 +810,15 @@ class ConfigEntries:
         ent_reg = entity_registry.async_get(self.hass)
 
         if not entry.disabled_by:
-            # The config entry is no longer disabled, enable devices and entities
+            # The config entry will no longer be disabled, enable devices and entities
             device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
             entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)
 
-        # Unload the config entry, then fire an event
+        # Load or unload the config entry
         reload_result = await self.async_reload(entry_id)
 
         if entry.disabled_by:
-            # The config entry is disabled, disable devices and entities
+            # The config entry has been disabled, disable devices and entities
             device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
             entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -202,7 +202,6 @@ CONF_ZONE = "zone"
 # #### EVENTS ####
 EVENT_CALL_SERVICE = "call_service"
 EVENT_COMPONENT_LOADED = "component_loaded"
-EVENT_CONFIG_ENTRY_DISABLED_BY_UPDATED = "config_entry_disabled_by_updated"
 EVENT_CORE_CONFIG_UPDATE = "core_config_updated"
 EVENT_HOMEASSISTANT_CLOSE = "homeassistant_close"
 EVENT_HOMEASSISTANT_START = "homeassistant_start"

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -313,7 +313,7 @@ async def test_updating_config_entry_id(hass, registry, update_events):
     assert update_events[0]["entity_id"] == entry.entity_id
     assert update_events[1]["action"] == "update"
     assert update_events[1]["entity_id"] == entry.entity_id
-    assert update_events[1]["changes"] == ["config_entry_id"]
+    assert update_events[1]["changes"] == {"config_entry_id": "mock-id-1"}
 
 
 async def test_removing_config_entry_id(hass, registry, update_events):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve behaviour when disabling or enabling config entries to avoid a 2nd reload of the config entry when its entities are enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
