### PR TITLE
Replace Entity.device_class with Entity.entity_class

### DIFF
--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -75,7 +75,6 @@ CONF_DELAY = "delay"
 CONF_DELAY_TIME = "delay_time"
 CONF_DEVICE = "device"
 CONF_DEVICES = "devices"
-CONF_DEVICE_CLASS = "device_class"
 CONF_DEVICE_ID = "device_id"
 CONF_DISARM_AFTER_TRIGGER = "disarm_after_trigger"
 CONF_DISCOVERY = "discovery"
@@ -88,6 +87,7 @@ CONF_EFFECT = "effect"
 CONF_ELEVATION = "elevation"
 CONF_EMAIL = "email"
 CONF_ENTITIES = "entities"
+CONF_ENTITY_CLASS = CONF_DEVICE_CLASS = "device_class"
 CONF_ENTITY_ID = "entity_id"
 CONF_ENTITY_NAMESPACE = "entity_namespace"
 CONF_ENTITY_PICTURE_TEMPLATE = "entity_picture_template"
@@ -218,19 +218,19 @@ EVENT_TIMER_OUT_OF_SYNC = "timer_out_of_sync"
 EVENT_TIME_CHANGED = "time_changed"
 
 
-# #### DEVICE CLASSES ####
-DEVICE_CLASS_BATTERY = "battery"
-DEVICE_CLASS_HUMIDITY = "humidity"
-DEVICE_CLASS_ILLUMINANCE = "illuminance"
-DEVICE_CLASS_SIGNAL_STRENGTH = "signal_strength"
-DEVICE_CLASS_TEMPERATURE = "temperature"
-DEVICE_CLASS_TIMESTAMP = "timestamp"
-DEVICE_CLASS_PRESSURE = "pressure"
-DEVICE_CLASS_POWER = "power"
-DEVICE_CLASS_CURRENT = "current"
-DEVICE_CLASS_ENERGY = "energy"
-DEVICE_CLASS_POWER_FACTOR = "power_factor"
-DEVICE_CLASS_VOLTAGE = "voltage"
+# #### SENSOR ENTITY CLASSES ####
+ENTITY_CLASS_BATTERY = DEVICE_CLASS_BATTERY = "battery"
+ENTITY_CLASS_HUMIDITY = DEVICE_CLASS_HUMIDITY = "humidity"
+ENTITY_CLASS_ILLUMINANCE = DEVICE_CLASS_ILLUMINANCE = "illuminance"
+ENTITY_CLASS_STRENGTH = DEVICE_CLASS_SIGNAL_STRENGTH = "signal_strength"
+ENTITY_CLASS_TEMPERATURE = DEVICE_CLASS_TEMPERATURE = "temperature"
+ENTITY_CLASS_TIMESTAMP = DEVICE_CLASS_TIMESTAMP = "timestamp"
+ENTITY_CLASS_PRESSURE = DEVICE_CLASS_PRESSURE = "pressure"
+ENTITY_CLASS_POWER = DEVICE_CLASS_POWER = "power"
+ENTITY_CLASS_CURRENT = DEVICE_CLASS_CURRENT = "current"
+ENTITY_CLASS_ENERGY = DEVICE_CLASS_ENERGY = "energy"
+ENTITY_CLASS_POWER_FACTOR = DEVICE_CLASS_POWER_FACTOR = "power_factor"
+ENTITY_CLASS_VOLTAGE = DEVICE_CLASS_VOLTAGE = "voltage"
 
 # #### STATES ####
 STATE_ON = "on"
@@ -312,7 +312,7 @@ CONF_UNIT_SYSTEM_IMPERIAL: str = "imperial"
 # Electrical attributes
 ATTR_VOLTAGE = "voltage"
 
-# Location of the device/sensor
+# Location of the entity/sensor
 ATTR_LOCATION = "location"
 
 ATTR_MODE = "mode"
@@ -321,17 +321,17 @@ ATTR_BATTERY_CHARGING = "battery_charging"
 ATTR_BATTERY_LEVEL = "battery_level"
 ATTR_WAKEUP = "wake_up_interval"
 
-# For devices which support a code attribute
+# For entities which support a code attribute
 ATTR_CODE = "code"
 ATTR_CODE_FORMAT = "code_format"
 
-# For calling a device specific command
+# For calling an entity specific command
 ATTR_COMMAND = "command"
 
-# For devices which support an armed state
+# For entities which support an armed state
 ATTR_ARMED = "device_armed"
 
-# For devices which support a locked state
+# For entities which support a locked state
 ATTR_LOCKED = "locked"
 
 # For sensors that support 'tripping', eg. motion and door sensors
@@ -364,8 +364,8 @@ ATTR_RESTORED = "restored"
 # Bitfield of supported component features for the entity
 ATTR_SUPPORTED_FEATURES = "supported_features"
 
-# Class of device within its domain
-ATTR_DEVICE_CLASS = "device_class"
+# Class of entity within its domain
+ATTR_ENTITY_CLASS = ATTR_DEVICE_CLASS = "device_class"
 
 # Temperature attribute
 ATTR_TEMPERATURE = "temperature"

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -10,7 +10,7 @@ from typing import Any, Awaitable, Dict, Iterable, List, Optional
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
-    ATTR_DEVICE_CLASS,
+    ATTR_ENTITY_CLASS,
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
@@ -183,8 +183,8 @@ class Entity(ABC):
         return None
 
     @property
-    def device_class(self) -> Optional[str]:
-        """Return the class of this device, from component DEVICE_CLASSES."""
+    def entity_class(self) -> Optional[str]:
+        """Return the class of this entity, from component DEVICE_CLASSES."""
         return None
 
     @property
@@ -347,9 +347,13 @@ class Entity(ABC):
         if supported_features is not None:
             attr[ATTR_SUPPORTED_FEATURES] = supported_features
 
-        device_class = self.device_class
-        if device_class is not None:
-            attr[ATTR_DEVICE_CLASS] = str(device_class)
+        entity_class = self.entity_class
+        # Backwards compatibility for "device_class" deprecated in 2021.4
+        # Add warning in 2021.6, remove in 2021.10
+        if entity_class is None and hasattr(self, "device_class"):
+            entity_class = getattr(self, "device_class")
+        if entity_class is not None:
+            attr[ATTR_ENTITY_CLASS] = str(entity_class)
 
         end = timer()
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -183,6 +183,15 @@ class Entity(ABC):
         return None
 
     @property
+    def device_class(self) -> Optional[str]:
+        """Return the class of this entity, from component DEVICE_CLASSES.
+
+        This method is deprecated, platform classes should implement entity_class
+        instead.
+        """
+        return None
+
+    @property
     def entity_class(self) -> Optional[str]:
         """Return the class of this entity, from component DEVICE_CLASSES."""
         return None
@@ -350,8 +359,8 @@ class Entity(ABC):
         entity_class = self.entity_class
         # Backwards compatibility for "device_class" deprecated in 2021.4
         # Add warning in 2021.6, remove in 2021.10
-        if entity_class is None and hasattr(self, "device_class"):
-            entity_class = getattr(self, "device_class")
+        if entity_class is None:
+            entity_class = self.device_class
         if entity_class is not None:
             attr[ATTR_ENTITY_CLASS] = str(entity_class)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed changes
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
1. Replace `Entity.device_class ` with `Entity.entity_class`.
Replace `Entity.device_class ` with `Entity.entity_class`.
The name `device_class ` is confusing because it's the class of an entity, not a device.

    To be backwards compatible, `Entity.device_class` is still called if it is implemented and `Entity.entity_class` returns `None`.

2. Replace global constants `CONF_DEVICE_CLASS` and `ATTR_DEVICE_CLASS` with `CONF_ENTITY_CLASS` and `ATTR_ENTITY_CLASS`, but keep their values unchanged (`"device_class"`) because they are user facing and hard coded in configuration and templates.

    A possible alternative could be to:
      - Define `CONF_ENTITY_CLASS="entity_class"`, and update configuration schemas to fall back to `CONF_DEVICE_CLASS`
      - Define `ATTR_ENTITY_CLASS="entity_class"`, but store the entity class also in `state.attributes["device_class"]` to be backwards compatible with templates etc.

#### Suggested plan for deprecation of `Entity.device_class`:
- Start logging a warning in 2021.6
- Remove backwards compatibility in 2021.10

#### Suggested plan for deprecation of `ATTR_DEVICE_CLASS` and `CONF_DEVICE_CLASS`:
- TBD

#### If accepted, follow up with PRs:
- Rename base components' `DEVICE_CLASSES` and `DEVICE_CLASS_*` to `ENTITY_CLASSES` and `ENTITY_CLASS_*`, with backwards compatible aliases for custom components.
- Update across the code base to use  `Entity.entity_class`, `ENTITY_CLASSES` and `ENTITY_CLASS_*`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
