### PR TITLE
Remove old Keenetic NDMS2 entities when some interfaces are unselected

### DIFF
--- a/homeassistant/components/keenetic_ndms2/__init__.py
+++ b/homeassistant/components/keenetic_ndms2/__init__.py
@@ -23,7 +23,7 @@ from .const import (
 )
 from .router import KeeneticRouter
 
-PLATFORMS = [DEVICE_TRACKER_DOMAIN, BINARY_SENSOR_DOMAIN]
+PLATFORMS = [BINARY_SENSOR_DOMAIN, DEVICE_TRACKER_DOMAIN]
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -65,8 +65,8 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
         _LOGGER.debug(
             "Removing device_tracker entities since some interfaces are now untracked"
         )
-        ent_reg = await entity_registry.async_get_registry(hass)
-        dev_reg = await device_registry.async_get_registry(hass)
+        ent_reg = entity_registry.async_get(hass)
+        dev_reg = device_registry.async_get(hass)
         for entity_entry in list(ent_reg.entities.values()):
             if (
                 entity_entry.config_entry_id == config_entry.entry_id

--- a/homeassistant/components/keenetic_ndms2/router.py
+++ b/homeassistant/components/keenetic_ndms2/router.py
@@ -48,6 +48,7 @@ class KeeneticRouter:
         self._cancel_periodic_update: Callable | None = None
         self._available = False
         self._progress = None
+        self._tracked_interfaces = set(config_entry.options[CONF_INTERFACES])
 
     @property
     def client(self):
@@ -104,6 +105,11 @@ class KeeneticRouter:
     def consider_home_interval(self):
         """Config entry option defining number of seconds from last seen to away."""
         return timedelta(seconds=self.config_entry.options[CONF_CONSIDER_HOME])
+
+    @property
+    def tracked_interfaces(self):
+        """Tracked interfaces."""
+        return self._tracked_interfaces
 
     @property
     def signal_update(self):
@@ -178,7 +184,7 @@ class KeeneticRouter:
             self._last_devices = {
                 dev.mac: dev
                 for dev in _response
-                if dev.interface in self.config_entry.options[CONF_INTERFACES]
+                if dev.interface in self._tracked_interfaces
             }
             _LOGGER.debug("Successfully fetched data from router: %s", str(_response))
             self._router_info = self._client.get_router_info()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Keenetic NDMS2: remove old entities when some interfaces are unselected in options.
Currently once first configured integration will collect all devices connected to Home interface. 
The interfaces are set up as part of options so that they can be edited later.
The issue is that when used deselect any interface that was selected before entities that were connected to this interface will be in the registry forever, having 'Away' status.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
