### PR TITLE
Allow running and restarting with both ozw and zwave active

### DIFF
--- a/homeassistant/components/ozw/manifest.json
+++ b/homeassistant/components/ozw/manifest.json
@@ -7,8 +7,7 @@
     "python-openzwave-mqtt[mqtt-client]==1.4.0"
   ],
   "after_dependencies": [
-    "mqtt",
-    "zwave"
+    "mqtt"
   ],
   "codeowners": [
     "@cgarwood",

--- a/homeassistant/components/zwave/manifest.json
+++ b/homeassistant/components/zwave/manifest.json
@@ -4,5 +4,6 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave",
   "requirements": ["homeassistant-pyozw==0.1.10", "pydispatcher==2.0.5"],
+  "after_dependencies": ["ozw"],
   "codeowners": ["@home-assistant/z-wave"]
 }

--- a/homeassistant/components/zwave/manifest.json
+++ b/homeassistant/components/zwave/manifest.json
@@ -4,6 +4,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave",
   "requirements": ["homeassistant-pyozw==0.1.10", "pydispatcher==2.0.5"],
-  "after_dependencies": ["ozw"],
   "codeowners": ["@home-assistant/z-wave"]
 }

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -147,6 +147,8 @@ IGNORE_VIOLATIONS = {
     # Demo
     ("demo", "manual"),
     ("demo", "openalpr_local"),
+    # Migration wizard from zwave to ozw.
+    "ozw",
     # This should become a helper method that integrations can submit data to
     ("websocket_api", "lovelace"),
     ("websocket_api", "shopping_list"),


### PR DESCRIPTION
Removing circular dependency introduced in the following pull
request that results in neither `ozw` or `zwave` integration 
starting.

[Add zwave to ozw migration #39081](https://github.com/home-assistant/core/pull/39081)

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes issue where `zwave` nor `ozw` will start (setup phase) if both are loaded on the system.  

Not sure this is the best fix for this issue because I'm uncertain from reviewing the original change what the to the dependencies was trying to solve.  I actually question if the original PR should be reverted as HA is officially moving to ZWaveJS and having a migration prompt to `ozw` and routine is just confusing to users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
N/A

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes issue: fixes #46679
This issue was introduced in PR: #39081

The setup is `ozw` and `zwave` integrations are loaded and functioning independently of each other.  

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

N/A

If the code communicates with devices, web services, or third-party tools:

N/A

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

N/A

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
