### PR TITLE
Cleanup homekit and remove aid storage from hass.data

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -605,10 +605,10 @@ class HomeKit:
             )
             self.status = STATUS_STOPPED
             return
-        self._async_register_bridge()
         self.aid_storage = AccessoryAidStorage(self.hass, self._entry_id)
         await self.aid_storage.async_initialize()
         await self._async_create_accessories()
+        self._async_register_bridge()
         _LOGGER.debug("Driver start for %s", self._name)
         await self.driver.async_start()
         self.status = STATUS_RUNNING
@@ -651,7 +651,7 @@ class HomeKit:
             identifiers={identifier},
             connections={connection},
             manufacturer=MANUFACTURER,
-            name=self._name,
+            name=accessory_friendly_name(self._entry_title, self.driver.accessory),
             model=f"Home Assistant HomeKit {hk_mode_name}",
         )
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -641,7 +641,7 @@ class HomeKit:
             connections={connection},
             manufacturer=MANUFACTURER,
             name=accessory_friendly_name(self._entry_title, self.driver.accessory),
-            model=f"Home Assistant HomeKit {hk_mode_name}",
+            model=f"HomeKit {hk_mode_name}",
             entry_type="service",
         )
 

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -592,9 +592,8 @@ class HomeKit:
         if self.status != STATUS_READY:
             return
         self.status = STATUS_WAIT
-        await self.hass.async_add_executor_job(
-            self.setup, await zeroconf.async_get_instance(self.hass)
-        )
+        zc_instance = await zeroconf.async_get_instance(self.hass)
+        await self.hass.async_add_executor_job(self.setup, zc_instance)
         self.aid_storage = AccessoryAidStorage(self.hass, self._entry_id)
         await self.aid_storage.async_initialize()
         await self._async_create_accessories()

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -592,19 +592,9 @@ class HomeKit:
         if self.status != STATUS_READY:
             return
         self.status = STATUS_WAIT
-        try:
-            await self.hass.async_add_executor_job(
-                self.setup, await zeroconf.async_get_instance(self.hass)
-            )
-        except (OSError, AttributeError) as ex:
-            _LOGGER.warning(
-                "%s could not be setup because the local port %s is in use",
-                self._name,
-                self._port,
-                exc_info=ex,
-            )
-            self.status = STATUS_STOPPED
-            return
+        await self.hass.async_add_executor_job(
+            self.setup, await zeroconf.async_get_instance(self.hass)
+        )
         self.aid_storage = AccessoryAidStorage(self.hass, self._entry_id)
         await self.aid_storage.async_initialize()
         await self._async_create_accessories()

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -240,9 +240,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     port = conf[CONF_PORT]
     _LOGGER.debug("Begin setup HomeKit for %s", name)
 
-    aid_storage = AccessoryAidStorage(hass, entry.entry_id)
-
-    await aid_storage.async_initialize()
     # ip_address and advertise_ip are yaml only
     ip_address = conf.get(CONF_IP_ADDRESS)
     advertise_ip = conf.get(CONF_ADVERTISE_IP)

--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -642,6 +642,7 @@ class HomeKit:
             manufacturer=MANUFACTURER,
             name=accessory_friendly_name(self._entry_title, self.driver.accessory),
             model=f"Home Assistant HomeKit {hk_mode_name}",
+            entry_type="service",
         )
 
     @callback

--- a/homeassistant/components/homekit/const.py
+++ b/homeassistant/components/homekit/const.py
@@ -5,7 +5,6 @@ DEBOUNCE_TIMEOUT = 0.5
 DEVICE_PRECISION_LEEWAY = 6
 DOMAIN = "homekit"
 HOMEKIT_FILE = ".homekit.state"
-AID_STORAGE = "homekit-aid-allocations"
 HOMEKIT_PAIRING_QR = "homekit-pairing-qr"
 HOMEKIT_PAIRING_QR_SECRET = "homekit-pairing-qr-secret"
 HOMEKIT = "homekit"

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -487,9 +487,9 @@ def accessory_friendly_name(hass_name, accessory):
     see both to identify the accessory.
     """
     accessory_mdns_name = accessory.display_name
-    if hass_name.startswith(accessory_mdns_name):
+    if hass_name.casefold().startswith(accessory_mdns_name.casefold()):
         return hass_name
-    if accessory_mdns_name.startswith(hass_name):
+    if accessory_mdns_name.casefold().startswith(hass_name.casefold()):
         return accessory_mdns_name
     return f"{hass_name} ({accessory_mdns_name})"
 

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -489,6 +489,8 @@ def accessory_friendly_name(hass_name, accessory):
     accessory_mdns_name = accessory.display_name
     if hass_name.startswith(accessory_mdns_name):
         return hass_name
+    if accessory_mdns_name.startswith(hass_name):
+        return accessory_mdns_name
     return f"{hass_name} ({accessory_mdns_name})"
 
 

--- a/tests/components/homekit/conftest.py
+++ b/tests/components/homekit/conftest.py
@@ -14,7 +14,9 @@ def hk_driver(loop):
     """Return a custom AccessoryDriver instance for HomeKit accessory init."""
     with patch("pyhap.accessory_driver.Zeroconf"), patch(
         "pyhap.accessory_driver.AccessoryEncoder"
-    ), patch("pyhap.accessory_driver.HAPServer"), patch(
+    ), patch("pyhap.accessory_driver.HAPServer.async_stop"), patch(
+        "pyhap.accessory_driver.HAPServer.async_start"
+    ), patch(
         "pyhap.accessory_driver.AccessoryDriver.publish"
     ), patch(
         "pyhap.accessory_driver.AccessoryDriver.persist"

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1138,7 +1138,9 @@ def _get_fixtures_base_path():
     return os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 
 
-async def test_homekit_start_in_accessory_mode(hass, hk_driver, device_reg):
+async def test_homekit_start_in_accessory_mode(
+    hass, hk_driver, mock_zeroconf, device_reg
+):
     """Test HomeKit start method in accessory mode."""
     entry = await async_init_integration(hass)
 

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -294,7 +294,7 @@ async def test_accessory_friendly_name():
 
     accessory = Mock()
     accessory.display_name = "same"
-    assert accessory_friendly_name("same", accessory) == "same"
+    assert accessory_friendly_name("Same", accessory) == "Same"
     assert accessory_friendly_name("hass title", accessory) == "hass title (same)"
-    accessory.display_name = "hass title 123"
-    assert accessory_friendly_name("hass title", accessory) == "hass title 123"
+    accessory.display_name = "Hass title 123"
+    assert accessory_friendly_name("hass title", accessory) == "Hass title 123"

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -296,3 +296,5 @@ async def test_accessory_friendly_name():
     accessory.display_name = "same"
     assert accessory_friendly_name("same", accessory) == "same"
     assert accessory_friendly_name("hass title", accessory) == "hass title (same)"
+    accessory.display_name = "hass title 123"
+    assert accessory_friendly_name("hass title", accessory) == "hass title 123"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cleanup homekit and remove aid storage from hass.data
- Fixes a case of I/O in the event loop (writing the state file)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
