### PR TITLE
Update tests a-b to use async_get() instead of async_get_registry()

### DIFF
--- a/tests/components/abode/test_alarm_control_panel.py
+++ b/tests/components/abode/test_alarm_control_panel.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_DISARMED,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -25,7 +26,7 @@ DEVICE_ID = "alarm_control_panel.abode_alarm"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, ALARM_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     # Abode alarm device unique_id is the MAC address

--- a/tests/components/abode/test_binary_sensor.py
+++ b/tests/components/abode/test_binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     STATE_OFF,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -18,7 +19,7 @@ from .common import setup_platform
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, BINARY_SENSOR_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("binary_sensor.front_door")
     assert entry.unique_id == "2834013428b6035fba7d4054aa7b25a3"

--- a/tests/components/abode/test_camera.py
+++ b/tests/components/abode/test_camera.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from homeassistant.components.abode.const import DOMAIN as ABODE_DOMAIN
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, STATE_IDLE
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -11,7 +12,7 @@ from .common import setup_platform
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, CAMERA_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("camera.test_cam")
     assert entry.unique_id == "d0a3a1c316891ceb00c20118aae2a133"

--- a/tests/components/abode/test_cover.py
+++ b/tests/components/abode/test_cover.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER,
     STATE_CLOSED,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -19,7 +20,7 @@ DEVICE_ID = "cover.garage_door"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, COVER_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry.unique_id == "61cbz3b542d2o33ed2fz02721bda3324"

--- a/tests/components/abode/test_light.py
+++ b/tests/components/abode/test_light.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -25,7 +26,7 @@ DEVICE_ID = "light.living_room_lamp"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, LIGHT_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry.unique_id == "741385f4388b2637df4c6b398fe50581"

--- a/tests/components/abode/test_lock.py
+++ b/tests/components/abode/test_lock.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     SERVICE_UNLOCK,
     STATE_LOCKED,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -19,7 +20,7 @@ DEVICE_ID = "lock.test_lock"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, LOCK_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(DEVICE_ID)
     assert entry.unique_id == "51cab3b545d2o34ed7fz02731bda5324"

--- a/tests/components/abode/test_sensor.py
+++ b/tests/components/abode/test_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.const import (
     PERCENTAGE,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -16,7 +17,7 @@ from .common import setup_platform
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, SENSOR_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("sensor.environment_sensor_humidity")
     assert entry.unique_id == "13545b21f4bdcd33d9abd461f8443e65-humidity"

--- a/tests/components/abode/test_switch.py
+++ b/tests/components/abode/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -25,7 +26,7 @@ DEVICE_UID = "0012a4d3614cb7e2b8c9abea31d2fb2a"
 async def test_entity_registry(hass):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, SWITCH_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(AUTOMATION_ID)
     assert entry.unique_id == AUTOMATION_UID

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     TIME_HOURS,
     UV_INDEX,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -32,7 +33,7 @@ from tests.components.accuweather import init_integration
 async def test_sensor_without_forecast(hass):
     """Test states of the sensor without forecast."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_cloud_ceiling")
     assert state
@@ -94,7 +95,7 @@ async def test_sensor_without_forecast(hass):
 async def test_sensor_with_forecast(hass):
     """Test states of the sensor with forecast."""
     await init_integration(hass, forecast=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_hours_of_sun_0d")
     assert state
@@ -166,7 +167,7 @@ async def test_sensor_with_forecast(hass):
 async def test_sensor_disabled(hass):
     """Test sensor disabled by default."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get("sensor.home_apparent_temperature")
     assert entry
@@ -185,7 +186,7 @@ async def test_sensor_disabled(hass):
 
 async def test_sensor_enabled_without_forecast(hass):
     """Test enabling an advanced sensor."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     registry.async_get_or_create(
         SENSOR_DOMAIN,

--- a/tests/components/accuweather/test_weather.py
+++ b/tests/components/accuweather/test_weather.py
@@ -23,6 +23,7 @@ from homeassistant.components.weather import (
     ATTR_WEATHER_WIND_SPEED,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -33,7 +34,7 @@ from tests.components.accuweather import init_integration
 async def test_weather_without_forecast(hass):
     """Test states of the weather without forecast."""
     await init_integration(hass)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("weather.home")
     assert state
@@ -56,7 +57,7 @@ async def test_weather_without_forecast(hass):
 async def test_weather_with_forecast(hass):
     """Test states of the weather with forecast."""
     await init_integration(hass, forecast=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("weather.home")
     assert state

--- a/tests/components/advantage_air/test_binary_sensor.py
+++ b/tests/components/advantage_air/test_binary_sensor.py
@@ -1,6 +1,7 @@
 """Test the Advantage Air Binary Sensor Platform."""
 
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -24,7 +25,7 @@ async def test_binary_sensor_async_setup_entry(hass, aioclient_mock):
     )
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_climate.py
+++ b/tests/components/advantage_air/test_climate.py
@@ -22,6 +22,7 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -45,7 +46,7 @@ async def test_climate_async_setup_entry(hass, aioclient_mock):
     )
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_cover.py
+++ b/tests/components/advantage_air/test_cover.py
@@ -15,6 +15,7 @@ from homeassistant.components.cover import (
     SERVICE_SET_COVER_POSITION,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OPEN
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -39,7 +40,7 @@ async def test_cover_async_setup_entry(hass, aioclient_mock):
 
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_sensor.py
+++ b/tests/components/advantage_air/test_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.advantage_air.sensor import (
     ADVANTAGE_AIR_SET_COUNTDOWN_VALUE,
 )
 from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -31,7 +32,7 @@ async def test_sensor_platform(hass, aioclient_mock):
     )
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/advantage_air/test_switch.py
+++ b/tests/components/advantage_air/test_switch.py
@@ -1,5 +1,4 @@
 """Test the Advantage Air Switch Platform."""
-
 from json import loads
 
 from homeassistant.components.advantage_air.const import (
@@ -12,6 +11,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.advantage_air import (
     TEST_SET_RESPONSE,
@@ -36,7 +36,7 @@ async def test_cover_async_setup_entry(hass, aioclient_mock):
 
     await add_mock_config(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert len(aioclient_mock.mock_calls) == 1
 

--- a/tests/components/airly/test_air_quality.py
+++ b/tests/components/airly/test_air_quality.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     HTTP_INTERNAL_SERVER_ERROR,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -35,7 +36,7 @@ from tests.components.airly import init_integration
 async def test_air_quality(hass, aioclient_mock):
     """Test states of the air_quality."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("air_quality.home")
     assert state

--- a/tests/components/airly/test_sensor.py
+++ b/tests/components/airly/test_sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -29,7 +30,7 @@ from tests.components.airly import init_integration
 async def test_sensor(hass, aioclient_mock):
     """Test states of the sensor."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.home_humidity")
     assert state

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
@@ -64,7 +65,7 @@ def mock_controller_connect():
 
 async def test_sensors(hass, connect):
     """Test creating an AsusWRT sensor."""
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    entity_reg = er.async_get(hass)
 
     # init config entry
     config_entry = MockConfigEntry(

--- a/tests/components/atag/test_climate.py
+++ b/tests/components/atag/test_climate.py
@@ -1,5 +1,4 @@
 """Tests for the Atag climate platform."""
-
 from unittest.mock import PropertyMock, patch
 
 from homeassistant.components.atag import CLIMATE, DOMAIN
@@ -19,6 +18,7 @@ from homeassistant.components.homeassistant import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.components.atag import UID, init_integration
@@ -33,7 +33,7 @@ async def test_climate(
     """Test the creation and values of Atag climate device."""
     with patch("pyatag.entities.Climate.status"):
         entry = await init_integration(hass, aioclient_mock)
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
 
         assert registry.async_is_registered(CLIMATE_ID)
         entry = registry.async_get(CLIMATE_ID)

--- a/tests/components/atag/test_sensors.py
+++ b/tests/components/atag/test_sensors.py
@@ -1,7 +1,7 @@
 """Tests for the Atag sensor platform."""
-
 from homeassistant.components.atag.sensor import SENSORS
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -12,7 +12,7 @@ async def test_sensors(
 ) -> None:
     """Test the creation of ATAG sensors."""
     entry = await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     for item in SENSORS:
         sensor_id = "_".join(f"sensor.{item}".lower().split())

--- a/tests/components/atag/test_water_heater.py
+++ b/tests/components/atag/test_water_heater.py
@@ -1,11 +1,11 @@
 """Tests for the Atag water heater platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.atag import DOMAIN, WATER_HEATER
 from homeassistant.components.water_heater import SERVICE_SET_TEMPERATURE
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_TEMPERATURE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.atag import UID, init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -19,7 +19,7 @@ async def test_water_heater(
     """Test the creation of Atag water heater."""
     with patch("pyatag.entities.DHW.status"):
         entry = await init_integration(hass, aioclient_mock)
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
 
         assert registry.async_is_registered(WATER_HEATER_ID)
         entry = registry.async_get(WATER_HEATER_ID)

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -1,5 +1,4 @@
 """The binary_sensor tests for the august platform."""
-
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -9,6 +8,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -119,7 +119,7 @@ async def test_doorbell_device_registry(hass):
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     reg_device = device_registry.async_get_device(identifiers={("august", "tmt100")})
     assert reg_device.model == "hydra1"

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -1,5 +1,4 @@
 """The lock tests for the august platform."""
-
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -9,6 +8,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     STATE_UNLOCKED,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -23,7 +23,7 @@ async def test_lock_device_registry(hass):
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
     await _create_august_with_devices(hass, [lock_one])
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     reg_device = device_registry.async_get_device(
         identifiers={("august", "online_with_doorsense")}
@@ -90,7 +90,7 @@ async def test_one_lock_operation(hass):
     assert lock_online_with_doorsense_name.state == STATE_LOCKED
 
     # No activity means it will be unavailable until the activity feed has data
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )

--- a/tests/components/august/test_sensor.py
+++ b/tests/components/august/test_sensor.py
@@ -1,6 +1,6 @@
 """The sensor tests for the august platform."""
-
 from homeassistant.const import ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE, STATE_UNKNOWN
+from homeassistant.helpers import entity_registry as er
 
 from tests.components.august.mocks import (
     _create_august_with_devices,
@@ -29,7 +29,7 @@ async def test_create_doorbell_offline(hass):
     """Test creation of a doorbell that is offline."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
     await _create_august_with_devices(hass, [doorbell_one])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor_tmt100_name_battery = hass.states.get("sensor.tmt100_name_battery")
     assert sensor_tmt100_name_battery.state == "81"
@@ -55,7 +55,7 @@ async def test_create_lock_with_linked_keypad(hass):
     """Test creation of a lock with a linked keypad that both have a battery."""
     lock_one = await _mock_lock_from_fixture(hass, "get_lock.doorsense_init.json")
     await _create_august_with_devices(hass, [lock_one])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor_a6697750d607098bae8d6baa11ef8063_name_battery = hass.states.get(
         "sensor.a6697750d607098bae8d6baa11ef8063_name_battery"
@@ -85,7 +85,7 @@ async def test_create_lock_with_low_battery_linked_keypad(hass):
     """Test creation of a lock with a linked keypad that both have a battery."""
     lock_one = await _mock_lock_from_fixture(hass, "get_lock.low_keypad_battery.json")
     await _create_august_with_devices(hass, [lock_one])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     sensor_a6697750d607098bae8d6baa11ef8063_name_battery = hass.states.get(
         "sensor.a6697750d607098bae8d6baa11ef8063_name_battery"
@@ -133,7 +133,7 @@ async def test_lock_operator_bluetooth(hass):
     )
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )
@@ -177,7 +177,7 @@ async def test_lock_operator_keypad(hass):
     )
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )
@@ -219,7 +219,7 @@ async def test_lock_operator_remote(hass):
     activities = await _mock_activities_from_fixture(hass, "get_activity.lock.json")
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )
@@ -263,7 +263,7 @@ async def test_lock_operator_autorelock(hass):
     )
     await _create_august_with_devices(hass, [lock_one], activities=activities)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     lock_operator_sensor = entity_registry.async_get(
         "sensor.online_with_doorsense_name_operator"
     )

--- a/tests/components/awair/test_sensor.py
+++ b/tests/components/awair/test_sensor.py
@@ -1,5 +1,4 @@
 """Tests for the Awair sensor platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.awair.const import (
@@ -27,6 +26,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
     AWAIR_UUID,
@@ -74,7 +74,7 @@ async def test_awair_gen1_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GEN1_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -170,7 +170,7 @@ async def test_awair_gen2_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GEN2_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -204,7 +204,7 @@ async def test_awair_mint_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, MINT_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -246,7 +246,7 @@ async def test_awair_glow_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GLOW_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -266,7 +266,7 @@ async def test_awair_omni_sensors(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, OMNI_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,
@@ -319,7 +319,7 @@ async def test_awair_unavailable(hass):
 
     fixtures = [USER_FIXTURE, DEVICES_FIXTURE, GEN1_DATA_FIXTURE]
     await setup_awair(hass, fixtures)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert_expected_properties(
         hass,

--- a/tests/components/axis/test_init.py
+++ b/tests/components/axis/test_init.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_USERNAME,
 )
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.setup import async_setup_component
 
@@ -83,7 +83,7 @@ async def test_migrate_entry(hass):
     assert not entry.unique_id
 
     # Create entity entry to migrate to new unique ID
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         BINARY_SENSOR_DOMAIN,
         AXIS_DOMAIN,

--- a/tests/components/blebox/conftest.py
+++ b/tests/components/blebox/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from homeassistant.components.blebox.const import DOMAIN
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -84,7 +85,7 @@ async def async_setup_entities(hass, config, entity_ids):
     assert await async_setup_component(hass, DOMAIN, config)
     await hass.async_block_till_done()
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     return [entity_registry.async_get(entity_id) for entity_id in entity_ids]
 
 

--- a/tests/components/blebox/test_air_quality.py
+++ b/tests/components/blebox/test_air_quality.py
@@ -1,5 +1,4 @@
 """Blebox air_quality tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -8,6 +7,7 @@ import pytest
 
 from homeassistant.components.air_quality import ATTR_PM_0_1, ATTR_PM_2_5, ATTR_PM_10
 from homeassistant.const import ATTR_ICON, STATE_UNKNOWN
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -49,7 +49,7 @@ async def test_init(airsensor, hass, config):
 
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My air sensor"

--- a/tests/components/blebox/test_climate.py
+++ b/tests/components/blebox/test_climate.py
@@ -1,5 +1,4 @@
 """BleBox climate entities tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -28,6 +27,7 @@ from homeassistant.const import (
     ATTR_TEMPERATURE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -79,7 +79,7 @@ async def test_init(saunabox, hass, config):
 
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My sauna"

--- a/tests/components/blebox/test_cover.py
+++ b/tests/components/blebox/test_cover.py
@@ -1,5 +1,4 @@
 """BleBox cover entities tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -30,6 +29,7 @@ from homeassistant.const import (
     SERVICE_STOP_COVER,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -117,7 +117,7 @@ async def test_init_gatecontroller(gatecontroller, hass, config):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My gate controller"
@@ -147,7 +147,7 @@ async def test_init_shutterbox(shutterbox, hass, config):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My shutter"
@@ -179,7 +179,7 @@ async def test_init_gatebox(gatebox, hass, config):
     assert ATTR_CURRENT_POSITION not in state.attributes
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My gatebox"

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -1,5 +1,4 @@
 """BleBox light entities tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -21,6 +20,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.util import color
 
 from .conftest import async_setup_entity, mock_feature
@@ -65,7 +65,7 @@ async def test_dimmer_init(dimmer, hass, config):
     assert state.attributes[ATTR_BRIGHTNESS] == 65
     assert state.state == STATE_ON
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My dimmer"
@@ -236,7 +236,7 @@ async def test_wlightbox_s_init(wlightbox_s, hass, config):
     assert ATTR_BRIGHTNESS not in state.attributes
     assert state.state == STATE_OFF
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My wLightBoxS"
@@ -339,7 +339,7 @@ async def test_wlightbox_init(wlightbox, hass, config):
     assert ATTR_BRIGHTNESS not in state.attributes
     assert state.state == STATE_OFF
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My wLightBox"

--- a/tests/components/blebox/test_sensor.py
+++ b/tests/components/blebox/test_sensor.py
@@ -1,5 +1,4 @@
 """Blebox sensors tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -13,6 +12,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
     TEMP_CELSIUS,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -49,7 +49,7 @@ async def test_init(tempsensor, hass, config):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
     assert state.state == STATE_UNKNOWN
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My temperature sensor"

--- a/tests/components/blebox/test_switch.py
+++ b/tests/components/blebox/test_switch.py
@@ -1,5 +1,4 @@
 """Blebox switch tests."""
-
 import logging
 from unittest.mock import AsyncMock, PropertyMock
 
@@ -14,6 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import (
     async_setup_entities,
@@ -58,7 +58,7 @@ async def test_switchbox_init(switchbox, hass, config):
 
     assert state.state == STATE_OFF
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My switch box"
@@ -204,7 +204,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_SWITCH
     assert state.state == STATE_OFF  # NOTE: should instead be STATE_UNKNOWN?
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My relays"
@@ -221,7 +221,7 @@ async def test_switchbox_d_init(switchbox_d, hass, config):
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_SWITCH
     assert state.state == STATE_OFF  # NOTE: should instead be STATE_UNKNOWN?
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
 
     assert device.name == "My relays"

--- a/tests/components/bond/test_cover.py
+++ b/tests/components/bond/test_cover.py
@@ -11,6 +11,7 @@ from homeassistant.const import (
     SERVICE_OPEN_COVER,
     SERVICE_STOP_COVER,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -39,7 +40,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["cover.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/bond/test_fan.py
+++ b/tests/components/bond/test_fan.py
@@ -18,6 +18,7 @@ from homeassistant.components.fan import (
     SPEED_OFF,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -71,7 +72,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["fan.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/bond/test_init.py
+++ b/tests/components/bond/test_init.py
@@ -79,7 +79,7 @@ async def test_async_setup_entry_sets_up_hub_and_supported_domains(hass: HomeAss
     assert config_entry.unique_id == "test-bond-id"
 
     # verify hub device is registered correctly
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     hub = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert hub.name == "bond-name"
     assert hub.manufacturer == "Olibra"
@@ -127,7 +127,7 @@ async def test_old_identifiers_are_removed(hass: HomeAssistant):
 
     old_identifers = (DOMAIN, "device_id")
     new_identifiers = (DOMAIN, "test-bond-id", "device_id")
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={old_identifers},
@@ -204,7 +204,7 @@ async def test_smart_by_bond_device_suggested_area(hass: HomeAssistant):
     assert config_entry.state == ENTRY_STATE_LOADED
     assert config_entry.unique_id == "test-bond-id"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert device is not None
     assert device.suggested_area == "Den"
@@ -250,7 +250,7 @@ async def test_bridge_device_suggested_area(hass: HomeAssistant):
     assert config_entry.state == ENTRY_STATE_LOADED
     assert config_entry.unique_id == "test-bond-id"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(DOMAIN, "test-bond-id")})
     assert device is not None
     assert device.suggested_area == "Office"

--- a/tests/components/bond/test_light.py
+++ b/tests/components/bond/test_light.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -107,7 +108,7 @@ async def test_fan_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fan_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
@@ -122,7 +123,7 @@ async def test_fan_up_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fan_name_up_light"]
     assert entity.unique_id == "test-hub-id_test-device-id_up_light"
 
@@ -137,7 +138,7 @@ async def test_fan_down_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fan_name_down_light"]
     assert entity.unique_id == "test-hub-id_test-device-id_down_light"
 
@@ -152,7 +153,7 @@ async def test_fireplace_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.fireplace_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 
@@ -167,7 +168,7 @@ async def test_fireplace_with_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity_flame = registry.entities["light.fireplace_name"]
     assert entity_flame.unique_id == "test-hub-id_test-device-id"
     entity_light = registry.entities["light.fireplace_name_light"]
@@ -184,7 +185,7 @@ async def test_light_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["light.light_name"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/bond/test_switch.py
+++ b/tests/components/bond/test_switch.py
@@ -6,6 +6,7 @@ from bond_api import Action, DeviceType
 from homeassistant import core
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EntityRegistry
 from homeassistant.util import utcnow
 
@@ -34,7 +35,7 @@ async def test_entity_registry(hass: core.HomeAssistant):
         bond_device_id="test-device-id",
     )
 
-    registry: EntityRegistry = await hass.helpers.entity_registry.async_get_registry()
+    registry: EntityRegistry = er.async_get(hass)
     entity = registry.entities["switch.name_1"]
     assert entity.unique_id == "test-hub-id_test-device-id"
 

--- a/tests/components/brother/test_sensor.py
+++ b/tests/components/brother/test_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     PERCENTAGE,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import UTC, utcnow
 
@@ -28,7 +29,7 @@ async def test_sensors(hass):
     """Test states of the sensors."""
     entry = await init_integration(hass, skip_setup=True)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
@@ -241,7 +242,7 @@ async def test_disabled_by_default_sensors(hass):
     """Test the disabled by default Brother sensors."""
     await init_integration(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     state = hass.states.get("sensor.hl_l2340dw_uptime")
     assert state is None
 

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant import config_entries, data_entry_flow, loader
 from homeassistant.core import callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -299,7 +300,7 @@ async def test_remove_entry(hass, manager):
     assert len(hass.states.async_all()) == 1
 
     # Check entity got added to entity registry
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 1
     entity_entry = list(ent_reg.entities.values())[0]
     assert entity_entry.config_entry_id == entry.entry_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update tests to use `*_registry.async_get()` instead of deprecated `*_registry.depreceated async_get_registry()`
(#47274 split up, part 1/5)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
