### PR TITLE
UniFi has changed to not report uptime in epoch form

### DIFF
--- a/homeassistant/components/unifi/sensor.py
+++ b/homeassistant/components/unifi/sensor.py
@@ -3,6 +3,9 @@
 Support for bandwidth sensors of network clients.
 Support for uptime sensors of network clients.
 """
+
+from datetime import datetime, timedelta
+
 from homeassistant.components.sensor import DEVICE_CLASS_TIMESTAMP, DOMAIN
 from homeassistant.const import DATA_MEGABYTES
 from homeassistant.core import callback
@@ -140,8 +143,10 @@ class UniFiUpTimeSensor(UniFiClient):
         return f"{super().name} {self.TYPE.capitalize()}"
 
     @property
-    def state(self) -> int:
+    def state(self) -> datetime:
         """Return the uptime of the client."""
+        if self.client.uptime < 1000000000:
+            return (dt_util.now() - timedelta(seconds=self.client.uptime)).isoformat()
         return dt_util.utc_from_timestamp(float(self.client.uptime)).isoformat()
 
     async def options_updated(self) -> None:

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -1,6 +1,5 @@
 """UniFi sensor platform tests."""
 
-from copy import deepcopy
 from datetime import datetime
 from unittest.mock import patch
 
@@ -20,37 +19,6 @@ import homeassistant.util.dt as dt_util
 
 from .test_controller import setup_unifi_integration
 
-CLIENTS = [
-    {
-        "hostname": "Wired client hostname",
-        "ip": "10.0.0.1",
-        "is_wired": True,
-        "last_seen": 1562600145,
-        "mac": "00:00:00:00:00:01",
-        "name": "Wired client name",
-        "oui": "Producer",
-        "sw_mac": "00:00:00:00:01:01",
-        "sw_port": 1,
-        "wired-rx_bytes": 1234000000,
-        "wired-tx_bytes": 5678000000,
-        "uptime": 1600094505,
-    },
-    {
-        "hostname": "Wireless client hostname",
-        "ip": "10.0.0.2",
-        "is_wired": False,
-        "last_seen": 1562600145,
-        "mac": "00:00:00:00:00:02",
-        "name": "Wireless client name",
-        "oui": "Producer",
-        "sw_mac": "00:00:00:00:01:01",
-        "sw_port": 2,
-        "rx_bytes": 1234000000,
-        "tx_bytes": 5678000000,
-        "uptime": 1600094505,
-    },
-]
-
 
 async def test_no_clients(hass, aioclient_mock):
     """Test the update_clients function when no clients are found."""
@@ -66,112 +34,93 @@ async def test_no_clients(hass, aioclient_mock):
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
 
 
-async def test_sensors(hass, aioclient_mock, mock_unifi_websocket):
+async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
     """Test the update_items function with some clients."""
+    wired_client = {
+        "hostname": "Wired client",
+        "is_wired": True,
+        "mac": "00:00:00:00:00:01",
+        "oui": "Producer",
+        "wired-rx_bytes": 1234000000,
+        "wired-tx_bytes": 5678000000,
+    }
+    wireless_client = {
+        "is_wired": False,
+        "mac": "00:00:00:00:00:02",
+        "name": "Wireless client",
+        "oui": "Producer",
+        "rx_bytes": 2345000000,
+        "tx_bytes": 6789000000,
+    }
+    options = {
+        CONF_ALLOW_BANDWIDTH_SENSORS: True,
+        CONF_ALLOW_UPTIME_SENSORS: False,
+        CONF_TRACK_CLIENTS: False,
+        CONF_TRACK_DEVICES: False,
+    }
+
     config_entry = await setup_unifi_integration(
         hass,
         aioclient_mock,
-        options={
-            CONF_ALLOW_BANDWIDTH_SENSORS: True,
-            CONF_ALLOW_UPTIME_SENSORS: True,
-            CONF_TRACK_CLIENTS: False,
-            CONF_TRACK_DEVICES: False,
-        },
-        clients_response=CLIENTS,
+        options=options,
+        clients_response=[wired_client, wireless_client],
     )
-    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert hass.states.get("sensor.wired_client_rx").state == "1234.0"
+    assert hass.states.get("sensor.wired_client_tx").state == "5678.0"
+    assert hass.states.get("sensor.wireless_client_rx").state == "2345.0"
+    assert hass.states.get("sensor.wireless_client_tx").state == "6789.0"
 
-    wired_client_rx = hass.states.get("sensor.wired_client_name_rx")
-    assert wired_client_rx.state == "1234.0"
+    # Verify state update
 
-    wired_client_tx = hass.states.get("sensor.wired_client_name_tx")
-    assert wired_client_tx.state == "5678.0"
-
-    wired_client_uptime = hass.states.get("sensor.wired_client_name_uptime")
-    assert wired_client_uptime.state == "2020-09-14T14:41:45+00:00"
-
-    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
-    assert wireless_client_rx.state == "1234.0"
-
-    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
-    assert wireless_client_tx.state == "5678.0"
-
-    wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
-    assert wireless_client_uptime.state == "2020-09-14T14:41:45+00:00"
-
-    clients = deepcopy(CLIENTS)
-    clients[0]["is_wired"] = False
-    clients[1]["rx_bytes"] = 2345000000
-    clients[1]["tx_bytes"] = 6789000000
-    clients[1]["uptime"] = 1600180860
+    wireless_client["rx_bytes"] = 3456000000
+    wireless_client["tx_bytes"] = 7891000000
 
     mock_unifi_websocket(
         data={
             "meta": {"message": MESSAGE_CLIENT},
-            "data": clients,
+            "data": [wireless_client],
         }
     )
     await hass.async_block_till_done()
 
-    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
-    assert wireless_client_rx.state == "2345.0"
+    assert hass.states.get("sensor.wireless_client_rx").state == "3456.0"
+    assert hass.states.get("sensor.wireless_client_tx").state == "7891.0"
 
-    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
-    assert wireless_client_tx.state == "6789.0"
+    # Disable option
 
-    wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
-    assert wireless_client_uptime.state == "2020-09-15T14:41:00+00:00"
-
-    hass.config_entries.async_update_entry(
-        config_entry,
-        options={
-            CONF_ALLOW_BANDWIDTH_SENSORS: False,
-            CONF_ALLOW_UPTIME_SENSORS: False,
-        },
-    )
+    options[CONF_ALLOW_BANDWIDTH_SENSORS] = False
+    hass.config_entries.async_update_entry(config_entry, options=options.copy())
     await hass.async_block_till_done()
 
-    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
-    assert wireless_client_rx is None
+    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
+    assert hass.states.get("sensor.wireless_client_rx") is None
+    assert hass.states.get("sensor.wireless_client_tx") is None
+    assert hass.states.get("sensor.wired_client_rx") is None
+    assert hass.states.get("sensor.wired_client_tx") is None
 
-    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
-    assert wireless_client_tx is None
+    # Enable option
 
-    wired_client_uptime = hass.states.get("sensor.wired_client_name_uptime")
-    assert wired_client_uptime is None
-
-    wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
-    assert wireless_client_uptime is None
-
-    hass.config_entries.async_update_entry(
-        config_entry,
-        options={
-            CONF_ALLOW_BANDWIDTH_SENSORS: True,
-            CONF_ALLOW_UPTIME_SENSORS: True,
-        },
-    )
+    options[CONF_ALLOW_BANDWIDTH_SENSORS] = True
+    hass.config_entries.async_update_entry(config_entry, options=options.copy())
     await hass.async_block_till_done()
 
-    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
-    assert wireless_client_rx.state == "2345.0"
-
-    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
-    assert wireless_client_tx.state == "6789.0"
-
-    wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
-    assert wireless_client_uptime.state == "2020-09-15T14:41:00+00:00"
-
-    wired_client_uptime = hass.states.get("sensor.wired_client_name_uptime")
-    assert wired_client_uptime.state == "2020-09-14T14:41:45+00:00"
+    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
+    assert hass.states.get("sensor.wireless_client_rx")
+    assert hass.states.get("sensor.wireless_client_tx")
+    assert hass.states.get("sensor.wired_client_rx")
+    assert hass.states.get("sensor.wired_client_tx")
 
     # Try to add the sensors again, using a signal
-    clients_connected = set()
+
+    clients_connected = {wired_client["mac"], wireless_client["mac"]}
     devices_connected = set()
 
-    clients_connected.add(clients[0]["mac"])
-    clients_connected.add(clients[1]["mac"])
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     async_dispatcher_send(
         hass,
@@ -179,10 +128,10 @@ async def test_sensors(hass, aioclient_mock, mock_unifi_websocket):
         clients_connected,
         devices_connected,
     )
-
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
+    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 4
 
 
 async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
@@ -214,18 +163,11 @@ async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
             options=options,
             clients_response=[client1, client2],
         )
-        controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
-        assert len(hass.states.async_all()) == 3
-        assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
-        assert (
-            hass.states.get("sensor.client1_uptime").state
-            == "2021-01-01T13:01:01+00:00"
-        )
-        assert (
-            hass.states.get("sensor.client2_uptime").state
-            == "2021-01-01T00:59:00+00:00"
-        )
+    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
+    assert hass.states.get("sensor.client1_uptime").state == "2021-01-01T13:01:01+00:00"
+    assert hass.states.get("sensor.client2_uptime").state == "2021-01-01T00:59:00+00:00"
 
     # Verify state update
 
@@ -246,6 +188,8 @@ async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
     hass.config_entries.async_update_entry(config_entry, options=options.copy())
     await hass.async_block_till_done()
 
+    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 0
     assert hass.states.get("sensor.client1_uptime") is None
     assert hass.states.get("sensor.client2_uptime") is None
 
@@ -256,12 +200,17 @@ async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
         hass.config_entries.async_update_entry(config_entry, options=options.copy())
         await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.client1_uptime").state == "2021-01-01T13:01:02+00:00"
-    assert hass.states.get("sensor.client2_uptime").state == "2021-01-01T00:59:00+00:00"
+    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 2
+    assert hass.states.get("sensor.client1_uptime")
+    assert hass.states.get("sensor.client2_uptime")
 
     # Try to add the sensors again, using a signal
+
     clients_connected = {client1["mac"], client2["mac"]}
     devices_connected = set()
+
+    controller = hass.data[UNIFI_DOMAIN][config_entry.entry_id]
 
     async_dispatcher_send(
         hass,
@@ -277,6 +226,25 @@ async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
 
 async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
     """Test the remove_items function with some clients."""
+    wired_client = {
+        "hostname": "Wired client",
+        "is_wired": True,
+        "mac": "00:00:00:00:00:01",
+        "oui": "Producer",
+        "wired-rx_bytes": 1234000000,
+        "wired-tx_bytes": 5678000000,
+        "uptime": 1600094505,
+    }
+    wireless_client = {
+        "is_wired": False,
+        "mac": "00:00:00:00:00:02",
+        "name": "Wireless client",
+        "oui": "Producer",
+        "rx_bytes": 2345000000,
+        "tx_bytes": 6789000000,
+        "uptime": 60,
+    }
+
     await setup_unifi_integration(
         hass,
         aioclient_mock,
@@ -284,51 +252,35 @@ async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
             CONF_ALLOW_BANDWIDTH_SENSORS: True,
             CONF_ALLOW_UPTIME_SENSORS: True,
         },
-        clients_response=CLIENTS,
+        clients_response=[wired_client, wireless_client],
     )
 
+    assert len(hass.states.async_all()) == 9
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 6
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 2
+    assert hass.states.get("sensor.wired_client_rx")
+    assert hass.states.get("sensor.wired_client_tx")
+    assert hass.states.get("sensor.wired_client_uptime")
+    assert hass.states.get("sensor.wireless_client_rx")
+    assert hass.states.get("sensor.wireless_client_tx")
+    assert hass.states.get("sensor.wireless_client_uptime")
 
-    wired_client_rx = hass.states.get("sensor.wired_client_name_rx")
-    assert wired_client_rx is not None
-    wired_client_tx = hass.states.get("sensor.wired_client_name_tx")
-    assert wired_client_tx is not None
-
-    wired_client_uptime = hass.states.get("sensor.wired_client_name_uptime")
-    assert wired_client_uptime is not None
-
-    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
-    assert wireless_client_rx is not None
-    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
-    assert wireless_client_tx is not None
-
-    wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
-    assert wireless_client_uptime is not None
+    # Remove wired client
 
     mock_unifi_websocket(
         data={
             "meta": {"message": MESSAGE_CLIENT_REMOVED},
-            "data": [CLIENTS[0]],
+            "data": [wired_client],
         }
     )
     await hass.async_block_till_done()
 
+    assert len(hass.states.async_all()) == 5
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 3
     assert len(hass.states.async_entity_ids(TRACKER_DOMAIN)) == 1
-
-    wired_client_rx = hass.states.get("sensor.wired_client_name_rx")
-    assert wired_client_rx is None
-    wired_client_tx = hass.states.get("sensor.wired_client_name_tx")
-    assert wired_client_tx is None
-
-    wired_client_uptime = hass.states.get("sensor.wired_client_name_uptime")
-    assert wired_client_uptime is None
-
-    wireless_client_rx = hass.states.get("sensor.wireless_client_name_rx")
-    assert wireless_client_rx is not None
-    wireless_client_tx = hass.states.get("sensor.wireless_client_name_tx")
-    assert wireless_client_tx is not None
-
-    wireless_client_uptime = hass.states.get("sensor.wireless_client_name_uptime")
-    assert wireless_client_uptime is not None
+    assert hass.states.get("sensor.wired_client_rx") is None
+    assert hass.states.get("sensor.wired_client_tx") is None
+    assert hass.states.get("sensor.wired_client_uptime") is None
+    assert hass.states.get("sensor.wireless_client_rx")
+    assert hass.states.get("sensor.wireless_client_tx")
+    assert hass.states.get("sensor.wireless_client_uptime")

--- a/tests/components/unifi/test_sensor.py
+++ b/tests/components/unifi/test_sensor.py
@@ -35,7 +35,7 @@ async def test_no_clients(hass, aioclient_mock):
 
 
 async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
-    """Test the update_items function with some clients."""
+    """Verify that bandwidth sensors are working as expected."""
     wired_client = {
         "hostname": "Wired client",
         "is_wired": True,
@@ -135,7 +135,7 @@ async def test_bandwidth_sensors(hass, aioclient_mock, mock_unifi_websocket):
 
 
 async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
-    """Test the update_items function with some clients."""
+    """Verify that uptime sensors are working as expected."""
     client1 = {
         "mac": "00:00:00:00:00:01",
         "name": "client1",
@@ -225,7 +225,7 @@ async def test_uptime_sensors(hass, aioclient_mock, mock_unifi_websocket):
 
 
 async def test_remove_sensors(hass, aioclient_mock, mock_unifi_websocket):
-    """Test the remove_items function with some clients."""
+    """Verify removing of clients work as expected."""
     wired_client = {
         "hostname": "Wired client",
         "is_wired": True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
From a fairly recent release UniFi has changed from reporting uptime in epoch form to uptime in seconds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46469
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
