### PR TITLE
Add support for overriding SMTP recipient(s) in a service call

### DIFF
--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -17,8 +17,8 @@ class MockSMTP(MailNotificationService):
     """Test SMTP object that doesn't need a working server."""
 
     def _send_email(self, msg, recipients):
-        """Just return string for testing."""
-        return msg.as_string()
+        """Just return msg string and recipients for testing."""
+        return msg.as_string(), recipients
 
 
 async def test_reload_notify(hass):
@@ -140,7 +140,7 @@ def test_send_message(message_data, data, content_type, hass, message):
     """Verify if we can send messages of all types correctly."""
     sample_email = "<mock@mock>"
     with patch("email.utils.make_msgid", return_value=sample_email):
-        result = message.send_message(message_data, data=data)
+        result, _ = message.send_message(message_data, data=data)
         assert content_type in result
 
 
@@ -162,5 +162,30 @@ def test_send_text_message(hass, message):
     sample_email = "<mock@mock>"
     message_data = "Test msg"
     with patch("email.utils.make_msgid", return_value=sample_email):
-        result = message.send_message(message_data)
+        result, _ = message.send_message(message_data)
         assert re.search(expected, result)
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        None,
+        "target@example.com",
+    ],
+    ids=[
+        "Verify we can send email to default recipient.",
+        "Verify email recipient can be overwritten by target arg.",
+    ],
+)
+def test_send_target_message(target, hass, message):
+    """Verify if we can send email to correct recipient."""
+    sample_email = "<mock@mock>"
+    message_data = "Test msg"
+    with patch("email.utils.make_msgid", return_value=sample_email):
+        if not target:
+            expected_recipient = ["recip1@example.com", "testrecip@test.com"]
+        else:
+            expected_recipient = target
+
+        _, recipient = message.send_message(message_data, target=target)
+        assert recipient == expected_recipient

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -16,7 +16,7 @@ from homeassistant.setup import async_setup_component
 class MockSMTP(MailNotificationService):
     """Test SMTP object that doesn't need a working server."""
 
-    def _send_email(self, msg):
+    def _send_email(self, msg, recipients):
         """Just return string for testing."""
         return msg.as_string()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for parsing target field in a service call to override email recipient(s).
The recipient field in platform config is used as default recipient list when target field doesn't exist in a service call.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18038

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
