### PR TITLE
Add option to reverse switch behaviour in KMTronic 

### DIFF
--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -34,7 +34,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the kmtronic component."""
-    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN] = {}
 
     return True
 
@@ -76,7 +76,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_HUB: hub,
         DATA_COORDINATOR: coordinator,
-        DATA_REVERSE: _get_config_value(entry, CONF_REVERSE, False),
+        DATA_REVERSE: entry.options.get(CONF_REVERSE, False),
     }
 
     for platform in PLATFORMS:
@@ -90,7 +90,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry):
+async def async_update_options(hass: HomeAssistant, config_entry: ConfigEntry) -> None:
     """Update options."""
     await hass.config_entries.async_reload(config_entry.entry_id)
 
@@ -111,9 +111,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
-
-
-def _get_config_value(config_entry, key, default):
-    if config_entry.options and key in config_entry.options:
-        return config_entry.options[key]
-    return config_entry.data.get(key, default)

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_COORDINATOR, DATA_HOST, DATA_HUB, DOMAIN, MANUFACTURER
+from .const import DATA_COORDINATOR, DATA_HOST, DATA_HUB, DOMAIN, MANUFACTURER, CONF_REVERSE, DATA_REVERSE
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -67,7 +67,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_HUB: hub,
-        DATA_HOST: entry.data[DATA_HOST],
+        DATA_HOST: entry.data[CONF_HOSTNAME],
+        DATA_REVERSE: entry.data[CONF_REVERSE],
         DATA_COORDINATOR: coordinator,
     }
 

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DATA_COORDINATOR, DATA_HOST, DATA_HUB, DOMAIN, MANUFACTURER, CONF_REVERSE, DATA_REVERSE
@@ -77,6 +78,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
+    return True
+
+
+async def async_migrate_entry(
+    hass: HomeAssistantType, config_entry: ConfigEntry
+) -> bool:
+    """Migrate config entry to new version."""
+    if config_entry.version == 1:
+        options = dict(config_entry.options)
+        options[CONF_REVERSE] = False
+        config_entry.version = 2
+        hass.config_entries.async_update_entry(config_entry, options=options)
+        _LOGGER.info("Migrated config entry to version %d", config_entry.version)
     return True
 
 

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.config_entries import ConfigEntry, ConfigEntryNotReady
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import CONF_REVERSE, DATA_COORDINATOR, DATA_HUB, DOMAIN, MANUFACTURER
@@ -34,6 +33,10 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up kmtronic from a config entry."""
+    # light migration of config entry in https://github.com/home-assistant/core/pull/47532
+    if CONF_REVERSE not in entry.data:
+        entry.data[CONF_REVERSE] = False
+
     session = aiohttp_client.async_get_clientsession(hass)
     auth = Auth(
         session,
@@ -76,19 +79,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    return True
-
-
-async def async_migrate_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry
-) -> bool:
-    """Migrate config entry to new version."""
-    if config_entry.version == 1:
-        options = dict(config_entry.options)
-        options[CONF_REVERSE] = False
-        config_entry.version = 2
-        hass.config_entries.async_update_entry(config_entry, options=options)
-        _LOGGER.info("Migrated config entry to version %d", config_entry.version)
     return True
 
 

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_COORDINATOR, DATA_HOST, DATA_HUB, DOMAIN, MANUFACTURER, CONF_REVERSE, DATA_REVERSE
+from .const import CONF_REVERSE, DATA_COORDINATOR, DATA_HUB, DOMAIN, MANUFACTURER
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -68,8 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_HUB: hub,
-        DATA_HOST: entry.data[CONF_HOSTNAME],
-        DATA_REVERSE: entry.data[CONF_REVERSE],
         DATA_COORDINATOR: coordinator,
     }
 

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -15,15 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import (
-    CONF_REVERSE,
-    DATA_COORDINATOR,
-    DATA_HUB,
-    DATA_REVERSE,
-    DOMAIN,
-    MANUFACTURER,
-    UPDATE_LISTENER,
-)
+from .const import DATA_COORDINATOR, DATA_HUB, DOMAIN, MANUFACTURER, UPDATE_LISTENER
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -76,7 +68,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_HUB: hub,
         DATA_COORDINATOR: coordinator,
-        DATA_REVERSE: entry.options.get(CONF_REVERSE, False),
     }
 
     for platform in PLATFORMS:

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_REVERSE, DATA_COORDINATOR, DATA_HUB, DOMAIN, MANUFACTURER
+from .const import DATA_COORDINATOR, DATA_HUB, DOMAIN, MANUFACTURER
 
 CONFIG_SCHEMA = vol.Schema({DOMAIN: vol.Schema({})}, extra=vol.ALLOW_EXTRA)
 
@@ -33,10 +33,6 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up kmtronic from a config entry."""
-    # light migration of config entry in https://github.com/home-assistant/core/pull/47532
-    if CONF_REVERSE not in entry.data:
-        entry.data[CONF_REVERSE] = False
-
     session = aiohttp_client.async_get_clientsession(hass)
     auth = Auth(
         session,

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -101,14 +101,12 @@ class KMTronicOptionsFlow(config_entries.OptionsFlow):
 
         return self.async_show_form(
             step_id="init",
-            data_schema=self._get_options_schema(),
-        )
-
-    def _get_options_schema(self):
-        return vol.Schema(
-            {
-                vol.Optional(
-                    CONF_REVERSE, default=self.config_entry.options.get(CONF_REVERSE)
-                ): bool,
-            }
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_REVERSE,
+                        default=self.config_entry.options.get(CONF_REVERSE),
+                    ): bool,
+                }
+            ),
         )

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -16,7 +16,12 @@ from .const import DOMAIN  # pylint:disable=unused-import
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
-    {CONF_HOST: str, CONF_USERNAME: str, CONF_PASSWORD: str, CONF_REVERSE: bool}
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Optional(CONF_REVERSE, default=False): bool,
+    }
 )
 
 

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -44,7 +44,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for kmtronic."""
 
-    VERSION = 1
+    VERSION = 2
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -8,6 +8,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
 from .const import CONF_REVERSE
@@ -52,6 +53,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return KMTronicOptionsFlow(config_entry)
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
@@ -79,3 +86,30 @@ class CannotConnect(exceptions.HomeAssistantError):
 
 class InvalidAuth(exceptions.HomeAssistantError):
     """Error to indicate there is invalid auth."""
+
+
+class KMTronicOptionsFlow(config_entries.OptionsFlow):
+    """Handle options."""
+
+    def __init__(self, config_entry):
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self._get_options_schema(),
+        )
+
+    def _get_options_schema(self):
+        return vol.Schema(
+            {
+                vol.Optional(
+                    CONF_REVERSE, default=self.config_entry.options.get(CONF_REVERSE)
+                ): bool,
+            }
+        )

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -21,7 +21,6 @@ DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
-        vol.Optional(CONF_REVERSE, default=False): bool,
     }
 )
 

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -10,11 +10,14 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import aiohttp_client
 
+from .const import CONF_REVERSE
 from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
-DATA_SCHEMA = vol.Schema({CONF_HOST: str, CONF_USERNAME: str, CONF_PASSWORD: str})
+DATA_SCHEMA = vol.Schema(
+    {CONF_HOST: str, CONF_USERNAME: str, CONF_PASSWORD: str, CONF_REVERSE: bool}
+)
 
 
 async def validate_input(hass: core.HomeAssistant, data):

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -44,7 +44,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for kmtronic."""
 
-    VERSION = 2
+    VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(self, user_input=None):

--- a/homeassistant/components/kmtronic/const.py
+++ b/homeassistant/components/kmtronic/const.py
@@ -2,6 +2,9 @@
 
 DOMAIN = "kmtronic"
 
+CONF_HOSTNAME = "host"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
 CONF_REVERSE = "reverse"
 
 DATA_HUB = "hub"

--- a/homeassistant/components/kmtronic/const.py
+++ b/homeassistant/components/kmtronic/const.py
@@ -11,3 +11,5 @@ DATA_REVERSE = "reverse"
 MANUFACTURER = "KMtronic"
 ATTR_MANUFACTURER = "manufacturer"
 ATTR_IDENTIFIERS = "identifiers"
+
+UPDATE_LISTENER = "update_listener"

--- a/homeassistant/components/kmtronic/const.py
+++ b/homeassistant/components/kmtronic/const.py
@@ -6,7 +6,6 @@ CONF_REVERSE = "reverse"
 
 DATA_HUB = "hub"
 DATA_COORDINATOR = "coordinator"
-DATA_REVERSE = "reverse"
 
 MANUFACTURER = "KMtronic"
 ATTR_MANUFACTURER = "manufacturer"

--- a/homeassistant/components/kmtronic/const.py
+++ b/homeassistant/components/kmtronic/const.py
@@ -5,7 +5,6 @@ DOMAIN = "kmtronic"
 CONF_REVERSE = "reverse"
 
 DATA_HUB = "hub"
-DATA_HOST = "host"
 DATA_COORDINATOR = "coordinator"
 DATA_REVERSE = "reverse"
 

--- a/homeassistant/components/kmtronic/const.py
+++ b/homeassistant/components/kmtronic/const.py
@@ -2,9 +2,6 @@
 
 DOMAIN = "kmtronic"
 
-CONF_HOSTNAME = "host"
-CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
 CONF_REVERSE = "reverse"
 
 DATA_HUB = "hub"

--- a/homeassistant/components/kmtronic/const.py
+++ b/homeassistant/components/kmtronic/const.py
@@ -2,9 +2,12 @@
 
 DOMAIN = "kmtronic"
 
+CONF_REVERSE = "reverse"
+
 DATA_HUB = "hub"
 DATA_HOST = "host"
 DATA_COORDINATOR = "coordinator"
+DATA_REVERSE = "reverse"
 
 MANUFACTURER = "KMtronic"
 ATTR_MANUFACTURER = "manufacturer"

--- a/homeassistant/components/kmtronic/strings.json
+++ b/homeassistant/components/kmtronic/strings.json
@@ -5,8 +5,7 @@
                 "data": {
                     "host": "[%key:common::config_flow::data::host%]",
                     "username": "[%key:common::config_flow::data::username%]",
-                    "password": "[%key:common::config_flow::data::password%]",
-                    "reverse": "Reverse switch logic (use NC)"
+                    "password": "[%key:common::config_flow::data::password%]"
                 }
             }
         },

--- a/homeassistant/components/kmtronic/strings.json
+++ b/homeassistant/components/kmtronic/strings.json
@@ -5,7 +5,8 @@
                 "data": {
                     "host": "[%key:common::config_flow::data::host%]",
                     "username": "[%key:common::config_flow::data::username%]",
-                    "password": "[%key:common::config_flow::data::password%]"
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "reverse": "Reverse switch logic (use NC)"
                 }
             }
         },

--- a/homeassistant/components/kmtronic/strings.json
+++ b/homeassistant/components/kmtronic/strings.json
@@ -18,5 +18,14 @@
         "abort": {
             "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "reverse": "Reverse switch logic (use NC)"
+                }
+            }
+        }
     }
 }

--- a/homeassistant/components/kmtronic/switch.py
+++ b/homeassistant/components/kmtronic/switch.py
@@ -10,7 +10,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Config entry example."""
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
     hub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    reverse = entry.data[DATA_REVERSE]
+    reverse = entry.data.get(DATA_REVERSE, False)
     await hub.async_get_relays()
 
     async_add_entities(

--- a/homeassistant/components/kmtronic/switch.py
+++ b/homeassistant/components/kmtronic/switch.py
@@ -3,20 +3,19 @@
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA_COORDINATOR, DATA_HOST, DATA_HUB, DATA_REVERSE, DOMAIN
+from .const import DATA_COORDINATOR, DATA_HUB, DATA_REVERSE, DOMAIN
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Config entry example."""
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
     hub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    host = hass.data[DOMAIN][entry.entry_id][DATA_HOST]
-    reverse = hass.data[DOMAIN][entry.entry_id][DATA_REVERSE]
+    reverse = entry.data[DATA_REVERSE]
     await hub.async_get_relays()
 
     async_add_entities(
         [
-            KMtronicSwitch(coordinator, host, relay, reverse, entry.unique_id)
+            KMtronicSwitch(coordinator, relay, reverse, entry.entry_id)
             for relay in hub.relays
         ]
     )
@@ -25,18 +24,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
 class KMtronicSwitch(CoordinatorEntity, SwitchEntity):
     """KMtronic Switch Entity."""
 
-    def __init__(self, coordinator, host, relay, reverse, config_entry_id):
+    def __init__(self, coordinator, relay, reverse, config_entry_id):
         """Pass coordinator to CoordinatorEntity."""
         super().__init__(coordinator)
-        self._host = host
         self._relay = relay
         self._config_entry_id = config_entry_id
         self._reverse = reverse
-
-    @property
-    def available(self) -> bool:
-        """Return whether the entity is available."""
-        return self.coordinator.last_update_success
 
     @property
     def name(self) -> str:
@@ -47,11 +40,6 @@ class KMtronicSwitch(CoordinatorEntity, SwitchEntity):
     def unique_id(self) -> str:
         """Return the unique ID of the entity."""
         return f"{self._config_entry_id}_relay{self._relay.id}"
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return True
 
     @property
     def is_on(self):

--- a/homeassistant/components/kmtronic/switch.py
+++ b/homeassistant/components/kmtronic/switch.py
@@ -10,7 +10,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     """Config entry example."""
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
     hub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    reverse = entry.data.get(DATA_REVERSE, False)
+    reverse = hass.data[DOMAIN][entry.entry_id][DATA_REVERSE]
     await hub.async_get_relays()
 
     async_add_entities(

--- a/homeassistant/components/kmtronic/switch.py
+++ b/homeassistant/components/kmtronic/switch.py
@@ -3,14 +3,14 @@
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DATA_COORDINATOR, DATA_HUB, DATA_REVERSE, DOMAIN
+from .const import CONF_REVERSE, DATA_COORDINATOR, DATA_HUB, DOMAIN
 
 
 async def async_setup_entry(hass, entry, async_add_entities):
     """Config entry example."""
     coordinator = hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
     hub = hass.data[DOMAIN][entry.entry_id][DATA_HUB]
-    reverse = hass.data[DOMAIN][entry.entry_id][DATA_REVERSE]
+    reverse = entry.options.get(CONF_REVERSE, False)
     await hub.async_get_relays()
 
     async_add_entities(

--- a/homeassistant/components/kmtronic/translations/en.json
+++ b/homeassistant/components/kmtronic/translations/en.json
@@ -13,7 +13,17 @@
                 "data": {
                     "host": "Host",
                     "password": "Password",
-                    "username": "Username"
+                    "username": "Username",
+                    "reverse": "Reverse switch logic (use NC)"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "reverse": "Reverse switch logic (use NC)"
                 }
             }
         }

--- a/homeassistant/components/kmtronic/translations/en.json
+++ b/homeassistant/components/kmtronic/translations/en.json
@@ -13,8 +13,7 @@
                 "data": {
                     "host": "Host",
                     "password": "Password",
-                    "username": "Username",
-                    "reverse": "Reverse switch logic (use NC)"
+                    "username": "Username"
                 }
             }
         }

--- a/homeassistant/components/kmtronic/translations/en.json
+++ b/homeassistant/components/kmtronic/translations/en.json
@@ -13,7 +13,8 @@
                 "data": {
                     "host": "Host",
                     "password": "Password",
-                    "username": "Username"
+                    "username": "Username",
+                    "reverse": "Reverse switch logic (use NC)"
                 }
             }
         }

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -34,6 +34,7 @@ async def test_form(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
+                "reverse": False,
             },
         )
 
@@ -43,6 +44,7 @@ async def test_form(hass):
         "host": "1.1.1.1",
         "username": "test-username",
         "password": "test-password",
+        "reverse": False,
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -65,6 +67,7 @@ async def test_form_invalid_auth(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
+                "reverse": False,
             },
         )
 
@@ -88,6 +91,7 @@ async def test_form_cannot_connect(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
+                "reverse": False,
             },
         )
 
@@ -111,6 +115,7 @@ async def test_form_unknown_error(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
+                "reverse": False,
             },
         )
 
@@ -123,7 +128,12 @@ async def test_unload_config_entry(hass, aioclient_mock):
 
     config_entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"host": "1.1.1.1", "username": "admin", "password": "admin"},
+        data={
+            "host": "1.1.1.1",
+            "username": "admin",
+            "password": "admin",
+            "reverse": False,
+        },
     )
     config_entry.add_to_hass(hass)
 

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -5,9 +5,6 @@ from aiohttp import ClientConnectorError, ClientResponseError
 
 from homeassistant import config_entries, setup
 from homeassistant.components.kmtronic.const import DOMAIN
-from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
-
-from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
@@ -121,35 +118,3 @@ async def test_form_unknown_error(hass):
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "unknown"}
-
-
-async def test_unload_config_entry(hass, aioclient_mock):
-    """Test entry unloading."""
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "1.1.1.1",
-            "username": "admin",
-            "password": "admin",
-            "reverse": False,
-        },
-    )
-    config_entry.add_to_hass(hass)
-
-    aioclient_mock.get(
-        "http://1.1.1.1/status.xml",
-        text="<response><relay0>0</relay0><relay1>0</relay1></response>",
-    )
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    config_entries = hass.config_entries.async_entries(DOMAIN)
-    assert len(config_entries) == 1
-    assert config_entries[0] is config_entry
-    assert config_entry.state == ENTRY_STATE_LOADED
-
-    await hass.config_entries.async_unload(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert config_entry.state == ENTRY_STATE_NOT_LOADED

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -3,8 +3,11 @@ from unittest.mock import Mock, patch
 
 from aiohttp import ClientConnectorError, ClientResponseError
 
-from homeassistant import config_entries, setup
-from homeassistant.components.kmtronic.const import DOMAIN
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.kmtronic.const import CONF_REVERSE, DOMAIN
+from homeassistant.config_entries import ENTRY_STATE_LOADED
+
+from tests.common import MockConfigEntry
 
 
 async def test_form(hass):
@@ -46,6 +49,43 @@ async def test_form(hass):
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_options(hass, aioclient_mock):
+    """Test that the options form."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.1.1.1",
+            "username": "admin",
+            "password": "admin",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    aioclient_mock.get(
+        "http://1.1.1.1/status.xml",
+        text="<response><relay0>0</relay0><relay1>0</relay1></response>",
+    )
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ENTRY_STATE_LOADED
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_REVERSE: True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {CONF_REVERSE: True}
+
+    await hass.async_block_till_done()
+
+    assert config_entry.state == "loaded"
 
 
 async def test_form_invalid_auth(hass):

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -34,7 +34,6 @@ async def test_form(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
-                "reverse": False,
             },
         )
 
@@ -44,7 +43,6 @@ async def test_form(hass):
         "host": "1.1.1.1",
         "username": "test-username",
         "password": "test-password",
-        "reverse": False,
     }
     await hass.async_block_till_done()
     assert len(mock_setup.mock_calls) == 1
@@ -104,7 +102,6 @@ async def test_form_invalid_auth(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
-                "reverse": False,
             },
         )
 
@@ -128,7 +125,6 @@ async def test_form_cannot_connect(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
-                "reverse": False,
             },
         )
 
@@ -152,7 +148,6 @@ async def test_form_unknown_error(hass):
                 "host": "1.1.1.1",
                 "username": "test-username",
                 "password": "test-password",
-                "reverse": False,
             },
         )
 

--- a/tests/components/kmtronic/test_init.py
+++ b/tests/components/kmtronic/test_init.py
@@ -1,0 +1,64 @@
+"""The tests for the KMtronic component."""
+import asyncio
+
+from homeassistant.components.kmtronic.const import DOMAIN
+from homeassistant.config_entries import (
+    ENTRY_STATE_LOADED,
+    ENTRY_STATE_NOT_LOADED,
+    ENTRY_STATE_SETUP_RETRY,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_unload_config_entry(hass, aioclient_mock):
+    """Test entry unloading."""
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.1.1.1",
+            "username": "admin",
+            "password": "admin",
+            "reverse": False,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    aioclient_mock.get(
+        "http://1.1.1.1/status.xml",
+        text="<response><relay0>0</relay0><relay1>0</relay1></response>",
+    )
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ENTRY_STATE_LOADED
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ENTRY_STATE_NOT_LOADED
+
+
+async def test_config_entry_not_ready(hass, aioclient_mock):
+    """Tests configuration entry not ready."""
+
+    aioclient_mock.get(
+        "http://1.1.1.1/status.xml",
+        exc=asyncio.TimeoutError(),
+    )
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "host": "1.1.1.1",
+            "username": "foo",
+            "password": "bar",
+            "reverse": False,
+        },
+    )
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state == ENTRY_STATE_SETUP_RETRY

--- a/tests/components/kmtronic/test_init.py
+++ b/tests/components/kmtronic/test_init.py
@@ -20,7 +20,6 @@ async def test_unload_config_entry(hass, aioclient_mock):
             "host": "1.1.1.1",
             "username": "admin",
             "password": "admin",
-            "reverse": False,
         },
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/kmtronic/test_init.py
+++ b/tests/components/kmtronic/test_init.py
@@ -53,7 +53,6 @@ async def test_config_entry_not_ready(hass, aioclient_mock):
             "host": "1.1.1.1",
             "username": "foo",
             "password": "bar",
-            "reverse": False,
         },
     )
     config_entry.add_to_hass(hass)

--- a/tests/components/kmtronic/test_switch.py
+++ b/tests/components/kmtronic/test_switch.py
@@ -3,7 +3,6 @@ import asyncio
 from datetime import timedelta
 
 from homeassistant.components.kmtronic.const import DOMAIN
-from homeassistant.config_entries import ENTRY_STATE_SETUP_RETRY
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
@@ -98,30 +97,6 @@ async def test_update(hass, aioclient_mock):
     await hass.async_block_till_done()
     state = hass.states.get("switch.relay1")
     assert state.state == "on"
-
-
-async def test_config_entry_not_ready(hass, aioclient_mock):
-    """Tests configuration entry not ready."""
-
-    aioclient_mock.get(
-        "http://1.1.1.1/status.xml",
-        exc=asyncio.TimeoutError(),
-    )
-
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "1.1.1.1",
-            "username": "foo",
-            "password": "bar",
-            "reverse": False,
-        },
-    )
-    config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert config_entry.state == ENTRY_STATE_SETUP_RETRY
 
 
 async def test_failed_update(hass, aioclient_mock):

--- a/tests/components/kmtronic/test_switch.py
+++ b/tests/components/kmtronic/test_switch.py
@@ -19,13 +19,7 @@ async def test_relay_on_off(hass, aioclient_mock):
     )
 
     MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "1.1.1.1",
-            "username": "foo",
-            "password": "bar",
-            "reverse": False,
-        },
+        domain=DOMAIN, data={"host": "1.1.1.1", "username": "foo", "password": "bar"}
     ).add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()
@@ -73,13 +67,7 @@ async def test_update(hass, aioclient_mock):
     )
 
     MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "1.1.1.1",
-            "username": "foo",
-            "password": "bar",
-            "reverse": False,
-        },
+        domain=DOMAIN, data={"host": "1.1.1.1", "username": "foo", "password": "bar"}
     ).add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -110,13 +98,7 @@ async def test_failed_update(hass, aioclient_mock):
     )
 
     MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "1.1.1.1",
-            "username": "foo",
-            "password": "bar",
-            "reverse": False,
-        },
+        domain=DOMAIN, data={"host": "1.1.1.1", "username": "foo", "password": "bar"}
     ).add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -159,7 +141,8 @@ async def test_relay_on_off_reversed(hass, aioclient_mock):
 
     MockConfigEntry(
         domain=DOMAIN,
-        data={"host": "1.1.1.1", "username": "foo", "password": "bar", "reverse": True},
+        data={"host": "1.1.1.1", "username": "foo", "password": "bar"},
+        options={"reverse": True},
     ).add_to_hass(hass)
     assert await async_setup_component(hass, DOMAIN, {})
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Addresses issue https://github.com/home-assistant/core/issues/47443

Some of KMTronic models expose the relay 3 contacts (NO, COM, NC). Usually you use a relay with NO and COM (for failsafe reasons), but you can also use NC and COM since it is exposed. This PR adds the option "reverse" in order to work in systems where NC and COM are used.

NC=Normally Connected
NO=Normally Open
COM=Common


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47443
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
