### PR TITLE
Add fallback zwave_js entity name using node ID

### DIFF
--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -105,7 +105,11 @@ class ZWaveBaseEntity(Entity):
         """Generate entity name."""
         if additional_info is None:
             additional_info = []
-        name: str = self.info.node.name or self.info.node.device_config.description
+        name: str = (
+            self.info.node.name
+            or self.info.node.device_config.description
+            or f"Node {self.info.node.node_id}"
+        )
         if include_value_name:
             value_name = (
                 alternate_value_name

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -294,6 +294,12 @@ def inovelli_lzw36_state_fixture():
     return json.loads(load_fixture("zwave_js/inovelli_lzw36_state.json"))
 
 
+@pytest.fixture(name="null_name_check_state", scope="session")
+def null_name_check_state_fixture():
+    """Load the null name check node state fixture data."""
+    return json.loads(load_fixture("zwave_js/null_name_check_state.json"))
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state):
     """Mock a client."""
@@ -486,6 +492,14 @@ def window_cover_fixture(client, chain_actuator_zws12_state):
 def in_wall_smart_fan_control_fixture(client, in_wall_smart_fan_control_state):
     """Mock a fan node."""
     node = Node(client, copy.deepcopy(in_wall_smart_fan_control_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="null_name_check")
+def null_name_check_fixture(client, null_name_check_state):
+    """Mock a node with no name."""
+    node = Node(client, copy.deepcopy(null_name_check_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -459,6 +459,12 @@ async def test_existing_node_ready(
     )
 
 
+async def test_null_name(hass, client, null_name_check, integration):
+    """Test that node without a name gets a generic node name."""
+    node = null_name_check
+    assert hass.states.get(f"switch.node_{node.node_id}")
+
+
 async def test_existing_node_not_ready(hass, client, multisensor_6, device_registry):
     """Test we handle a non ready node that exists during integration setup."""
     node = multisensor_6

--- a/tests/fixtures/zwave_js/null_name_check_state.json
+++ b/tests/fixtures/zwave_js/null_name_check_state.json
@@ -1,0 +1,414 @@
+{
+	"nodeId": 10,
+	"index": 0,
+	"installerIcon": 3328,
+	"userIcon": 3328,
+	"status": 4,
+	"ready": true,
+	"isListening": true,
+	"isFrequentListening": false,
+	"isRouting": true,
+	"maxBaudRate": 40000,
+	"isSecure": false,
+	"version": 4,
+	"isBeaming": true,
+	"manufacturerId": 277,
+	"productId": 1,
+	"productType": 272,
+	"firmwareVersion": "2.17",
+	"zwavePlusVersion": 1,
+	"nodeType": 0,
+	"roleType": 1,
+	"neighbors": [],
+	"endpointCountIsDynamic": false,
+	"endpointsHaveIdenticalCapabilities": false,
+	"individualEndpointCount": 4,
+	"aggregatedEndpointCount": 0,
+	"interviewAttempts": 1,
+	"interviewStage": 7,
+	"endpoints": [
+		{
+			"nodeId": 10,
+			"index": 0,
+			"installerIcon": 3328,
+			"userIcon": 3328
+		},
+		{
+			"nodeId": 10,
+			"index": 1
+		},
+		{
+			"nodeId": 10,
+			"index": 2
+		},
+		{
+			"nodeId": 10,
+			"index": 3
+		},
+		{
+			"nodeId": 10,
+			"index": 4
+		}
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 7,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"unit": "\u00b0C",
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 0
+				}
+			},
+			"value": 2.9
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Humidity",
+			"propertyName": "Humidity",
+			"ccVersion": 7,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"unit": "%",
+				"label": "Humidity",
+				"ccSpecific": {
+					"sensorType": 5,
+					"scale": 0
+				}
+			},
+			"value": 8
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Manufacturer ID"
+			},
+			"value": 277
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Product type"
+			},
+			"value": 272
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Product ID"
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "4.38"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["2.17"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hardwareVersion",
+			"propertyName": "hardwareVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip hardware version"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 3,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 3,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value"
+			}
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value"
+			},
+			"value": true
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value"
+			},
+			"value": true
+		}
+	],
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 33,
+			"label": "Multilevel Sensor"
+		},
+		"specific": {
+			"key": 1,
+			"label": "Routing Multilevel Sensor"
+		},
+		"mandatorySupportedCCs": [32, 49],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 37,
+			"name": "Binary Switch",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 49,
+			"name": "Multilevel Sensor",
+			"version": 7,
+			"isSecure": false
+		},
+		{
+			"id": 89,
+			"name": "Association Group Information",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 90,
+			"name": "Device Reset Locally",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 94,
+			"name": "Z-Wave Plus Info",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 96,
+			"name": "Multi Channel",
+			"version": 4,
+			"isSecure": false
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 122,
+			"name": "Firmware Update Meta Data",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 142,
+			"name": "Multi Channel Association",
+			"version": 3,
+			"isSecure": false
+		}
+	]
+}


### PR DESCRIPTION
## Proposed change
In certain cases, the existing base name will be `None` which would raise an exception during name generation. This PR adds a fallback to ensure the base name is never `None`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47468
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
