### PR TITLE
None optional hass typing in base entity and notify

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -635,14 +635,14 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         if self._trigger_variables:
             try:
                 variables = self._trigger_variables.async_render(
-                    cast(HomeAssistant, self.hass), None, limited=True
+                    self.hass, None, limited=True
                 )
             except template.TemplateError as err:
                 self._logger.error("Error rendering trigger variables: %s", err)
                 return None
 
         return await async_initialize_triggers(
-            cast(HomeAssistant, self.hass),
+            self.hass,
             self._trigger_config,
             self.async_trigger,
             DOMAIN,

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -158,7 +158,6 @@ class BondEntity(Entity):
         await super().async_added_to_hass()
         self._update_lock = Lock()
         self._bpup_subs.subscribe(self._device_id, self._async_bpup_callback)
-        assert self.hass is not None
         self.async_on_remove(
             async_track_time_interval(
                 self.hass, self._async_update_if_bpup_not_alive, _FALLBACK_SCAN_INTERVAL

--- a/homeassistant/components/climacell/config_flow.py
+++ b/homeassistant/components/climacell/config_flow.py
@@ -110,7 +110,6 @@ class ClimaCellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: Dict[str, Any] = None
     ) -> Dict[str, Any]:
         """Handle the initial step."""
-        assert self.hass
         errors = {}
         if user_input is not None:
             await self.async_set_unique_id(

--- a/homeassistant/components/group/__init__.py
+++ b/homeassistant/components/group/__init__.py
@@ -395,7 +395,6 @@ class GroupEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Register listeners."""
-        assert self.hass is not None
 
         async def _update_at_start(_):
             await self.async_update()
@@ -405,8 +404,6 @@ class GroupEntity(Entity):
 
     async def async_defer_or_update_ha_state(self) -> None:
         """Only update once at start."""
-        assert self.hass is not None
-
         if self.hass.state != CoreState.running:
             return
 

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -155,7 +155,6 @@ class CoverGroup(GroupEntity, CoverEntity):
             await self.async_update_supported_features(
                 entity_id, new_state, update_state=False
             )
-        assert self.hass is not None
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass, self._entities, self._update_supported_features_event

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -103,7 +103,6 @@ class LightGroup(GroupEntity, light.LightEntity):
             self.async_set_context(event.context)
             await self.async_defer_or_update_ha_state()
 
-        assert self.hass
         self.async_on_remove(
             async_track_state_change_event(
                 self.hass, self._entity_ids, async_state_changed_listener

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -636,7 +636,6 @@ class HuaweiLteBaseEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Connect to update signals."""
-        assert self.hass is not None
         self._unsub_handlers.append(
             async_dispatcher_connect(self.hass, UPDATE_SIGNAL, self._async_maybe_update)
         )

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -397,7 +397,6 @@ class HyperionBaseLight(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""
-        assert self.hass
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -193,7 +193,6 @@ class HyperionComponentSwitch(SwitchEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks when entity added to hass."""
-        assert self.hass
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -2,7 +2,7 @@
 import asyncio
 from functools import partial
 import logging
-from typing import Any, Dict, Optional, cast
+from typing import Any, Dict, cast
 
 import voluptuous as vol
 
@@ -114,7 +114,11 @@ def _async_integration_has_notify_services(
 class BaseNotificationService:
     """An abstract class for notification services."""
 
-    hass: Optional[HomeAssistantType] = None
+    # While not purely typed, it makes typehinting more useful for us
+    # and removes the need for constant None checks or asserts.
+    # Ignore types: https://github.com/PyCQA/pylint/issues/3167
+    hass: HomeAssistantType = None  # type: ignore
+
     # Name => target
     registered_targets: Dict[str, str]
 
@@ -130,7 +134,9 @@ class BaseNotificationService:
 
         kwargs can contain ATTR_TITLE to specify a title.
         """
-        await self.hass.async_add_executor_job(partial(self.send_message, message, **kwargs))  # type: ignore
+        await self.hass.async_add_executor_job(
+            partial(self.send_message, message, **kwargs)
+        )
 
     async def _async_notify_message_service(self, service: ServiceCall) -> None:
         """Handle sending notification message service calls."""

--- a/homeassistant/components/notify/__init__.py
+++ b/homeassistant/components/notify/__init__.py
@@ -181,8 +181,6 @@ class BaseNotificationService:
 
     async def async_register_services(self) -> None:
         """Create or update the notify services."""
-        assert self.hass
-
         if hasattr(self, "targets"):
             stale_targets = set(self.registered_targets)
 
@@ -238,8 +236,6 @@ class BaseNotificationService:
 
     async def async_unregister_services(self) -> None:
         """Unregister the notify services."""
-        assert self.hass
-
         if self.registered_targets:
             remove_targets = set(self.registered_targets)
             for remove_target_name in remove_targets:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -110,5 +110,4 @@ class NumberEntity(Entity):
 
     async def async_set_value(self, value: float) -> None:
         """Set new value."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(self.set_value, value)

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -147,5 +147,4 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
     def update_data(self, data):
         """Mark the device as seen."""
         self._data = data
-        if self.hass:
-            self.async_write_ha_state()
+        self.async_write_ha_state()

--- a/homeassistant/components/owntracks/device_tracker.py
+++ b/homeassistant/components/owntracks/device_tracker.py
@@ -147,4 +147,5 @@ class OwnTracksEntity(TrackerEntity, RestoreEntity):
     def update_data(self, data):
         """Mark the device as seen."""
         self._data = data
-        self.async_write_ha_state()
+        if self.hass:
+            self.async_write_ha_state()

--- a/homeassistant/components/remote/__init__.py
+++ b/homeassistant/components/remote/__init__.py
@@ -173,7 +173,6 @@ class RemoteEntity(ToggleEntity):
 
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send commands to a device."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(
             ft.partial(self.send_command, command, **kwargs)
         )
@@ -184,7 +183,6 @@ class RemoteEntity(ToggleEntity):
 
     async def async_learn_command(self, **kwargs: Any) -> None:
         """Learn a command from a device."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(ft.partial(self.learn_command, **kwargs))
 
     def delete_command(self, **kwargs: Any) -> None:
@@ -193,7 +191,6 @@ class RemoteEntity(ToggleEntity):
 
     async def async_delete_command(self, **kwargs: Any) -> None:
         """Delete commands from the database."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(
             ft.partial(self.delete_command, **kwargs)
         )

--- a/homeassistant/components/scene/__init__.py
+++ b/homeassistant/components/scene/__init__.py
@@ -104,7 +104,6 @@ class Scene(Entity):
 
     async def async_activate(self, **kwargs: Any) -> None:
         """Activate scene. Try to get entities into requested state."""
-        assert self.hass
         task = self.hass.async_add_job(ft.partial(self.activate, **kwargs))
         if task:
             await task

--- a/homeassistant/components/switch/light.py
+++ b/homeassistant/components/switch/light.py
@@ -120,13 +120,11 @@ class LightSwitch(LightEntity):
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        assert self.hass is not None
         self._switch_state = self.hass.states.get(self._switch_entity_id)
 
         @callback
         def async_state_changed_listener(*_: Any) -> None:
             """Handle child updates."""
-            assert self.hass is not None
             self._switch_state = self.hass.states.get(self._switch_entity_id)
             self.async_write_ha_state()
 

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -364,7 +364,6 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        assert self.hass
         hvac_mode: Optional[str] = kwargs.get(ATTR_HVAC_MODE)
 
         if hvac_mode is not None:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -89,7 +89,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Handle the initial step."""
-        assert self.hass  # typing
         if is_hassio(self.hass):  # type: ignore  # no-untyped-call
             return await self.async_step_on_supervisor()
 
@@ -266,7 +265,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Start Z-Wave JS add-on."""
-        assert self.hass
         if not self.start_task:
             self.start_task = self.hass.async_create_task(self._async_start_addon())
             return self.async_show_progress(
@@ -289,7 +287,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_start_addon(self) -> None:
         """Start the Z-Wave JS add-on."""
-        assert self.hass
         addon_manager: AddonManager = get_addon_manager(self.hass)
         try:
             await addon_manager.async_schedule_start_addon()
@@ -327,7 +324,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Get add-on discovery info and server version info.
         Set unique id and abort if already configured.
         """
-        assert self.hass
         if not self.ws_address:
             discovery_info = await self._async_get_addon_discovery_info()
             self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -46,7 +46,6 @@ class ZWaveBaseEntity(Entity):
 
     async def async_poll_value(self, refresh_all_values: bool) -> None:
         """Poll a value."""
-        assert self.hass
         if not refresh_all_values:
             self.hass.async_create_task(
                 self.info.node.async_poll_value(self.info.primary_value)
@@ -75,7 +74,6 @@ class ZWaveBaseEntity(Entity):
 
     async def async_added_to_hass(self) -> None:
         """Call when entity is added."""
-        assert self.hass  # typing
         # Add value_changed callbacks.
         self.async_on_remove(
             self.info.node.on(EVENT_VALUE_UPDATED, self._value_changed)

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -58,7 +58,6 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
                 return self.async_abort(reason="no_devices_found")
 
             # Cancel the discovered one.
-            assert self.hass is not None
             for flow in in_progress:
                 self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
@@ -90,7 +89,6 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
             return self.async_abort(reason="single_instance_allowed")
 
         # Cancel other flows.
-        assert self.hass is not None
         in_progress = self._async_in_progress()
         for flow in in_progress:
             self.hass.config_entries.flow.async_abort(flow["flow_id"])
@@ -143,7 +141,6 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
         if user_input is None:
             return self.async_show_form(step_id="user")
 
-        assert self.hass is not None
         webhook_id = self.hass.components.webhook.async_generate_id()
 
         if (

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -234,7 +234,6 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
         self, user_input: Optional[dict] = None
     ) -> dict:
         """Handle a flow start."""
-        assert self.hass
         implementations = await async_get_implementations(self.hass, self.DOMAIN)
 
         if user_input is not None:
@@ -318,7 +317,6 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
         """Handle a flow initialized by discovery."""
         await self.async_set_unique_id(self.DOMAIN)
 
-        assert self.hass is not None
         if self.hass.config_entries.async_entries(self.DOMAIN):
             return self.async_abort(reason="already_configured")
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -89,10 +89,13 @@ class Entity(ABC):
     # SAFE TO OVERWRITE
     # The properties and methods here are safe to overwrite when inheriting
     # this class. These may be used to customize the behavior of the entity.
-    entity_id = None  # type: str
+    entity_id: str = None  # type: ignore
 
     # Owning hass instance. Will be set by EntityPlatform
-    hass: Optional[HomeAssistant] = None
+    # While not purely typed, it makes typehinting more useful for us
+    # and removes the need for constant None checks or asserts.
+    # Ignore types: https://github.com/PyCQA/pylint/issues/3167
+    hass: HomeAssistant = None  # type: ignore
 
     # Owning platform instance. Will be set by EntityPlatform
     platform: Optional[EntityPlatform] = None
@@ -518,7 +521,7 @@ class Entity(ABC):
     @callback
     def add_to_platform_abort(self) -> None:
         """Abort adding an entity to a platform."""
-        self.hass = None
+        self.hass = None  # type: ignore
         self.platform = None
         self.parallel_updates = None
         self._added = False

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -380,7 +380,6 @@ class Entity(ABC):
             )
 
         # Overwrite properties that have been set in the config file.
-        assert self.hass is not None
         if DATA_CUSTOMIZE in self.hass.data:
             attr.update(self.hass.data[DATA_CUSTOMIZE].get(self.entity_id))
 
@@ -421,7 +420,6 @@ class Entity(ABC):
         If state is changed more than once before the ha state change task has
         been executed, the intermediate state transitions will be missed.
         """
-        assert self.hass is not None
         self.hass.add_job(self.async_update_ha_state(force_refresh))  # type: ignore
 
     @callback
@@ -437,7 +435,6 @@ class Entity(ABC):
         been executed, the intermediate state transitions will be missed.
         """
         if force_refresh:
-            assert self.hass is not None
             self.hass.async_create_task(self.async_update_ha_state(force_refresh))
         else:
             self.async_write_ha_state()
@@ -542,8 +539,6 @@ class Entity(ABC):
         If the entity doesn't have a non disabled entry in the entity registry,
         or if force_remove=True, its state will be removed.
         """
-        assert self.hass is not None
-
         if self.platform and not self._added:
             raise HomeAssistantError(
                 f"Entity {self.entity_id} async_remove called twice"
@@ -586,8 +581,6 @@ class Entity(ABC):
 
         Not to be extended by integrations.
         """
-        assert self.hass is not None
-
         if self.platform:
             info = {"domain": self.platform.platform_name}
 
@@ -617,7 +610,6 @@ class Entity(ABC):
         Not to be extended by integrations.
         """
         if self.platform:
-            assert self.hass is not None
             self.hass.data[DATA_ENTITY_SOURCE].pop(self.entity_id)
 
     async def _async_registry_updated(self, event: Event) -> None:
@@ -631,7 +623,6 @@ class Entity(ABC):
         if data["action"] != "update":
             return
 
-        assert self.hass is not None
         ent_reg = await self.hass.helpers.entity_registry.async_get_registry()
         old = self.registry_entry
         self.registry_entry = ent_reg.async_get(data["entity_id"])
@@ -706,7 +697,6 @@ class ToggleEntity(Entity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(ft.partial(self.turn_on, **kwargs))
 
     def turn_off(self, **kwargs: Any) -> None:
@@ -715,7 +705,6 @@ class ToggleEntity(Entity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        assert self.hass is not None
         await self.hass.async_add_executor_job(ft.partial(self.turn_off, **kwargs))
 
     def toggle(self, **kwargs: Any) -> None:

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -235,7 +235,6 @@ class RestoreEntity(Entity):
 
     async def async_internal_added_to_hass(self) -> None:
         """Register this entity as a restorable entity."""
-        assert self.hass is not None
         _, data = await asyncio.gather(
             super().async_internal_added_to_hass(),
             RestoreStateData.async_get_instance(self.hass),
@@ -244,7 +243,6 @@ class RestoreEntity(Entity):
 
     async def async_internal_will_remove_from_hass(self) -> None:
         """Run when entity will be removed from hass."""
-        assert self.hass is not None
         _, data = await asyncio.gather(
             super().async_internal_will_remove_from_hass(),
             RestoreStateData.async_get_instance(self.hass),
@@ -253,10 +251,6 @@ class RestoreEntity(Entity):
 
     async def async_get_last_state(self) -> Optional[State]:
         """Get the entity state from the previous run."""
-        if self.hass is None or self.entity_id is None:
-            # Return None if this entity isn't added to hass yet
-            _LOGGER.warning("Cannot get last state. Entity not added to hass")
-            return None
         data = await RestoreStateData.async_get_instance(self.hass)
         if self.entity_id not in data.last_states:
             return None

--- a/homeassistant/helpers/restore_state.py
+++ b/homeassistant/helpers/restore_state.py
@@ -251,6 +251,10 @@ class RestoreEntity(Entity):
 
     async def async_get_last_state(self) -> Optional[State]:
         """Get the entity state from the previous run."""
+        if self.hass is None or self.entity_id is None:
+            # Return None if this entity isn't added to hass yet
+            _LOGGER.warning("Cannot get last state. Entity not added to hass")  # type: ignore[unreachable]
+            return None
         data = await RestoreStateData.async_get_instance(self.hass)
         if self.entity_id not in data.last_states:
             return None

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -425,8 +425,6 @@ class Template:
 
         This method must be run in the event loop.
         """
-        assert self.hass
-
         if self.is_static:
             return False
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Followup of #46462

This type change, is not 100% pure. However, IMHO, more helpful and useful in our situation.

Type hinting wise, `self.hass` can be `None`. However, we know it actually won't be `None`. We act like it as well. We either ignore the warning or assert it to make it shut up everywhere; or simply don't do anything at all (even though mypy/pyright will warn if we actually checked).

So as the current solution, we recently started riddling our code base with `assert self.hass`, which works... for the type checker, but for the code base, it actually makes 0 sense.

Using this PR I want to propose, that we remove the optional typing, removing the need for asserting it constantly.

Commit 5a122d2 contains the actual suggested change. The other commit is cleaning up obsolete checks because of this change.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
