### PR TITLE
Correct gogogate2 battery sensor attributes

### DIFF
--- a/homeassistant/components/gogogate2/cover.py
+++ b/homeassistant/components/gogogate2/cover.py
@@ -122,8 +122,6 @@ class DeviceCover(GoGoGate2Entity, CoverEntity):
         await self._api.async_close_door(self._get_door().door_id)
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
-        attrs = super().state_attributes
-        attrs["door_id"] = self._get_door().door_id
-        return attrs
+        return {"door_id": self._get_door().door_id}

--- a/homeassistant/components/gogogate2/sensor.py
+++ b/homeassistant/components/gogogate2/sensor.py
@@ -50,10 +50,9 @@ class DoorSensor(GoGoGate2Entity):
         return door.voltage  # This is a percentage, not an absolute voltage
 
     @property
-    def state_attributes(self):
+    def device_state_attributes(self):
         """Return the state attributes."""
-        attrs = super().state_attributes or {}
         door = self._get_door()
         if door.sensorid is not None:
-            attrs["sensorid"] = door.door_id
-        return attrs
+            return {"door_id": door.door_id, "sensor_id": door.sensorid}
+        return None

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -21,6 +21,8 @@ from homeassistant.components.cover import (
     DEVICE_CLASS_GARAGE,
     DEVICE_CLASS_GATE,
     DOMAIN as COVER_DOMAIN,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
 )
 from homeassistant.components.gogogate2.const import (
     DEVICE_TYPE_GOGOGATE2,
@@ -319,6 +321,13 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
             wifi=Wifi(SSID="", linkquality="", signal=""),
         )
 
+    expected_attributes = {
+        "device_class": "garage",
+        "door_id": 1,
+        "friendly_name": "Door1",
+        "supported_features": SUPPORT_CLOSE | SUPPORT_OPEN,
+    }
+
     api = MagicMock(GogoGate2Api)
     api.async_activate.return_value = GogoGate2ActivateResponse(result=True)
     api.async_info.return_value = info_response(DoorStatus.OPENED)
@@ -339,6 +348,7 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_OPEN
+    assert dict(hass.states.get("cover.door1").attributes) == expected_attributes
 
     api.async_info.return_value = info_response(DoorStatus.CLOSED)
     await hass.services.async_call(
@@ -375,6 +385,13 @@ async def test_open_close_update(gogogate2api_mock, hass: HomeAssistant) -> None
 async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
     """Test availability."""
     closed_door_response = _mocked_ismartgate_closed_door_response()
+
+    expected_attributes = {
+        "device_class": "garage",
+        "door_id": 1,
+        "friendly_name": "Door1",
+        "supported_features": SUPPORT_CLOSE | SUPPORT_OPEN,
+    }
 
     api = MagicMock(ISmartGateApi)
     api.async_info.return_value = closed_door_response
@@ -416,6 +433,7 @@ async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("cover.door1").state == STATE_CLOSED
+    assert dict(hass.states.get("cover.door1").attributes) == expected_attributes
 
 
 @patch("homeassistant.components.gogogate2.common.ISmartGateApi")

--- a/tests/components/gogogate2/test_sensor.py
+++ b/tests/components/gogogate2/test_sensor.py
@@ -164,6 +164,13 @@ def _mocked_ismartgate_sensor_response(battery_level: int):
 async def test_sensor_update(gogogate2api_mock, hass: HomeAssistant) -> None:
     """Test data update."""
 
+    expected_attributes = {
+        "device_class": "battery",
+        "door_id": 1,
+        "friendly_name": "Door1 battery",
+        "sensor_id": "ABCD",
+    }
+
     api = MagicMock(GogoGate2Api)
     api.async_activate.return_value = GogoGate2ActivateResponse(result=True)
     api.async_info.return_value = _mocked_gogogate_sensor_response(25)
@@ -192,6 +199,9 @@ async def test_sensor_update(gogogate2api_mock, hass: HomeAssistant) -> None:
     assert hass.states.get("cover.door2")
     assert hass.states.get("cover.door2")
     assert hass.states.get("sensor.door1_battery").state == "25"
+    assert (
+        dict(hass.states.get("sensor.door1_battery").attributes) == expected_attributes
+    )
     assert hass.states.get("sensor.door2_battery") is None
     assert hass.states.get("sensor.door2_battery") is None
 
@@ -212,6 +222,13 @@ async def test_sensor_update(gogogate2api_mock, hass: HomeAssistant) -> None:
 @patch("homeassistant.components.gogogate2.common.ISmartGateApi")
 async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
     """Test availability."""
+    expected_attributes = {
+        "device_class": "battery",
+        "door_id": 1,
+        "friendly_name": "Door1 battery",
+        "sensor_id": "ABCD",
+    }
+
     sensor_response = _mocked_ismartgate_sensor_response(35)
     api = MagicMock(ISmartGateApi)
     api.async_info.return_value = sensor_response
@@ -259,3 +276,6 @@ async def test_availability(ismartgateapi_mock, hass: HomeAssistant) -> None:
     async_fire_time_changed(hass, utcnow() + timedelta(hours=2))
     await hass.async_block_till_done()
     assert hass.states.get("sensor.door1_battery").state == "35"
+    assert (
+        dict(hass.states.get("sensor.door1_battery").attributes) == expected_attributes
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Correct gogogate2 battery sensor attributes
Add tests to gogogate2 cover and sensor for attributes
Override `device_state_attributes` instead of `state_attributes` as requested in #47145 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/pull/47145#discussion_r585998675

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
