### PR TITLE
Ensure template fan value_template always determines on state

### DIFF
--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -523,7 +523,6 @@ class TemplateFan(TemplateEntity, FanEntity):
         speed = str(speed)
 
         if speed in self._speed_list:
-            self._state = STATE_OFF if speed == SPEED_OFF else STATE_ON
             self._speed = speed
             self._percentage = self.speed_to_percentage(speed)
             self._preset_mode = speed if speed in self.preset_modes else None
@@ -552,7 +551,6 @@ class TemplateFan(TemplateEntity, FanEntity):
             return
 
         if 0 <= percentage <= 100:
-            self._state = STATE_OFF if percentage == 0 else STATE_ON
             self._percentage = percentage
             if self._speed_list:
                 self._speed = self.percentage_to_speed(percentage)
@@ -569,7 +567,6 @@ class TemplateFan(TemplateEntity, FanEntity):
         preset_mode = str(preset_mode)
 
         if preset_mode in self.preset_modes:
-            self._state = STATE_ON
             self._speed = preset_mode
             self._percentage = None
             self._preset_mode = preset_mode

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -246,6 +246,10 @@ async def test_templates_with_entities(hass, calls):
     await hass.async_block_till_done()
     _verify(hass, STATE_ON, None, 0, True, DIRECTION_FORWARD, None)
 
+    hass.states.async_set(_STATE_INPUT_BOOLEAN, False)
+    await hass.async_block_till_done()
+    _verify(hass, STATE_OFF, None, 0, True, DIRECTION_FORWARD, None)
+
 
 async def test_templates_with_entities_and_invalid_percentage(hass, calls):
     """Test templates with values from other entities."""
@@ -274,7 +278,7 @@ async def test_templates_with_entities_and_invalid_percentage(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    _verify(hass, STATE_OFF, SPEED_OFF, 0, None, None, None)
+    _verify(hass, STATE_ON, SPEED_OFF, 0, None, None, None)
 
     hass.states.async_set("sensor.percentage", "33")
     await hass.async_block_till_done()
@@ -299,7 +303,7 @@ async def test_templates_with_entities_and_invalid_percentage(hass, calls):
     hass.states.async_set("sensor.percentage", "0")
     await hass.async_block_till_done()
 
-    _verify(hass, STATE_OFF, SPEED_OFF, 0, None, None, None)
+    _verify(hass, STATE_ON, SPEED_OFF, 0, None, None, None)
 
 
 async def test_templates_with_entities_and_preset_modes(hass, calls):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure template fan value_template always determines on state

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47318
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
