### PR TITLE
Add visibility and wind direction to weather template

### DIFF
--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -50,6 +50,8 @@ CONF_TEMPERATURE_TEMPLATE = "temperature_template"
 CONF_HUMIDITY_TEMPLATE = "humidity_template"
 CONF_CONDITION_TEMPLATE = "condition_template"
 CONF_PRESSURE_TEMPLATE = "pressure_template"
+CONF_VISIBILITY_TEMPLATE = "visibility_template"
+CONF_WIND_BEARING_TEMPLATE = "wind_bearing_template"
 CONF_WIND_SPEED_TEMPLATE = "wind_speed_template"
 CONF_FORECAST_TEMPLATE = "forecast_template"
 
@@ -60,6 +62,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_TEMPERATURE_TEMPLATE): cv.template,
         vol.Required(CONF_HUMIDITY_TEMPLATE): cv.template,
         vol.Optional(CONF_PRESSURE_TEMPLATE): cv.template,
+        vol.Optional(CONF_VISIBILITY_TEMPLATE): cv.template,
+        vol.Optional(CONF_WIND_BEARING_TEMPLATE): cv.template,
         vol.Optional(CONF_WIND_SPEED_TEMPLATE): cv.template,
         vol.Optional(CONF_FORECAST_TEMPLATE): cv.template,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
@@ -76,6 +80,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     temperature_template = config[CONF_TEMPERATURE_TEMPLATE]
     humidity_template = config[CONF_HUMIDITY_TEMPLATE]
     pressure_template = config.get(CONF_PRESSURE_TEMPLATE)
+    visibility_template = config.get(CONF_VISIBILITY_TEMPLATE)
+    wind_bearing_template = config.get(CONF_WIND_BEARING_TEMPLATE)
     wind_speed_template = config.get(CONF_WIND_SPEED_TEMPLATE)
     forecast_template = config.get(CONF_FORECAST_TEMPLATE)
     unique_id = config.get(CONF_UNIQUE_ID)
@@ -89,6 +95,8 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 temperature_template,
                 humidity_template,
                 pressure_template,
+                visibility_template,
+                wind_bearing_template,
                 wind_speed_template,
                 forecast_template,
                 unique_id,
@@ -108,6 +116,8 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         temperature_template,
         humidity_template,
         pressure_template,
+        visibility_template,
+        wind_bearing_template,
         wind_speed_template,
         forecast_template,
         unique_id,
@@ -120,6 +130,8 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         self._temperature_template = temperature_template
         self._humidity_template = humidity_template
         self._pressure_template = pressure_template
+        self._visibility_template = visibility_template
+        self._wind_bearing_template = wind_bearing_template
         self._wind_speed_template = wind_speed_template
         self._forecast_template = forecast_template
         self._unique_id = unique_id
@@ -130,6 +142,8 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
         self._temperature = None
         self._humidity = None
         self._pressure = None
+        self._visibility = None
+        self._wind_bearing = None
         self._wind_speed = None
         self._forecast = []
 
@@ -157,6 +171,16 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
     def humidity(self):
         """Return the humidity."""
         return self._humidity
+
+    @property
+    def visibility(self):
+        """Return the visibility."""
+        return self._visibility
+
+    @property
+    def wind_bearing(self):
+        """Return the wind direction."""
+        return self._wind_bearing
 
     @property
     def wind_speed(self):
@@ -206,6 +230,16 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
             self.add_template_attribute(
                 "_pressure",
                 self._pressure_template,
+            )
+        if self._visibility_template:
+            self.add_template_attribute(
+                "_visibility",
+                self._visibility_template,
+            )
+        if self._wind_bearing_template:
+            self.add_template_attribute(
+                "_wind_bearing",
+                self._wind_bearing_template,
             )
         if self._wind_speed_template:
             self.add_template_attribute(

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -47,7 +47,7 @@ async def test_template_state_text(hass):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.visibility", "20km")
     await hass.async_block_till_done()
-    hass.states.async_set("sensor.wind_directon", "N")
+    hass.states.async_set("sensor.wind_direction", "N")
     await hass.async_block_till_done()
     hass.states.async_set("sensor.windspeed", 20)
     await hass.async_block_till_done()

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -3,6 +3,8 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_HUMIDITY,
     ATTR_WEATHER_PRESSURE,
     ATTR_WEATHER_TEMPERATURE,
+    ATTR_WEATHER_VISIBILITY,
+    ATTR_WEATHER_WIND_BEARING,
     ATTR_WEATHER_WIND_SPEED,
     DOMAIN,
 )
@@ -25,6 +27,8 @@ async def test_template_state_text(hass):
                     "temperature_template": "{{ states('sensor.temperature') | float }}",
                     "humidity_template": "{{ states('sensor.humidity') | int }}",
                     "pressure_template": "{{ states('sensor.pressure') }}",
+                    "visibility_template": "{{ states('sensor.visibility') }}",
+                    "wind_bearing_template": "{{ states('sensor.wind_direction') }}",
                     "wind_speed_template": "{{ states('sensor.windspeed') }}",
                 },
             ]
@@ -41,6 +45,10 @@ async def test_template_state_text(hass):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.pressure", 1000)
     await hass.async_block_till_done()
+    hass.states.async_set("sensor.visibility", "20km")
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.wind_directon", "N")
+    await hass.async_block_till_done()
     hass.states.async_set("sensor.windspeed", 20)
     await hass.async_block_till_done()
 
@@ -53,4 +61,6 @@ async def test_template_state_text(hass):
     assert data.get(ATTR_WEATHER_TEMPERATURE) == 22.3
     assert data.get(ATTR_WEATHER_HUMIDITY) == 60
     assert data.get(ATTR_WEATHER_PRESSURE) == 1000
+    assert data.get(ATTR_WEATHER_VISIBILITY) == "20km"
+    assert data.get(ATTR_WEATHER_WIND_BEARING) == "N"
     assert data.get(ATTR_WEATHER_WIND_SPEED) == 20

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -45,9 +45,9 @@ async def test_template_state_text(hass):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.pressure", 1000)
     await hass.async_block_till_done()
-    hass.states.async_set("sensor.visibility", "20km")
+    hass.states.async_set("sensor.visibility", 20)
     await hass.async_block_till_done()
-    hass.states.async_set("sensor.wind_direction", "N")
+    hass.states.async_set("sensor.wind_direction", 45)
     await hass.async_block_till_done()
     hass.states.async_set("sensor.windspeed", 20)
     await hass.async_block_till_done()
@@ -61,6 +61,6 @@ async def test_template_state_text(hass):
     assert data.get(ATTR_WEATHER_TEMPERATURE) == 22.3
     assert data.get(ATTR_WEATHER_HUMIDITY) == 60
     assert data.get(ATTR_WEATHER_PRESSURE) == 1000
-    assert data.get(ATTR_WEATHER_VISIBILITY) == "20km"
-    assert data.get(ATTR_WEATHER_WIND_BEARING) == "N"
+    assert data.get(ATTR_WEATHER_VISIBILITY) == 20
+    assert data.get(ATTR_WEATHER_WIND_BEARING) == 45
     assert data.get(ATTR_WEATHER_WIND_SPEED) == 20


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently weather template doesn't support these attributes. They are useful, for instance, when you want to create a weather entity from multiple sources and show them in a rich weather card.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
weather:
  - platform: template
    name: Composite Weather
    condition_template: "{{ states('weather.home') }}"
    temperature_template: "{{ states('sensor.outdoor_temperature') | float}}"
    humidity_template: "{{ states('sensor.outdoor_humidity') | float }}"
    pressure_template: "{{ states('sensor.outdoor_pressure') | float }}"
    forecast_template: "{{ state_attr('weather.home', 'forecast') }}"
    visibility_template: "{{ state_attr('weather.home', 'visibility') }}"
    wind_bearing_template: "{{ state_attr('weather.home', 'wind_bearing') }}"
    wind_speed_template: "{{ state_attr('weather.home', 'wind_speed') }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/16851

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
