### PR TITLE
Ensure bond devices recover when wifi disconnects and reconnects

### DIFF
--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -102,7 +102,7 @@ class BondEntity(Entity):
 
     async def _async_update_if_bpup_not_alive(self, *_: Any) -> None:
         """Fetch via the API if BPUP is not alive."""
-        if self._bpup_subs.alive and self._initialized:
+        if self._bpup_subs.alive and self._initialized and self._available:
             return
 
         assert self._update_lock is not None

--- a/tests/components/bond/test_entity.py
+++ b/tests/components/bond/test_entity.py
@@ -1,0 +1,169 @@
+"""Tests for the Bond entities."""
+import asyncio
+from datetime import timedelta
+from unittest.mock import patch
+
+from bond_api import BPUPSubscriptions, DeviceType
+
+from homeassistant import core
+from homeassistant.components import fan
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
+from homeassistant.util import utcnow
+
+from .common import patch_bond_device_state, setup_platform
+
+from tests.common import async_fire_time_changed
+
+
+def ceiling_fan(name: str):
+    """Create a ceiling fan with given name."""
+    return {
+        "name": name,
+        "type": DeviceType.CEILING_FAN,
+        "actions": ["SetSpeed", "SetDirection"],
+    }
+
+
+async def test_bpup_goes_offline_and_recovers_same_entity(hass: core.HomeAssistant):
+    """Test that push updates fail and we fallback to polling and then bpup recovers.
+
+    The BPUP recovery is triggered by an update for the entity and
+    we do not fallback to polling because state is in sync.
+    """
+    bpup_subs = BPUPSubscriptions()
+    with patch(
+        "homeassistant.components.bond.BPUPSubscriptions",
+        return_value=bpup_subs,
+    ):
+        await setup_platform(
+            hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
+        )
+
+    bpup_subs.notify(
+        {
+            "s": 200,
+            "t": "bond/test-device-id/update",
+            "b": {"power": 1, "speed": 3, "direction": 0},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("fan.name_1").attributes[fan.ATTR_PERCENTAGE] == 100
+
+    bpup_subs.notify(
+        {
+            "s": 200,
+            "t": "bond/test-device-id/update",
+            "b": {"power": 1, "speed": 1, "direction": 0},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("fan.name_1").attributes[fan.ATTR_PERCENTAGE] == 33
+
+    bpup_subs.last_message_time = 0
+    with patch_bond_device_state(side_effect=asyncio.TimeoutError):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=230))
+        await hass.async_block_till_done()
+
+    assert hass.states.get("fan.name_1").state == STATE_UNAVAILABLE
+
+    # Ensure we do not poll to get the state
+    # since bpup has recovered and we know we
+    # are back in sync
+    with patch_bond_device_state(side_effect=Exception):
+        bpup_subs.notify(
+            {
+                "s": 200,
+                "t": "bond/test-device-id/update",
+                "b": {"power": 1, "speed": 2, "direction": 0},
+            }
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.name_1")
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 66
+
+
+async def test_bpup_goes_offline_and_recovers_different_entity(
+    hass: core.HomeAssistant,
+):
+    """Test that push updates fail and we fallback to polling and then bpup recovers.
+
+    The BPUP recovery is triggered by an update for a different entity which
+    forces a poll since we need to re-get the state.
+    """
+    bpup_subs = BPUPSubscriptions()
+    with patch(
+        "homeassistant.components.bond.BPUPSubscriptions",
+        return_value=bpup_subs,
+    ):
+        await setup_platform(
+            hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
+        )
+
+    bpup_subs.notify(
+        {
+            "s": 200,
+            "t": "bond/test-device-id/update",
+            "b": {"power": 1, "speed": 3, "direction": 0},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("fan.name_1").attributes[fan.ATTR_PERCENTAGE] == 100
+
+    bpup_subs.notify(
+        {
+            "s": 200,
+            "t": "bond/test-device-id/update",
+            "b": {"power": 1, "speed": 1, "direction": 0},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("fan.name_1").attributes[fan.ATTR_PERCENTAGE] == 33
+
+    bpup_subs.last_message_time = 0
+    with patch_bond_device_state(side_effect=asyncio.TimeoutError):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=230))
+        await hass.async_block_till_done()
+
+    assert hass.states.get("fan.name_1").state == STATE_UNAVAILABLE
+
+    bpup_subs.notify(
+        {
+            "s": 200,
+            "t": "bond/not-this-device-id/update",
+            "b": {"power": 1, "speed": 2, "direction": 0},
+        }
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("fan.name_1").state == STATE_UNAVAILABLE
+
+    with patch_bond_device_state(return_value={"power": 1, "speed": 1}):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=430))
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.name_1")
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 33
+
+
+async def test_polling_fails_and_recovers(hass: core.HomeAssistant):
+    """Test that polling fails and we recover."""
+    await setup_platform(
+        hass, FAN_DOMAIN, ceiling_fan("name-1"), bond_device_id="test-device-id"
+    )
+
+    with patch_bond_device_state(side_effect=asyncio.TimeoutError):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=230))
+        await hass.async_block_till_done()
+
+    assert hass.states.get("fan.name_1").state == STATE_UNAVAILABLE
+
+    with patch_bond_device_state(return_value={"power": 1, "speed": 1}):
+        async_fire_time_changed(hass, utcnow() + timedelta(seconds=230))
+        await hass.async_block_till_done()
+
+    state = hass.states.get("fan.name_1")
+    assert state.state == STATE_ON
+    assert state.attributes[fan.ATTR_PERCENTAGE] == 33


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bond devices would never recover if the wifi disconnected and reconnected for a long period after

```
2021-03-07 20:53:03 WARNING (MainThread) [homeassistant.components.bond.entity] Entity cover.den_5_east_door has become unavailable
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/components/bond/entity.py", line 124, in _async_update_from_api
    state: dict = await self._hub.bond.device_state(self._device_id)
  File "/usr/local/lib/python3.8/site-packages/bond_api/bond.py", line 63, in device_state
    return await self.__get(f"/v2/devices/{device_id}/state")
  File "/usr/local/lib/python3.8/site-packages/bond_api/bond.py", line 85, in __get
    return await self.__call(get)
  File "/usr/local/lib/python3.8/site-packages/bond_api/bond.py", line 90, in __call
    return await handler(request_session)
  File "/usr/local/lib/python3.8/site-packages/bond_api/bond.py", line 79, in get
    async with session.get(
  File "/usr/local/lib/python3.8/site-packages/aiohttp/client.py", line 1117, in __aenter__
    self._resp = await self._coro
  File "/usr/local/lib/python3.8/site-packages/aiohttp/client.py", line 544, in _request
    await resp.start(conn)
  File "/usr/local/lib/python3.8/site-packages/aiohttp/client_reqrep.py", line 905, in start
    self._continue = None
  File "/usr/local/lib/python3.8/site-packages/aiohttp/helpers.py", line 656, in __exit__
    raise asyncio.TimeoutError from None
asyncio.exceptions.TimeoutError
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
