### PR TITLE
Update tests i-o to use async_get() instead of async_get_registry()

### DIFF
--- a/tests/components/input_boolean/test_init.py
+++ b/tests/components/input_boolean/test_init.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_ON,
 )
 from homeassistant.core import Context, CoreState, State
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_restore_cache
@@ -192,7 +192,7 @@ async def test_input_boolean_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     _LOGGER.debug("ENTITIES @ start: %s", hass.states.async_entity_ids())
 
@@ -313,7 +313,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None

--- a/tests/components/input_datetime/test_init.py
+++ b/tests/components/input_datetime/test_init.py
@@ -28,7 +28,7 @@ from homeassistant.components.input_datetime import (
 from homeassistant.const import ATTR_ENTITY_ID, ATTR_FRIENDLY_NAME, ATTR_NAME
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -415,7 +415,7 @@ async def test_input_datetime_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -544,7 +544,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.datetime_from_storage"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -570,7 +570,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.datetime_from_storage"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "datetime from storage"
@@ -602,7 +602,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_datetime"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/input_number/test_init.py
+++ b/tests/components/input_number/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_restore_cache
@@ -300,7 +300,7 @@ async def test_input_number_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -442,7 +442,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -478,7 +478,7 @@ async def test_update_min_max(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -518,7 +518,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/input_select/test_init.py
+++ b/tests/components/input_select/test_init.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
@@ -425,7 +425,7 @@ async def test_input_select_context(hass, hass_admin_user):
 async def test_reload(hass, hass_admin_user, hass_read_only_user):
     """Test reload service."""
     count_start = len(hass.states.async_entity_ids())
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     assert await async_setup_component(
         hass,
@@ -559,7 +559,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -592,7 +592,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_OPTIONS] == ["yaml update 1", "yaml update 2"]
@@ -633,7 +633,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/input_text/test_init.py
+++ b/tests/components/input_text/test_init.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Context, CoreState, State
 from homeassistant.exceptions import Unauthorized
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.loader import bind_hass
 from homeassistant.setup import async_setup_component
 
@@ -393,7 +393,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is not None
@@ -419,7 +419,7 @@ async def test_update(hass, hass_ws_client, storage_setup):
 
     input_id = "from_storage"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
@@ -457,7 +457,7 @@ async def test_ws_create(hass, hass_ws_client, storage_setup):
 
     input_id = "new_input"
     input_entity_id = f"{DOMAIN}.{input_id}"
-    ent_reg = await entity_registry.async_get_registry(hass)
+    ent_reg = er.async_get(hass)
 
     state = hass.states.get(input_entity_id)
     assert state is None

--- a/tests/components/ipma/test_config_flow.py
+++ b/tests/components/ipma/test_config_flow.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 
 from homeassistant.components.ipma import DOMAIN, config_flow
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .test_weather import MockLocation
@@ -143,13 +143,13 @@ async def test_config_entry_migration(hass):
     mock_registry(
         hass,
         {
-            "weather.hometown": entity_registry.RegistryEntry(
+            "weather.hometown": er.RegistryEntry(
                 entity_id="weather.hometown",
                 unique_id="0, 0",
                 platform="ipma",
                 config_entry_id=ipma_entry.entry_id,
             ),
-            "weather.hometown_2": entity_registry.RegistryEntry(
+            "weather.hometown_2": er.RegistryEntry(
                 entity_id="weather.hometown_2",
                 unique_id="0, 0, hourly",
                 platform="ipma",
@@ -165,7 +165,7 @@ async def test_config_entry_migration(hass):
         assert await async_setup_component(hass, DOMAIN, {})
         await hass.async_block_till_done()
 
-        ent_reg = await entity_registry.async_get_registry(hass)
+        ent_reg = er.async_get(hass)
 
         weather_home = ent_reg.async_get("weather.hometown")
         assert weather_home.unique_id == "0, 0, daily"

--- a/tests/components/ipp/test_sensor.py
+++ b/tests/components/ipp/test_sensor.py
@@ -6,6 +6,7 @@ from homeassistant.components.ipp.const import DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ICON, ATTR_UNIT_OF_MEASUREMENT, PERCENTAGE
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from tests.components.ipp import init_integration, mock_connection
@@ -19,7 +20,7 @@ async def test_sensors(
     mock_connection(aioclient_mock)
 
     entry = await init_integration(hass, aioclient_mock, skip_setup=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     registry.async_get_or_create(
@@ -86,7 +87,7 @@ async def test_disabled_by_default_sensors(
 ) -> None:
     """Test the disabled by default IPP sensors."""
     await init_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("sensor.epson_xp_6000_series_uptime")
     assert state is None
@@ -102,7 +103,7 @@ async def test_missing_entry_unique_id(
 ) -> None:
     """Test the unique_id of IPP sensor when printer is missing identifiers."""
     entry = await init_integration(hass, aioclient_mock, uuid=None, unique_id=None)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entity = registry.async_get("sensor.epson_xp_6000_series")
     assert entity

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -5,6 +5,7 @@ import pytest
 
 from homeassistant.components import jewish_calendar
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -84,7 +85,7 @@ async def test_issur_melacha_sensor(
     hass.config.latitude = latitude
     hass.config.longitude = longitude
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     with alter_time(test_time):
         assert await async_setup_component(

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -4,6 +4,7 @@ from datetime import datetime as dt, timedelta
 import pytest
 
 from homeassistant.components import jewish_calendar
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -511,7 +512,7 @@ async def test_shabbat_times_sensor(
     hass.config.latitude = latitude
     hass.config.longitude = longitude
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     with alter_time(test_time):
         assert await async_setup_component(

--- a/tests/components/litejet/__init__.py
+++ b/tests/components/litejet/__init__.py
@@ -2,6 +2,7 @@
 from homeassistant.components import scene, switch
 from homeassistant.components.litejet import DOMAIN
 from homeassistant.const import CONF_PORT
+from homeassistant.helpers import entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -11,7 +12,7 @@ async def async_init_integration(
 ) -> MockConfigEntry:
     """Set up the LiteJet integration in Home Assistant."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry_data = {CONF_PORT: "/dev/mock"}
 

--- a/tests/components/litejet/test_scene.py
+++ b/tests/components/litejet/test_scene.py
@@ -1,6 +1,7 @@
 """The tests for the litejet component."""
 from homeassistant.components import scene
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 
 from . import async_init_integration
 
@@ -14,7 +15,7 @@ async def test_disabled_by_default(hass, mock_litejet):
     """Test the scene is disabled by default."""
     await async_init_integration(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get(ENTITY_SCENE)
     assert state is None

--- a/tests/components/mazda/test_sensor.py
+++ b/tests/components/mazda/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     PERCENTAGE,
     PRESSURE_PSI,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM
 
 from tests.components.mazda import init_integration
@@ -19,7 +20,7 @@ async def test_device_nickname(hass):
     """Test creation of the device when vehicle has a nickname."""
     await init_integration(hass, use_nickname=True)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={(DOMAIN, "JM000000000000000")},
     )
@@ -33,7 +34,7 @@ async def test_device_no_nickname(hass):
     """Test creation of the device when vehicle has no nickname."""
     await init_integration(hass, use_nickname=False)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={(DOMAIN, "JM000000000000000")},
     )
@@ -47,7 +48,7 @@ async def test_sensors(hass):
     """Test creation of the sensors."""
     await init_integration(hass)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     # Fuel Remaining Percentage
     state = hass.states.get("sensor.my_mazda3_fuel_remaining_percentage")

--- a/tests/components/met/test_weather.py
+++ b/tests/components/met/test_weather.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.met import DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 
 async def test_tracking_home(hass, mock_weather):
@@ -12,7 +13,7 @@ async def test_tracking_home(hass, mock_weather):
     assert len(mock_weather.mock_calls) == 4
 
     # Test the hourly sensor is disabled by default
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     state = hass.states.get("weather.test_home_hourly")
     assert state is None
@@ -38,7 +39,7 @@ async def test_not_tracking_home(hass, mock_weather):
     """Test when we not track home."""
 
     # Pre-create registry entry for disabled by default hourly weather
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         WEATHER_DOMAIN,
         DOMAIN,

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 from homeassistant.components import mikrotik
 import homeassistant.components.device_tracker as device_tracker
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -101,7 +101,7 @@ async def test_restoring_devices(hass):
     )
     config_entry.add_to_hass(hass)
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         device_tracker.DOMAIN,
         mikrotik.DOMAIN,

--- a/tests/components/mobile_app/test_binary_sensor.py
+++ b/tests/components/mobile_app/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Entity tests for mobile_app."""
 from homeassistant.const import STATE_OFF
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 
 
 async def test_sensor(hass, create_registrations, webhook_client):
@@ -70,7 +70,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert updated_entity.state == "off"
     assert "foo" not in updated_entity.attributes
 
-    dev_reg = await device_registry.async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == len(create_registrations)
 
     # Reload to verify state is restored

--- a/tests/components/mobile_app/test_init.py
+++ b/tests/components/mobile_app/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the mobile app integration."""
 from homeassistant.components.mobile_app.const import DATA_DELETED_IDS, DOMAIN
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import CALL_SERVICE
 
@@ -30,8 +31,8 @@ async def test_remove_entry(hass, create_registrations):
         await hass.config_entries.async_remove(config_entry.entry_id)
         assert config_entry.data["webhook_id"] in hass.data[DOMAIN][DATA_DELETED_IDS]
 
-    dev_reg = await hass.helpers.device_registry.async_get_registry()
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == 0
 
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert len(ent_reg.entities) == 0

--- a/tests/components/mobile_app/test_sensor.py
+++ b/tests/components/mobile_app/test_sensor.py
@@ -1,6 +1,6 @@
 """Entity tests for mobile_app."""
 from homeassistant.const import PERCENTAGE, STATE_UNKNOWN
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 
 
 async def test_sensor(hass, create_registrations, webhook_client):
@@ -68,7 +68,7 @@ async def test_sensor(hass, create_registrations, webhook_client):
     assert updated_entity.state == "123"
     assert "foo" not in updated_entity.attributes
 
-    dev_reg = await device_registry.async_get_registry(hass)
+    dev_reg = dr.async_get(hass)
     assert len(dev_reg.devices) == len(create_registrations)
 
     # Reload to verify state is restored

--- a/tests/components/monoprice/test_media_player.py
+++ b/tests/components/monoprice/test_media_player.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     SERVICE_VOLUME_UP,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from tests.common import MockConfigEntry
@@ -497,7 +498,7 @@ async def test_first_run_with_available_zones(hass):
     monoprice = MockMonoprice()
     await _setup_monoprice(hass, monoprice)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get(ZONE_7_ID)
     assert not entry.disabled
@@ -510,7 +511,7 @@ async def test_first_run_with_failing_zones(hass):
     with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
         await _setup_monoprice(hass, monoprice)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get(ZONE_1_ID)
     assert not entry.disabled
@@ -527,7 +528,7 @@ async def test_not_first_run_with_failing_zone(hass):
     with patch.object(MockMonoprice, "zone_status", side_effect=SerialException):
         await _setup_monoprice_not_first_run(hass, monoprice)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get(ZONE_1_ID)
     assert not entry.disabled

--- a/tests/components/mqtt/test_common.py
+++ b/tests/components/mqtt/test_common.py
@@ -8,6 +8,7 @@ from homeassistant.components import mqtt
 from homeassistant.components.mqtt import debug_info
 from homeassistant.components.mqtt.const import MQTT_DISCONNECTED
 from homeassistant.const import ATTR_ASSUMED_STATE, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.setup import async_setup_component
 
@@ -725,7 +726,7 @@ async def help_test_entity_device_info_with_identifier(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -750,7 +751,7 @@ async def help_test_entity_device_info_with_connection(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_MAC)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -772,8 +773,8 @@ async def help_test_entity_device_info_remove(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    dev_registry = await hass.helpers.device_registry.async_get_registry()
-    ent_registry = await hass.helpers.entity_registry.async_get_registry()
+    dev_registry = dr.async_get(hass)
+    ent_registry = er.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -801,7 +802,7 @@ async def help_test_entity_device_info_update(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -913,7 +914,7 @@ async def help_test_entity_debug_info(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -946,7 +947,7 @@ async def help_test_entity_debug_info_max_messages(hass, mqtt_mock, domain, conf
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -1008,7 +1009,7 @@ async def help_test_entity_debug_info_message(
     if payload is None:
         payload = "ON"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -1054,7 +1055,7 @@ async def help_test_entity_debug_info_remove(hass, mqtt_mock, domain, config):
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, f"homeassistant/{domain}/bla/config", data)
@@ -1097,7 +1098,7 @@ async def help_test_entity_debug_info_update_entity_id(hass, mqtt_mock, domain, 
     config["device"] = copy.deepcopy(DEFAULT_CONFIG_DEVICE_INFO_ID)
     config["unique_id"] = "veryunique"
 
-    dev_registry = await hass.helpers.device_registry.async_get_registry()
+    dev_registry = dr.async_get(hass)
     ent_registry = mock_registry(hass, {})
 
     data = json.dumps(config)

--- a/tests/components/mqtt/test_device_trigger.py
+++ b/tests/components/mqtt/test_device_trigger.py
@@ -6,6 +6,7 @@ import pytest
 import homeassistant.components.automation as automation
 from homeassistant.components.mqtt import DOMAIN, debug_info
 from homeassistant.components.mqtt.device_trigger import async_attach_trigger
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import (
@@ -836,7 +837,7 @@ async def test_attach_remove_late2(hass, device_reg, mqtt_mock):
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -867,7 +868,7 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock):
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -898,7 +899,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
 
 async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     config = {
         "automation_type": "trigger",
@@ -1159,7 +1160,7 @@ async def test_trigger_debug_info(hass, mqtt_mock):
 
     This is a test helper for MQTT debug_info.
     """
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     config = {
         "platform": "mqtt",

--- a/tests/components/mqtt/test_init.py
+++ b/tests/components/mqtt/test_init.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import device_registry
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -1058,7 +1058,7 @@ async def test_mqtt_ws_remove_non_mqtt_device(
 
     device_entry = device_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     assert device_entry is not None
 
@@ -1157,7 +1157,7 @@ async def test_debug_info_multiple_devices(hass, mqtt_mock):
         },
     ]
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     for d in devices:
         data = json.dumps(d["config"])
@@ -1236,7 +1236,7 @@ async def test_debug_info_multiple_entities_triggers(hass, mqtt_mock):
         },
     ]
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     for c in config:
         data = json.dumps(c["config"])
@@ -1284,7 +1284,7 @@ async def test_debug_info_non_mqtt(hass, device_reg, entity_reg):
     config_entry.add_to_hass(hass)
     device_entry = device_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
     for device_class in DEVICE_CLASSES:
         entity_reg.async_get_or_create(
@@ -1311,7 +1311,7 @@ async def test_debug_info_wildcard(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
@@ -1357,7 +1357,7 @@ async def test_debug_info_filter_same(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
@@ -1416,7 +1416,7 @@ async def test_debug_info_same_topic(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)
@@ -1467,7 +1467,7 @@ async def test_debug_info_qos_retain(hass, mqtt_mock):
         "unique_id": "veryunique",
     }
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(config)
     async_fire_mqtt_message(hass, "homeassistant/sensor/bla/config", data)

--- a/tests/components/mqtt/test_sensor.py
+++ b/tests/components/mqtt/test_sensor.py
@@ -9,6 +9,7 @@ import pytest
 import homeassistant.components.sensor as sensor
 from homeassistant.const import EVENT_STATE_CHANGED, STATE_UNAVAILABLE
 import homeassistant.core as ha
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -574,7 +575,7 @@ async def test_entity_id_update_discovery_update(hass, mqtt_mock):
 
 async def test_entity_device_info_with_hub(hass, mqtt_mock):
     """Test MQTT sensor device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     hub = registry.async_get_or_create(
         config_entry_id="123",
         connections=set(),

--- a/tests/components/mqtt/test_tag.py
+++ b/tests/components/mqtt/test_tag.py
@@ -5,6 +5,8 @@ from unittest.mock import ANY, patch
 
 import pytest
 
+from homeassistant.helpers import device_registry as dr
+
 from tests.common import (
     async_fire_mqtt_message,
     async_get_device_automations,
@@ -378,7 +380,7 @@ async def test_not_fires_on_mqtt_message_after_remove_from_registry(
 
 async def test_entity_device_info_with_connection(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -406,7 +408,7 @@ async def test_entity_device_info_with_connection(hass, mqtt_mock):
 
 async def test_entity_device_info_with_identifier(hass, mqtt_mock):
     """Test MQTT device registry integration."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     data = json.dumps(
         {
@@ -434,7 +436,7 @@ async def test_entity_device_info_with_identifier(hass, mqtt_mock):
 
 async def test_entity_device_info_update(hass, mqtt_mock):
     """Test device registry update."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
 
     config = {
         "topic": "test-topic",

--- a/tests/components/nest/camera_sdm_test.py
+++ b/tests/components/nest/camera_sdm_test.py
@@ -16,6 +16,7 @@ import pytest
 from homeassistant.components import camera
 from homeassistant.components.camera import STATE_IDLE
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -168,13 +169,13 @@ async def test_camera_device(hass):
     assert camera is not None
     assert camera.state == STATE_IDLE
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.my_camera")
     assert entry.unique_id == "some-device-id-camera"
     assert entry.original_name == "My Camera"
     assert entry.domain == "camera"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Camera"
     assert device.model == "Camera"

--- a/tests/components/nest/sensor_sdm_test.py
+++ b/tests/components/nest/sensor_sdm_test.py
@@ -8,6 +8,8 @@ pubsub subscriber.
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
 from .common import async_setup_sdm_platform
 
 PLATFORM = "sensor"
@@ -52,13 +54,13 @@ async def test_thermostat_device(hass):
     assert humidity is not None
     assert humidity.state == "35.0"
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.my_sensor_temperature")
     assert entry.unique_id == "some-device-id-temperature"
     assert entry.original_name == "My Sensor Temperature"
     assert entry.domain == "sensor"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Sensor"
     assert device.model == "Thermostat"
@@ -197,13 +199,13 @@ async def test_device_with_unknown_type(hass):
     assert temperature is not None
     assert temperature.state == "25.1"
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.my_sensor_temperature")
     assert entry.unique_id == "some-device-id-temperature"
     assert entry.original_name == "My Sensor Temperature"
     assert entry.domain == "sensor"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "My Sensor"
     assert device.model is None

--- a/tests/components/nest/test_device_trigger.py
+++ b/tests/components/nest/test_device_trigger.py
@@ -9,6 +9,7 @@ from homeassistant.components.device_automation.exceptions import (
 )
 from homeassistant.components.nest import DOMAIN
 from homeassistant.components.nest.events import NEST_EVENT
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
@@ -101,7 +102,7 @@ async def test_get_triggers(hass):
     )
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
 
     expected_triggers = [
@@ -140,7 +141,7 @@ async def test_multiple_devices(hass):
     )
     await async_setup_camera(hass, {"device-id-1": camera1, "device-id-2": camera2})
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry1 = registry.async_get("camera.camera_1")
     assert entry1.unique_id == "device-id-1-camera"
     entry2 = registry.async_get("camera.camera_2")
@@ -176,7 +177,7 @@ async def test_triggers_for_invalid_device_id(hass):
     )
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
     assert device_entry is not None
 
@@ -198,7 +199,7 @@ async def test_no_triggers(hass):
     camera = make_camera(device_id=DEVICE_ID, traits={})
     await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.my_camera")
     assert entry.unique_id == "some-device-id-camera"
 
@@ -288,7 +289,7 @@ async def test_subscriber_automation(hass, calls):
     )
     subscriber = await async_setup_camera(hass, {DEVICE_ID: camera})
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device_entry = device_registry.async_get_device({("nest", DEVICE_ID)})
 
     assert await setup_automation(hass, device_entry.id, "camera_motion")

--- a/tests/components/nest/test_events.py
+++ b/tests/components/nest/test_events.py
@@ -7,6 +7,7 @@ pubsub subscriber.
 from google_nest_sdm.device import Device
 from google_nest_sdm.event import EventMessage
 
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from .common import async_setup_sdm_platform
@@ -91,14 +92,14 @@ async def test_doorbell_chime_event(hass):
         create_device_traits("sdm.devices.traits.DoorbellChime"),
     )
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
     assert entry.unique_id == "some-device-id-camera"
     assert entry.original_name == "Front"
     assert entry.domain == "camera"
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get(entry.device_id)
     assert device.name == "Front"
     assert device.model == "Doorbell"
@@ -127,7 +128,7 @@ async def test_camera_motion_event(hass):
         "sdm.devices.types.CAMERA",
         create_device_traits("sdm.devices.traits.CameraMotion"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 
@@ -154,7 +155,7 @@ async def test_camera_sound_event(hass):
         "sdm.devices.types.CAMERA",
         create_device_traits("sdm.devices.traits.CameraSound"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 
@@ -181,7 +182,7 @@ async def test_camera_person_event(hass):
         "sdm.devices.types.DOORBELL",
         create_device_traits("sdm.devices.traits.CameraEventImage"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 
@@ -208,7 +209,7 @@ async def test_camera_multiple_event(hass):
         "sdm.devices.types.DOORBELL",
         create_device_traits("sdm.devices.traits.CameraEventImage"),
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("camera.front")
     assert entry is not None
 

--- a/tests/components/nut/test_sensor.py
+++ b/tests/components/nut/test_sensor.py
@@ -1,6 +1,7 @@
 """The sensor tests for the nut platform."""
 
 from homeassistant.const import PERCENTAGE
+from homeassistant.helpers import entity_registry as er
 
 from .util import async_init_integration
 
@@ -9,7 +10,7 @@ async def test_pr3000rt2u(hass):
     """Test creation of PR3000RT2U sensors."""
 
     await async_init_integration(hass, "PR3000RT2U", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == "CPS_PR3000RT2U_PYVJO2000034_battery.charge"
@@ -35,7 +36,7 @@ async def test_cp1350c(hass):
 
     config_entry = await async_init_integration(hass, "CP1350C", ["battery.charge"])
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -60,7 +61,7 @@ async def test_5e850i(hass):
     """Test creation of 5E850I sensors."""
 
     config_entry = await async_init_integration(hass, "5E850I", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -85,7 +86,7 @@ async def test_5e650i(hass):
     """Test creation of 5E650I sensors."""
 
     config_entry = await async_init_integration(hass, "5E650I", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -110,7 +111,7 @@ async def test_backupsses600m1(hass):
     """Test creation of BACKUPSES600M1 sensors."""
 
     await async_init_integration(hass, "BACKUPSES600M1", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert (
@@ -140,7 +141,7 @@ async def test_cp1500pfclcd(hass):
     config_entry = await async_init_integration(
         hass, "CP1500PFCLCD", ["battery.charge"]
     )
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -165,7 +166,7 @@ async def test_dl650elcd(hass):
     """Test creation of DL650ELCD sensors."""
 
     config_entry = await async_init_integration(hass, "DL650ELCD", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"
@@ -190,7 +191,7 @@ async def test_blazer_usb(hass):
     """Test creation of blazer_usb sensors."""
 
     config_entry = await async_init_integration(hass, "blazer_usb", ["battery.charge"])
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get("sensor.ups1_battery_charge")
     assert entry
     assert entry.unique_id == f"{config_entry.entry_id}_battery.charge"

--- a/tests/components/nws/test_weather.py
+++ b/tests/components/nws/test_weather.py
@@ -12,6 +12,7 @@ from homeassistant.components.weather import (
     DOMAIN as WEATHER_DOMAIN,
 )
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 from homeassistant.util.unit_system import IMPERIAL_SYSTEM, METRIC_SYSTEM
@@ -40,7 +41,7 @@ async def test_imperial_metric(
 ):
     """Test with imperial and metric units."""
     # enable the hourly entity
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         WEATHER_DOMAIN,
         nws.DOMAIN,
@@ -284,7 +285,7 @@ async def test_error_forecast_hourly(hass, mock_simple_nws):
     instance.update_forecast_hourly.side_effect = aiohttp.ClientError
 
     # enable the hourly entity
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         WEATHER_DOMAIN,
         nws.DOMAIN,
@@ -330,7 +331,7 @@ async def test_forecast_hourly_disable_enable(hass, mock_simple_nws):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entry = registry.async_get_or_create(
         WEATHER_DOMAIN,
         nws.DOMAIN,

--- a/tests/components/nzbget/test_sensor.py
+++ b/tests/components/nzbget/test_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.const import (
     DATA_RATE_MEGABYTES_PER_SECOND,
     DEVICE_CLASS_TIMESTAMP,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import init_integration
@@ -19,7 +20,7 @@ async def test_sensors(hass, nzbget_api) -> None:
     with patch("homeassistant.components.nzbget.sensor.utcnow", return_value=now):
         entry = await init_integration(hass)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     uptime = now - timedelta(seconds=600)
 

--- a/tests/components/nzbget/test_switch.py
+++ b/tests/components/nzbget/test_switch.py
@@ -7,6 +7,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.helpers import entity_registry as er
 
 from . import init_integration
 
@@ -18,7 +19,7 @@ async def test_download_switch(hass, nzbget_api) -> None:
     entry = await init_integration(hass)
     assert entry
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = "switch.nzbgettest_download"
     entity_entry = registry.async_get(entity_id)
     assert entity_entry

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components import onboarding
 from homeassistant.components.onboarding import const, views
 from homeassistant.const import HTTP_FORBIDDEN
+from homeassistant.helpers import area_registry as ar
 from homeassistant.setup import async_setup_component
 
 from . import mock_storage
@@ -181,7 +182,7 @@ async def test_onboarding_user(hass, hass_storage, aiohttp_client):
     )
 
     # Validate created areas
-    area_registry = await hass.helpers.area_registry.async_get_registry()
+    area_registry = ar.async_get(hass)
     assert len(area_registry.areas) == 3
     assert sorted([area.name for area in area_registry.async_list_areas()]) == [
         "Bedroom",

--- a/tests/components/opentherm_gw/test_init.py
+++ b/tests/components/opentherm_gw/test_init.py
@@ -6,6 +6,7 @@ from pyotgw.vars import OTGW, OTGW_ABOUT
 from homeassistant import setup
 from homeassistant.components.opentherm_gw.const import DOMAIN
 from homeassistant.const import CONF_DEVICE, CONF_ID, CONF_NAME
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry, mock_device_registry
 
@@ -38,7 +39,7 @@ async def test_device_registry_insert(hass):
 
     await hass.async_block_till_done()
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
 
     gw_dev = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_GATEWAY_ID)})
     assert gw_dev.sw_version == VERSION_OLD

--- a/tests/components/ozw/test_binary_sensor.py
+++ b/tests/components/ozw/test_binary_sensor.py
@@ -5,6 +5,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.components.ozw.const import DOMAIN
 from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_ozw
 
@@ -14,7 +15,7 @@ async def test_binary_sensor(hass, generic_data, binary_sensor_msg):
     receive_msg = await setup_ozw(hass, fixture=generic_data)
 
     # Test Legacy sensor (disabled by default)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = "binary_sensor.trisensor_sensor"
     state = hass.states.get(entity_id)
     assert state is None
@@ -46,7 +47,7 @@ async def test_binary_sensor(hass, generic_data, binary_sensor_msg):
 async def test_sensor_enabled(hass, generic_data, binary_sensor_alt_msg):
     """Test enabling a legacy binary_sensor."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get_or_create(
         BINARY_SENSOR_DOMAIN,

--- a/tests/components/ozw/test_migration.py
+++ b/tests/components/ozw/test_migration.py
@@ -4,14 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.ozw.websocket_api import ID, TYPE
-from homeassistant.helpers.device_registry import (
-    DeviceEntry,
-    async_get_registry as async_get_device_registry,
-)
-from homeassistant.helpers.entity_registry import (
-    RegistryEntry,
-    async_get_registry as async_get_entity_registry,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .common import setup_ozw
 
@@ -41,35 +34,35 @@ ZWAVE_POWER_ICON = "mdi:zwave-test-power"
 @pytest.fixture(name="zwave_migration_data")
 def zwave_migration_data_fixture(hass):
     """Return mock zwave migration data."""
-    zwave_source_node_device = DeviceEntry(
+    zwave_source_node_device = dr.DeviceEntry(
         id=ZWAVE_SOURCE_NODE_DEVICE_ID,
         name_by_user=ZWAVE_SOURCE_NODE_DEVICE_NAME,
         area_id=ZWAVE_SOURCE_NODE_DEVICE_AREA,
     )
-    zwave_source_node_entry = RegistryEntry(
+    zwave_source_node_entry = er.RegistryEntry(
         entity_id=ZWAVE_SOURCE_ENTITY,
         unique_id=ZWAVE_SOURCE_NODE_UNIQUE_ID,
         platform="zwave",
         name="Z-Wave Source Node",
     )
-    zwave_battery_device = DeviceEntry(
+    zwave_battery_device = dr.DeviceEntry(
         id=ZWAVE_BATTERY_DEVICE_ID,
         name_by_user=ZWAVE_BATTERY_DEVICE_NAME,
         area_id=ZWAVE_BATTERY_DEVICE_AREA,
     )
-    zwave_battery_entry = RegistryEntry(
+    zwave_battery_entry = er.RegistryEntry(
         entity_id=ZWAVE_BATTERY_ENTITY,
         unique_id=ZWAVE_BATTERY_UNIQUE_ID,
         platform="zwave",
         name=ZWAVE_BATTERY_NAME,
         icon=ZWAVE_BATTERY_ICON,
     )
-    zwave_power_device = DeviceEntry(
+    zwave_power_device = dr.DeviceEntry(
         id=ZWAVE_POWER_DEVICE_ID,
         name_by_user=ZWAVE_POWER_DEVICE_NAME,
         area_id=ZWAVE_POWER_DEVICE_AREA,
     )
-    zwave_power_entry = RegistryEntry(
+    zwave_power_entry = er.RegistryEntry(
         entity_id=ZWAVE_POWER_ENTITY,
         unique_id=ZWAVE_POWER_UNIQUE_ID,
         platform="zwave",
@@ -169,8 +162,8 @@ async def test_migrate_zwave(hass, migration_data, hass_ws_client, zwave_integra
     assert result["migration_entity_map"] == migration_entity_map
     assert result["migrated"] is True
 
-    dev_reg = await async_get_device_registry(hass)
-    ent_reg = await async_get_entity_registry(hass)
+    dev_reg = dr.async_get(hass)
+    ent_reg = er.async_get(hass)
 
     # check the device registry migration
 
@@ -252,7 +245,7 @@ async def test_migrate_zwave_dry_run(
     assert result["migration_entity_map"] == migration_entity_map
     assert result["migrated"] is False
 
-    ent_reg = await async_get_entity_registry(hass)
+    ent_reg = er.async_get(hass)
 
     # no real migration should have been done
     assert ent_reg.async_is_registered("sensor.water_sensor_6_battery_level")

--- a/tests/components/ozw/test_sensor.py
+++ b/tests/components/ozw/test_sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
 )
 from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_ozw
 
@@ -34,7 +35,7 @@ async def test_sensor(hass, generic_data):
     assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_POWER
 
     # Test ZWaveListSensor disabled by default
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity_id = "sensor.water_sensor_6_instance_1_water"
     state = hass.states.get(entity_id)
     assert state is None
@@ -55,7 +56,7 @@ async def test_sensor(hass, generic_data):
 async def test_sensor_enabled(hass, generic_data, sensor_msg):
     """Test enabling an advanced sensor."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get_or_create(
         SENSOR_DOMAIN,
@@ -79,7 +80,7 @@ async def test_sensor_enabled(hass, generic_data, sensor_msg):
 async def test_string_sensor(hass, string_sensor_data):
     """Test so the returned type is a string sensor."""
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     entry = registry.async_get_or_create(
         SENSOR_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update tests to use `*_registry.async_get()` instead of deprecated `*_registry.depreceated async_get_registry()`
(#47274 split up, part 3/5)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
