### PR TITLE
Disable audio stream when ADTS AAC detected

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -208,6 +208,16 @@ def stream_worker(source, options, segment_buffer, quit_event):
                     missing_dts += 1
                     continue
                 if packet.stream == audio_stream:
+                    # detect ADTS AAC and disable audio
+                    if audio_stream.codec.name == "aac" and packet.size > 2:
+                        packet_view = memoryview(packet)
+                        if packet_view[0] == 0xFF and packet_view[1] & 0xF0 == 0xF0:
+                            _LOGGER.warning(
+                                "ADTS AAC detected - disabling audio stream"
+                            )
+                            container_packets = container.demux(video_stream)
+                            audio_stream = None
+                            continue
                     found_audio = True
                 elif (
                     segment_start_pts is None

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -210,14 +210,14 @@ def stream_worker(source, options, segment_buffer, quit_event):
                 if packet.stream == audio_stream:
                     # detect ADTS AAC and disable audio
                     if audio_stream.codec.name == "aac" and packet.size > 2:
-                        packet_view = memoryview(packet)
-                        if packet_view[0] == 0xFF and packet_view[1] & 0xF0 == 0xF0:
-                            _LOGGER.warning(
-                                "ADTS AAC detected - disabling audio stream"
-                            )
-                            container_packets = container.demux(video_stream)
-                            audio_stream = None
-                            continue
+                        with memoryview(packet) as packet_view:
+                            if packet_view[0] == 0xFF and packet_view[1] & 0xF0 == 0xF0:
+                                _LOGGER.warning(
+                                    "ADTS AAC detected - disabling audio stream"
+                                )
+                                container_packets = container.demux(video_stream)
+                                audio_stream = None
+                                continue
                     found_audio = True
                 elif (
                     segment_start_pts is None

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -95,7 +95,7 @@ class PacketSequence:
         class FakePacket(bytearray):
             # Be a bytearray so that memoryview works
             def __init__(self):
-                super().__init__(2)
+                super().__init__(3)
 
             time_base = fractions.Fraction(1, VIDEO_FRAME_RATE)
             dts = self.packet * PACKET_DURATION / time_base

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -17,7 +17,7 @@ import fractions
 import io
 import math
 import threading
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import av
 
@@ -56,6 +56,7 @@ class FakePyAvStream:
         self.name = name
         self.time_base = fractions.Fraction(1, rate)
         self.profile = "ignored-profile"
+        self.codec = Mock()
 
 
 VIDEO_STREAM = FakePyAvStream(VIDEO_STREAM_FORMAT, VIDEO_FRAME_RATE)
@@ -107,8 +108,8 @@ class FakePyAvContainer:
         self.packets = PacketSequence(0)
 
         class FakePyAvStreams:
-            video = video_stream
-            audio = audio_stream
+            video = [video_stream] if video_stream else []
+            audio = [audio_stream] if audio_stream else []
 
         self.streams = FakePyAvStreams()
 
@@ -171,8 +172,8 @@ class MockPyAv:
 
     def __init__(self, video=True, audio=False):
         """Initialize the MockPyAv."""
-        video_stream = [VIDEO_STREAM] if video else []
-        audio_stream = [AUDIO_STREAM] if audio else []
+        video_stream = VIDEO_STREAM if video else None
+        audio_stream = AUDIO_STREAM if audio else None
         self.container = FakePyAvContainer(
             video_stream=video_stream, audio_stream=audio_stream
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
ADTS AAC audio needs to be converted with a bitstream filter to be used in mp4 segments, and this capability is currently not available through PyAV. This PR detects ADTS audio similar to how it is [done in ffmpeg](https://ffmpeg.org/doxygen/trunk/movenc_8c_source.html#l05648) and disables the audio stream instead of trying to use it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41932, #47084
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
