### PR TITLE
Convert august to be push instead of poll

### DIFF
--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -9,6 +9,7 @@ from yalexs.exceptions import AugustApiAIOHTTPError
 from yalexs.lock import LockDetail
 from yalexs.pubnub_async import AugustPubNub, async_create_pubnub
 from yalexs.util import (
+    create_activity_from_pubnub_message,
     update_doorbell_details_from_pubnub_message,
     update_lock_details_from_pubnub_message,
 )
@@ -178,6 +179,9 @@ class AugustData(AugustSubscriberMixin):
                 self.async_signal_device_id_update(device.device_id)
         elif isinstance(device, DoorbellDetail):
             update_doorbell_details_from_pubnub_message(device, date_time, message)
+            activity = create_activity_from_pubnub_message(device, date_time, message)
+            if activity is not None:
+                self.activity_stream.add_activity(activity)
             _LOGGER.debug(
                 "async_signal_device_id_update (from pubnub): %s",
                 device.device_id,

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -281,8 +281,7 @@ class AugustData(AugustSubscriberMixin):
         return ret
 
     def _remove_inoperative_doorbells(self):
-        doorbells = list(self.doorbells)
-        for doorbell in doorbells:
+        for doorbell in list(self.doorbells):
             device_id = doorbell.device_id
             doorbell_is_operative = False
             doorbell_detail = self._device_detail_by_id.get(device_id)
@@ -302,9 +301,7 @@ class AugustData(AugustSubscriberMixin):
         # Remove non-operative locks as there must
         # be a bridge (August Connect) for them to
         # be usable
-        locks = list(self.locks)
-
-        for lock in locks:
+        for lock in list(self.locks):
             device_id = lock.device_id
             lock_is_operative = False
             lock_detail = self._device_detail_by_id.get(device_id)

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -4,7 +4,6 @@ from itertools import chain
 import logging
 
 from aiohttp import ClientError, ClientResponseError
-from august.authenticator import ValidationResult
 from august.doorbell import DoorbellDetail
 from august.exceptions import AugustApiAIOHTTPError
 from august.lock import LockDetail
@@ -13,15 +12,9 @@ from august.util import (
     update_doorbell_details_from_pubnub_message,
     update_lock_details_from_pubnub_message,
 )
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_PASSWORD,
-    CONF_TIMEOUT,
-    CONF_USERNAME,
-    HTTP_UNAUTHORIZED,
-)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, HTTP_UNAUTHORIZED
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -318,11 +318,8 @@ class AugustData(AugustSubscriberMixin):
                     "The lock %s could not be setup because it does not have a bridge (Connect)",
                     lock.device_name,
                 )
-            elif not lock_detail.bridge.operative:
-                _LOGGER.info(
-                    "The lock %s could not be setup because the bridge (Connect) is not operative",
-                    lock.device_name,
-                )
+            # Bridge may come back online later so we still add the device since we will
+            # have a pubnub subscription to tell use when it recovers
             else:
                 lock_is_operative = True
 

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -172,9 +172,17 @@ class AugustData(AugustSubscriberMixin):
         device = self.get_device_detail(device_id)
         if isinstance(device, LockDetail):
             if update_lock_details_from_pubnub_message(device, date_time, message):
+                _LOGGER.debug(
+                    "async_signal_device_id_update (from pubnub): %s",
+                    device.device_id,
+                )
                 self.async_signal_device_id_update(device.device_id)
         elif isinstance(device, DoorbellDetail):
             update_doorbell_details_from_pubnub_message(device, date_time, message)
+            _LOGGER.debug(
+                "async_signal_device_id_update (from pubnub): %s",
+                device.device_id,
+            )
             self.async_signal_device_id_update(device.device_id)
         self.activity_stream.async_schedule_house_id_refresh(device.house_id)
 

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -4,11 +4,11 @@ from itertools import chain
 import logging
 
 from aiohttp import ClientError, ClientResponseError
-from august.doorbell import DoorbellDetail
-from august.exceptions import AugustApiAIOHTTPError
-from august.lock import LockDetail
-from august.pubnub_async import AugustPubNub, async_create_pubnub
-from august.util import (
+from yalexs.doorbell import DoorbellDetail
+from yalexs.exceptions import AugustApiAIOHTTPError
+from yalexs.lock import LockDetail
+from yalexs.pubnub_async import AugustPubNub, async_create_pubnub
+from yalexs.util import (
     update_doorbell_details_from_pubnub_message,
     update_lock_details_from_pubnub_message,
 )

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -177,6 +177,8 @@ class AugustData(AugustSubscriberMixin):
         #    - DoorOperationActivity
         #    - DoorbellDingActivity
         #    - DoorbellMotionActivity
+        #    - BridgeOnlineActivity
+        #    - BridgeOfflineActivity
         #    self.activity_stream.add_activity(activity)
         # if schedule_update:
         #    self.async_signal_device_id_update(device.device_id)

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -170,6 +170,13 @@ class AugustData(AugustSubscriberMixin):
     def async_pubnub_message(self, device_id, date_time, message):
         """Process a pubnub message."""
         device = self.get_device_detail(device_id)
+        # TODO: move this to pypi
+        # schedule_update, activity = update_from_pubnub_message(device, data_time, message)
+        # if activity:
+        #    self.activity_stream.add_activity(activity)
+        # if schedule_update:
+        #    self.async_signal_device_id_update(device.device_id)
+        # self.activity_stream.async_schedule_house_id_refresh(device.house_id)
         if isinstance(device, LockDetail):
             if update_lock_details_from_pubnub_message(device, date_time, message):
                 _LOGGER.debug(

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -173,15 +173,15 @@ class AugustData(AugustSubscriberMixin):
         # TODO: move this to pypi
         # from yalexs.pubnub_activity import activity_from_pubnub_message
         # then get rid of update_doorbell_details_from_pubnub_message and update_lock_details_from_pubnub_message
-        # activity = activity_from_pubnub_message(device, data_time, message)
-        # if activity:
+        # activities = activities_from_pubnub_message(device, data_time, message)
+        # if activities:
         #    - LockOperationActivity (users in LockDetail)
         #    - DoorOperationActivity
         #    - DoorbellDingActivity
         #    - DoorbellMotionActivity
         #    - BridgeOnlineActivity (TODO)
         #    - BridgeOfflineActivity (TODO)
-        #    self.activity_stream.add_activity(activity)
+        #    self.activity_stream.add_activities(activities)
         #    self.async_signal_device_id_update(device.device_id)
         # self.activity_stream.async_schedule_house_id_refresh(device.house_id)
         if isinstance(device, LockDetail):

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -172,6 +172,7 @@ class AugustData(AugustSubscriberMixin):
         device = self.get_device_detail(device_id)
         # TODO: move this to pypi
         # from yalexs.pubnub_activity import activity_from_pubnub_message
+        # then get rid of update_doorbell_details_from_pubnub_message and update_lock_details_from_pubnub_message
         # activity = activity_from_pubnub_message(device, data_time, message)
         # if activity:
         #    - LockOperationActivity (users in LockDetail)

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -174,8 +174,8 @@ class AugustData(AugustSubscriberMixin):
             if update_lock_details_from_pubnub_message(device, date_time, message):
                 self.async_signal_device_id_update(device.device_id)
         elif isinstance(device, DoorbellDetail):
-            if update_doorbell_details_from_pubnub_message(device, date_time, message):
-                self.async_signal_device_id_update(device.device_id)
+            update_doorbell_details_from_pubnub_message(device, date_time, message)
+            self.async_signal_device_id_update(device.device_id)
         self.activity_stream.async_schedule_house_id_refresh(device.house_id)
 
     @callback

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -1,14 +1,23 @@
 """Support for August devices."""
 import asyncio
-import itertools
+from itertools import chain
 import logging
 
 from aiohttp import ClientError, ClientResponseError
 from august.exceptions import AugustApiAIOHTTPError
+from august.lock import LockDetail
+from august.pubnub_async import AugustPubNub, async_create_pubnub
+from august.util import update_lock_details_from_pubnub_message
+import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, HTTP_UNAUTHORIZED
-from homeassistant.core import HomeAssistant
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_TIMEOUT,
+    CONF_USERNAME,
+    HTTP_UNAUTHORIZED,
+)
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 
 from .activity import ActivityStream
@@ -60,6 +69,9 @@ def _async_start_reauth(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
+
+    hass.data[DOMAIN][entry.entry_id][DATA_AUGUST].async_stop()
+
     unload_ok = all(
         await asyncio.gather(
             *[
@@ -114,25 +126,21 @@ class AugustData(AugustSubscriberMixin):
         self._doorbells_by_id = {}
         self._locks_by_id = {}
         self._house_ids = set()
+        self._pubnub_unsub = None
 
     async def async_setup(self):
         """Async setup of august device data and activities."""
-        locks = (
-            await self._api.async_get_operable_locks(self._august_gateway.access_token)
-            or []
-        )
-        doorbells = (
-            await self._api.async_get_doorbells(self._august_gateway.access_token) or []
-        )
+        token = self._august_gateway.access_token
+        user_data = await self._api.async_get_user(token)
+        locks = await self._api.async_get_operable_locks(token) or []
+        doorbells = await self._api.async_get_doorbells(token) or []
 
         self._doorbells_by_id = {device.device_id: device for device in doorbells}
         self._locks_by_id = {device.device_id: device for device in locks}
-        self._house_ids = {
-            device.house_id for device in itertools.chain(locks, doorbells)
-        }
+        self._house_ids = {device.house_id for device in chain(locks, doorbells)}
 
         await self._async_refresh_device_detail_by_ids(
-            [device.device_id for device in itertools.chain(locks, doorbells)]
+            [device.device_id for device in chain(locks, doorbells)]
         )
 
         # We remove all devices that we are missing
@@ -142,10 +150,31 @@ class AugustData(AugustSubscriberMixin):
         self._remove_inoperative_locks()
         self._remove_inoperative_doorbells()
 
+        pubnub = AugustPubNub()
+        for device in self._device_detail_by_id.values():
+            pubnub.register_device(device)
+
         self.activity_stream = ActivityStream(
-            self._hass, self._api, self._august_gateway, self._house_ids
+            self._hass, self._api, self._august_gateway, self._house_ids, pubnub
         )
         await self.activity_stream.async_setup()
+        pubnub.subscribe(self.async_pubnub_message)
+        self._pubnub_unsub = async_create_pubnub(user_data["UserID"], pubnub)
+
+    @callback
+    def async_pubnub_message(self, device_id, date_time, message):
+        """Process a pubnub message."""
+        device = self.get_device_detail(device_id)
+        if isinstance(device, LockDetail):
+            if update_lock_details_from_pubnub_message(device, date_time, message):
+                self.async_signal_device_id_update(device.device_id)
+        self.activity_stream.async_schedule_house_id_refresh(device.house_id)
+
+    @callback
+    def async_stop(self):
+        """Stop the subscriptions."""
+        self._pubnub_unsub()
+        self.activity_stream.async_stop()
 
     @property
     def doorbells(self):
@@ -213,9 +242,9 @@ class AugustData(AugustSubscriberMixin):
 
     def _get_device_name(self, device_id):
         """Return doorbell or lock name as August has it stored."""
-        if self._locks_by_id.get(device_id):
+        if device_id in self._locks_by_id:
             return self._locks_by_id[device_id].device_name
-        if self._doorbells_by_id.get(device_id):
+        if device_id in self._doorbells_by_id:
             return self._doorbells_by_id[device_id].device_name
 
     async def async_lock(self, device_id):

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -4,10 +4,15 @@ from itertools import chain
 import logging
 
 from aiohttp import ClientError, ClientResponseError
+from august.authenticator import ValidationResult
+from august.doorbell import DoorbellDetail
 from august.exceptions import AugustApiAIOHTTPError
 from august.lock import LockDetail
 from august.pubnub_async import AugustPubNub, async_create_pubnub
-from august.util import update_lock_details_from_pubnub_message
+from august.util import (
+    update_doorbell_details_from_pubnub_message,
+    update_lock_details_from_pubnub_message,
+)
 import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
@@ -167,6 +172,9 @@ class AugustData(AugustSubscriberMixin):
         device = self.get_device_detail(device_id)
         if isinstance(device, LockDetail):
             if update_lock_details_from_pubnub_message(device, date_time, message):
+                self.async_signal_device_id_update(device.device_id)
+        elif isinstance(device, DoorbellDetail):
+            if update_doorbell_details_from_pubnub_message(device, date_time, message):
                 self.async_signal_device_id_update(device.device_id)
         self.activity_stream.async_schedule_house_id_refresh(device.house_id)
 

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -171,16 +171,15 @@ class AugustData(AugustSubscriberMixin):
         """Process a pubnub message."""
         device = self.get_device_detail(device_id)
         # TODO: move this to pypi
-        # schedule_update, activity = update_from_pubnub_message(device, data_time, message)
+        # activity = activity_from_pubnub_message(device, data_time, message)
         # if activity:
         #    - LockOperationActivity (users in LockDetail)
         #    - DoorOperationActivity
         #    - DoorbellDingActivity
         #    - DoorbellMotionActivity
-        #    - BridgeOnlineActivity
-        #    - BridgeOfflineActivity
+        #    - BridgeOnlineActivity (TODO)
+        #    - BridgeOfflineActivity (TODO)
         #    self.activity_stream.add_activity(activity)
-        # if schedule_update:
         #    self.async_signal_device_id_update(device.device_id)
         # self.activity_stream.async_schedule_house_id_refresh(device.house_id)
         if isinstance(device, LockDetail):

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -171,6 +171,7 @@ class AugustData(AugustSubscriberMixin):
         """Process a pubnub message."""
         device = self.get_device_detail(device_id)
         # TODO: move this to pypi
+        # from yalexs.pubnub_activity import activity_from_pubnub_message
         # activity = activity_from_pubnub_message(device, data_time, message)
         # if activity:
         #    - LockOperationActivity (users in LockDetail)

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -173,6 +173,10 @@ class AugustData(AugustSubscriberMixin):
         # TODO: move this to pypi
         # schedule_update, activity = update_from_pubnub_message(device, data_time, message)
         # if activity:
+        #    - LockOperationActivity (users in LockDetail)
+        #    - DoorOperationActivity
+        #    - DoorbellDingActivity
+        #    - DoorbellMotionActivity
         #    self.activity_stream.add_activity(activity)
         # if schedule_update:
         #    self.async_signal_device_id_update(device.device_id)

--- a/homeassistant/components/august/__init__.py
+++ b/homeassistant/components/august/__init__.py
@@ -210,13 +210,13 @@ class AugustData(AugustSubscriberMixin):
 
     async def _async_refresh_device_detail_by_id(self, device_id):
         if device_id in self._locks_by_id:
-            if self.activity_stream.pubnub.connected:
-                saved_attrs = _save_live_attrs(self._locks_by_id[device_id])
+            if self.activity_stream and self.activity_stream.pubnub.connected:
+                saved_attrs = _save_live_attrs(self._device_detail_by_id[device_id])
             await self._async_update_device_detail(
                 self._locks_by_id[device_id], self._api.async_get_lock_detail
             )
-            if self.activity_stream.pubnub.connected:
-                _restore_live_attrs(self._locks_by_id[device_id], saved_attrs)
+            if self.activity_stream and self.activity_stream.pubnub.connected:
+                _restore_live_attrs(self._device_detail_by_id[device_id], saved_attrs)
             # keypads are always attached to locks
             if (
                 device_id in self._device_detail_by_id

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -1,8 +1,11 @@
 """Consume the august activity stream."""
+import asyncio
 import logging
 
 from aiohttp import ClientError
 
+from homeassistant.core import callback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.util.dt import utcnow
 
 from .const import ACTIVITY_UPDATE_INTERVAL
@@ -17,27 +20,48 @@ ACTIVITY_CATCH_UP_FETCH_LIMIT = 2500
 class ActivityStream(AugustSubscriberMixin):
     """August activity stream handler."""
 
-    def __init__(self, hass, api, august_gateway, house_ids):
+    def __init__(self, hass, api, august_gateway, house_ids, pubnub):
         """Init August activity stream object."""
         super().__init__(hass, ACTIVITY_UPDATE_INTERVAL)
         self._hass = hass
         self._august_gateway = august_gateway
         self._api = api
         self._house_ids = house_ids
-        self._latest_activities_by_id_type = {}
+        self._latest_activities = {}
         self._last_update_time = None
         self._abort_async_track_time_interval = None
+        self._pubnub = pubnub
+        self._update_debounce = {}
 
     async def async_setup(self):
         """Token refresh check and catch up the activity stream."""
-        await self._async_refresh(utcnow)
+        for house_id in self._house_ids:
+
+            async def _async_update_house_id():
+                await self._async_update_house_id(house_id)
+
+            self._update_debounce[house_id] = Debouncer(
+                self.hass,
+                _LOGGER,
+                cooldown=ACTIVITY_UPDATE_INTERVAL.seconds,
+                immediate=True,
+                function=_async_update_house_id,
+            )
+
+        await self._async_refresh(utcnow())
+
+    @callback
+    def async_stop(self):
+        """Cleanup any debounces."""
+        for debouncer in self._update_debounce.values():
+            debouncer.async_cancel()
 
     def get_latest_device_activity(self, device_id, activity_types):
         """Return latest activity that is one of the acitivty_types."""
-        if device_id not in self._latest_activities_by_id_type:
+        if device_id not in self._latest_activities:
             return None
 
-        latest_device_activities = self._latest_activities_by_id_type[device_id]
+        latest_device_activities = self._latest_activities[device_id]
         latest_activity = None
 
         for activity_type in activity_types:
@@ -54,62 +78,69 @@ class ActivityStream(AugustSubscriberMixin):
 
     async def _async_refresh(self, time):
         """Update the activity stream from August."""
-
         # This is the only place we refresh the api token
         await self._august_gateway.async_refresh_access_token_if_needed()
+        if self._pubnub.connected:
+            _LOGGER.debug("Skipping update because pubnub is connected.")
+            return
         await self._async_update_device_activities(time)
 
     async def _async_update_device_activities(self, time):
         _LOGGER.debug("Start retrieving device activities")
-
-        limit = (
-            ACTIVITY_STREAM_FETCH_LIMIT
-            if self._last_update_time
-            else ACTIVITY_CATCH_UP_FETCH_LIMIT
-        )
-
         for house_id in self._house_ids:
-            _LOGGER.debug("Updating device activity for house id %s", house_id)
-            try:
-                activities = await self._api.async_get_house_activities(
-                    self._august_gateway.access_token, house_id, limit=limit
-                )
-            except ClientError as ex:
-                _LOGGER.error(
-                    "Request error trying to retrieve activity for house id %s: %s",
-                    house_id,
-                    ex,
-                )
-                # Make sure we process the next house if one of them fails
-                continue
-
-            _LOGGER.debug(
-                "Completed retrieving device activities for house id %s", house_id
-            )
-
-            updated_device_ids = self._process_newer_device_activities(activities)
-
-            if updated_device_ids:
-                for device_id in updated_device_ids:
-                    _LOGGER.debug(
-                        "async_signal_device_id_update (from activity stream): %s",
-                        device_id,
-                    )
-                    self.async_signal_device_id_update(device_id)
+            await self._update_debounce[house_id].async_call()
 
         self._last_update_time = time
+
+    @callback
+    def async_schedule_house_id_refresh(self, house_id):
+        """Update for a house activities."""
+        asyncio.create_task(self._update_debounce[house_id].async_call())
+
+    async def _async_update_house_id(self, house_id):
+        """Update device activities for a house."""
+        if self._last_update_time:
+            limit = ACTIVITY_STREAM_FETCH_LIMIT
+        else:
+            limit = ACTIVITY_CATCH_UP_FETCH_LIMIT
+
+        _LOGGER.debug("Updating device activity for house id %s", house_id)
+        try:
+            activities = await self._api.async_get_house_activities(
+                self._august_gateway.access_token, house_id, limit=limit
+            )
+        except ClientError as ex:
+            _LOGGER.error(
+                "Request error trying to retrieve activity for house id %s: %s",
+                house_id,
+                ex,
+            )
+            # Make sure we process the next house if one of them fails
+            return
+
+        _LOGGER.debug(
+            "Completed retrieving device activities for house id %s", house_id
+        )
+
+        updated_device_ids = self._process_newer_device_activities(activities)
+
+        if not updated_device_ids:
+            return
+
+        for device_id in updated_device_ids:
+            _LOGGER.debug(
+                "async_signal_device_id_update (from activity stream): %s",
+                device_id,
+            )
+            self.async_signal_device_id_update(device_id)
 
     def _process_newer_device_activities(self, activities):
         updated_device_ids = set()
         for activity in activities:
             device_id = activity.device_id
             activity_type = activity.activity_type
-
-            self._latest_activities_by_id_type.setdefault(device_id, {})
-
-            lastest_activity = self._latest_activities_by_id_type[device_id].get(
-                activity_type
-            )
+            device_activities = self._latest_activities.setdefault(device_id, {})
+            lastest_activity = device_activities.get(activity_type)
 
             # Ignore activities that are older than the latest one
             if (
@@ -118,7 +149,7 @@ class ActivityStream(AugustSubscriberMixin):
             ):
                 continue
 
-            self._latest_activities_by_id_type[device_id][activity_type] = activity
+            device_activities[activity_type] = activity
 
             updated_device_ids.add(device_id)
 

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -32,7 +32,7 @@ class ActivityStream(AugustSubscriberMixin):
         self._latest_activities = {}
         self._last_update_time = None
         self._abort_async_track_time_interval = None
-        self._pubnub = pubnub
+        self.pubnub = pubnub
         self._update_debounce = {}
 
     async def async_setup(self):
@@ -90,7 +90,7 @@ class ActivityStream(AugustSubscriberMixin):
         """Update the activity stream from August."""
         # This is the only place we refresh the api token
         await self._august_gateway.async_refresh_access_token_if_needed()
-        if self._pubnub.connected:
+        if self.pubnub.connected:
             _LOGGER.debug("Skipping update because pubnub is connected")
             return
         await self._async_update_device_activities(time)

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -41,7 +41,7 @@ class ActivityStream(AugustSubscriberMixin):
                 await self._async_update_house_id(house_id)
 
             self._update_debounce[house_id] = Debouncer(
-                self.hass,
+                self._hass,
                 _LOGGER,
                 cooldown=ACTIVITY_UPDATE_INTERVAL.seconds,
                 immediate=True,

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -115,8 +115,7 @@ class ActivityStream(AugustSubscriberMixin):
         async def _update_house_activities():
             await self._update_debounce[house_id].async_call()
 
-        asyncio.create_task(self._update_debounce[house_id].async_call())
-
+        self._hass.async_create_task(self._update_debounce[house_id].async_call())
         # Schedule an update past the debounce to ensure
         # we catch the case where the lock operator is
         # not updated or the lock failed

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -6,7 +6,7 @@ from aiohttp import ClientError
 
 from homeassistant.core import callback
 from homeassistant.helpers.debounce import Debouncer
-from homeassistant.helpers.events import async_call_later
+from homeassistant.helpers.event import async_call_later
 from homeassistant.util.dt import utcnow
 
 from .const import ACTIVITY_UPDATE_INTERVAL

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -46,7 +46,7 @@ class ActivityStream(AugustSubscriberMixin):
     def _async_create_debouncer(self, house_id):
         """Create a debouncer for the house id."""
 
-        async def _async_update_house_id(_):
+        async def _async_update_house_id():
             await self._async_update_house_id(house_id)
 
         return Debouncer(
@@ -112,7 +112,7 @@ class ActivityStream(AugustSubscriberMixin):
             self._schedule_updates[house_id]()
             self._schedule_updates[house_id] = None
 
-        async def _update_house_activities():
+        async def _update_house_activities(_):
             await self._update_debounce[house_id].async_call()
 
         self._hass.async_create_task(self._update_debounce[house_id].async_call())

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -3,7 +3,6 @@ import asyncio
 import logging
 
 from aiohttp import ClientError
-from yalexs.activity import SOURCE_LOG
 
 from homeassistant.core import callback
 from homeassistant.helpers.debounce import Debouncer
@@ -153,18 +152,14 @@ class ActivityStream(AugustSubscriberMixin):
             lastest_activity = device_activities.get(activity_type)
 
             # Ignore activities that are older than the latest one
-            # unless they come from the log which we allow to override pubsub and
-            # lock operations
             if (
-                not lastest_activity
-                or lastest_activity.activity_start_time < activity.activity_start_time
-                or (
-                    lastest_activity.source != SOURCE_LOG
-                    and activity.source == SOURCE_LOG
-                )
+                lastest_activity
+                and lastest_activity.activity_start_time >= activity.activity_start_time
             ):
+                continue
 
-                device_activities[activity_type] = activity
-                updated_device_ids.add(device_id)
+            device_activities[activity_type] = activity
+
+            updated_device_ids.add(device_id)
 
         return updated_device_ids

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -3,6 +3,7 @@ import asyncio
 import logging
 
 from aiohttp import ClientError
+from yalexs.activity import SOURCE_LOG
 
 from homeassistant.core import callback
 from homeassistant.helpers.debounce import Debouncer
@@ -152,14 +153,18 @@ class ActivityStream(AugustSubscriberMixin):
             lastest_activity = device_activities.get(activity_type)
 
             # Ignore activities that are older than the latest one
+            # unless they come from the log which we allow to override pubsub and
+            # lock operations
             if (
-                lastest_activity
-                and lastest_activity.activity_start_time >= activity.activity_start_time
+                not lastest_activity
+                or lastest_activity.activity_start_time < activity.activity_start_time
+                or (
+                    lastest_activity.source != SOURCE_LOG
+                    and activity.source == SOURCE_LOG
+                )
             ):
-                continue
 
-            device_activities[activity_type] = activity
-
-            updated_device_ids.add(device_id)
+                device_activities[activity_type] = activity
+                updated_device_ids.add(device_id)
 
         return updated_device_ids

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -133,7 +133,7 @@ class ActivityStream(AugustSubscriberMixin):
             "Completed retrieving device activities for house id %s", house_id
         )
 
-        updated_device_ids = self._process_newer_device_activities(activities)
+        updated_device_ids = self.async_process_newer_device_activities(activities)
 
         if not updated_device_ids:
             return
@@ -145,7 +145,8 @@ class ActivityStream(AugustSubscriberMixin):
             )
             self.async_signal_device_id_update(device_id)
 
-    def _process_newer_device_activities(self, activities):
+    def async_process_newer_device_activities(self, activities):
+        """Process activities if they are newer than the last one."""
         updated_device_ids = set()
         for activity in activities:
             device_id = activity.device_id

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -62,9 +62,10 @@ class ActivityStream(AugustSubscriberMixin):
         """Cleanup any debounces."""
         for debouncer in self._update_debounce.values():
             debouncer.async_cancel()
-        for house_id in self._scheduled_updates:
-            self._scheduled_updates[house_id]()
-            self._scheduled_updates[house_id] = None
+        for house_id in self._schedule_updates:
+            if self._schedule_updates[house_id] is not None:
+                self._schedule_updates[house_id]()
+                self._schedule_updates[house_id] = None
 
     def get_latest_device_activity(self, device_id, activity_types):
         """Return latest activity that is one of the acitivty_types."""

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -25,7 +25,7 @@ class ActivityStream(AugustSubscriberMixin):
         """Init August activity stream object."""
         super().__init__(hass, ACTIVITY_UPDATE_INTERVAL)
         self._hass = hass
-        self._scheduled_updates = {}
+        self._schedule_updates = {}
         self._august_gateway = august_gateway
         self._api = api
         self._house_ids = house_ids

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -46,7 +46,7 @@ class ActivityStream(AugustSubscriberMixin):
     def _async_create_debouncer(self, house_id):
         """Create a debouncer for the house id."""
 
-        async def _async_update_house_id():
+        async def _async_update_house_id(_):
             await self._async_update_house_id(house_id)
 
         return Debouncer(

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -62,9 +62,9 @@ class ActivityStream(AugustSubscriberMixin):
         """Cleanup any debounces."""
         for debouncer in self._update_debounce.values():
             debouncer.async_cancel()
-        for house_id in list(self._scheduled_updates):
+        for house_id in self._scheduled_updates:
             self._scheduled_updates[house_id]()
-            del self._scheduled_updates[house_id]
+            self._scheduled_updates[house_id] = None
 
     def get_latest_device_activity(self, device_id, activity_types):
         """Return latest activity that is one of the acitivty_types."""
@@ -108,7 +108,7 @@ class ActivityStream(AugustSubscriberMixin):
     @callback
     def async_schedule_house_id_refresh(self, house_id):
         """Update for a house activities now and once in the future."""
-        if self._schedule_updates[house_id]:
+        if self._schedule_updates.get(house_id):
             self._schedule_updates[house_id]()
             self._schedule_updates[house_id] = None
 

--- a/homeassistant/components/august/activity.py
+++ b/homeassistant/components/august/activity.py
@@ -40,9 +40,6 @@ class ActivityStream(AugustSubscriberMixin):
 
         await self._async_refresh(utcnow())
 
-        for house_id in self._house_ids:
-            self._update_debounce[house_id].immediate = False
-
     @callback
     def _async_create_debouncer(self, house_id):
         """Create a debouncer for the house id."""

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -38,7 +38,6 @@ def _retrieve_motion_state(data, detail):
     latest = data.activity_stream.get_latest_device_activity(
         detail.device_id, {ActivityType.DOORBELL_MOTION}
     )
-    _LOGGER.debug("_retrieve_motion_state: latest=%s", latest)
 
     if latest is None:
         return False
@@ -51,7 +50,6 @@ def _retrieve_ding_state(data, detail):
         detail.device_id, {ActivityType.DOORBELL_DING}
     )
 
-    _LOGGER.debug("_retrieve_ding_state: latest=%s", latest)
     if latest is None:
         return False
 
@@ -69,9 +67,6 @@ def _activity_time_based_state(latest):
     start = latest.activity_start_time
     end = latest.activity_end_time + TIME_TO_DECLARE_DETECTION
     now = datetime.now()
-    _LOGGER.debug(
-        "_activity_time_based_state: start=%s <= now=%s <= end=%s", start, now, end
-    )
     return start <= now <= end
 
 

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -254,6 +254,7 @@ class AugustDoorbellBinarySensor(AugustEntityMixin, BinarySensorEntity):
             """Timer callback for sensor update."""
             self._check_for_off_update_listener = None
             self._update_from_data()
+            self.async_write_ha_state()
 
         self._check_for_off_update_listener = async_call_later(
             self.hass, TIME_TO_RECHECK_DETECTION.seconds, _scheduled_update

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -17,12 +17,13 @@ from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.util.dt import utcnow
 
-from .const import DATA_AUGUST, DOMAIN
+from .const import ACTIVITY_UPDATE_INTERVAL, DATA_AUGUST, DOMAIN
 from .entity import AugustEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
 
-TIME_TO_DECLARE_DETECTION = timedelta(seconds=5)
+TIME_TO_DECLARE_DETECTION = timedelta(seconds=ACTIVITY_UPDATE_INTERVAL.seconds / 2)
+TIME_TO_RECHECK_DETECTION = timedelta(seconds=ACTIVITY_UPDATE_INTERVAL.seconds * 2)
 
 
 def _retrieve_online_state(data, detail):
@@ -230,7 +231,7 @@ class AugustDoorbellBinarySensor(AugustEntityMixin, BinarySensorEntity):
             self._update_from_data()
 
         self._check_for_off_update_listener = async_track_point_in_utc_time(
-            self.hass, _scheduled_update, utcnow() + TIME_TO_DECLARE_DETECTION
+            self.hass, _scheduled_update, utcnow() + TIME_TO_RECHECK_DETECTION
         )
 
     def _cancel_any_pending_updates(self):

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -22,7 +22,7 @@ from .entity import AugustEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
 
-TIME_TO_DECLARE_DETECTION = timedelta(seconds=60)
+TIME_TO_DECLARE_DETECTION = timedelta(seconds=5)
 
 
 def _retrieve_online_state(data, detail):

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -2,9 +2,9 @@
 from datetime import datetime, timedelta
 import logging
 
-from august.activity import ActivityType
-from august.lock import LockDoorStatus
-from august.util import update_lock_detail_from_activity
+from yalexs.activity import ActivityType
+from yalexs.lock import LockDoorStatus
+from yalexs.util import update_lock_detail_from_activity
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -150,6 +150,13 @@ class AugustDoorBinarySensor(AugustEntityMixin, BinarySensorEntity):
         if door_activity is not None:
             update_lock_detail_from_activity(self._detail, door_activity)
 
+        bridge_activity = self._data.activity_stream.get_latest_device_activity(
+            self._device_id, [ActivityType.BRIDGE_OPERATION]
+        )
+
+        if bridge_activity is not None:
+            update_lock_detail_from_activity(self._detail, bridge_activity)
+
     @property
     def unique_id(self) -> str:
         """Get the unique of the door open binary sensor."""

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -40,14 +40,14 @@ def _retrieve_motion_state(data, detail):
     return _activity_time_based_state(
         data,
         detail.device_id,
-        [ActivityType.DOORBELL_MOTION, ActivityType.DOORBELL_DING],
+        {ActivityType.DOORBELL_MOTION, ActivityType.DOORBELL_DING},
     )
 
 
 def _retrieve_ding_state(data, detail):
 
     return _activity_time_based_state(
-        data, detail.device_id, [ActivityType.DOORBELL_DING]
+        data, detail.device_id, {ActivityType.DOORBELL_DING}
     )
 
 
@@ -144,14 +144,14 @@ class AugustDoorBinarySensor(AugustEntityMixin, BinarySensorEntity):
     def _update_from_data(self):
         """Get the latest state of the sensor and update activity."""
         door_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id, [ActivityType.DOOR_OPERATION]
+            self._device_id, {ActivityType.DOOR_OPERATION}
         )
 
         if door_activity is not None:
             update_lock_detail_from_activity(self._detail, door_activity)
 
         bridge_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id, [ActivityType.BRIDGE_OPERATION]
+            self._device_id, {ActivityType.BRIDGE_OPERATION}
         )
 
         if bridge_activity is not None:

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -66,8 +66,12 @@ def _activity_time_based_state(latest):
     """Get the latest state of the sensor."""
     start = latest.activity_start_time
     end = latest.activity_end_time + TIME_TO_DECLARE_DETECTION
-    now = datetime.now()
-    return start <= now <= end
+    return start <= _native_datetime() <= end
+
+
+def _native_datetime():
+    """Return time in the format august uses without timezone."""
+    return datetime.now()
 
 
 SENSOR_NAME = 0
@@ -249,7 +253,8 @@ class AugustDoorbellBinarySensor(AugustEntityMixin, BinarySensorEntity):
             """Timer callback for sensor update."""
             self._check_for_off_update_listener = None
             self._update_from_data()
-            self.async_write_ha_state()
+            if not self._state:
+                self.async_write_ha_state()
 
         self._check_for_off_update_listener = async_call_later(
             self.hass, TIME_TO_RECHECK_DETECTION.seconds, _scheduled_update

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -21,8 +21,8 @@ from .entity import AugustEntityMixin
 
 _LOGGER = logging.getLogger(__name__)
 
-TIME_TO_DECLARE_DETECTION = timedelta(seconds=ACTIVITY_UPDATE_INTERVAL.seconds / 2)
-TIME_TO_RECHECK_DETECTION = timedelta(seconds=ACTIVITY_UPDATE_INTERVAL.seconds * 2)
+TIME_TO_DECLARE_DETECTION = timedelta(seconds=ACTIVITY_UPDATE_INTERVAL.seconds)
+TIME_TO_RECHECK_DETECTION = timedelta(seconds=ACTIVITY_UPDATE_INTERVAL.seconds * 3)
 
 
 def _retrieve_online_state(data, detail):

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -39,6 +39,8 @@ def _retrieve_motion_state(data, detail):
     latest = data.activity_stream.get_latest_device_activity(
         detail.device_id, {ActivityType.DOORBELL_MOTION}
     )
+    _LOGGER.debug("_retrieve_motion_state: latest=%s", latest)
+
     if latest is None:
         return False
 
@@ -49,6 +51,8 @@ def _retrieve_ding_state(data, detail):
     latest = data.activity_stream.get_latest_device_activity(
         detail.device_id, {ActivityType.DOORBELL_DING}
     )
+
+    _LOGGER.debug("_retrieve_ding_state: latest=%s", latest)
     if latest is None:
         return False
 

--- a/homeassistant/components/august/binary_sensor.py
+++ b/homeassistant/components/august/binary_sensor.py
@@ -14,8 +14,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.core import callback
-from homeassistant.helpers.event import async_track_point_in_utc_time
-from homeassistant.util.dt import utcnow
+from homeassistant.helpers.event import async_call_later
 
 from .const import ACTIVITY_UPDATE_INTERVAL, DATA_AUGUST, DOMAIN
 from .entity import AugustEntityMixin
@@ -69,7 +68,11 @@ def _activity_time_based_state(latest):
     """Get the latest state of the sensor."""
     start = latest.activity_start_time
     end = latest.activity_end_time + TIME_TO_DECLARE_DETECTION
-    return start <= datetime.now() <= end
+    now = datetime.now()
+    _LOGGER.debug(
+        "_activity_time_based_state: start=%s <= now=%s <= end=%s", start, now, end
+    )
+    return start <= now <= end
 
 
 SENSOR_NAME = 0
@@ -252,8 +255,8 @@ class AugustDoorbellBinarySensor(AugustEntityMixin, BinarySensorEntity):
             self._check_for_off_update_listener = None
             self._update_from_data()
 
-        self._check_for_off_update_listener = async_track_point_in_utc_time(
-            self.hass, _scheduled_update, utcnow() + TIME_TO_RECHECK_DETECTION
+        self._check_for_off_update_listener = async_call_later(
+            self.hass, TIME_TO_RECHECK_DETECTION.seconds, _scheduled_update
         )
 
     def _cancel_any_pending_updates(self):

--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -1,7 +1,7 @@
 """Support for August doorbell camera."""
 
-from august.activity import ActivityType
-from august.util import update_doorbell_image_from_activity
+from yalexs.activity import ActivityType
+from yalexs.util import update_doorbell_image_from_activity
 
 from homeassistant.components.camera import Camera
 from homeassistant.core import callback

--- a/homeassistant/components/august/camera.py
+++ b/homeassistant/components/august/camera.py
@@ -63,7 +63,7 @@ class AugustCamera(AugustEntityMixin, Camera):
     def _update_from_data(self):
         """Get the latest state of the sensor."""
         doorbell_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id, [ActivityType.DOORBELL_MOTION]
+            self._device_id, {ActivityType.DOORBELL_MOTION}
         )
 
         if doorbell_activity is not None:

--- a/homeassistant/components/august/config_flow.py
+++ b/homeassistant/components/august/config_flow.py
@@ -1,8 +1,8 @@
 """Config flow for August integration."""
 import logging
 
-from august.authenticator import ValidationResult
 import voluptuous as vol
+from yalexs.authenticator import ValidationResult
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME

--- a/homeassistant/components/august/const.py
+++ b/homeassistant/components/august/const.py
@@ -3,7 +3,6 @@
 from datetime import timedelta
 
 DEFAULT_TIMEOUT = 10
-DEFAULT_OPERATION_TIME = 10
 
 CONF_ACCESS_TOKEN_CACHE_FILE = "access_token_cache_file"
 CONF_LOGIN_METHOD = "login_method"

--- a/homeassistant/components/august/const.py
+++ b/homeassistant/components/august/const.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 
 DEFAULT_TIMEOUT = 10
+DEFAULT_OPERATION_TIME = 10
 
 CONF_ACCESS_TOKEN_CACHE_FILE = "access_token_cache_file"
 CONF_LOGIN_METHOD = "login_method"

--- a/homeassistant/components/august/gateway.py
+++ b/homeassistant/components/august/gateway.py
@@ -5,8 +5,8 @@ import logging
 import os
 
 from aiohttp import ClientError, ClientResponseError
-from august.api_async import ApiAsync
-from august.authenticator_async import AuthenticationState, AuthenticatorAsync
+from yalexs.api_async import ApiAsync
+from yalexs.authenticator_async import AuthenticationState, AuthenticatorAsync
 
 from homeassistant.const import (
     CONF_PASSWORD,

--- a/homeassistant/components/august/gateway.py
+++ b/homeassistant/components/august/gateway.py
@@ -128,14 +128,15 @@ class AugustGateway:
 
     async def async_refresh_access_token_if_needed(self):
         """Refresh the august access token if needed."""
-        if self.authenticator.should_refresh():
-            async with self._token_refresh_lock:
-                refreshed_authentication = (
-                    await self.authenticator.async_refresh_access_token(force=False)
-                )
-                _LOGGER.info(
-                    "Refreshed august access token. The old token expired at %s, and the new token expires at %s",
-                    self.authentication.access_token_expires,
-                    refreshed_authentication.access_token_expires,
-                )
-                self.authentication = refreshed_authentication
+        if not self.authenticator.should_refresh():
+            return
+        async with self._token_refresh_lock:
+            refreshed_authentication = (
+                await self.authenticator.async_refresh_access_token(force=False)
+            )
+            _LOGGER.info(
+                "Refreshed august access token. The old token expired at %s, and the new token expires at %s",
+                self.authentication.access_token_expires,
+                refreshed_authentication.access_token_expires,
+            )
+            self.authentication = refreshed_authentication

--- a/homeassistant/components/august/gateway.py
+++ b/homeassistant/components/august/gateway.py
@@ -128,15 +128,14 @@ class AugustGateway:
 
     async def async_refresh_access_token_if_needed(self):
         """Refresh the august access token if needed."""
-        if not self.authenticator.should_refresh():
-            return
-        async with self._token_refresh_lock:
-            refreshed_authentication = (
-                await self.authenticator.async_refresh_access_token(force=False)
-            )
-            _LOGGER.info(
-                "Refreshed august access token. The old token expired at %s, and the new token expires at %s",
-                self.authentication.access_token_expires,
-                refreshed_authentication.access_token_expires,
-            )
-            self.authentication = refreshed_authentication
+        if self.authenticator.should_refresh():
+            async with self._token_refresh_lock:
+                refreshed_authentication = (
+                    await self.authenticator.async_refresh_access_token(force=False)
+                )
+                _LOGGER.info(
+                    "Refreshed august access token. The old token expired at %s, and the new token expires at %s",
+                    self.authentication.access_token_expires,
+                    refreshed_authentication.access_token_expires,
+                )
+                self.authentication = refreshed_authentication

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -73,7 +73,8 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
     def _update_from_data(self):
         """Get the latest state of the sensor and update activity."""
         lock_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id, [ActivityType.LOCK_OPERATION]
+            self._device_id,
+            {ActivityType.LOCK_OPERATION, ActivityType.LOCK_OPERATION_WITHOUT_OPERATOR},
         )
 
         if lock_activity is not None:
@@ -81,7 +82,7 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
             update_lock_detail_from_activity(self._detail, lock_activity)
 
         bridge_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id, [ActivityType.BRIDGE_OPERATION]
+            self._device_id, {ActivityType.BRIDGE_OPERATION}
         )
 
         if bridge_activity is not None:

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -1,9 +1,9 @@
 """Support for August lock."""
 import logging
 
-from august.activity import ActivityType
-from august.lock import LockStatus
-from august.util import update_lock_detail_from_activity
+from yalexs.activity import ActivityType
+from yalexs.lock import LockStatus
+from yalexs.util import update_lock_detail_from_activity
 
 from homeassistant.components.lock import ATTR_CHANGED_BY, LockEntity
 from homeassistant.const import ATTR_BATTERY_LEVEL

--- a/homeassistant/components/august/lock.py
+++ b/homeassistant/components/august/lock.py
@@ -80,6 +80,13 @@ class AugustLock(AugustEntityMixin, RestoreEntity, LockEntity):
             self._changed_by = lock_activity.operated_by
             update_lock_detail_from_activity(self._detail, lock_activity)
 
+        bridge_activity = self._data.activity_stream.get_latest_device_activity(
+            self._device_id, [ActivityType.BRIDGE_OPERATION]
+        )
+
+        if bridge_activity is not None:
+            update_lock_detail_from_activity(self._detail, bridge_activity)
+
         self._update_lock_status_from_detail()
 
     @property

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.2"],
+  "requirements": ["yalexs==1.1.4"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.3"],
+  "requirements": ["yalexs==1.1.2"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.0"],
+  "requirements": ["yalexs==1.1.1"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["py-august==0.25.2"],
+  "requirements": ["py-august==0.26.0"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["py-august==0.26.0"],
+  "requirements": ["yalexs==1.0.3"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.1"],
+  "requirements": ["yalexs==1.1.2"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.0.3"],
+  "requirements": ["yalexs==1.1.0"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -2,7 +2,7 @@
   "domain": "august",
   "name": "August",
   "documentation": "https://www.home-assistant.io/integrations/august",
-  "requirements": ["yalexs==1.1.2"],
+  "requirements": ["yalexs==1.1.3"],
   "codeowners": ["@bdraco"],
   "dhcp": [
       {"hostname":"connect","macaddress":"D86162*"},

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -154,11 +154,11 @@ class AugustOperatorSensor(AugustEntityMixin, RestoreEntity, Entity):
     def _update_from_data(self):
         """Get the latest state of the sensor and update activity."""
         lock_activity = self._data.activity_stream.get_latest_device_activity(
-            self._device_id, [ActivityType.LOCK_OPERATION]
+            self._device_id, {ActivityType.LOCK_OPERATION}
         )
 
         self._available = True
-        if lock_activity is not None and lock_activity.operated_by is not None:
+        if lock_activity is not None:
             self._state = lock_activity.operated_by
             self._operated_remote = lock_activity.operated_remote
             self._operated_keypad = lock_activity.operated_keypad

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -1,7 +1,7 @@
 """Support for August sensors."""
 import logging
 
-from august.activity import ActivityType
+from yalexs.activity import ActivityType
 
 from homeassistant.components.sensor import DEVICE_CLASS_BATTERY
 from homeassistant.const import ATTR_ENTITY_PICTURE, PERCENTAGE, STATE_UNAVAILABLE

--- a/homeassistant/components/august/sensor.py
+++ b/homeassistant/components/august/sensor.py
@@ -158,7 +158,7 @@ class AugustOperatorSensor(AugustEntityMixin, RestoreEntity, Entity):
         )
 
         self._available = True
-        if lock_activity is not None:
+        if lock_activity is not None and lock_activity.operated_by is not None:
             self._state = lock_activity.operated_by
             self._operated_remote = lock_activity.operated_remote
             self._operated_keypad = lock_activity.operated_keypad

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1192,7 +1192,7 @@ pushover_complete==1.1.1
 pwmled==1.6.7
 
 # homeassistant.components.august
-py-august==0.25.2
+py-august==0.26.0
 
 # homeassistant.components.canary
 py-canary==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.august
-yalexs==1.1.1
+yalexs==1.1.2
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.august
-yalexs==1.0.3
+yalexs==1.1.0
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1191,9 +1191,6 @@ pushover_complete==1.1.1
 # homeassistant.components.rpi_gpio_pwm
 pwmled==1.6.7
 
-# homeassistant.components.august
-py-august==0.26.0
-
 # homeassistant.components.canary
 py-canary==0.5.1
 
@@ -2346,6 +2343,9 @@ xs1-api-client==3.0.0
 
 # homeassistant.components.yale_smart_alarm
 yalesmartalarmclient==0.1.6
+
+# homeassistant.components.august
+yalexs==1.0.3
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.august
-yalexs==1.1.3
+yalexs==1.1.2
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.august
-yalexs==1.1.0
+yalexs==1.1.1
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.august
-yalexs==1.1.2
+yalexs==1.1.4
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ xs1-api-client==3.0.0
 yalesmartalarmclient==0.1.6
 
 # homeassistant.components.august
-yalexs==1.1.2
+yalexs==1.1.3
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ xbox-webapi==2.0.8
 xmltodict==0.12.0
 
 # homeassistant.components.august
-yalexs==1.1.2
+yalexs==1.1.4
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -616,9 +616,6 @@ pure-python-adb[async]==0.3.0.dev0
 # homeassistant.components.pushbullet
 pushbullet.py==0.11.0
 
-# homeassistant.components.august
-py-august==0.26.0
-
 # homeassistant.components.canary
 py-canary==0.5.1
 
@@ -1207,6 +1204,9 @@ xbox-webapi==2.0.8
 # homeassistant.components.ted5000
 # homeassistant.components.zestimate
 xmltodict==0.12.0
+
+# homeassistant.components.august
+yalexs==1.0.3
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ xbox-webapi==2.0.8
 xmltodict==0.12.0
 
 # homeassistant.components.august
-yalexs==1.0.3
+yalexs==1.1.0
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ xbox-webapi==2.0.8
 xmltodict==0.12.0
 
 # homeassistant.components.august
-yalexs==1.1.3
+yalexs==1.1.2
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ xbox-webapi==2.0.8
 xmltodict==0.12.0
 
 # homeassistant.components.august
-yalexs==1.1.0
+yalexs==1.1.1
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ xbox-webapi==2.0.8
 xmltodict==0.12.0
 
 # homeassistant.components.august
-yalexs==1.1.2
+yalexs==1.1.3
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -617,7 +617,7 @@ pure-python-adb[async]==0.3.0.dev0
 pushbullet.py==0.11.0
 
 # homeassistant.components.august
-py-august==0.25.2
+py-august==0.26.0
 
 # homeassistant.components.canary
 py-canary==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1206,7 +1206,7 @@ xbox-webapi==2.0.8
 xmltodict==0.12.0
 
 # homeassistant.components.august
-yalexs==1.1.1
+yalexs==1.1.2
 
 # homeassistant.components.yeelight
 yeelight==0.5.4

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -193,6 +193,8 @@ async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects):
             side_effect=api_call_side_effects["unlock_return_activities"]
         )
 
+    api_instance.async_get_user = AsyncMock(return_value={"UserID": "abc"})
+
     return await _mock_setup_august(hass, api_instance)
 
 

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -7,11 +7,15 @@ import time
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from yalexs.activity import (
+    ACTIVITY_ACTIONS_BRIDGE_OPERATION,
     ACTIVITY_ACTIONS_DOOR_OPERATION,
     ACTIVITY_ACTIONS_DOORBELL_DING,
     ACTIVITY_ACTIONS_DOORBELL_MOTION,
     ACTIVITY_ACTIONS_DOORBELL_VIEW,
     ACTIVITY_ACTIONS_LOCK_OPERATION,
+    SOURCE_LOCK_OPERATE,
+    SOURCE_LOG,
+    BridgeOperationActivity,
     DoorbellDingActivity,
     DoorbellMotionActivity,
     DoorbellViewActivity,
@@ -306,23 +310,25 @@ async def _mock_doorsense_missing_august_lock_detail(hass):
 
 def _mock_lock_operation_activity(lock, action, offset):
     return LockOperationActivity(
+        SOURCE_LOCK_OPERATE,
         {
             "dateTime": (time.time() + offset) * 1000,
             "deviceID": lock.device_id,
             "deviceType": "lock",
             "action": action,
-        }
+        },
     )
 
 
 def _mock_door_operation_activity(lock, action, offset):
     return DoorOperationActivity(
+        SOURCE_LOCK_OPERATE,
         {
             "dateTime": (time.time() + offset) * 1000,
             "deviceID": lock.device_id,
             "deviceType": "lock",
             "action": action,
-        }
+        },
     )
 
 
@@ -332,13 +338,15 @@ def _activity_from_dict(activity_dict):
     activity_dict["dateTime"] = time.time() * 1000
 
     if action in ACTIVITY_ACTIONS_DOORBELL_DING:
-        return DoorbellDingActivity(activity_dict)
+        return DoorbellDingActivity(SOURCE_LOG, activity_dict)
     if action in ACTIVITY_ACTIONS_DOORBELL_MOTION:
-        return DoorbellMotionActivity(activity_dict)
+        return DoorbellMotionActivity(SOURCE_LOG, activity_dict)
     if action in ACTIVITY_ACTIONS_DOORBELL_VIEW:
-        return DoorbellViewActivity(activity_dict)
+        return DoorbellViewActivity(SOURCE_LOG, activity_dict)
     if action in ACTIVITY_ACTIONS_LOCK_OPERATION:
-        return LockOperationActivity(activity_dict)
+        return LockOperationActivity(SOURCE_LOG, activity_dict)
     if action in ACTIVITY_ACTIONS_DOOR_OPERATION:
-        return DoorOperationActivity(activity_dict)
+        return DoorOperationActivity(SOURCE_LOG, activity_dict)
+    if action in ACTIVITY_ACTIONS_BRIDGE_OPERATION:
+        return BridgeOperationActivity(SOURCE_LOG, activity_dict)
     return None

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -6,7 +6,7 @@ import time
 # from unittest.mock import AsyncMock
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-from august.activity import (
+from yalexs.activity import (
     ACTIVITY_ACTIONS_DOOR_OPERATION,
     ACTIVITY_ACTIONS_DOORBELL_DING,
     ACTIVITY_ACTIONS_DOORBELL_MOTION,
@@ -18,9 +18,9 @@ from august.activity import (
     DoorOperationActivity,
     LockOperationActivity,
 )
-from august.authenticator import AuthenticationState
-from august.doorbell import Doorbell, DoorbellDetail
-from august.lock import Lock, LockDetail
+from yalexs.authenticator import AuthenticationState
+from yalexs.doorbell import Doorbell, DoorbellDetail
+from yalexs.lock import Lock, LockDetail
 
 from homeassistant.components.august.const import CONF_LOGIN_METHOD, DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
@@ -197,7 +197,7 @@ async def _mock_setup_august_with_api_side_effects(hass, api_call_side_effects):
 
 
 def _mock_august_authentication(token_text, token_timestamp, state):
-    authentication = MagicMock(name="august.authentication")
+    authentication = MagicMock(name="yalexs.authentication")
     type(authentication).state = PropertyMock(return_value=state)
     type(authentication).access_token = PropertyMock(return_value=token_text)
     type(authentication).access_token_expires = PropertyMock(

--- a/tests/components/august/mocks.py
+++ b/tests/components/august/mocks.py
@@ -46,9 +46,12 @@ def _mock_authenticator(auth_state):
     return authenticator
 
 
+@patch("homeassistant.components.august.async_create_pubnub")
 @patch("homeassistant.components.august.gateway.ApiAsync")
 @patch("homeassistant.components.august.gateway.AuthenticatorAsync.async_authenticate")
-async def _mock_setup_august(hass, api_instance, authenticate_mock, api_mock):
+async def _mock_setup_august(
+    hass, api_instance, authenticate_mock, api_mock, pubnub_mock
+):
     """Set up august integration."""
     authenticate_mock.side_effect = MagicMock(
         return_value=_mock_august_authentication(

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -1,4 +1,9 @@
 """The binary_sensor tests for the august platform."""
+import datetime
+from unittest.mock import Mock, patch
+
+from yalexs.pubnub_async import AugustPubNub
+
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -9,7 +14,9 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.helpers import device_registry as dr
+import homeassistant.util.dt as dt_util
 
+from tests.common import async_fire_time_changed
 from tests.components.august.mocks import (
     _create_august_with_devices,
     _mock_activities_from_fixture,
@@ -124,6 +131,108 @@ async def test_create_doorbell_with_motion(hass):
         "binary_sensor.k98gidt45gul_name_online"
     )
     assert binary_sensor_k98gidt45gul_name_online.state == STATE_ON
+    binary_sensor_k98gidt45gul_name_ding = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_ding"
+    )
+    assert binary_sensor_k98gidt45gul_name_ding.state == STATE_OFF
+    new_time = dt_util.utcnow() + datetime.timedelta(seconds=40)
+    native_time = datetime.datetime.now() + datetime.timedelta(seconds=40)
+    with patch(
+        "homeassistant.components.august.binary_sensor._native_datetime",
+        return_value=native_time,
+    ):
+        async_fire_time_changed(hass, new_time)
+        await hass.async_block_till_done()
+    binary_sensor_k98gidt45gul_name_motion = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_motion"
+    )
+    assert binary_sensor_k98gidt45gul_name_motion.state == STATE_OFF
+
+
+async def test_doorbell_update_via_pubnub(hass):
+    """Test creation of a doorbell that can be updated via pubnub."""
+    doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
+    pubnub = AugustPubNub()
+
+    await _create_august_with_devices(hass, [doorbell_one], pubnub=pubnub)
+    assert doorbell_one.pubsub_channel == "7c7a6672-59c8-3333-ffff-dcd98705cccc"
+
+    binary_sensor_k98gidt45gul_name_motion = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_motion"
+    )
+    assert binary_sensor_k98gidt45gul_name_motion.state == STATE_OFF
+    binary_sensor_k98gidt45gul_name_ding = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_ding"
+    )
+    assert binary_sensor_k98gidt45gul_name_ding.state == STATE_OFF
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=doorbell_one.pubsub_channel,
+            timetoken=dt_util.utcnow().timestamp() * 10000000,
+            message={
+                "status": "imagecapture",
+                "data": {
+                    "result": {
+                        "created_at": "2021-03-16T01:07:08.817Z",
+                        "secure_url": "https://dyu7azbnaoi74.cloudfront.net/zip/images/zip.jpeg",
+                    },
+                },
+            },
+        ),
+    )
+
+    await hass.async_block_till_done()
+
+    binary_sensor_k98gidt45gul_name_motion = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_motion"
+    )
+    assert binary_sensor_k98gidt45gul_name_motion.state == STATE_ON
+    binary_sensor_k98gidt45gul_name_ding = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_ding"
+    )
+    assert binary_sensor_k98gidt45gul_name_ding.state == STATE_OFF
+
+    new_time = dt_util.utcnow() + datetime.timedelta(seconds=40)
+    native_time = datetime.datetime.now() + datetime.timedelta(seconds=40)
+    with patch(
+        "homeassistant.components.august.binary_sensor._native_datetime",
+        return_value=native_time,
+    ):
+        async_fire_time_changed(hass, new_time)
+        await hass.async_block_till_done()
+
+    binary_sensor_k98gidt45gul_name_motion = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_motion"
+    )
+    assert binary_sensor_k98gidt45gul_name_motion.state == STATE_OFF
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=doorbell_one.pubsub_channel,
+            timetoken=dt_util.utcnow().timestamp() * 10000000,
+            message={
+                "status": "buttonpush",
+            },
+        ),
+    )
+    await hass.async_block_till_done()
+
+    binary_sensor_k98gidt45gul_name_ding = hass.states.get(
+        "binary_sensor.k98gidt45gul_name_ding"
+    )
+    assert binary_sensor_k98gidt45gul_name_ding.state == STATE_ON
+    new_time = dt_util.utcnow() + datetime.timedelta(seconds=40)
+    native_time = datetime.datetime.now() + datetime.timedelta(seconds=40)
+    with patch(
+        "homeassistant.components.august.binary_sensor._native_datetime",
+        return_value=native_time,
+    ):
+        async_fire_time_changed(hass, new_time)
+        await hass.async_block_till_done()
+
     binary_sensor_k98gidt45gul_name_ding = hass.states.get(
         "binary_sensor.k98gidt45gul_name_ding"
     )

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -52,6 +52,22 @@ async def test_doorsense(hass):
     assert binary_sensor_online_with_doorsense_name.state == STATE_OFF
 
 
+async def test_lock_bridge_offline(hass):
+    """Test creation of a lock with doorsense and bridge that goes offline."""
+    lock_one = await _mock_lock_from_fixture(
+        hass, "get_lock.online_with_doorsense.json"
+    )
+    activities = await _mock_activities_from_fixture(
+        hass, "get_activity.bridge_offline.json"
+    )
+    await _create_august_with_devices(hass, [lock_one], activities=activities)
+
+    binary_sensor_online_with_doorsense_name = hass.states.get(
+        "binary_sensor.online_with_doorsense_name_open"
+    )
+    assert binary_sensor_online_with_doorsense_name.state == STATE_UNAVAILABLE
+
+
 async def test_create_doorbell(hass):
     """Test creation of a doorbell."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")

--- a/tests/components/august/test_config_flow.py
+++ b/tests/components/august/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the August config flow."""
 from unittest.mock import patch
 
-from august.authenticator import ValidationResult
+from yalexs.authenticator import ValidationResult
 
 from homeassistant import config_entries, setup
 from homeassistant.components.august.const import (

--- a/tests/components/august/test_gateway.py
+++ b/tests/components/august/test_gateway.py
@@ -1,7 +1,7 @@
 """The gateway tests for the august platform."""
 from unittest.mock import MagicMock, patch
 
-from august.authenticator_common import AuthenticationState
+from yalexs.authenticator_common import AuthenticationState
 
 from homeassistant.components.august.const import DOMAIN
 from homeassistant.components.august.gateway import AugustGateway

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -283,3 +283,4 @@ async def test_load_unload(hass):
     assert config_entry.state == ENTRY_STATE_LOADED
 
     await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -3,8 +3,8 @@ import asyncio
 from unittest.mock import patch
 
 from aiohttp import ClientResponseError
-from august.authenticator_common import AuthenticationState
-from august.exceptions import AugustApiAIOHTTPError
+from yalexs.authenticator_common import AuthenticationState
+from yalexs.exceptions import AugustApiAIOHTTPError
 
 from homeassistant import setup
 from homeassistant.components.august.const import DOMAIN
@@ -46,7 +46,7 @@ async def test_august_is_offline(hass):
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "august.authenticator_async.AuthenticatorAsync.async_authenticate",
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         side_effect=asyncio.TimeoutError,
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -152,7 +152,7 @@ async def test_auth_fails(hass):
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "august.authenticator_async.AuthenticatorAsync.async_authenticate",
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         side_effect=ClientResponseError(None, None, status=401),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -178,7 +178,7 @@ async def test_bad_password(hass):
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "august.authenticator_async.AuthenticatorAsync.async_authenticate",
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication(
             "original_token", 1234, AuthenticationState.BAD_PASSWORD
         ),
@@ -206,7 +206,7 @@ async def test_http_failure(hass):
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "august.authenticator_async.AuthenticatorAsync.async_authenticate",
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         side_effect=ClientResponseError(None, None, status=500),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -230,7 +230,7 @@ async def test_unknown_auth_state(hass):
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "august.authenticator_async.AuthenticatorAsync.async_authenticate",
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication("original_token", 1234, None),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -256,7 +256,7 @@ async def test_requires_validation_state(hass):
 
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "august.authenticator_async.AuthenticatorAsync.async_authenticate",
+        "yalexs.authenticator_async.AuthenticatorAsync.async_authenticate",
         return_value=_mock_august_authentication(
             "original_token", 1234, AuthenticationState.REQUIRES_VALIDATION
         ),

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -10,6 +10,7 @@ from homeassistant import setup
 from homeassistant.components.august.const import DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.config_entries import (
+    ENTRY_STATE_LOADED,
     ENTRY_STATE_SETUP_ERROR,
     ENTRY_STATE_SETUP_RETRY,
 )
@@ -268,3 +269,17 @@ async def test_requires_validation_state(hass):
 
     assert len(hass.config_entries.flow.async_progress()) == 1
     assert hass.config_entries.flow.async_progress()[0]["context"]["source"] == "reauth"
+
+
+async def test_load_unload(hass):
+    """Config entry can be unloaded."""
+
+    august_operative_lock = await _mock_operative_august_lock_detail(hass)
+    august_inoperative_lock = await _mock_inoperative_august_lock_detail(hass)
+    config_entry = await _create_august_with_devices(
+        hass, [august_operative_lock, august_inoperative_lock]
+    )
+
+    assert config_entry.state == ENTRY_STATE_LOADED
+
+    await hass.config_entries.async_unload(config_entry.entry_id)

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -1,4 +1,9 @@
 """The lock tests for the august platform."""
+import datetime
+from unittest.mock import Mock
+
+from yalexs.pubnub_async import AugustPubNub
+
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -10,7 +15,9 @@ from homeassistant.const import (
     STATE_UNLOCKED,
 )
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+import homeassistant.util.dt as dt_util
 
+from tests.common import async_fire_time_changed
 from tests.components.august.mocks import (
     _create_august_with_devices,
     _mock_activities_from_fixture,
@@ -141,3 +148,63 @@ async def test_lock_bridge_online(hass):
     lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
 
     assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+
+async def test_lock_update_via_pubnub(hass):
+    """Test creation of a lock with doorsense and bridge."""
+    lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
+    assert lock_one.pubsub_channel == "pubsub"
+    pubnub = AugustPubNub()
+
+    activities = await _mock_activities_from_fixture(hass, "get_activity.lock.json")
+    config_entry = await _create_august_with_devices(
+        hass, [lock_one], activities=activities, pubnub=pubnub
+    )
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=lock_one.pubsub_channel,
+            timetoken=dt_util.utcnow().timestamp() * 10000000,
+            message={
+                "status": "kAugLockState_Unlocking",
+            },
+        ),
+    )
+
+    await hass.async_block_till_done()
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_UNLOCKED
+
+    pubnub.message(
+        pubnub,
+        Mock(
+            channel=lock_one.pubsub_channel,
+            timetoken=dt_util.utcnow().timestamp() * 10000000,
+            message={
+                "status": "kAugLockState_Locking",
+            },
+        ),
+    )
+
+    await hass.async_block_till_done()
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+    async_fire_time_changed(hass, dt_util.utcnow() + datetime.timedelta(seconds=30))
+    await hass.async_block_till_done()
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+    pubnub.connected = True
+    async_fire_time_changed(hass, dt_util.utcnow() + datetime.timedelta(seconds=30))
+    await hass.async_block_till_done()
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -5,6 +5,7 @@ from homeassistant.const import (
     SERVICE_LOCK,
     SERVICE_UNLOCK,
     STATE_LOCKED,
+    STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
@@ -112,3 +113,31 @@ async def test_one_lock_unknown_state(hass):
     lock_brokenid_name = hass.states.get("lock.brokenid_name")
 
     assert lock_brokenid_name.state == STATE_UNKNOWN
+
+
+async def test_lock_bridge_offline(hass):
+    """Test creation of a lock with doorsense and bridge that goes offline."""
+    lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
+
+    activities = await _mock_activities_from_fixture(
+        hass, "get_activity.bridge_offline.json"
+    )
+    await _create_august_with_devices(hass, [lock_one], activities=activities)
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+
+    assert lock_online_with_doorsense_name.state == STATE_UNAVAILABLE
+
+
+async def test_lock_bridge_online(hass):
+    """Test creation of a lock with doorsense and bridge that goes offline."""
+    lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
+
+    activities = await _mock_activities_from_fixture(
+        hass, "get_activity.bridge_online.json"
+    )
+    await _create_august_with_devices(hass, [lock_one], activities=activities)
+
+    lock_online_with_doorsense_name = hass.states.get("lock.online_with_doorsense_name")
+
+    assert lock_online_with_doorsense_name.state == STATE_LOCKED

--- a/tests/fixtures/august/get_activity.bridge_offline.json
+++ b/tests/fixtures/august/get_activity.bridge_offline.json
@@ -1,0 +1,34 @@
+[{
+   "entities" : {
+      "activity" : "mockActivity2",
+      "house" : "123",
+      "device" : "online_with_doorsense",
+      "callingUser" : "mockUserId2",
+      "otherUser" : "deleted"
+   },
+   "callingUser" : {
+      "LastName" : "elven princess",
+      "UserID" : "mockUserId2",
+      "FirstName" : "Your favorite"
+   },
+   "otherUser" : {
+      "LastName" : "User",
+      "UserName" : "deleteduser",
+      "FirstName" : "Unknown",
+      "UserID" : "deleted",
+      "PhoneNo" : "deleted"
+   },
+   "deviceType" : "lock",
+   "deviceName" : "MockHouseTDoor",
+   "action" : "associated_bridge_offline",
+   "dateTime" : 1582007218000,
+   "info" : {
+      "remote" : true,
+      "DateLogActionID" : "ABC+Time"
+   },
+   "deviceID" : "online_with_doorsense",
+   "house" : {
+      "houseName" : "MockHouse",
+      "houseID" : "123"
+   }
+}]

--- a/tests/fixtures/august/get_activity.bridge_online.json
+++ b/tests/fixtures/august/get_activity.bridge_online.json
@@ -1,0 +1,34 @@
+[{
+   "entities" : {
+      "activity" : "mockActivity2",
+      "house" : "123",
+      "device" : "online_with_doorsense",
+      "callingUser" : "mockUserId2",
+      "otherUser" : "deleted"
+   },
+   "callingUser" : {
+      "LastName" : "elven princess",
+      "UserID" : "mockUserId2",
+      "FirstName" : "Your favorite"
+   },
+   "otherUser" : {
+      "LastName" : "User",
+      "UserName" : "deleteduser",
+      "FirstName" : "Unknown",
+      "UserID" : "deleted",
+      "PhoneNo" : "deleted"
+   },
+   "deviceType" : "lock",
+   "deviceName" : "MockHouseTDoor",
+   "action" : "associated_bridge_online",
+   "dateTime" : 1582007218000,
+   "info" : {
+      "remote" : true,
+      "DateLogActionID" : "ABC+Time"
+   },
+   "deviceID" : "online_with_doorsense",
+   "house" : {
+      "houseName" : "MockHouse",
+      "houseID" : "123"
+   }
+}]

--- a/tests/fixtures/august/get_doorbell.json
+++ b/tests/fixtures/august/get_doorbell.json
@@ -55,7 +55,7 @@
       "reconnect"
    ],
    "doorbellID" : "K98GiDT45GUL",
-   "HouseID" : "3dd2accaea08",
+   "HouseID" : "mockhouseid1",
    "telemetry" : {
       "signal_level" : -56,
       "date" : "2017-12-10 08:05:12",

--- a/tests/fixtures/august/get_lock.online_with_doorsense.json
+++ b/tests/fixtures/august/get_lock.online_with_doorsense.json
@@ -13,9 +13,10 @@
          "updated" : "2000-00-00T00:00:00.447Z"
       }
    },
+   "pubsubChannel":"pubsub",
    "Calibrated" : false,
    "Created" : "2000-00-00T00:00:00.447Z",
-   "HouseID" : "123",
+   "HouseID" : "mockhouseid1",
    "HouseName" : "Test",
    "LockID" : "online_with_doorsense",
    "LockName" : "Online door with doorsense",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Convert august to be push instead of poll.

For locks that support both, the cloud service is sometimes even able to deliver the status update faster than the zwave state change.

Changelog: https://github.com/bdraco/yalexs/compare/0.25.0...v1.1.4

I ended up forking `py-august` as the maintainer has been dormant and the last bugfix PR took months to merge (see https://github.com/home-assistant/core/pull/40109#issuecomment-731395167)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17074

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
