### PR TITLE
Prevent Zerproc leaving open unnecessary connections

### DIFF
--- a/homeassistant/components/zerproc/__init__.py
+++ b/homeassistant/components/zerproc/__init__.py
@@ -20,6 +20,11 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Zerproc from a config entry."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    if "addresses" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["addresses"] = set()
+
     for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
@@ -30,6 +35,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
+    hass.data.pop(DOMAIN, None)
     return all(
         await asyncio.gather(
             *[

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -52,11 +52,6 @@ async def async_setup_entry(
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:
     """Set up Zerproc light devices."""
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-    if "addresses" not in hass.data[DOMAIN]:
-        hass.data[DOMAIN]["addresses"] = set()
-
     warned = False
 
     async def discover(*args):
@@ -76,11 +71,6 @@ async def async_setup_entry(
 
     # Perform recurring discovery of new devices
     async_track_time_interval(hass, discover, DISCOVERY_INTERVAL)
-
-
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Cleanup the Zerproc integration."""
-    hass.data.pop(DOMAIN, None)
 
 
 class ZerprocLight(LightEntity):

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -1,5 +1,4 @@
 """Zerproc light platform."""
-import asyncio
 from datetime import timedelta
 import logging
 from typing import Callable, List, Optional
@@ -30,16 +29,6 @@ SUPPORT_ZERPROC = SUPPORT_BRIGHTNESS | SUPPORT_COLOR
 DISCOVERY_INTERVAL = timedelta(seconds=60)
 
 
-async def connect_light(light: pyzerproc.Light) -> Optional[pyzerproc.Light]:
-    """Return the given light if it connects successfully."""
-    try:
-        await light.connect()
-    except pyzerproc.ZerprocException:
-        _LOGGER.debug("Unable to connect to '%s'", light.address, exc_info=True)
-        return None
-    return light
-
-
 async def discover_entities(hass: HomeAssistant) -> List[Entity]:
     """Attempt to discover new lights."""
     lights = await pyzerproc.discover()
@@ -50,14 +39,9 @@ async def discover_entities(hass: HomeAssistant) -> List[Entity]:
     ]
 
     entities = []
-    connected_lights = filter(
-        None, await asyncio.gather(*(connect_light(light) for light in new_lights))
-    )
-    for light in connected_lights:
-        # Double-check the light hasn't been added in the meantime
-        if light.address not in hass.data[DOMAIN]["addresses"]:
-            hass.data[DOMAIN]["addresses"].add(light.address)
-            entities.append(ZerprocLight(light))
+    for light in new_lights:
+        hass.data[DOMAIN]["addresses"].add(light.address)
+        entities.append(ZerprocLight(light))
 
     return entities
 
@@ -94,6 +78,11 @@ async def async_setup_entry(
     async_track_time_interval(hass, discover, DISCOVERY_INTERVAL)
 
 
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Cleanup the Zerproc integration."""
+    hass.data.pop(DOMAIN, None)
+
+
 class ZerprocLight(LightEntity):
     """Representation of an Zerproc Light."""
 
@@ -120,7 +109,7 @@ class ZerprocLight(LightEntity):
             await self._light.disconnect()
         except pyzerproc.ZerprocException:
             _LOGGER.debug(
-                "Exception disconnected from %s", self.entity_id, exc_info=True
+                "Exception disconnecting from %s", self._light.address, exc_info=True
             )
 
     @property
@@ -198,11 +187,11 @@ class ZerprocLight(LightEntity):
             state = await self._light.get_state()
         except pyzerproc.ZerprocException:
             if self._available:
-                _LOGGER.warning("Unable to connect to %s", self.entity_id)
+                _LOGGER.warning("Unable to connect to %s", self._light.address)
             self._available = False
             return
         if self._available is False:
-            _LOGGER.info("Reconnected to %s", self.entity_id)
+            _LOGGER.info("Reconnected to %s", self._light.address)
             self._available = True
         self._is_on = state.is_on
         hsv = color_util.color_RGB_to_hsv(*state.color)

--- a/homeassistant/components/zerproc/manifest.json
+++ b/homeassistant/components/zerproc/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zerproc",
   "requirements": [
-    "pyzerproc==0.4.7"
+    "pyzerproc==0.4.8"
   ],
   "codeowners": [
     "@emlove"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1920,7 +1920,7 @@ pyxeoma==1.4.1
 pyzbar==0.1.7
 
 # homeassistant.components.zerproc
-pyzerproc==0.4.7
+pyzerproc==0.4.8
 
 # homeassistant.components.qnap
 qnapstats==0.3.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -993,7 +993,7 @@ pywemo==0.6.3
 pywilight==0.0.68
 
 # homeassistant.components.zerproc
-pyzerproc==0.4.7
+pyzerproc==0.4.8
 
 # homeassistant.components.rachio
 rachiopy==1.0.3

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -118,6 +118,8 @@ async def test_init(hass, mock_entry):
     assert mock_light_1.disconnect.called
     assert mock_light_2.disconnect.called
 
+    assert hass.data[DOMAIN]["addresses"] == {"AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66"}
+
 
 async def test_discovery_exception(hass, mock_entry):
     """Test platform setup."""
@@ -138,10 +140,13 @@ async def test_discovery_exception(hass, mock_entry):
 
 async def test_remove_entry(hass, mock_light, mock_entry):
     """Test platform setup."""
+    assert hass.data[DOMAIN]["addresses"] == {"AA:BB:CC:DD:EE:FF"}
+
     with patch.object(mock_light, "disconnect") as mock_disconnect:
         await hass.config_entries.async_remove(mock_entry.entry_id)
 
     assert mock_disconnect.called
+    assert DOMAIN not in hass.data
 
 
 async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -136,36 +136,6 @@ async def test_discovery_exception(hass, mock_entry):
     assert len(hass.data[DOMAIN]["addresses"]) == 0
 
 
-async def test_connect_exception(hass, mock_entry):
-    """Test platform setup."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    mock_entry.add_to_hass(hass)
-
-    mock_light_1 = MagicMock(spec=pyzerproc.Light)
-    mock_light_1.address = "AA:BB:CC:DD:EE:FF"
-    mock_light_1.name = "LEDBlue-CCDDEEFF"
-    mock_light_1.is_connected.return_value = False
-
-    mock_light_2 = MagicMock(spec=pyzerproc.Light)
-    mock_light_2.address = "11:22:33:44:55:66"
-    mock_light_2.name = "LEDBlue-33445566"
-    mock_light_2.is_connected.return_value = False
-
-    with patch(
-        "homeassistant.components.zerproc.light.pyzerproc.discover",
-        return_value=[mock_light_1, mock_light_2],
-    ), patch.object(
-        mock_light_1, "connect", side_effect=pyzerproc.ZerprocException("TEST")
-    ):
-        await hass.config_entries.async_setup(mock_entry.entry_id)
-        await hass.async_block_till_done()
-
-    # The exception connecting to light 1 should be captured, but light 2
-    # should still be added
-    assert len(hass.data[DOMAIN]["addresses"]) == 1
-
-
 async def test_remove_entry(hass, mock_light, mock_entry):
     """Test platform setup."""
     with patch.object(mock_light, "disconnect") as mock_disconnect:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes a bug in the Zerproc integration that caused a leak of open connections. Since the upstream discovery has improved, it's no longer necessary to attempt to connect to a device to validate it. Previously, this logic was causing a new bluetooth connection to be opened with every poll. Unloading entries has also been fixed.

Upstream changelog: https://github.com/emlove/pyzerproc#048-2021-02-12

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
