### PR TITLE
Bump HAP-python to 3.4.0

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -616,7 +616,7 @@ class HomeKit:
         self._async_register_bridge(dev_reg)
         await self._async_start(bridged_states)
         _LOGGER.debug("Driver start for %s", self._name)
-        self.hass.add_job(self.driver.start_service)
+        await self.driver.async_start()
         self.status = STATUS_RUNNING
 
     @callback

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": [
-    "HAP-python==3.3.2",
+    "HAP-python==3.3.3",
     "fnvhash==0.1.0",
     "PyQRCode==1.2.1",
     "base36==0.1.1",

--- a/homeassistant/components/homekit/manifest.json
+++ b/homeassistant/components/homekit/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomeKit",
   "documentation": "https://www.home-assistant.io/integrations/homekit",
   "requirements": [
-    "HAP-python==3.3.3",
+    "HAP-python==3.4.0",
     "fnvhash==0.1.0",
     "PyQRCode==1.2.1",
     "base36==0.1.1",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -17,7 +17,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==3.3.3
+HAP-python==3.4.0
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -17,7 +17,7 @@ Adafruit-SHT31==1.0.2
 # Adafruit_BBIO==1.1.1
 
 # homeassistant.components.homekit
-HAP-python==3.3.2
+HAP-python==3.3.3
 
 # homeassistant.components.mastodon
 Mastodon.py==1.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.1.8
 
 # homeassistant.components.homekit
-HAP-python==3.3.2
+HAP-python==3.3.3
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -7,7 +7,7 @@
 AEMET-OpenData==0.1.8
 
 # homeassistant.components.homekit
-HAP-python==3.3.3
+HAP-python==3.4.0
 
 # homeassistant.components.flick_electric
 PyFlick==0.0.2

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -493,7 +493,7 @@ async def test_homekit_start(hass, hk_driver, device_reg):
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -528,7 +528,7 @@ async def test_homekit_start(hass, hk_driver, device_reg):
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -567,7 +567,7 @@ async def test_homekit_start_with_a_broken_accessory(hass, hk_driver, mock_zeroc
     ) as mock_setup_msg, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory",
     ) as hk_driver_add_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
         await homekit.async_start()
 
@@ -630,7 +630,7 @@ async def test_homekit_reset_accessories(hass, mock_zeroconf):
     ), patch("pyhap.accessory.Bridge.add_accessory") as mock_add_accessory, patch(
         "pyhap.accessory_driver.AccessoryDriver.config_changed"
     ) as hk_driver_config_changed, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         await async_init_entry(hass, entry)
 
@@ -674,7 +674,7 @@ async def test_homekit_too_many_accessories(hass, hk_driver, caplog, mock_zeroco
     hass.states.async_set("light.demo2", "on")
     hass.states.async_set("light.demo3", "on")
 
-    with patch("pyhap.accessory_driver.AccessoryDriver.start_service"), patch(
+    with patch("pyhap.accessory_driver.AccessoryDriver.async_start"), patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ), patch(f"{PATH_HOMEKIT}.show_setup_message"), patch(
         f"{PATH_HOMEKIT}.HomeBridge", _mock_bridge
@@ -738,7 +738,7 @@ async def test_homekit_finds_linked_batteries(
     with patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         await homekit.async_start()
     await hass.async_block_till_done()
@@ -810,7 +810,7 @@ async def test_homekit_async_get_integration_fails(
     with patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         await homekit.async_start()
     await hass.async_block_till_done()
@@ -895,7 +895,7 @@ async def test_homekit_uses_system_zeroconf(hass, hk_driver, mock_zeroconf):
     assert await async_setup_component(hass, "zeroconf", {"zeroconf": {}})
     system_zc = await zeroconf.async_get_instance(hass)
 
-    with patch("pyhap.accessory_driver.AccessoryDriver.start_service"), patch(
+    with patch("pyhap.accessory_driver.AccessoryDriver.async_start"), patch(
         f"{PATH_HOMEKIT}.HomeKit.async_stop"
     ):
         entry.add_to_hass(hass)
@@ -963,7 +963,7 @@ async def test_homekit_ignored_missing_devices(
     with patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         await homekit.async_start()
     await hass.async_block_till_done()
@@ -1025,7 +1025,7 @@ async def test_homekit_finds_linked_motion_sensors(
     with patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         await homekit.async_start()
     await hass.async_block_till_done()
@@ -1090,7 +1090,7 @@ async def test_homekit_finds_linked_humidity_sensors(
     with patch.object(homekit.bridge, "add_accessory"), patch(
         f"{PATH_HOMEKIT}.show_setup_message"
     ), patch(f"{PATH_HOMEKIT}.get_accessory") as mock_get_acc, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         await homekit.async_start()
     await hass.async_block_till_done()
@@ -1153,7 +1153,7 @@ async def test_reload(hass, mock_zeroconf):
     ), patch(
         f"{PATH_HOMEKIT}.get_accessory"
     ), patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ):
         mock_homekit2.return_value = homekit = Mock()
         type(homekit).async_start = AsyncMock()
@@ -1205,7 +1205,7 @@ async def test_homekit_start_in_accessory_mode(hass, hk_driver, device_reg):
     with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
         "pyhap.accessory_driver.AccessoryDriver.add_accessory"
     ), patch(f"{PATH_HOMEKIT}.show_setup_message") as mock_setup_msg, patch(
-        "pyhap.accessory_driver.AccessoryDriver.start_service"
+        "pyhap.accessory_driver.AccessoryDriver.async_start"
     ) as hk_driver_start:
         await homekit.async_start()
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update HAP-python to 3.4.0

https://github.com/ikalchev/HAP-python/releases/tag/v3.4.0

## [3.4.0] - 2021-03-06

### Added
- Python 3.10 support. [#328](https://github.com/ikalchev/HAP-python/pull/328)

### Fixed
- Improve connection stability with large responses. [#320](https://github.com/ikalchev/HAP-python/pull/320)
- Fix `Accessroy.run` not being awaited from a bridge. [#323](https://github.com/ikalchev/HAP-python/pull/323)
- Clean up event subscriptions on client disconnect. [#324](https://github.com/ikalchev/HAP-python/pull/324)

### Removed
- Remove legacy python code. [#321](https://github.com/ikalchev/HAP-python/pull/321)
- Remove deprecated `get_char_loader` and `get_serv_loader`. [#322](https://github.com/ikalchev/HAP-python/pull/322)

### Developers
- Increase code coverage. [#325](https://github.com/ikalchev/HAP-python/pull/325), [#326](https://github.com/ikalchev/HAP-python/pull/326), [#330](https://github.com/ikalchev/HAP-python/pull/330), [#331](https://github.com/ikalchev/HAP-python/pull/331), [#332](https://github.com/ikalchev/HAP-python/pull/332)
- Add bandit to CI. [#329](https://github.com/ikalchev/HAP-python/pull/329)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47152
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
