### PR TITLE
Shelly: set confirm only

### DIFF
--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -160,52 +160,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured({CONF_HOST: zeroconf_info["host"]})
         self.host = zeroconf_info["host"]
 
-        if not info["auth"] and info.get("sleep_mode", False):
-            try:
-                self.device_info = await validate_input(self.hass, self.host, {})
-            except HTTP_CONNECT_ERRORS:
-                return self.async_abort(reason="cannot_connect")
-
         self.context["title_placeholders"] = {
             "name": zeroconf_info.get("name", "").split(".")[0]
         }
+
+        if info["auth"]:
+            return await self.async_step_credentials()
+
+        try:
+            self.device_info = await validate_input(self.hass, self.host, {})
+        except HTTP_CONNECT_ERRORS:
+            return self.async_abort(reason="cannot_connect")
+
         return await self.async_step_confirm_discovery()
 
     async def async_step_confirm_discovery(self, user_input=None):
         """Handle discovery confirm."""
         errors = {}
         if user_input is not None:
-            if self.info["auth"]:
-                return await self.async_step_credentials()
+            return self.async_create_entry(
+                title=self.device_info["title"] or self.device_info["hostname"],
+                data={
+                    "host": self.host,
+                    "sleep_period": self.device_info["sleep_period"],
+                    "model": self.device_info["model"],
+                },
+            )
 
-            if self.device_info:
-                return self.async_create_entry(
-                    title=self.device_info["title"] or self.device_info["hostname"],
-                    data={
-                        "host": self.host,
-                        "sleep_period": self.device_info["sleep_period"],
-                        "model": self.device_info["model"],
-                    },
-                )
-
-            try:
-                device_info = await validate_input(self.hass, self.host, {})
-            except HTTP_CONNECT_ERRORS:
-                errors["base"] = "cannot_connect"
-            except aioshelly.AuthRequired:
-                return await self.async_step_credentials()
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
-            else:
-                return self.async_create_entry(
-                    title=device_info["title"] or device_info["hostname"],
-                    data={
-                        "host": self.host,
-                        "sleep_period": device_info["sleep_period"],
-                        "model": device_info["model"],
-                    },
-                )
+        self._set_confirm_only()
 
         return self.async_show_form(
             step_id="confirm_discovery",

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -338,6 +338,13 @@ async def test_zeroconf(hass):
     with patch(
         "aioshelly.get_info",
         return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
+    ), patch(
+        "aioshelly.Device.create",
+        new=AsyncMock(
+            return_value=Mock(
+                settings=MOCK_SETTINGS,
+            )
+        ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
@@ -352,14 +359,8 @@ async def test_zeroconf(hass):
             if flow["flow_id"] == result["flow_id"]
         )
         assert context["title_placeholders"]["name"] == "shelly1pm-12345"
+        assert context["confirm_only"] is True
     with patch(
-        "aioshelly.Device.create",
-        new=AsyncMock(
-            return_value=Mock(
-                settings=MOCK_SETTINGS,
-            )
-        ),
-    ), patch(
         "homeassistant.components.shelly.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.shelly.async_setup_entry",
@@ -479,69 +480,6 @@ async def test_zeroconf_sleeping_device_error(hass, error):
         assert result["reason"] == "cannot_connect"
 
 
-@pytest.mark.parametrize(
-    "error", [(asyncio.TimeoutError, "cannot_connect"), (ValueError, "unknown")]
-)
-async def test_zeroconf_confirm_error(hass, error):
-    """Test we get the form."""
-    exc, base_error = error
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    with patch(
-        "aioshelly.get_info",
-        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DISCOVERY_INFO,
-            context={"source": config_entries.SOURCE_ZEROCONF},
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {}
-
-    with patch(
-        "aioshelly.Device.create",
-        new=AsyncMock(side_effect=exc),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {},
-        )
-
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": base_error}
-
-
-async def test_zeroconf_confirm_auth_error(hass):
-    """Test we get credentials form after an auth error when confirming discovery."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-
-    with patch(
-        "aioshelly.get_info",
-        return_value={"mac": "test-mac", "type": "SHSW-1", "auth": False},
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data=DISCOVERY_INFO,
-            context={"source": config_entries.SOURCE_ZEROCONF},
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {}
-
-    with patch(
-        "aioshelly.Device.create",
-        new=AsyncMock(side_effect=aioshelly.AuthRequired),
-    ):
-        result2 = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {},
-        )
-
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["step_id"] == "credentials"
-    assert result2["errors"] == {}
-
-
 async def test_zeroconf_already_configured(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
@@ -607,13 +545,6 @@ async def test_zeroconf_require_auth(hass):
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {}
 
-    result2 = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {},
-    )
-    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
-    assert result2["errors"] == {}
-
     with patch(
         "aioshelly.Device.create",
         new=AsyncMock(
@@ -627,15 +558,15 @@ async def test_zeroconf_require_auth(hass):
         "homeassistant.components.shelly.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result3 = await hass.config_entries.flow.async_configure(
-            result2["flow_id"],
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
             {"username": "test username", "password": "test password"},
         )
         await hass.async_block_till_done()
 
-    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result3["title"] == "Test name"
-    assert result3["data"] == {
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "Test name"
+    assert result2["data"] == {
         "host": "1.1.1.1",
         "model": "SHSW-1",
         "sleep_period": 0,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Simplify Shelly discovery flow. If there is no auth required, always get the current device info. 
- Mark discovery as "confirm only" if no auth required

Requires #47607

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
