### PR TITLE
Fix zwave_js manual reconfiguration of add-on managed entry

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -120,7 +120,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Make sure we disable any add-on handling
             # if the controller is reconfigured in a manual step.
             self._abort_if_unique_id_configured(
-                updates={**user_input, CONF_USE_ADDON: False}
+                updates={
+                    **user_input,
+                    CONF_USE_ADDON: False,
+                    CONF_INTEGRATION_CREATED_ADDON: False,
+                }
             )
             self.ws_address = user_input[CONF_URL]
             return self._async_create_entry_from_vars()

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -117,7 +117,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(
                 version_info.home_id, raise_on_progress=False
             )
-            self._abort_if_unique_id_configured(user_input)
+            # Make sure we disable any add-on handling
+            # if the controller is reconfigured in a manual step.
+            self._abort_if_unique_id_configured(
+                updates={**user_input, CONF_USE_ADDON: False}
+            )
             self.ws_address = user_input[CONF_URL]
             return self._async_create_entry_from_vars()
 

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -186,7 +186,11 @@ async def test_manual_already_configured(hass):
     """Test that only one unique instance is allowed."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"url": "ws://localhost:3000", "use_addon": True},
+        data={
+            "url": "ws://localhost:3000",
+            "use_addon": True,
+            "integration_created_addon": True,
+        },
         title=TITLE,
         unique_id=1234,
     )
@@ -211,6 +215,7 @@ async def test_manual_already_configured(hass):
     assert result["reason"] == "already_configured"
     assert entry.data["url"] == "ws://1.1.1.1:3001"
     assert entry.data["use_addon"] is False
+    assert entry.data["integration_created_addon"] is False
 
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -184,7 +184,12 @@ async def test_manual_errors(
 
 async def test_manual_already_configured(hass):
     """Test that only one unique instance is allowed."""
-    entry = MockConfigEntry(domain=DOMAIN, data={}, title=TITLE, unique_id=1234)
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"url": "ws://localhost:3000", "use_addon": True},
+        title=TITLE,
+        unique_id=1234,
+    )
     entry.add_to_hass(hass)
 
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -198,12 +203,14 @@ async def test_manual_already_configured(hass):
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         {
-            "url": "ws://localhost:3000",
+            "url": "ws://1.1.1.1:3001",
         },
     )
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+    assert entry.data["url"] == "ws://1.1.1.1:3001"
+    assert entry.data["use_addon"] is False
 
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Fix the `"use_addon"` and `"integration_created_addon"` settings remaining True after manual reconfiguration. A manual configuration should always set these settings to False, also on abort as already configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47376
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
