### PR TITLE
Add turn on/off services to VLC

### DIFF
--- a/homeassistant/components/vlc/media_player.py
+++ b/homeassistant/components/vlc/media_player.py
@@ -1,5 +1,6 @@
 """Provide functionality to interact with vlc devices on the network."""
 import logging
+from functools import wraps
 
 import vlc
 import voluptuous as vol
@@ -13,8 +14,16 @@ from homeassistant.components.media_player.const import (
     SUPPORT_STOP,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
+    SUPPORT_TURN_ON,
+    SUPPORT_TURN_OFF,
 )
-from homeassistant.const import CONF_NAME, STATE_IDLE, STATE_PAUSED, STATE_PLAYING
+from homeassistant.const import (
+    CONF_NAME,
+    STATE_IDLE,
+    STATE_PAUSED,
+    STATE_PLAYING,
+    STATE_OFF,
+)
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
 
@@ -30,6 +39,8 @@ SUPPORT_VLC = (
     | SUPPORT_PLAY_MEDIA
     | SUPPORT_PLAY
     | SUPPORT_STOP
+    | SUPPORT_TURN_ON
+    | SUPPORT_TURN_OFF
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -47,13 +58,41 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     )
 
 
+def cmd(func):
+    """Catch command exceptions."""
+
+    @wraps(func)
+    def wrapper(obj, *args, **kwargs):
+        """Wrap all command methods."""
+        try:
+            func(obj, *args, **kwargs)
+        except AttributeError as exc:
+            # If VLC is off, we expect calls to fail.
+            if obj.state == STATE_OFF:
+                _LOGGER.info(
+                    "Cannot call %s on entity %s because it is turned off: %r",
+                    func.__name__,
+                    obj.entity_id,
+                    exc,
+                )
+            else:
+                _LOGGER.error(
+                    "Error calling %s on entity %s: %r",
+                    func.__name__,
+                    obj.entity_id,
+                    exc,
+                )
+
+    return wrapper
+
+
 class VlcDevice(MediaPlayerEntity):
     """Representation of a vlc player."""
 
     def __init__(self, name, arguments):
         """Initialize the vlc device."""
-        self._instance = vlc.Instance(arguments)
-        self._vlc = self._instance.media_player_new()
+        self._instance = None
+        self._vlc = None
         self._name = name
         self._volume = None
         self._muted = None
@@ -61,24 +100,45 @@ class VlcDevice(MediaPlayerEntity):
         self._media_position_updated_at = None
         self._media_position = None
         self._media_duration = None
+        self._arguments = arguments
+        self.turn_on()
+
+    @property
+    def _vlc_is_off(self):
+        return self._vlc is None
+
+    def turn_on(self):
+        """Create a new instance of the vlc client."""
+        self._instance = vlc.Instance(self._arguments)
+        self._vlc = self._instance.media_player_new()
+
+    def turn_off(self):
+        """Turn off and destroy the current vlc client."""
+        self._instance.release()
+        self._instance = None
+        self._vlc = None
 
     def update(self):
         """Get the latest details from the device."""
-        status = self._vlc.get_state()
-        if status == vlc.State.Playing:
-            self._state = STATE_PLAYING
-        elif status == vlc.State.Paused:
-            self._state = STATE_PAUSED
+        if self._vlc_is_off:
+            self._state = STATE_OFF
+            self._media_duration = None
+            self._media_position = None
         else:
-            self._state = STATE_IDLE
-        self._media_duration = self._vlc.get_length() / 1000
-        position = self._vlc.get_position() * self._media_duration
-        if position != self._media_position:
-            self._media_position_updated_at = dt_util.utcnow()
-            self._media_position = position
+            status = self._vlc.get_state()
+            if status == vlc.State.Playing:
+                self._state = STATE_PLAYING
+            elif status == vlc.State.Paused:
+                self._state = STATE_PAUSED
+            else:
+                self._state = STATE_IDLE
+            self._media_duration = self._vlc.get_length() / 1000
+            position = self._vlc.get_position() * self._media_duration
+            if position != self._media_position:
+                self._media_position_updated_at = dt_util.utcnow()
 
-        self._volume = self._vlc.audio_get_volume() / 100
-        self._muted = self._vlc.audio_get_mute() == 1
+            self._volume = self._vlc.audio_get_volume() / 100
+            self._muted = self._vlc.audio_get_mute() == 1
 
         return True
 
@@ -127,36 +187,43 @@ class VlcDevice(MediaPlayerEntity):
         """When was the position of the current playing media valid."""
         return self._media_position_updated_at
 
+    @cmd
     def media_seek(self, position):
         """Seek the media to a specific location."""
         track_length = self._vlc.get_length() / 1000
         self._vlc.set_position(position / track_length)
 
+    @cmd
     def mute_volume(self, mute):
         """Mute the volume."""
         self._vlc.audio_set_mute(mute)
         self._muted = mute
 
+    @cmd
     def set_volume_level(self, volume):
         """Set volume level, range 0..1."""
         self._vlc.audio_set_volume(int(volume * 100))
         self._volume = volume
 
+    @cmd
     def media_play(self):
         """Send play command."""
         self._vlc.play()
         self._state = STATE_PLAYING
 
+    @cmd
     def media_pause(self):
         """Send pause command."""
         self._vlc.pause()
         self._state = STATE_PAUSED
 
+    @cmd
     def media_stop(self):
         """Send stop command."""
         self._vlc.stop()
         self._state = STATE_IDLE
 
+    @cmd
     def play_media(self, media_type, media_id, **kwargs):
         """Play media from a URL or file."""
         if not media_type == MEDIA_TYPE_MUSIC:

--- a/homeassistant/components/vlc/media_player.py
+++ b/homeassistant/components/vlc/media_player.py
@@ -1,6 +1,6 @@
 """Provide functionality to interact with vlc devices on the network."""
-import logging
 from functools import wraps
+import logging
 
 import vlc
 import voluptuous as vol
@@ -12,17 +12,17 @@ from homeassistant.components.media_player.const import (
     SUPPORT_PLAY,
     SUPPORT_PLAY_MEDIA,
     SUPPORT_STOP,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
     SUPPORT_VOLUME_MUTE,
     SUPPORT_VOLUME_SET,
-    SUPPORT_TURN_ON,
-    SUPPORT_TURN_OFF,
 )
 from homeassistant.const import (
     CONF_NAME,
     STATE_IDLE,
+    STATE_OFF,
     STATE_PAUSED,
     STATE_PLAYING,
-    STATE_OFF,
 )
 import homeassistant.helpers.config_validation as cv
 import homeassistant.util.dt as dt_util
@@ -59,7 +59,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 def cmd(func):
-    """Catch command exceptions."""
+    """Catch command exceptions when vlc is turned off."""
 
     @wraps(func)
     def wrapper(obj, *args, **kwargs):
@@ -105,6 +105,7 @@ class VlcDevice(MediaPlayerEntity):
 
     @property
     def _vlc_is_off(self):
+        """Indicate whether or not the vlc instance is turned off."""
         return self._vlc is None
 
     def turn_on(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The VLC component previously made a single instance that would connect
to the sound backend once and for all. However, if the backend was
restarted for any reason (e.g. pulseaudio work on the server) then any
further action on the VLC component would result in an error like:

  vlcpulse audio output error: stream connection failure: Bad state

By adding turn_on/turn_off services that release the instance and allow
its recreation, we can begin working around these situations, at least
by 'power cycling' the component.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests




## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
