### PR TITLE
Update tests p-s to use async_get() instead of async_get_registry()

### DIFF
--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, CoreState, State
-from homeassistant.helpers import collection, entity_registry
+from homeassistant.helpers import collection, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import mock_component, mock_restore_cache
@@ -589,7 +589,7 @@ async def test_ws_delete(hass, hass_ws_client, storage_setup):
 
     assert resp["success"]
     assert len(hass.states.async_entity_ids("person")) == 0
-    ent_reg = await hass.helpers.entity_registry.async_get_registry()
+    ent_reg = er.async_get(hass)
     assert not ent_reg.async_is_registered("person.tracked_person")
 
 
@@ -681,7 +681,7 @@ async def test_update_person_when_user_removed(
 async def test_removing_device_tracker(hass, storage_setup):
     """Test we automatically remove removed device trackers."""
     storage_collection = hass.data[DOMAIN][1]
-    reg = await entity_registry.async_get_registry(hass)
+    reg = er.async_get(hass)
     entry = reg.async_get_or_create(
         "device_tracker", "mobile_app", "bla", suggested_object_id="pixel"
     )

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -1,9 +1,9 @@
 """The sensor tests for the powerwall platform."""
-
 from unittest.mock import patch
 
 from homeassistant.components.powerwall.const import DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, PERCENTAGE
+from homeassistant.helpers import device_registry as dr
 
 from .mocks import _mock_powerwall_with_fixtures
 
@@ -26,7 +26,7 @@ async def test_sensors(hass):
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={("powerwall", "TG0123456789AB_TG9876543210BA")},
     )

--- a/tests/components/pvpc_hourly_pricing/test_config_flow.py
+++ b/tests/components/pvpc_hourly_pricing/test_config_flow.py
@@ -7,7 +7,7 @@ from pytz import timezone
 from homeassistant import data_entry_flow
 from homeassistant.components.pvpc_hourly_pricing import ATTR_TARIFF, DOMAIN
 from homeassistant.const import CONF_NAME
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import check_valid_state
 
@@ -60,7 +60,7 @@ async def test_config_flow(
         assert pvpc_aioclient_mock.call_count == 1
 
         # Check removal
-        registry = await entity_registry.async_get_registry(hass)
+        registry = er.async_get(hass)
         registry_entity = registry.async_get("sensor.test")
         assert await hass.config_entries.async_remove(registry_entity.config_entry_id)
 

--- a/tests/components/rfxtrx/test_config_flow.py
+++ b/tests/components/rfxtrx/test_config_flow.py
@@ -6,13 +6,7 @@ import serial.tools.list_ports
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.rfxtrx import DOMAIN, config_flow
-from homeassistant.helpers.device_registry import (
-    async_entries_for_config_entry,
-    async_get_registry as async_get_device_registry,
-)
-from homeassistant.helpers.entity_registry import (
-    async_get_registry as async_get_entity_registry,
-)
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from tests.common import MockConfigEntry
 
@@ -610,8 +604,8 @@ async def test_options_add_remove_device(hass):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "AC 213c7f2:48"
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
 
@@ -704,8 +698,8 @@ async def test_options_replace_sensor_device(hass):
     )
     assert state
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     old_device = next(
         (
@@ -751,7 +745,7 @@ async def test_options_replace_sensor_device(hass):
 
     await hass.async_block_till_done()
 
-    entity_registry = await async_get_entity_registry(hass)
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get(
         "sensor.thgn122_123_thgn132_thgr122_228_238_268_f0_04_rssi_numeric"
@@ -843,8 +837,8 @@ async def test_options_replace_control_device(hass):
     state = hass.states.get("switch.ac_1118cdea_2")
     assert state
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     old_device = next(
         (
@@ -890,7 +884,7 @@ async def test_options_replace_control_device(hass):
 
     await hass.async_block_till_done()
 
-    entity_registry = await async_get_entity_registry(hass)
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("binary_sensor.ac_118cdea_2")
     assert entry
@@ -941,8 +935,8 @@ async def test_options_remove_multiple_devices(hass):
     state = hass.states.get("binary_sensor.ac_1118cdea_2")
     assert state
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert len(device_entries) == 3
 
@@ -1061,8 +1055,8 @@ async def test_options_add_and_configure_device(hass):
     assert state.state == "off"
     assert state.attributes.get("friendly_name") == "PT2262 22670e"
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
 
@@ -1151,8 +1145,8 @@ async def test_options_configure_rfy_cover_device(hass):
 
     assert entry.data["devices"]["071a000001020301"]["venetian_blind_mode"] == "EU"
 
-    device_registry = await async_get_device_registry(hass)
-    device_entries = async_entries_for_config_entry(device_registry, entry.entry_id)
+    device_registry = dr.async_get(hass)
+    device_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
 
     assert device_entries[0].id
 

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -5,10 +5,7 @@ from unittest.mock import call
 from homeassistant.components.rfxtrx import DOMAIN
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.core import callback
-from homeassistant.helpers.device_registry import (
-    DeviceRegistry,
-    async_get_registry as async_get_device_registry,
-)
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -79,7 +76,7 @@ async def test_fire_event(hass, rfxtrx):
     await hass.async_block_till_done()
     await hass.async_start()
 
-    device_registry: DeviceRegistry = await async_get_device_registry(hass)
+    device_registry: dr.DeviceRegistry = dr.async_get(hass)
 
     calls = []
 

--- a/tests/components/ring/test_light.py
+++ b/tests/components/ring/test_light.py
@@ -1,5 +1,6 @@
 """The tests for the Ring light platform."""
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -9,7 +10,7 @@ from tests.common import load_fixture
 async def test_entity_registry(hass, requests_mock):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, LIGHT_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("light.front_light")
     assert entry.unique_id == 765432

--- a/tests/components/ring/test_switch.py
+++ b/tests/components/ring/test_switch.py
@@ -1,5 +1,6 @@
 """The tests for the Ring switch platform."""
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.helpers import entity_registry as er
 
 from .common import setup_platform
 
@@ -9,7 +10,7 @@ from tests.common import load_fixture
 async def test_entity_registry(hass, requests_mock):
     """Tests that the devices are registered in the entity registry."""
     await setup_platform(hass, SWITCH_DOMAIN)
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     entry = entity_registry.async_get("switch.front_siren")
     assert entry.unique_id == "765432-siren"

--- a/tests/components/risco/test_alarm_control_panel.py
+++ b/tests/components/risco/test_alarm_control_panel.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from .util import TEST_CONFIG, TEST_SITE_UUID, setup_risco
@@ -114,7 +115,7 @@ async def test_cannot_connect(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
@@ -130,14 +131,14 @@ async def test_unauthorized(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
 async def test_setup(hass, two_part_alarm):
     """Test entity setup."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert not registry.async_is_registered(FIRST_ENTITY_ID)
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
@@ -147,7 +148,7 @@ async def test_setup(hass, two_part_alarm):
     assert registry.async_is_registered(FIRST_ENTITY_ID)
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_0")})
     assert device is not None
     assert device.manufacturer == "Risco"
@@ -251,7 +252,7 @@ async def test_sets_custom_mapping(hass, two_part_alarm):
     """Test settings the various modes when mapping some states."""
     await setup_risco(hass, [], CUSTOM_MAPPING_OPTIONS)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity = registry.async_get(FIRST_ENTITY_ID)
     assert entity.supported_features == EXPECTED_FEATURES
 
@@ -277,7 +278,7 @@ async def test_sets_full_custom_mapping(hass, two_part_alarm):
     """Test settings the various modes when mapping all states."""
     await setup_risco(hass, [], FULL_CUSTOM_MAPPING)
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity = registry.async_get(FIRST_ENTITY_ID)
     assert (
         entity.supported_features == EXPECTED_FEATURES | SUPPORT_ALARM_ARM_CUSTOM_BYPASS

--- a/tests/components/risco/test_binary_sensor.py
+++ b/tests/components/risco/test_binary_sensor.py
@@ -4,6 +4,7 @@ from unittest.mock import PropertyMock, patch
 from homeassistant.components.risco import CannotConnectError, UnauthorizedError
 from homeassistant.components.risco.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.entity_component import async_update_entity
 
 from .util import TEST_CONFIG, TEST_SITE_UUID, setup_risco
@@ -26,7 +27,7 @@ async def test_cannot_connect(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
@@ -42,14 +43,14 @@ async def test_unauthorized(hass):
         config_entry.add_to_hass(hass)
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
-        registry = await hass.helpers.entity_registry.async_get_registry()
+        registry = er.async_get(hass)
         assert not registry.async_is_registered(FIRST_ENTITY_ID)
         assert not registry.async_is_registered(SECOND_ENTITY_ID)
 
 
 async def test_setup(hass, two_zone_alarm):  # noqa: F811
     """Test entity setup."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     assert not registry.async_is_registered(FIRST_ENTITY_ID)
     assert not registry.async_is_registered(SECOND_ENTITY_ID)
@@ -59,7 +60,7 @@ async def test_setup(hass, two_zone_alarm):  # noqa: F811
     assert registry.async_is_registered(FIRST_ENTITY_ID)
     assert registry.async_is_registered(SECOND_ENTITY_ID)
 
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, TEST_SITE_UUID + "_zone_0")})
     assert device is not None
     assert device.manufacturer == "Risco"

--- a/tests/components/risco/test_sensor.py
+++ b/tests/components/risco/test_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.risco import (
     UnauthorizedError,
 )
 from homeassistant.components.risco.const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt
 
 from .util import TEST_CONFIG, TEST_SITE_UUID, setup_risco
@@ -120,7 +121,7 @@ async def test_cannot_connect(hass):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)
 
@@ -137,7 +138,7 @@ async def test_unauthorized(hass):
         await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)
 
@@ -167,7 +168,7 @@ def _check_state(hass, category, entity_id):
 
 async def test_setup(hass, two_zone_alarm):  # noqa: F811
     """Test entity setup."""
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     for id in ENTITY_IDS.values():
         assert not registry.async_is_registered(id)

--- a/tests/components/roku/test_media_player.py
+++ b/tests/components/roku/test_media_player.py
@@ -61,6 +61,7 @@ from homeassistant.const import (
     STATE_STANDBY,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import dt as dt_util
 
@@ -85,7 +86,7 @@ async def test_setup(
     """Test setup with basic config."""
     await setup_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     main = entity_registry.async_get(MAIN_ENTITY_ID)
 
     assert hass.states.get(MAIN_ENTITY_ID)
@@ -117,7 +118,7 @@ async def test_tv_setup(
         unique_id=TV_SERIAL,
     )
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     tv = entity_registry.async_get(TV_ENTITY_ID)
 
     assert hass.states.get(TV_ENTITY_ID)
@@ -321,7 +322,7 @@ async def test_tv_device_registry(
         unique_id=TV_SERIAL,
     )
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(identifiers={(DOMAIN, TV_SERIAL)})
 
     assert reg_device.model == TV_MODEL

--- a/tests/components/roku/test_remote.py
+++ b/tests/components/roku/test_remote.py
@@ -7,6 +7,7 @@ from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.roku import UPNP_SERIAL, setup_integration
@@ -31,7 +32,7 @@ async def test_unique_id(
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
 
     main = entity_registry.async_get(MAIN_ENTITY_ID)
     assert main.unique_id == UPNP_SERIAL

--- a/tests/components/ruckus_unleashed/test_device_tracker.py
+++ b/tests/components/ruckus_unleashed/test_device_tracker.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from homeassistant.components.ruckus_unleashed import API_MAC, DOMAIN
 from homeassistant.components.ruckus_unleashed.const import API_AP, API_ID, API_NAME
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME, STATE_UNAVAILABLE
-from homeassistant.helpers import entity_registry
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.util import utcnow
 
@@ -80,7 +80,7 @@ async def test_restoring_clients(hass):
     entry = mock_config_entry()
     entry.add_to_hass(hass)
 
-    registry = await entity_registry.async_get_registry(hass)
+    registry = er.async_get(hass)
     registry.async_get_or_create(
         "device_tracker",
         DOMAIN,
@@ -120,7 +120,7 @@ async def test_client_device_setup(hass):
 
     router_info = DEFAULT_AP_INFO[API_AP][API_ID]["1"]
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     client_device = device_registry.async_get_device(
         identifiers={},
         connections={(CONNECTION_NETWORK_MAC, TEST_CLIENT[API_MAC])},

--- a/tests/components/ruckus_unleashed/test_init.py
+++ b/tests/components/ruckus_unleashed/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_RETRY,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
 from tests.components.ruckus_unleashed import (
@@ -64,7 +65,7 @@ async def test_router_device_setup(hass):
 
     device_info = DEFAULT_AP_INFO[API_AP][API_ID]["1"]
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(
         identifiers={(CONNECTION_NETWORK_MAC, device_info[API_MAC])},
         connections={(CONNECTION_NETWORK_MAC, device_info[API_MAC])},

--- a/tests/components/search/test_init.py
+++ b/tests/components/search/test_init.py
@@ -1,5 +1,10 @@
 """Tests for Search integration."""
 from homeassistant.components import search
+from homeassistant.helpers import (
+    area_registry as ar,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -8,9 +13,9 @@ from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa:
 
 async def test_search(hass):
     """Test that search works."""
-    area_reg = await hass.helpers.area_registry.async_get_registry()
-    device_reg = await hass.helpers.device_registry.async_get_registry()
-    entity_reg = await hass.helpers.entity_registry.async_get_registry()
+    area_reg = ar.async_get(hass)
+    device_reg = dr.async_get(hass)
+    entity_reg = er.async_get(hass)
 
     living_room_area = area_reg.async_create("Living Room")
 
@@ -275,8 +280,8 @@ async def test_ws_api(hass, hass_ws_client):
     """Test WS API."""
     assert await async_setup_component(hass, "search", {})
 
-    area_reg = await hass.helpers.area_registry.async_get_registry()
-    device_reg = await hass.helpers.device_registry.async_get_registry()
+    area_reg = ar.async_get(hass)
+    device_reg = dr.async_get(hass)
 
     kitchen_area = area_reg.async_create("Kitchen")
 

--- a/tests/components/sharkiq/test_vacuum.py
+++ b/tests/components/sharkiq/test_vacuum.py
@@ -46,6 +46,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from .const import (
@@ -128,7 +129,7 @@ async def setup_integration(hass):
 async def test_simple_properties(hass: HomeAssistant):
     """Test that simple properties work as intended."""
     state = hass.states.get(VAC_ENTITY_ID)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     entity = registry.async_get(VAC_ENTITY_ID)
 
     assert entity
@@ -199,7 +200,7 @@ async def test_device_properties(
     hass: HomeAssistant, device_property: str, target_value: str
 ):
     """Test device properties."""
-    registry = await hass.helpers.device_registry.async_get_registry()
+    registry = dr.async_get(hass)
     device = registry.async_get_device({(DOMAIN, "AC000Wxxxxxxxxx")})
     assert getattr(device, device_property) == target_value
 

--- a/tests/components/smartthings/test_binary_sensor.py
+++ b/tests/components/smartthings/test_binary_sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.smartthings import binary_sensor
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import ATTR_FRIENDLY_NAME, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -49,8 +50,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     device = device_factory(
         "Motion Sensor 1", [Capability.motion_sensor], {Attribute.motion: "inactive"}
     )
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, BINARY_SENSOR_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_climate.py
+++ b/tests/components/smartthings/test_climate.py
@@ -44,6 +44,7 @@ from homeassistant.const import (
     SERVICE_TURN_ON,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import setup_platform
 
@@ -569,8 +570,8 @@ async def test_set_turn_on(hass, air_conditioner):
 async def test_entity_and_device_attributes(hass, thermostat):
     """Test the attributes of the entries are correct."""
     await setup_platform(hass, CLIMATE_DOMAIN, devices=[thermostat])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
 
     entry = entity_registry.async_get("climate.thermostat")
     assert entry

--- a/tests/components/smartthings/test_cover.py
+++ b/tests/components/smartthings/test_cover.py
@@ -20,6 +20,7 @@ from homeassistant.components.cover import (
 )
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import ATTR_BATTERY_LEVEL, ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -31,8 +32,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     device = device_factory(
         "Garage", [Capability.garage_door_control], {Attribute.door: "open"}
     )
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, COVER_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_fan.py
+++ b/tests/components/smartthings/test_fan.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -59,8 +60,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     )
     # Act
     await setup_platform(hass, FAN_DOMAIN, devices=[device])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Assert
     entry = entity_registry.async_get("fan.fan_1")
     assert entry

--- a/tests/components/smartthings/test_light.py
+++ b/tests/components/smartthings/test_light.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     ATTR_SUPPORTED_FEATURES,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -110,8 +111,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Light 1", [Capability.switch, Capability.switch_level])
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, LIGHT_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_lock.py
+++ b/tests/components/smartthings/test_lock.py
@@ -10,6 +10,7 @@ from pysmartthings.device import Status
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.smartthings.const import DOMAIN, SIGNAL_SMARTTHINGS_UPDATE
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -19,8 +20,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Lock_1", [Capability.lock], {Attribute.lock: "unlocked"})
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, LOCK_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_scene.py
+++ b/tests/components/smartthings/test_scene.py
@@ -6,6 +6,7 @@ real HTTP calls are not initiated during testing.
 """
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON, STATE_UNAVAILABLE
+from homeassistant.helpers import entity_registry as er
 
 from .conftest import setup_platform
 
@@ -13,7 +14,7 @@ from .conftest import setup_platform
 async def test_entity_and_device_attributes(hass, scene):
     """Test the attributes of the entity are correct."""
     # Arrange
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     # Act
     await setup_platform(hass, SCENE_DOMAIN, scenes=[scene])
     # Assert

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -78,8 +79,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Sensor 1", [Capability.battery], {Attribute.battery: 100})
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, SENSOR_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/smartthings/test_switch.py
+++ b/tests/components/smartthings/test_switch.py
@@ -13,6 +13,7 @@ from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
 )
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .conftest import setup_platform
@@ -22,8 +23,8 @@ async def test_entity_and_device_attributes(hass, device_factory):
     """Test the attributes of the entity are correct."""
     # Arrange
     device = device_factory("Switch_1", [Capability.switch], {Attribute.switch: "on"})
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
     # Act
     await setup_platform(hass, SWITCH_DOMAIN, devices=[device])
     # Assert

--- a/tests/components/sonarr/test_sensor.py
+++ b/tests/components/sonarr/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     DATA_GIGABYTES,
     STATE_UNAVAILABLE,
 )
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import dt as dt_util
 
@@ -27,7 +28,7 @@ async def test_sensors(
 ) -> None:
     """Test the creation and values of the sensors."""
     entry = await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
 
     # Pre-create registry entries for disabled by default sensors
     sensors = {
@@ -107,7 +108,7 @@ async def test_disabled_by_default_sensors(
 ) -> None:
     """Test the disabled by default sensors."""
     await setup_integration(hass, aioclient_mock)
-    registry = await hass.helpers.entity_registry.async_get_registry()
+    registry = er.async_get(hass)
     print(registry.entities)
 
     state = hass.states.get(entity_id)

--- a/tests/components/songpal/test_media_player.py
+++ b/tests/components/songpal/test_media_player.py
@@ -113,7 +113,7 @@ async def test_state(hass):
     assert attributes["source"] == "title2"
     assert attributes["supported_features"] == SUPPORT_SONGPAL
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device = device_registry.async_get_device(identifiers={(songpal.DOMAIN, MAC)})
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, MAC)}
     assert device.manufacturer == "Sony Corporation"
@@ -121,7 +121,7 @@ async def test_state(hass):
     assert device.sw_version == SW_VERSION
     assert device.model == MODEL
 
-    entity_registry = await er.async_get_registry(hass)
+    entity_registry = er.async_get(hass)
     entity = entity_registry.async_get(ENTITY_ID)
     assert entity.unique_id == MAC
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -4,6 +4,7 @@ import pytest
 from homeassistant.components.sonos import DOMAIN, media_player
 from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 
@@ -48,7 +49,7 @@ async def test_device_registry(hass, config_entry, config, soco):
     """Test sonos device registered in the device registry."""
     await setup_platform(hass, config_entry, config)
 
-    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device_registry = dr.async_get(hass)
     reg_device = device_registry.async_get_device(
         identifiers={("sonos", "RINCON_test")}
     )

--- a/tests/components/surepetcare/test_binary_sensor.py
+++ b/tests/components/surepetcare/test_binary_sensor.py
@@ -2,6 +2,7 @@
 from surepy import MESTART_RESOURCE
 
 from homeassistant.components.surepetcare.const import DOMAIN
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import MOCK_API_DATA, MOCK_CONFIG, _patch_sensor_setup
@@ -24,7 +25,7 @@ async def test_binary_sensors(hass, surepetcare) -> None:
         assert await async_setup_component(hass, DOMAIN, MOCK_CONFIG)
         await hass.async_block_till_done()
 
-    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    entity_registry = er.async_get(hass)
     state_entity_ids = hass.states.async_entity_ids()
 
     for entity_id, unique_id in EXPECTED_ENTITY_IDS.items():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update tests to use `*_registry.async_get()` instead of deprecated `*_registry.depreceated async_get_registry()`
(#47274 split up, part 4/5)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
