### PR TITLE
Support Bedrock and add MOTD Sensor

### DIFF
--- a/homeassistant/components/minecraft_server/__init__.py
+++ b/homeassistant/components/minecraft_server/__init__.py
@@ -20,8 +20,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
 from . import helpers
-from .const import DOMAIN, MANUFACTURER, SCAN_INTERVAL, SIGNAL_NAME_PREFIX, CONF_SERVER_TYPE, CONF_SERVER_TYPE_BEDROCK
-
+from .const import DOMAIN, MANUFACTURER, SCAN_INTERVAL, SIGNAL_NAME_PREFIX, CONF_SERVER_TYPE, CONF_SERVER_TYPE_BEDROCK, CONF_SERVER_TYPE_JAVA
 
 
 PLATFORMS = ["binary_sensor", "sensor"]
@@ -316,3 +315,22 @@ class MinecraftServerEntity(Entity):
     def _update_callback(self) -> None:
         """Triggers update of properties after receiving signal from server."""
         self.async_schedule_update_ha_state(force_refresh=True)
+
+async def async_migrate_entry(hass, config_entry: ConfigEntry):
+    """Migrate old entry."""
+    _LOGGER.debug("Migrating from version %s", config_entry.version)
+
+    if config_entry.version == 1:
+        new = {
+            CONF_NAME: config_entry.data[CONF_NAME],
+            CONF_HOST: config_entry.data[CONF_HOST],
+            CONF_PORT: config_entry.data[CONF_PORT],
+            CONF_SERVER_TYPE: CONF_SERVER_TYPE_JAVA,
+            }
+                
+        config_entry.data = {**new}
+        config_entry.version = 2
+
+    _LOGGER.info("Migration to version %s successful", config_entry.version)
+
+    return True

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlow
-from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
 
 from . import MinecraftServer, helpers
 from .const import (  # pylint: disable=unused-import
@@ -15,6 +15,11 @@ from .const import (  # pylint: disable=unused-import
     DEFAULT_NAME,
     DEFAULT_PORT,
     DOMAIN,
+    CONF_SERVER_TYPE,
+    CONF_SERVER_TYPE_ALL,
+    CONF_SERVER_TYPE_JAVA,
+    CONF_SERVER_TYPE_BEDROCK,
+    ConfServerType,
 )
 
 
@@ -31,6 +36,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             host = None
             port = DEFAULT_PORT
+            servertype = user_input[CONF_SERVER_TYPE]
             # Split address at last occurrence of ':'.
             address_left, separator, address_right = user_input[CONF_HOST].rpartition(
                 ":"
@@ -82,6 +88,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_NAME: user_input[CONF_NAME],
                     CONF_HOST: host,
                     CONF_PORT: port,
+                    CONF_SERVER_TYPE: servertype,
                 }
                 server = MinecraftServer(self.hass, "dummy_unique_id", config_data)
                 await server.async_check_connection()
@@ -139,6 +146,7 @@ class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Required(
                         CONF_HOST, default=user_input.get(CONF_HOST, DEFAULT_HOST)
                     ): vol.All(str, vol.Lower),
+                    vol.Required(CONF_SERVER_TYPE): vol.In(CONF_SERVER_TYPE_ALL)
                 }
             ),
             errors=errors,

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -26,7 +26,7 @@ from .const import (  # pylint: disable=unused-import
 class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Minecraft Server."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/minecraft_server/const.py
+++ b/homeassistant/components/minecraft_server/const.py
@@ -1,9 +1,12 @@
 """Constants for the Minecraft Server integration."""
+from collections import defaultdict
+from typing import Dict, List, Literal, Set, Tuple
 
 ATTR_PLAYERS_LIST = "players_list"
 
 DEFAULT_HOST = "localhost:25565"
 DEFAULT_NAME = "Minecraft Server"
+DEFAULT_TYPE = "JAVA"
 DEFAULT_PORT = 25565
 
 DOMAIN = "minecraft_server"
@@ -14,6 +17,7 @@ ICON_PLAYERS_ONLINE = "mdi:account-multiple"
 ICON_PROTOCOL_VERSION = "mdi:numeric"
 ICON_STATUS = "mdi:lan"
 ICON_VERSION = "mdi:numeric"
+ICON_MOTD = "mdi:message-text"
 
 KEY_SERVERS = "servers"
 
@@ -25,6 +29,7 @@ NAME_PLAYERS_ONLINE = "Players Online"
 NAME_PROTOCOL_VERSION = "Protocol Version"
 NAME_STATUS = "Status"
 NAME_VERSION = "Version"
+NAME_MOTD = "MOTD"
 
 SCAN_INTERVAL = 60
 
@@ -36,3 +41,13 @@ UNIT_PLAYERS_MAX = "players"
 UNIT_PLAYERS_ONLINE = "players"
 UNIT_PROTOCOL_VERSION = None
 UNIT_VERSION = None
+UNIT_MOTD = None
+
+CONF_SERVER_TYPE: str = "server_type"
+ConfServerType = Literal["Java", "Bedrock"]
+CONF_SERVER_TYPE_JAVA: ConfServerType = "Java"
+CONF_SERVER_TYPE_BEDROCK: ConfServerType = "Bedrock"
+CONF_SERVER_TYPE_ALL: List[str] = [
+    CONF_SERVER_TYPE_JAVA,
+    CONF_SERVER_TYPE_BEDROCK,
+]

--- a/homeassistant/components/minecraft_server/sensor.py
+++ b/homeassistant/components/minecraft_server/sensor.py
@@ -14,15 +14,18 @@ from .const import (
     ICON_PLAYERS_ONLINE,
     ICON_PROTOCOL_VERSION,
     ICON_VERSION,
+    ICON_MOTD,
     NAME_LATENCY_TIME,
     NAME_PLAYERS_MAX,
     NAME_PLAYERS_ONLINE,
     NAME_PROTOCOL_VERSION,
     NAME_VERSION,
+    NAME_MOTD,
     UNIT_PLAYERS_MAX,
     UNIT_PLAYERS_ONLINE,
     UNIT_PROTOCOL_VERSION,
     UNIT_VERSION,
+    UNIT_MOTD,
 )
 
 
@@ -39,6 +42,7 @@ async def async_setup_entry(
         MinecraftServerLatencyTimeSensor(server),
         MinecraftServerPlayersOnlineSensor(server),
         MinecraftServerPlayersMaxSensor(server),
+        MinecraftServerMOTDSensor(server),
     ]
 
     # Add sensor entities.
@@ -171,3 +175,19 @@ class MinecraftServerPlayersMaxSensor(MinecraftServerSensorEntity):
     async def async_update(self) -> None:
         """Update maximum number of players."""
         self._state = self._server.players_max
+
+class MinecraftServerMOTDSensor(MinecraftServerSensorEntity):
+    """Representation of a Minecraft Server maximum number of players sensor."""
+
+    def __init__(self, server: MinecraftServer) -> None:
+        """Initialize maximum number of players sensor."""
+        super().__init__(
+            server=server,
+            type_name=NAME_MOTD,
+            icon=ICON_MOTD,
+            unit=UNIT_MOTD,
+        )
+
+    async def async_update(self) -> None:
+        """Update maximum number of players."""
+        self._state = self._server.motd

--- a/homeassistant/components/minecraft_server/strings.json
+++ b/homeassistant/components/minecraft_server/strings.json
@@ -6,13 +6,14 @@
         "description": "Set up your Minecraft Server instance to allow monitoring.",
         "data": {
           "name": "[%key:common::config_flow::data::name%]",
-          "host": "[%key:common::config_flow::data::host%]"
+          "host": "[%key:common::config_flow::data::host%]",
+		  "server_type": "Server Type"
         }
       }
     },
     "error": {
       "invalid_port": "Port must be in range from 1024 to 65535. Please correct it and try again.",
-      "cannot_connect": "Failed to connect to server. Please check the host and port and try again. Also ensure that you are running at least Minecraft version 1.7 on your server.",
+      "cannot_connect": "Failed to connect to server. Please check the host and port and try again. Also ensure that you are running at least Minecraft version 1.7 or Bedrock 1.6 on your server.",
       "invalid_ip": "IP address is invalid (MAC address could not be determined). Please correct it and try again."
     },
     "abort": {


### PR DESCRIPTION
Support Bedrock and add MOTD Sensor

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Bedrock Server capability. Old Integrations will be auto migrated and set to Java
Links to documentation change [home-assistant/home-assistant.io] Add documentation for Bedrock Edition (#16853)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This PR will added Bedrock server support. Also added a sensor for MOTD, but not formatted correctly for Java server but still works.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: [home-assistant/home-assistant.io] Add documentation for Bedrock Edition (#16853)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
