### PR TITLE
Update zwave_js supported features list to be static

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -162,6 +162,15 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             add_to_watched_value_ids=True,
         )
         self._set_modes_and_presets()
+        self._supported_features = SUPPORT_PRESET_MODE
+        # If any setpoint value exists, we can assume temperature
+        # can be set
+        if any(self._setpoint_values.values()):
+            self._supported_features |= SUPPORT_TARGET_TEMPERATURE
+        if HVAC_MODE_HEAT_COOL in self.hvac_modes:
+            self._supported_features |= SUPPORT_TARGET_TEMPERATURE_RANGE
+        if self._fan_mode:
+            self._supported_features |= SUPPORT_FAN_MODE
 
     def _setpoint_value(self, setpoint_type: ThermostatSetpointType) -> ZwaveValue:
         """Optionally return a ZwaveValue for a setpoint."""
@@ -335,16 +344,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
-        support = SUPPORT_PRESET_MODE
-        # If any setpoint value exists, we can assume temperature
-        # can be set
-        if any(self._setpoint_values.values()):
-            support |= SUPPORT_TARGET_TEMPERATURE
-        if HVAC_MODE_HEAT_COOL in self.hvac_modes:
-            support |= SUPPORT_TARGET_TEMPERATURE_RANGE
-        if self._fan_mode:
-            support |= SUPPORT_FAN_MODE
-        return support
+        return self._supported_features
 
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -259,7 +259,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             return None
         try:
             temp = self._setpoint_value(self._current_mode_setpoint_enums[0])
-        except ValueError:
+        except (IndexError, ValueError):
             return None
         return temp.value if temp else None
 
@@ -271,7 +271,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             return None
         try:
             temp = self._setpoint_value(self._current_mode_setpoint_enums[1])
-        except ValueError:
+        except (IndexError, ValueError):
             return None
         return temp.value if temp else None
 
@@ -336,9 +336,11 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
     def supported_features(self) -> int:
         """Return the list of supported features."""
         support = SUPPORT_PRESET_MODE
-        if len(self._current_mode_setpoint_enums) == 1:
+        # If any setpoint value exists, we can assume temperature
+        # can be set
+        if any(self._setpoint_values.values()):
             support |= SUPPORT_TARGET_TEMPERATURE
-        if len(self._current_mode_setpoint_enums) > 1:
+        if HVAC_MODE_HEAT_COOL in self.hvac_modes:
             support |= SUPPORT_TARGET_TEMPERATURE_RANGE
         if self._fan_mode:
             support |= SUPPORT_FAN_MODE

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -24,9 +24,17 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_TEMPERATURE,
+    SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.components.zwave_js.climate import ATTR_FAN_STATE
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
+    ATTR_TEMPERATURE,
+)
 
 from .common import (
     CLIMATE_DANFOSS_LC13_ENTITY,
@@ -58,6 +66,13 @@ async def test_thermostat_v2(
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
     assert state.attributes[ATTR_FAN_MODE] == "Auto low"
     assert state.attributes[ATTR_FAN_STATE] == "Idle / off"
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_PRESET_MODE
+        | SUPPORT_TARGET_TEMPERATURE
+        | SUPPORT_TARGET_TEMPERATURE_RANGE
+        | SUPPORT_FAN_MODE
+    )
 
     # Test setting preset mode
     await hass.services.async_call(
@@ -408,6 +423,10 @@ async def test_setpoint_thermostat(hass, client, climate_danfoss_lc_13, integrat
     assert state.attributes[ATTR_TEMPERATURE] == 14
     assert state.attributes[ATTR_HVAC_MODES] == [HVAC_MODE_HEAT]
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
+    )
 
     client.async_send_command_no_wait.reset_mock()
 
@@ -491,6 +510,10 @@ async def test_thermostat_heatit(hass, client, climate_heatit_z_trm3, integratio
     assert state.attributes[ATTR_TEMPERATURE] == 22.5
     assert state.attributes[ATTR_HVAC_ACTION] == CURRENT_HVAC_IDLE
     assert state.attributes[ATTR_PRESET_MODE] == PRESET_NONE
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_PRESET_MODE | SUPPORT_TARGET_TEMPERATURE
+    )
 
 
 async def test_thermostat_srt321_hrt4_zw(hass, client, srt321_hrt4_zw, integration):
@@ -507,3 +530,4 @@ async def test_thermostat_srt321_hrt4_zw(hass, client, srt321_hrt4_zw, integrati
         HVAC_MODE_HEAT,
     ]
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] is None
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == SUPPORT_PRESET_MODE


### PR DESCRIPTION
## Proposed change
The supported features property returns a different list depending on the current HVAC mode. This change makes the supported features list static.

QUESTION: In the linked issue, Martin mentioned that attributes should be `None` when appropriate. Should target_temp_low and high be `None` when the thermostat is in heat_cool mode? Right now, low will have the same value as target_temperature and high will be None in those cases. Similarly, when we are on heat_cool, target temperature will have a value even as target_temp_high and low have values


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/47327
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
