### PR TITLE
Don't raise on known non-matching states in numeric state condition

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -427,13 +427,15 @@ def async_numeric_state(
     if below is not None:
         if isinstance(below, str):
             below_entity = hass.states.get(below)
-            if not below_entity or below_entity.state in (
+            if not below_entity:
+                raise ConditionErrorMessage(
+                    "numeric_state", f"unknown 'below' entity {below}"
+                )
+            if below_entity.state in (
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                raise ConditionErrorMessage(
-                    "numeric_state", f"the 'below' entity {below} is unavailable"
-                )
+                return False
             try:
                 if fvalue >= float(below_entity.state):
                     condition_trace_set_result(
@@ -454,13 +456,15 @@ def async_numeric_state(
     if above is not None:
         if isinstance(above, str):
             above_entity = hass.states.get(above)
-            if not above_entity or above_entity.state in (
+            if not above_entity:
+                raise ConditionErrorMessage(
+                    "numeric_state", f"unknown 'above' entity {above}"
+                )
+            if above_entity.state in (
                 STATE_UNAVAILABLE,
                 STATE_UNKNOWN,
             ):
-                raise ConditionErrorMessage(
-                    "numeric_state", f"the 'above' entity {above} is unavailable"
-                )
+                return False
             try:
                 if fvalue <= float(above_entity.state):
                     condition_trace_set_result(

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -412,10 +412,9 @@ def async_numeric_state(
                 "numeric_state", f"template error: {ex}"
             ) from ex
 
+    # Known states that never match the numeric condition
     if value in (STATE_UNAVAILABLE, STATE_UNKNOWN):
-        raise ConditionErrorMessage(
-            "numeric_state", f"state of {entity_id} is unavailable"
-        )
+        return False
 
     try:
         fvalue = float(value)

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -10,12 +10,7 @@ import homeassistant.components.automation as automation
 from homeassistant.components.homeassistant.triggers import (
     numeric_state as numeric_state_trigger,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ENTITY_MATCH_ALL,
-    SERVICE_TURN_OFF,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import ATTR_ENTITY_ID, ENTITY_MATCH_ALL, SERVICE_TURN_OFF
 from homeassistant.core import Context
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -345,52 +340,6 @@ async def test_if_fires_on_entity_unavailable_at_startup(hass, calls):
     hass.states.async_set("test.entity", 11)
     await hass.async_block_till_done()
     assert len(calls) == 0
-
-
-async def test_if_not_fires_on_entity_unavailable(hass, calls):
-    """Test the firing with entity changing to unavailable."""
-    # set initial state
-    hass.states.async_set("test.entity", 9)
-    await hass.async_block_till_done()
-
-    assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: {
-                "trigger": {
-                    "platform": "numeric_state",
-                    "entity_id": "test.entity",
-                    "above": 10,
-                },
-                "action": {"service": "test.automation"},
-            }
-        },
-    )
-
-    # 11 is above 10
-    hass.states.async_set("test.entity", 11)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    # Going to unavailable and back should not fire
-    hass.states.async_set("test.entity", STATE_UNAVAILABLE)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    hass.states.async_set("test.entity", 11)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-
-    # Crossing threshold via unavailable should fire
-    hass.states.async_set("test.entity", 9)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    hass.states.async_set("test.entity", STATE_UNAVAILABLE)
-    await hass.async_block_till_done()
-    assert len(calls) == 1
-    hass.states.async_set("test.entity", 11)
-    await hass.async_block_till_done()
-    assert len(calls) == 2
 
 
 @pytest.mark.parametrize("above", (10, "input_number.value_10"))
@@ -1522,7 +1471,7 @@ async def test_if_fires_on_change_with_for_template_3(hass, calls, above, below)
     assert len(calls) == 1
 
 
-async def test_if_not_fires_on_error_with_for_template(hass, caplog, calls):
+async def test_if_not_fires_on_error_with_for_template(hass, calls):
     """Test for not firing on error with for template."""
     hass.states.async_set("test.entity", 0)
     await hass.async_block_till_done()
@@ -1547,16 +1496,10 @@ async def test_if_not_fires_on_error_with_for_template(hass, caplog, calls):
     await hass.async_block_till_done()
     assert len(calls) == 0
 
-    caplog.clear()
-    caplog.set_level(logging.WARNING)
-
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
     hass.states.async_set("test.entity", "unavailable")
     await hass.async_block_till_done()
     assert len(calls) == 0
-
-    assert len(caplog.record_tuples) == 1
-    assert caplog.record_tuples[0][1] == logging.WARNING
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=3))
     hass.states.async_set("test.entity", 101)

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1166,6 +1166,12 @@ async def test_numeric_state_using_input_number(hass):
     hass.states.async_set("sensor.temperature", 100)
     assert not test(hass)
 
+    hass.states.async_set("input_number.high", "unknown")
+    assert not test(hass)
+
+    hass.states.async_set("input_number.high", "unavailable")
+    assert not test(hass)
+
     await hass.services.async_call(
         "input_number",
         "set_value",
@@ -1176,6 +1182,12 @@ async def test_numeric_state_using_input_number(hass):
         blocking=True,
     )
     assert test(hass)
+
+    hass.states.async_set("input_number.low", "unknown")
+    assert not test(hass)
+
+    hass.states.async_set("input_number.low", "unavailable")
+    assert not test(hass)
 
     with pytest.raises(ConditionError):
         condition.async_numeric_state(

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -952,11 +952,11 @@ async def test_numeric_state_known_non_matching(hass):
     )
 
     # Unavailable state
-    not test(hass)
+    assert not test(hass)
 
     # Unknown state
     hass.states.async_set("sensor.temperature", "unknown")
-    not test(hass)
+    assert not test(hass)
 
 
 async def test_numeric_state_raises(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The numeric state condition should not raise on unavailable or unknown states. These are known states defined in our model. It are valid states, the entity exists as well, just not a matching one (for whatever reason).

Introduced in #45923

## Case 1

**Senario before this PR:**

- Entity available, condition matches -> trigger
- Entity becomes unavailable
- Entity becomes available again -> condition matches -> NO trigger

**Senario after:**

- Entity available, condition matches -> trigger
- Entity becomes unavailable
- Entity becomes available again -> condition matches -> trigger

The difference is in the trigger after the state becomes known or available again. It would trigger if it matches at that point. The main reason: We don't know the state in between and should not assume that either.

## Case 2

**Senario before this PR:**

- Home Assistant starts up, does not have a known state yet (battery-powered?)
- Entity becomes available again -> condition matches -> NO trigger

**Senario after:**

- Home Assistant starts up, does not have a known state yet (battery-powered?)
- Entity becomes available again -> condition matches -> trigger

The difference is in the trigger after the state becomes known or available again. It would trigger if it matches at that point. The main reason: We don't know the state in between and should not assume that either.

## Case 3

A condition can be unavailable/unknown at any time. This is part of our core state engine model. If an entity becomes unavailable/unknown, the numeric state condition would never match.


**Situation before this change:**

An warning is logged.

![image](https://user-images.githubusercontent.com/195327/109988795-2cd06f80-7d08-11eb-8b4e-769a77a532e9.png)


**Situation after:**

The condition doesn't match and returns `False`, not log is made.

The reasoning for this; is that it is a valid and known state that never matches. It is not up to automation to log/warn about known states that never match. If we want warnings/alerts/logs about devices being in an unknown or unavailable state, that should be handled by something else (e.g., the state engine, not automations).

See: #47368

As a final word; even if the created situation is the wanted one (which I highly doubt), it should have been marked as breaking change. As this changes the behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47368
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
