### PR TITLE
Correct weather entities forecast time

### DIFF
--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -393,7 +393,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
             ),
             ATTR_FORECAST_TEMP: self._get_temperature_day(day),
             ATTR_FORECAST_TEMP_LOW: self._get_temperature_low_day(day),
-            ATTR_FORECAST_TIME: dt_util.as_utc(date),
+            ATTR_FORECAST_TIME: dt_util.as_utc(date).isoformat(),
             ATTR_FORECAST_WIND_SPEED: self._get_wind_speed_day(day),
             ATTR_FORECAST_WIND_BEARING: self._get_wind_bearing_day(day),
         }
@@ -412,7 +412,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
                 day, hour
             ),
             ATTR_FORECAST_TEMP: self._get_temperature(day, hour),
-            ATTR_FORECAST_TIME: dt_util.as_utc(forecast_dt),
+            ATTR_FORECAST_TIME: dt_util.as_utc(forecast_dt).isoformat(),
             ATTR_FORECAST_WIND_SPEED: self._get_wind_speed(day, hour),
             ATTR_FORECAST_WIND_BEARING: self._get_wind_bearing(day, hour),
         }

--- a/homeassistant/components/openweathermap/weather_update_coordinator.py
+++ b/homeassistant/components/openweathermap/weather_update_coordinator.py
@@ -139,7 +139,9 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
 
     def _convert_forecast(self, entry):
         forecast = {
-            ATTR_FORECAST_TIME: dt.utc_from_timestamp(entry.reference_time("unix")),
+            ATTR_FORECAST_TIME: dt.utc_from_timestamp(
+                entry.reference_time("unix")
+            ).isoformat(),
             ATTR_FORECAST_PRECIPITATION: self._calc_precipitation(
                 entry.rain, entry.snow
             ),

--- a/tests/components/aemet/test_sensor.py
+++ b/tests/components/aemet/test_sensor.py
@@ -37,7 +37,9 @@ async def test_aemet_forecast_create_sensors(hass):
     assert state.state == "-4"
 
     state = hass.states.get("sensor.aemet_daily_forecast_time")
-    assert state.state == "2021-01-10 00:00:00+00:00"
+    assert (
+        state.state == dt_util.parse_datetime("2021-01-10 00:00:00+00:00").isoformat()
+    )
 
     state = hass.states.get("sensor.aemet_daily_forecast_wind_bearing")
     assert state.state == "45.0"

--- a/tests/components/aemet/test_weather.py
+++ b/tests/components/aemet/test_weather.py
@@ -51,8 +51,9 @@ async def test_aemet_weather(hass):
     assert forecast.get(ATTR_FORECAST_PRECIPITATION_PROBABILITY) == 30
     assert forecast.get(ATTR_FORECAST_TEMP) == 4
     assert forecast.get(ATTR_FORECAST_TEMP_LOW) == -4
-    assert forecast.get(ATTR_FORECAST_TIME) == dt_util.parse_datetime(
-        "2021-01-10 00:00:00+00:00"
+    assert (
+        forecast.get(ATTR_FORECAST_TIME)
+        == dt_util.parse_datetime("2021-01-10 00:00:00+00:00").isoformat()
     )
     assert forecast.get(ATTR_FORECAST_WIND_BEARING) == 45.0
     assert forecast.get(ATTR_FORECAST_WIND_SPEED) == 20


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The offending weather platforms would not return `datetime` as a string in accordance with https://developers.home-assistant.io/docs/core/entity/weather#forecast

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47450
- This PR is related to issue: https://github.com/home-assistant/core/pull/47543
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
