### PR TITLE
Fix Kulersky and Zerproc config unloading

### DIFF
--- a/homeassistant/components/kulersky/__init__.py
+++ b/homeassistant/components/kulersky/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 
 PLATFORMS = ["light"]
 
@@ -18,8 +18,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Kuler Sky from a config entry."""
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
-    if "addresses" not in hass.data[DOMAIN]:
-        hass.data[DOMAIN]["addresses"] = set()
+    if DATA_ADDRESSES not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][DATA_ADDRESSES] = set()
 
     for platform in PLATFORMS:
         hass.async_create_task(
@@ -31,7 +31,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
+    # Stop discovery
+    unregister_discovery = hass.data[DOMAIN].pop(DATA_DISCOVERY_SUBSCRIPTION, None)
+    if unregister_discovery:
+        unregister_discovery()
+
     hass.data.pop(DOMAIN, None)
+
     return all(
         await asyncio.gather(
             *[

--- a/homeassistant/components/kulersky/__init__.py
+++ b/homeassistant/components/kulersky/__init__.py
@@ -16,6 +16,11 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Kuler Sky from a config entry."""
+    if DOMAIN not in hass.data:
+        hass.data[DOMAIN] = {}
+    if "addresses" not in hass.data[DOMAIN]:
+        hass.data[DOMAIN]["addresses"] = set()
+
     for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
@@ -26,7 +31,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    unload_ok = all(
+    hass.data.pop(DOMAIN, None)
+    return all(
         await asyncio.gather(
             *[
                 hass.config_entries.async_forward_entry_unload(entry, platform)
@@ -34,7 +40,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
             ]
         )
     )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok

--- a/homeassistant/components/kulersky/const.py
+++ b/homeassistant/components/kulersky/const.py
@@ -1,2 +1,5 @@
 """Constants for the Kuler Sky integration."""
 DOMAIN = "kulersky"
+
+DATA_ADDRESSES = "addresses"
+DATA_DISCOVERY_SUBSCRIPTION = "discovery_subscription"

--- a/homeassistant/components/kulersky/light.py
+++ b/homeassistant/components/kulersky/light.py
@@ -21,7 +21,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
 
-from .const import DOMAIN
+from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,12 +45,12 @@ async def async_setup_entry(
         new_lights = [
             light
             for light in lights
-            if light.address not in hass.data[DOMAIN]["addresses"]
+            if light.address not in hass.data[DOMAIN][DATA_ADDRESSES]
         ]
 
         new_entities = []
         for light in new_lights:
-            hass.data[DOMAIN]["addresses"].add(light.address)
+            hass.data[DOMAIN][DATA_ADDRESSES].add(light.address)
             new_entities.append(KulerskyLight(light))
 
         async_add_entities(new_entities, update_before_add=True)
@@ -59,7 +59,9 @@ async def async_setup_entry(
     hass.async_create_task(discover())
 
     # Perform recurring discovery of new devices
-    async_track_time_interval(hass, discover, DISCOVERY_INTERVAL)
+    hass.data[DOMAIN][DATA_DISCOVERY_SUBSCRIPTION] = async_track_time_interval(
+        hass, discover, DISCOVERY_INTERVAL
+    )
 
 
 class KulerskyLight(LightEntity):

--- a/homeassistant/components/kulersky/light.py
+++ b/homeassistant/components/kulersky/light.py
@@ -16,7 +16,6 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
@@ -37,10 +36,6 @@ async def async_setup_entry(
     async_add_entities: Callable[[List[Entity], bool], None],
 ) -> None:
     """Set up Kuler sky light devices."""
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
-    if "addresses" not in hass.data[DOMAIN]:
-        hass.data[DOMAIN]["addresses"] = set()
 
     async def discover(*args):
         """Attempt to discover new lights."""
@@ -65,11 +60,6 @@ async def async_setup_entry(
 
     # Perform recurring discovery of new devices
     async_track_time_interval(hass, discover, DISCOVERY_INTERVAL)
-
-
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
-    """Cleanup the Kuler sky integration."""
-    hass.data.pop(DOMAIN, None)
 
 
 class KulerskyLight(LightEntity):

--- a/homeassistant/components/zerproc/__init__.py
+++ b/homeassistant/components/zerproc/__init__.py
@@ -4,7 +4,7 @@ import asyncio
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
+from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 
 PLATFORMS = ["light"]
 
@@ -22,8 +22,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Zerproc from a config entry."""
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {}
-    if "addresses" not in hass.data[DOMAIN]:
-        hass.data[DOMAIN]["addresses"] = set()
+    if DATA_ADDRESSES not in hass.data[DOMAIN]:
+        hass.data[DOMAIN][DATA_ADDRESSES] = set()
 
     for platform in PLATFORMS:
         hass.async_create_task(
@@ -35,7 +35,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
+    # Stop discovery
+    unregister_discovery = hass.data[DOMAIN].pop(DATA_DISCOVERY_SUBSCRIPTION, None)
+    if unregister_discovery:
+        unregister_discovery()
+
     hass.data.pop(DOMAIN, None)
+
     return all(
         await asyncio.gather(
             *[

--- a/homeassistant/components/zerproc/const.py
+++ b/homeassistant/components/zerproc/const.py
@@ -1,2 +1,5 @@
 """Constants for the Zerproc integration."""
 DOMAIN = "zerproc"
+
+DATA_ADDRESSES = "addresses"
+DATA_DISCOVERY_SUBSCRIPTION = "discovery_subscription"

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
 
-from .const import DOMAIN
+from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,12 +35,14 @@ async def discover_entities(hass: HomeAssistant) -> List[Entity]:
 
     # Filter out already discovered lights
     new_lights = [
-        light for light in lights if light.address not in hass.data[DOMAIN]["addresses"]
+        light
+        for light in lights
+        if light.address not in hass.data[DOMAIN][DATA_ADDRESSES]
     ]
 
     entities = []
     for light in new_lights:
-        hass.data[DOMAIN]["addresses"].add(light.address)
+        hass.data[DOMAIN][DATA_ADDRESSES].add(light.address)
         entities.append(ZerprocLight(light))
 
     return entities
@@ -70,7 +72,9 @@ async def async_setup_entry(
     hass.async_create_task(discover())
 
     # Perform recurring discovery of new devices
-    async_track_time_interval(hass, discover, DISCOVERY_INTERVAL)
+    hass.data[DOMAIN][DATA_DISCOVERY_SUBSCRIPTION] = async_track_time_interval(
+        hass, discover, DISCOVERY_INTERVAL
+    )
 
 
 class ZerprocLight(LightEntity):

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -5,7 +5,11 @@ import pykulersky
 import pytest
 
 from homeassistant import setup
-from homeassistant.components.kulersky.light import DOMAIN
+from homeassistant.components.kulersky.const import (
+    DATA_ADDRESSES,
+    DATA_DISCOVERY_SUBSCRIPTION,
+    DOMAIN,
+)
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_HS_COLOR,
@@ -79,7 +83,8 @@ async def test_init(hass, mock_light):
 
 async def test_remove_entry(hass, mock_light, mock_entry):
     """Test platform setup."""
-    assert hass.data[DOMAIN] == {"addresses": {"AA:BB:CC:11:22:33"}}
+    assert hass.data[DOMAIN][DATA_ADDRESSES] == {"AA:BB:CC:11:22:33"}
+    assert DATA_DISCOVERY_SUBSCRIPTION in hass.data[DOMAIN]
 
     await hass.config_entries.async_remove(mock_entry.entry_id)
 

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -79,9 +79,12 @@ async def test_init(hass, mock_light):
 
 async def test_remove_entry(hass, mock_light, mock_entry):
     """Test platform setup."""
+    assert hass.data[DOMAIN] == {"addresses": {"AA:BB:CC:11:22:33"}}
+
     await hass.config_entries.async_remove(mock_entry.entry_id)
 
     assert mock_light.disconnect.called
+    assert DOMAIN not in hass.data
 
 
 async def test_remove_entry_exceptions_caught(hass, mock_light, mock_entry):

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -14,7 +14,11 @@ from homeassistant.components.light import (
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
 )
-from homeassistant.components.zerproc.light import DOMAIN
+from homeassistant.components.zerproc.const import (
+    DATA_ADDRESSES,
+    DATA_DISCOVERY_SUBSCRIPTION,
+    DOMAIN,
+)
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -140,7 +144,8 @@ async def test_discovery_exception(hass, mock_entry):
 
 async def test_remove_entry(hass, mock_light, mock_entry):
     """Test platform setup."""
-    assert hass.data[DOMAIN]["addresses"] == {"AA:BB:CC:DD:EE:FF"}
+    assert hass.data[DOMAIN][DATA_ADDRESSES] == {"AA:BB:CC:DD:EE:FF"}
+    assert DATA_DISCOVERY_SUBSCRIPTION in hass.data[DOMAIN]
 
     with patch.object(mock_light, "disconnect") as mock_disconnect:
         await hass.config_entries.async_remove(mock_entry.entry_id)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes unloading of Kuler Sky and Zerproc config entries. It was affected by the same bug as zerproc. https://github.com/home-assistant/core/pull/47403#discussion_r588764343


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
