### PR TITLE
Catch dhcp setup permission errors sooner

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -207,8 +207,11 @@ class DHCPWatcher(WatcherBase):
 
     async def async_start(self):
         """Start watching for dhcp packets."""
+        # disable scapy promiscuous mode as we do not need it
+        conf.sniff_promisc = 0
+
         try:
-            _verify_l2socket_creation_permission()
+            await self.hass.async_add_executor_job(_verify_l2socket_setup, FILTER)
         except (Scapy_Exception, OSError) as ex:
             if os.geteuid() == 0:
                 _LOGGER.error("Cannot watch for dhcp packets: %s", ex)
@@ -219,7 +222,7 @@ class DHCPWatcher(WatcherBase):
             return
 
         try:
-            await _async_verify_working_pcap(self.hass, FILTER)
+            await self.hass.async_add_executor_job(_verify_working_pcap, FILTER)
         except (Scapy_Exception, ImportError) as ex:
             _LOGGER.error(
                 "Cannot watch for dhcp packets without a functional packet filter: %s",
@@ -233,6 +236,7 @@ class DHCPWatcher(WatcherBase):
             prn=self.handle_dhcp_packet,
             store=0,
         )
+
         self._sniffer.start()
 
     def handle_dhcp_packet(self, packet):
@@ -283,7 +287,7 @@ def _format_mac(mac_address):
     return format_mac(mac_address).replace(":", "")
 
 
-def _verify_l2socket_creation_permission():
+def _verify_l2socket_setup(cap_filter):
     """Create a socket using the scapy configured l2socket.
 
     Try to create the socket
@@ -292,15 +296,13 @@ def _verify_l2socket_creation_permission():
     thread so we will not be able to capture
     any permission or bind errors.
     """
-    # disable scapy promiscuous mode as we do not need it
-    conf.sniff_promisc = 0
-    conf.L2socket()
+    conf.L2socket(filter=cap_filter)
 
 
-async def _async_verify_working_pcap(hass, cap_filter):
+def _verify_working_pcap(cap_filter):
     """Verify we can create a packet filter.
 
     If we cannot create a filter we will be listening for
     all traffic which is too intensive.
     """
-    await hass.async_add_executor_job(compile_filter, cap_filter)
+    compile_filter(cap_filter)

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -281,7 +281,7 @@ async def test_setup_and_stop(hass):
     await hass.async_block_till_done()
 
     with patch("homeassistant.components.dhcp.AsyncSniffer.start") as start_call, patch(
-        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+        "homeassistant.components.dhcp._verify_l2socket_setup",
     ), patch(
         "homeassistant.components.dhcp.compile_filter",
     ):
@@ -307,7 +307,7 @@ async def test_setup_fails_as_root(hass, caplog):
     wait_event = threading.Event()
 
     with patch("os.geteuid", return_value=0), patch(
-        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+        "homeassistant.components.dhcp._verify_l2socket_setup",
         side_effect=Scapy_Exception,
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -330,7 +330,7 @@ async def test_setup_fails_non_root(hass, caplog):
     await hass.async_block_till_done()
 
     with patch("os.geteuid", return_value=10), patch(
-        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
+        "homeassistant.components.dhcp._verify_l2socket_setup",
         side_effect=Scapy_Exception,
     ):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -351,9 +351,7 @@ async def test_setup_fails_with_broken_libpcap(hass, caplog):
     )
     await hass.async_block_till_done()
 
-    with patch(
-        "homeassistant.components.dhcp._verify_l2socket_creation_permission",
-    ), patch(
+    with patch("homeassistant.components.dhcp._verify_l2socket_setup",), patch(
         "homeassistant.components.dhcp.compile_filter",
         side_effect=ImportError,
     ) as compile_filter, patch(


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This solves an unexpected thread exception on macs when running as
a user intead of root

```
2021-03-08 09:21:07 ERROR (Thread-6) [root] Uncaught thread exception
Traceback (most recent call last):
  File "/opt/homebrew/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 954, in _bootstrap_inner
    self.run()
  File "/opt/homebrew/Cellar/python@3.9/3.9.2_1/Frameworks/Python.framework/Versions/3.9/lib/python3.9/threading.py", line 892, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/sendrecv.py", line 906, in _run
    sniff_sockets[L2socket(type=ETH_P_ALL, iface=iface,
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/arch/bpf/supersocket.py", line 244, in __init__
    super(L2bpfListenSocket, self).__init__(*args, **kwargs)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/arch/bpf/supersocket.py", line 118, in __init__
    attach_filter(self.ins, filter, self.iface)
  File "/Users/bdraco/home-assistant/venv/lib/python3.9/site-packages/scapy/arch/bpf/core.py", line 123, in attach_filter
    raise Scapy_Exception("Can't attach the BPF filter !")
scapy.error.Scapy_Exception: Can't attach the BPF filter !
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
