### PR TITLE
Replace Entity.device_state_attributes with Entity.extra_state_attributes

### DIFF
--- a/homeassistant/components/huawei_lte/binary_sensor.py
+++ b/homeassistant/components/huawei_lte/binary_sensor.py
@@ -144,10 +144,8 @@ class HuaweiLteMobileConnectionBinarySensor(HuaweiLteBaseBinarySensor):
     @property
     def device_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Get additional attributes related to connection status."""
-        attributes = super().device_state_attributes
+        attributes = {}
         if self._raw_state in CONNECTION_STATE_ATTRIBUTES:
-            if attributes is None:
-                attributes = {}
             attributes["additional_state"] = CONNECTION_STATE_ATTRIBUTES[
                 self._raw_state
             ]

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -160,8 +160,8 @@ class Entity(ABC):
     def state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return the state attributes.
 
-        Implemented by component base class. Convention for attribute names
-        is lowercase snake_case.
+        Implemented by component base class, should not be extended by integrations.
+        Convention for attribute names is lowercase snake_case.
         """
         return None
 
@@ -170,12 +170,12 @@ class Entity(ABC):
         """Return entity specific state attributes.
 
         This method is deprecated, platform classes should implement
-        entity_state_attributes instead.
+        extra_state_attributes instead.
         """
         return None
 
     @property
-    def entity_state_attributes(self) -> Optional[Dict[str, Any]]:
+    def extra_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return entity specific state attributes.
 
         Implemented by platform classes. Convention for attribute names
@@ -328,12 +328,12 @@ class Entity(ABC):
             sstate = self.state
             state = STATE_UNKNOWN if sstate is None else str(sstate)
             attr.update(self.state_attributes or {})
-            entity_state_attributes = self.entity_state_attributes
+            extra_state_attributes = self.extra_state_attributes
             # Backwards compatibility for "device_state_attributes" deprecated in 2021.4
             # Add warning in 2021.6, remove in 2021.10
-            if entity_state_attributes is None:
-                entity_state_attributes = self.device_state_attributes
-            attr.update(entity_state_attributes or {})
+            if extra_state_attributes is None:
+                extra_state_attributes = self.device_state_attributes
+            attr.update(extra_state_attributes or {})
 
         unit_of_measurement = self.unit_of_measurement
         if unit_of_measurement is not None:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -166,8 +166,8 @@ class Entity(ABC):
         return None
 
     @property
-    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
-        """Return device specific state attributes.
+    def entity_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return entity specific state attributes.
 
         Implemented by platform classes. Convention for attribute names
         is lowercase snake_case.
@@ -319,7 +319,14 @@ class Entity(ABC):
             sstate = self.state
             state = STATE_UNKNOWN if sstate is None else str(sstate)
             attr.update(self.state_attributes or {})
-            attr.update(self.device_state_attributes or {})
+            entity_state_attributes = self.entity_state_attributes
+            # Backwards compatibility for "device_state_attributes" deprecated in 2021.4
+            # Add warning in 2021.6, remove in 2021.10
+            if entity_state_attributes is None and hasattr(
+                self, "device_state_attributes"
+            ):
+                entity_state_attributes = getattr(self, "device_state_attributes")
+            attr.update(entity_state_attributes or {})
 
         unit_of_measurement = self.unit_of_measurement
         if unit_of_measurement is not None:

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -166,6 +166,15 @@ class Entity(ABC):
         return None
 
     @property
+    def device_state_attributes(self) -> Optional[Dict[str, Any]]:
+        """Return entity specific state attributes.
+
+        This method is deprecated, platform classes should implement
+        entity_state_attributes instead.
+        """
+        return None
+
+    @property
     def entity_state_attributes(self) -> Optional[Dict[str, Any]]:
         """Return entity specific state attributes.
 
@@ -322,10 +331,8 @@ class Entity(ABC):
             entity_state_attributes = self.entity_state_attributes
             # Backwards compatibility for "device_state_attributes" deprecated in 2021.4
             # Add warning in 2021.6, remove in 2021.10
-            if entity_state_attributes is None and hasattr(
-                self, "device_state_attributes"
-            ):
-                entity_state_attributes = getattr(self, "device_state_attributes")
+            if entity_state_attributes is None:
+                entity_state_attributes = self.device_state_attributes
             attr.update(entity_state_attributes or {})
 
         unit_of_measurement = self.unit_of_measurement


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace `Entity.device_state_attributes` with `Entity.extra_state_attributes`.
The name `device_state_attributes` is confusing and the actual device attributes are available from `Entity.device_info`.

To be backwards compatible, `Entity.device_state_attributes` is still called if it is implemented and `Entity.extra_state_attributes` returns `None`.

Planned follow-up PRs:
- Mark `Entity.state_attributes` as `@final` in component base classes
  - Fixed in #48161
- Update integrations to override `Entity.extra_state_attributes` instead of `Entity.device_state_attributes`
  - Fixed in #47756, #47757, #47758, #47759, #47760
- Update integrations to override `Entity.extra_state_attributes` instead of `Entity.state_attributes`
  - Fixed in #48161

Suggested plan for deprecation:
- Start logging a warning in 2021.6
- Remove backwards compatibility in 2021.10

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
