### PR TITLE
Fix typo in docs link for forked_daapd

### DIFF
--- a/homeassistant/components/forked_daapd/manifest.json
+++ b/homeassistant/components/forked_daapd/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "forked_daapd",
   "name": "forked-daapd",
-  "documentation": "https://www.home-assistant.io/integrations/forked-daapd",
+  "documentation": "https://www.home-assistant.io/integrations/forked_daapd",
   "codeowners": ["@uvjustin"],
   "requirements": ["pyforked-daapd==0.1.11", "pylibrespot-java==0.1.0"],
   "config_flow": true,


### PR DESCRIPTION
## Proposed change
corrected typo in link to existing site

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: https://www.home-assistant.io/integrations/forked_daapd/

## Checklist

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.


just corrected typo _/-
