### PR TITLE
Add support for breakpoints in scripts

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -68,7 +68,12 @@ from homeassistant.helpers.script import (
 )
 from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.service import async_register_admin_service
-from homeassistant.helpers.trace import TraceElement, trace_get, trace_path
+from homeassistant.helpers.trace import (
+    TraceElement,
+    trace_get,
+    trace_id_set,
+    trace_path,
+)
 from homeassistant.helpers.trigger import async_initialize_triggers
 from homeassistant.helpers.typing import TemplateVarsType
 from homeassistant.loader import bind_hass
@@ -374,6 +379,7 @@ class LimitedSizeDict(OrderedDict):
 def trace_automation(hass, unique_id, config, trigger, context):
     """Trace action execution of automation with automation_id."""
     automation_trace = AutomationTrace(unique_id, config, trigger, context)
+    trace_id_set((unique_id, automation_trace.runid))
 
     if unique_id:
         automation_traces = hass.data[DATA_AUTOMATION_TRACE]

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -118,6 +118,7 @@ class EditAutomationConfigView(EditIdBasedConfigView):
 
 
 @callback
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {vol.Required("type"): "automation/trace/get", vol.Optional("automation_id"): str}
 )
@@ -135,6 +136,8 @@ def websocket_automation_trace_get(hass, connection, msg):
     connection.send_result(msg["id"], automation_traces)
 
 
+@callback
+@websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): "automation/trace/list"})
 def websocket_automation_trace_list(hass, connection, msg):
     """Summarize automation traces."""
@@ -193,9 +196,7 @@ def websocket_automation_breakpoint_clear(hass, connection, msg):
 @callback
 @websocket_api.require_admin
 @websocket_api.websocket_command(
-    {
-        vol.Required("type"): "automation/debug/breakpoint/list",
-    }
+    {vol.Required("type"): "automation/debug/breakpoint/list"}
 )
 def websocket_automation_breakpoint_list(hass, connection, msg):
     """List breakpoints."""
@@ -209,9 +210,7 @@ def websocket_automation_breakpoint_list(hass, connection, msg):
 @callback
 @websocket_api.require_admin
 @websocket_api.websocket_command(
-    {
-        vol.Required("type"): "automation/debug/breakpoint/subscribe",
-    }
+    {vol.Required("type"): "automation/debug/breakpoint/subscribe"}
 )
 def websocket_subscribe_breakpoint_events(hass, connection, msg):
     """Subscribe to breakpoint events."""

--- a/homeassistant/components/config/automation.py
+++ b/homeassistant/components/config/automation.py
@@ -200,8 +200,8 @@ def websocket_automation_breakpoint_clear(hass, connection, msg):
 def websocket_automation_breakpoint_list(hass, connection, msg):
     """List breakpoints."""
     breakpoints = breakpoint_list(hass)
-    for breakpoint in breakpoints:
-        breakpoint["automation_id"] = breakpoint.pop("unique_id")
+    for _breakpoint in breakpoints:
+        _breakpoint["automation_id"] = _breakpoint.pop("unique_id")
 
     connection.send_result(msg["id"], breakpoints)
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1,6 +1,6 @@
 """Helpers to execute scripts."""
 import asyncio
-from contextlib import contextmanager
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from functools import partial
 import itertools
@@ -78,6 +78,7 @@ from homeassistant.util.dt import utcnow
 from .trace import (
     TraceElement,
     trace_append_element,
+    trace_id_get,
     trace_path,
     trace_path_get,
     trace_set_result,
@@ -111,6 +112,9 @@ ATTR_CUR = "current"
 ATTR_MAX = "max"
 
 DATA_SCRIPTS = "helpers.script"
+DATA_SCRIPT_BREAKPOINTS = "helpers.script_breakpoints"
+RUN_ID_ANY = "*"
+NODE_ANY = "*"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,6 +126,9 @@ _SHUTDOWN_MAX_WAIT = 60
 
 ACTION_TRACE_NODE_MAX_LEN = 20  # Max length of a trace node for repeated actions
 
+EVENT_SCRIPT_BREAKPOINT_HIT = "script_breakpoint_hit"
+EVENT_SCRIPT_DEBUG_CONTINUE_STOP = "script_debug_continue_stop_{}_{}"
+
 
 def action_trace_append(variables, path):
     """Append a TraceElement to trace[path]."""
@@ -130,11 +137,56 @@ def action_trace_append(variables, path):
     return trace_element
 
 
-@contextmanager
-def trace_action(variables):
+@asynccontextmanager
+async def trace_action(hass, script_run, stop, variables):
     """Trace action execution."""
-    trace_element = action_trace_append(variables, trace_path_get())
+    path = trace_path_get()
+    trace_element = action_trace_append(variables, path)
     trace_stack_push(trace_stack_cv, trace_element)
+
+    trace_id = trace_id_get()
+    if trace_id:
+        unique_id = trace_id[0]
+        run_id = trace_id[1]
+        breakpoints = hass.data[DATA_SCRIPT_BREAKPOINTS]
+        if unique_id in breakpoints and (
+            (
+                run_id in breakpoints[unique_id]
+                and (
+                    path in breakpoints[unique_id][run_id]
+                    or NODE_ANY in breakpoints[unique_id][run_id]
+                )
+            )
+            or (
+                RUN_ID_ANY in breakpoints[unique_id]
+                and (
+                    path in breakpoints[unique_id][RUN_ID_ANY]
+                    or NODE_ANY in breakpoints[unique_id][RUN_ID_ANY]
+                )
+            )
+        ):
+            hass.bus.async_fire(
+                EVENT_SCRIPT_BREAKPOINT_HIT,
+                {"unique_id": unique_id, "run_id": run_id, "node": path},
+            )
+
+            done = asyncio.Event()
+
+            @callback
+            def async_continue_stop(event):
+                if event.data == "stop":
+                    stop.set()
+                done.set()
+
+            event_type = EVENT_SCRIPT_DEBUG_CONTINUE_STOP.format(unique_id, run_id)
+            remove_event = hass.bus.async_listen(event_type, async_continue_stop)
+
+            tasks = [hass.async_create_task(flag.wait()) for flag in (stop, done)]
+            await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for task in tasks:
+                task.cancel()
+            remove_event()
+
     try:
         yield trace_element
     except Exception as ex:  # pylint: disable=broad-except
@@ -294,16 +346,19 @@ class _ScriptRun:
             self._finish()
 
     async def _async_step(self, log_exceptions):
-        with trace_path(str(self._step)), trace_action(self._variables):
-            try:
-                handler = f"_async_{cv.determine_script_action(self._action)}_step"
-                await getattr(self, handler)()
-            except Exception as ex:
-                if not isinstance(ex, (_StopScript, asyncio.CancelledError)) and (
-                    self._log_exceptions or log_exceptions
-                ):
-                    self._log_exception(ex)
-                raise
+        with trace_path(str(self._step)):
+            async with trace_action(self._hass, self, self._stop, self._variables):
+                if self._stop.is_set():
+                    return
+                try:
+                    handler = f"_async_{cv.determine_script_action(self._action)}_step"
+                    await getattr(self, handler)()
+                except Exception as ex:
+                    if not isinstance(ex, (_StopScript, asyncio.CancelledError)) and (
+                        self._log_exceptions or log_exceptions
+                    ):
+                        self._log_exception(ex)
+                    raise
 
     def _finish(self) -> None:
         self._script._runs.remove(self)  # pylint: disable=protected-access
@@ -876,6 +931,8 @@ class Script:
             all_scripts.append(
                 {"instance": self, "started_before_shutdown": not hass.is_stopping}
             )
+        if DATA_SCRIPT_BREAKPOINTS not in hass.data:
+            hass.data[DATA_SCRIPT_BREAKPOINTS] = {}
 
         self._hass = hass
         self.sequence = sequence
@@ -1213,3 +1270,74 @@ class Script:
             self._logger.exception(msg, *args, **kwargs)
         else:
             self._logger.log(level, msg, *args, **kwargs)
+
+
+@callback
+def breakpoint_clear(hass, unique_id, run_id, node):
+    """Clear a breakpoint."""
+    run_id = run_id or RUN_ID_ANY
+    breakpoints = hass.data[DATA_SCRIPT_BREAKPOINTS]
+    if unique_id not in breakpoints or run_id not in breakpoints[unique_id]:
+        return
+    breakpoints[unique_id][run_id].discard(node)
+
+
+@callback
+def breakpoint_clear_all(hass):
+    """Clear all breakpoints."""
+    hass.data[DATA_SCRIPT_BREAKPOINTS] = {}
+
+
+@callback
+def breakpoint_set(hass, unique_id, run_id, node):
+    """Set a breakpoint."""
+    run_id = run_id or RUN_ID_ANY
+    breakpoints = hass.data[DATA_SCRIPT_BREAKPOINTS]
+    if unique_id not in breakpoints:
+        breakpoints[unique_id] = {}
+    if run_id not in breakpoints[unique_id]:
+        breakpoints[unique_id][run_id] = set()
+    breakpoints[unique_id][run_id].add(node)
+
+
+@callback
+def breakpoint_list(hass):
+    """List breakpoints."""
+    breakpoints = hass.data[DATA_SCRIPT_BREAKPOINTS]
+
+    return [
+        {"unique_id": unique_id, "run_id": run_id, "node": node}
+        for unique_id in breakpoints
+        for run_id in breakpoints[unique_id]
+        for node in breakpoints[unique_id][run_id]
+    ]
+
+
+@callback
+def debug_continue(hass, unique_id, run_id):
+    """Continue execution of a halted script."""
+    # Clear any wildcard breakpoint
+    breakpoint_clear(hass, unique_id, run_id, NODE_ANY)
+
+    hass.bus.async_fire(
+        EVENT_SCRIPT_DEBUG_CONTINUE_STOP.format(unique_id, run_id), "continue"
+    )
+
+
+@callback
+def debug_step(hass, unique_id, run_id):
+    """Single step a halted script."""
+    # Set a wildcard breakpoint
+    breakpoint_set(hass, unique_id, run_id, NODE_ANY)
+
+    hass.bus.async_fire(
+        EVENT_SCRIPT_DEBUG_CONTINUE_STOP.format(unique_id, run_id), "continue"
+    )
+
+
+@callback
+def debug_stop(hass, unique_id, run_id):
+    """Stop execution of a running or halted script."""
+    hass.bus.async_fire(
+        EVENT_SCRIPT_DEBUG_CONTINUE_STOP.format(unique_id, run_id), "stop"
+    )

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -2,7 +2,7 @@
 from collections import deque
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any, Deque, Dict, Generator, List, Optional, Union, cast
+from typing import Any, Deque, Dict, Generator, List, Optional, Tuple, Union, cast
 
 from homeassistant.helpers.typing import TemplateVarsType
 import homeassistant.util.dt as dt_util
@@ -67,6 +67,20 @@ trace_path_stack_cv: ContextVar[Optional[List[str]]] = ContextVar(
 )
 # Copy of last variables
 variables_cv: ContextVar[Optional[Any]] = ContextVar("variables_cv", default=None)
+# Automation ID + Run ID
+trace_id_cv: ContextVar[Optional[Tuple[str, str]]] = ContextVar(
+    "trace_id_cv", default=None
+)
+
+
+def trace_id_set(id: Tuple[str, str]) -> None:
+    """Set id if the current trace."""
+    trace_id_cv.set(id)
+
+
+def trace_id_get() -> Optional[Tuple[str, str]]:
+    """Get id if the current trace."""
+    return trace_id_cv.get()
 
 
 def trace_stack_push(trace_stack_var: ContextVar, node: Any) -> None:

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -73,9 +73,9 @@ trace_id_cv: ContextVar[Optional[Tuple[str, str]]] = ContextVar(
 )
 
 
-def trace_id_set(id: Tuple[str, str]) -> None:
-    """Set id if the current trace."""
-    trace_id_cv.set(id)
+def trace_id_set(trace_id: Tuple[str, str]) -> None:
+    """Set id of the current trace."""
+    trace_id_cv.set(trace_id)
 
 
 def trace_id_get() -> Optional[Tuple[str, str]]:

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from homeassistant.bootstrap import async_setup_component
 from homeassistant.components import automation, config
 
+from tests.common import assert_lists_same
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
 
@@ -510,3 +511,281 @@ async def test_list_automation_traces(hass, hass_ws_client):
     assert trace["timestamp"]
     assert trace["trigger"] == "event 'test_event2'"
     assert trace["unique_id"] == "moon"
+
+
+async def test_automation_breakpoints(hass, hass_ws_client):
+    """Test automation breakpoints."""
+    id = 1
+
+    def next_id():
+        nonlocal id
+        id += 1
+        return id
+
+    async def assert_last_action(automation_id, expected_action, expected_state):
+        await client.send_json({"id": next_id(), "type": "automation/trace/list"})
+        response = await client.receive_json()
+        assert response["success"]
+        trace = response["result"][automation_id][-1]
+        assert trace["last_action"] == expected_action
+        assert trace["state"] == expected_state
+        return trace["run_id"]
+
+    sun_config = {
+        "id": "sun",
+        "trigger": {"platform": "event", "event_type": "test_event"},
+        "action": [
+            {"event": "event0"},
+            {"event": "event1"},
+            {"event": "event2"},
+            {"event": "event3"},
+            {"event": "event4"},
+            {"event": "event5"},
+            {"event": "event6"},
+            {"event": "event7"},
+            {"event": "event8"},
+        ],
+    }
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                sun_config,
+            ]
+        },
+    )
+
+    with patch.object(config, "SECTIONS", ["automation"]):
+        await async_setup_component(hass, "config", {})
+
+    client = await hass_ws_client()
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "1",
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+
+    await client.send_json(
+        {"id": next_id(), "type": "automation/debug/breakpoint/list"}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == []
+
+    subscription_id = next_id()
+    await client.send_json(
+        {"id": subscription_id, "type": "automation/debug/breakpoint/subscribe"}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "action/1",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "action/5",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await client.send_json(
+        {"id": next_id(), "type": "automation/debug/breakpoint/list"}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    assert_lists_same(
+        response["result"],
+        [
+            {"node": "action/1", "run_id": "*", "automation_id": "sun"},
+            {"node": "action/5", "run_id": "*", "automation_id": "sun"},
+        ],
+    )
+
+    # Trigger "sun" automation
+    hass.bus.async_fire("test_event")
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/1", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/1",
+        "run_id": run_id,
+    }
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/step",
+            "automation_id": "sun",
+            "run_id": run_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/2", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/2",
+        "run_id": run_id,
+    }
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/continue",
+            "automation_id": "sun",
+            "run_id": run_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/5", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/5",
+        "run_id": run_id,
+    }
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/stop",
+            "automation_id": "sun",
+            "run_id": run_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    await hass.async_block_till_done()
+    await assert_last_action("sun", "action/5", "stopped")
+
+
+async def test_automation_breakpoints_2(hass, hass_ws_client):
+    """Test execution resumes and breakpoints are removed after subscription removed."""
+    id = 1
+
+    def next_id():
+        nonlocal id
+        id += 1
+        return id
+
+    async def assert_last_action(automation_id, expected_action, expected_state):
+        await client.send_json({"id": next_id(), "type": "automation/trace/list"})
+        response = await client.receive_json()
+        assert response["success"]
+        trace = response["result"][automation_id][-1]
+        assert trace["last_action"] == expected_action
+        assert trace["state"] == expected_state
+        return trace["run_id"]
+
+    sun_config = {
+        "id": "sun",
+        "trigger": {"platform": "event", "event_type": "test_event"},
+        "action": [
+            {"event": "event0"},
+            {"event": "event1"},
+            {"event": "event2"},
+            {"event": "event3"},
+            {"event": "event4"},
+            {"event": "event5"},
+            {"event": "event6"},
+            {"event": "event7"},
+            {"event": "event8"},
+        ],
+    }
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                sun_config,
+            ]
+        },
+    )
+
+    with patch.object(config, "SECTIONS", ["automation"]):
+        await async_setup_component(hass, "config", {})
+
+    client = await hass_ws_client()
+
+    subscription_id = next_id()
+    await client.send_json(
+        {"id": subscription_id, "type": "automation/debug/breakpoint/subscribe"}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "action/1",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    # Trigger "sun" automation
+    hass.bus.async_fire("test_event")
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/1", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/1",
+        "run_id": run_id,
+    }
+
+    # Unsubscribe - execution should resume
+    await client.send_json(
+        {"id": next_id(), "type": "unsubscribe_events", "subscription": subscription_id}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    await hass.async_block_till_done()
+    await assert_last_action("sun", "action/8", "stopped")
+
+    # Should not be possible to set breakpoints
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "1",
+        }
+    )
+    response = await client.receive_json()
+    assert not response["success"]
+
+    # Trigger "sun" automation, should finish without stopping on breakpoints
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+
+    new_run_id = await assert_last_action("sun", "action/8", "stopped")
+    assert new_run_id != run_id

--- a/tests/components/config/test_automation.py
+++ b/tests/components/config/test_automation.py
@@ -789,3 +789,148 @@ async def test_automation_breakpoints_2(hass, hass_ws_client):
 
     new_run_id = await assert_last_action("sun", "action/8", "stopped")
     assert new_run_id != run_id
+
+
+async def test_automation_breakpoints_3(hass, hass_ws_client):
+    """Test breakpoints can be cleared."""
+    id = 1
+
+    def next_id():
+        nonlocal id
+        id += 1
+        return id
+
+    async def assert_last_action(automation_id, expected_action, expected_state):
+        await client.send_json({"id": next_id(), "type": "automation/trace/list"})
+        response = await client.receive_json()
+        assert response["success"]
+        trace = response["result"][automation_id][-1]
+        assert trace["last_action"] == expected_action
+        assert trace["state"] == expected_state
+        return trace["run_id"]
+
+    sun_config = {
+        "id": "sun",
+        "trigger": {"platform": "event", "event_type": "test_event"},
+        "action": [
+            {"event": "event0"},
+            {"event": "event1"},
+            {"event": "event2"},
+            {"event": "event3"},
+            {"event": "event4"},
+            {"event": "event5"},
+            {"event": "event6"},
+            {"event": "event7"},
+            {"event": "event8"},
+        ],
+    }
+
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": [
+                sun_config,
+            ]
+        },
+    )
+
+    with patch.object(config, "SECTIONS", ["automation"]):
+        await async_setup_component(hass, "config", {})
+
+    client = await hass_ws_client()
+
+    subscription_id = next_id()
+    await client.send_json(
+        {"id": subscription_id, "type": "automation/debug/breakpoint/subscribe"}
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "action/1",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/set",
+            "automation_id": "sun",
+            "node": "action/5",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    # Trigger "sun" automation
+    hass.bus.async_fire("test_event")
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/1", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/1",
+        "run_id": run_id,
+    }
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/continue",
+            "automation_id": "sun",
+            "run_id": run_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/5", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/5",
+        "run_id": run_id,
+    }
+
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/stop",
+            "automation_id": "sun",
+            "run_id": run_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    await hass.async_block_till_done()
+    await assert_last_action("sun", "action/5", "stopped")
+
+    # Clear 1st breakpoint
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "automation/debug/breakpoint/clear",
+            "automation_id": "sun",
+            "node": "action/1",
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+
+    # Trigger "sun" automation
+    hass.bus.async_fire("test_event")
+
+    response = await client.receive_json()
+    run_id = await assert_last_action("sun", "action/5", "running")
+    assert response["event"] == {
+        "automation_id": "sun",
+        "node": "action/5",
+        "run_id": run_id,
+    }

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -80,14 +80,17 @@ async def test_firing_event_basic(hass, caplog):
     sequence = cv.SCRIPT_SCHEMA(
         {"alias": alias, "event": event, "event_data": {"hello": "world"}}
     )
-    with script.trace_action(None):
-        script_obj = script.Script(
-            hass,
-            sequence,
-            "Test Name",
-            "test_domain",
-            running_description="test script",
-        )
+
+    # Prepare tracing
+    trace.trace_get()
+
+    script_obj = script.Script(
+        hass,
+        sequence,
+        "Test Name",
+        "test_domain",
+        running_description="test script",
+    )
 
     await script_obj.async_run(context=context)
     await hass.async_block_till_done()
@@ -100,7 +103,6 @@ async def test_firing_event_basic(hass, caplog):
     assert f"Executing step {alias}" in caplog.text
     assert_action_trace(
         {
-            "": [{}],
             "0": [{}],
         }
     )
@@ -2348,3 +2350,165 @@ async def test_embedded_wait_for_trigger_in_automation(hass):
     await hass.async_block_till_done()
 
     assert len(mock_calls) == 1
+
+
+async def test_breakpoints_1(hass):
+    """Test setting a breakpoint halts execution, and execution can be resumed."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 0}},  # Node "0"
+            {"event": event, "event_data": {"value": 1}},  # Node "1"
+            {"event": event, "event_data": {"value": 2}},  # Node "2"
+            {"event": event, "event_data": {"value": 3}},  # Node "3"
+            {"event": event, "event_data": {"value": 4}},  # Node "4"
+            {"event": event, "event_data": {"value": 5}},  # Node "5"
+            {"event": event, "event_data": {"value": 6}},  # Node "6"
+            {"event": event, "event_data": {"value": 7}},  # Node "7"
+        ]
+    )
+    logger = logging.getLogger("TEST")
+    script_obj = script.Script(
+        hass,
+        sequence,
+        "Test Name",
+        "test_domain",
+        script_mode="queued",
+        max_runs=2,
+        logger=logger,
+    )
+    trace.trace_id_set(("script_1", "1"))
+    script.breakpoint_set(hass, "script_1", script.RUN_ID_ANY, "1")
+    script.breakpoint_set(hass, "script_1", script.RUN_ID_ANY, "5")
+
+    breakpoint_hit_event = asyncio.Event()
+
+    @callback
+    def breakpoint_hit(_):
+        breakpoint_hit_event.set()
+
+    hass.bus.async_listen(script.EVENT_SCRIPT_BREAKPOINT_HIT, breakpoint_hit)
+
+    watch_messages = []
+
+    @callback
+    def check_action():
+        for message, flag in watch_messages:
+            if script_obj.last_action and message in script_obj.last_action:
+                flag.set()
+
+    script_obj.change_listener = check_action
+
+    assert not script_obj.is_running
+    assert script_obj.runs == 0
+
+    # Start script, should stop on breakpoint at node "1"
+    hass.async_create_task(script_obj.async_run(context=Context()))
+    await breakpoint_hit_event.wait()
+    assert script_obj.is_running
+    assert script_obj.runs == 1
+    assert len(events) == 1
+    assert events[-1].data["value"] == 0
+
+    # Single step script, should stop at node "2"
+    breakpoint_hit_event.clear()
+    script.debug_step(hass, "script_1", "1")
+    await breakpoint_hit_event.wait()
+    assert script_obj.is_running
+    assert script_obj.runs == 1
+    assert len(events) == 2
+    assert events[-1].data["value"] == 1
+
+    # Single step script, should stop at node "3"
+    breakpoint_hit_event.clear()
+    script.debug_step(hass, "script_1", "1")
+    await breakpoint_hit_event.wait()
+    assert script_obj.is_running
+    assert script_obj.runs == 1
+    assert len(events) == 3
+    assert events[-1].data["value"] == 2
+
+    # Resume script, should stop on breakpoint at node "5"
+    breakpoint_hit_event.clear()
+    script.debug_continue(hass, "script_1", "1")
+    await breakpoint_hit_event.wait()
+    assert script_obj.is_running
+    assert script_obj.runs == 1
+    assert len(events) == 5
+    assert events[-1].data["value"] == 4
+
+    # Resume script, should run until completion
+    script.debug_continue(hass, "script_1", "1")
+    await hass.async_block_till_done()
+    assert not script_obj.is_running
+    assert script_obj.runs == 0
+    assert len(events) == 8
+    assert events[-1].data["value"] == 7
+
+
+async def test_breakpoints_2(hass):
+    """Test setting a breakpoint halts execution, and execution can be aborted."""
+    event = "test_event"
+    events = async_capture_events(hass, event)
+    sequence = cv.SCRIPT_SCHEMA(
+        [
+            {"event": event, "event_data": {"value": 0}},  # Node "0"
+            {"event": event, "event_data": {"value": 1}},  # Node "1"
+            {"event": event, "event_data": {"value": 2}},  # Node "2"
+            {"event": event, "event_data": {"value": 3}},  # Node "3"
+            {"event": event, "event_data": {"value": 4}},  # Node "4"
+            {"event": event, "event_data": {"value": 5}},  # Node "5"
+            {"event": event, "event_data": {"value": 6}},  # Node "6"
+            {"event": event, "event_data": {"value": 7}},  # Node "7"
+        ]
+    )
+    logger = logging.getLogger("TEST")
+    script_obj = script.Script(
+        hass,
+        sequence,
+        "Test Name",
+        "test_domain",
+        script_mode="queued",
+        max_runs=2,
+        logger=logger,
+    )
+    trace.trace_id_set(("script_1", "1"))
+    script.breakpoint_set(hass, "script_1", script.RUN_ID_ANY, "1")
+    script.breakpoint_set(hass, "script_1", script.RUN_ID_ANY, "5")
+
+    breakpoint_hit_event = asyncio.Event()
+
+    @callback
+    def breakpoint_hit(_):
+        breakpoint_hit_event.set()
+
+    hass.bus.async_listen(script.EVENT_SCRIPT_BREAKPOINT_HIT, breakpoint_hit)
+
+    watch_messages = []
+
+    @callback
+    def check_action():
+        for message, flag in watch_messages:
+            if script_obj.last_action and message in script_obj.last_action:
+                flag.set()
+
+    script_obj.change_listener = check_action
+
+    assert not script_obj.is_running
+    assert script_obj.runs == 0
+
+    # Start script, should stop on breakpoint at node "1"
+    hass.async_create_task(script_obj.async_run(context=Context()))
+    await breakpoint_hit_event.wait()
+    assert script_obj.is_running
+    assert script_obj.runs == 1
+    assert len(events) == 1
+    assert events[-1].data["value"] == 0
+
+    # Abort script
+    script.debug_stop(hass, "script_1", "1")
+    await hass.async_block_till_done()
+    assert not script_obj.is_running
+    assert script_obj.runs == 0
+    assert len(events) == 1

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -18,6 +18,7 @@ import homeassistant.components.scene as scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import Context, CoreState, callback
 from homeassistant.helpers import config_validation as cv, script, trace
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -2387,10 +2388,10 @@ async def test_breakpoints_1(hass):
     breakpoint_hit_event = asyncio.Event()
 
     @callback
-    def breakpoint_hit(_):
+    def breakpoint_hit(*_):
         breakpoint_hit_event.set()
 
-    hass.bus.async_listen(script.EVENT_SCRIPT_BREAKPOINT_HIT, breakpoint_hit)
+    async_dispatcher_connect(hass, script.SCRIPT_BREAKPOINT_HIT, breakpoint_hit)
 
     watch_messages = []
 
@@ -2482,10 +2483,10 @@ async def test_breakpoints_2(hass):
     breakpoint_hit_event = asyncio.Event()
 
     @callback
-    def breakpoint_hit(_):
+    def breakpoint_hit(*_):
         breakpoint_hit_event.set()
 
-    hass.bus.async_listen(script.EVENT_SCRIPT_BREAKPOINT_HIT, breakpoint_hit)
+    async_dispatcher_connect(hass, script.SCRIPT_BREAKPOINT_HIT, breakpoint_hit)
 
     watch_messages = []
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1217,8 +1217,11 @@ async def test_repeat_count(hass, caplog, count):
             },
         }
     )
-    with script.trace_action(None):
-        script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
+
+    # Prepare tracing
+    trace.trace_get()
+
+    script_obj = script.Script(hass, sequence, "Test Name", "test_domain")
 
     await script_obj.async_run(context=Context())
     await hass.async_block_till_done()
@@ -1231,7 +1234,6 @@ async def test_repeat_count(hass, caplog, count):
     assert caplog.text.count(f"Repeating {alias}") == count
     assert_action_trace(
         {
-            "": [{}],
             "0": [{}],
             "0/0/0": [{}] * min(count, script.ACTION_TRACE_NODE_MAX_LEN),
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for breakpoints in scripts.

Add breakpoint related WS APIs for automations:
- Possible to subscribe to events when a breakpoint is hit
- Breakpoints can be set
  - If no subscription to breakpoint hit events, attempt to set breakpoint is rejected
  - When the last subscription to breakpoint hit event is removed, all breakpoints are cleared and execution of any scripts stopped on a breakpoint is resumed
- Possible to continue execution, single step and stop an automation script stopped on a breakpoint

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
