### PR TITLE
Add transition to LiteJet

### DIFF
--- a/homeassistant/components/litejet/config_flow.py
+++ b/homeassistant/components/litejet/config_flow.py
@@ -10,11 +10,42 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PORT
+from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN
+from .const import CONF_DEFAULT_TRANSITION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class LiteJetOptionsFlow(config_entries.OptionsFlow):
+    """Handle LiteJet options."""
+
+    def __init__(self, config_entry):
+        """Initialize LiteJet options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Manage LiteJet options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_DEFAULT_TRANSITION,
+                        default=self.config_entry.options.get(
+                            CONF_DEFAULT_TRANSITION, 0
+                        ),
+                    ): cv.positive_int,
+                }
+            ),
+        )
 
 
 class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -54,3 +85,9 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, import_data):
         """Import litejet config from configuration.yaml."""
         return self.async_create_entry(title=import_data[CONF_PORT], data=import_data)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return LiteJetOptionsFlow(config_entry)

--- a/homeassistant/components/litejet/const.py
+++ b/homeassistant/components/litejet/const.py
@@ -6,3 +6,5 @@ CONF_EXCLUDE_NAMES = "exclude_names"
 CONF_INCLUDE_SWITCHES = "include_switches"
 
 PLATFORMS = ["light", "switch", "scene"]
+
+CONF_DEFAULT_TRANSITION = "default_transition"

--- a/homeassistant/components/litejet/light.py
+++ b/homeassistant/components/litejet/light.py
@@ -3,11 +3,13 @@ import logging
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_TRANSITION,
     SUPPORT_BRIGHTNESS,
+    SUPPORT_TRANSITION,
     LightEntity,
 )
 
-from .const import DOMAIN
+from .const import CONF_DEFAULT_TRANSITION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,7 +25,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         entities = []
         for i in system.loads():
             name = system.get_load_name(i)
-            entities.append(LiteJetLight(config_entry.entry_id, system, i, name))
+            entities.append(LiteJetLight(config_entry, system, i, name))
         return entities
 
     async_add_entities(await hass.async_add_executor_job(get_entities, system), True)
@@ -32,9 +34,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class LiteJetLight(LightEntity):
     """Representation of a single LiteJet light."""
 
-    def __init__(self, entry_id, lj, i, name):
+    def __init__(self, config_entry, lj, i, name):
         """Initialize a LiteJet light."""
-        self._entry_id = entry_id
+        self._config_entry = config_entry
         self._lj = lj
         self._index = i
         self._brightness = 0
@@ -57,7 +59,7 @@ class LiteJetLight(LightEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        return SUPPORT_BRIGHTNESS
+        return SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
 
     @property
     def name(self):
@@ -67,7 +69,7 @@ class LiteJetLight(LightEntity):
     @property
     def unique_id(self):
         """Return a unique identifier for this light."""
-        return f"{self._entry_id}_{self._index}"
+        return f"{self._config_entry.entry_id}_{self._index}"
 
     @property
     def brightness(self):
@@ -91,16 +93,37 @@ class LiteJetLight(LightEntity):
 
     def turn_on(self, **kwargs):
         """Turn on the light."""
+        is_complex = False
+        brightness = 99
+        transition = self._config_entry.options.get(CONF_DEFAULT_TRANSITION, 0)
+
         if ATTR_BRIGHTNESS in kwargs:
+            is_complex = True
             brightness = int(kwargs[ATTR_BRIGHTNESS] / 255 * 99)
-            self._lj.activate_load_at(self._index, brightness, 0)
+
+        if ATTR_TRANSITION in kwargs:
+            is_complex = True
+            transition = kwargs[ATTR_TRANSITION]
+
+        if is_complex:
+            self._lj.activate_load_at(self._index, brightness, int(transition))
         else:
             self._lj.activate_load(self._index)
 
     def turn_off(self, **kwargs):
         """Turn off the light."""
-        self._lj.deactivate_load(self._index)
+        is_complex = False
+        transition = self._config_entry.options.get(CONF_DEFAULT_TRANSITION, 0)
+
+        if ATTR_TRANSITION in kwargs:
+            is_complex = True
+            transition = kwargs[ATTR_TRANSITION]
+
+        if is_complex:
+            self._lj.activate_load_at(self._index, 0, transition)
+        else:
+            self._lj.deactivate_load(self._index)
 
     def update(self):
         """Retrieve the light's brightness from the LiteJet system."""
-        self._brightness = self._lj.get_load_level(self._index) / 99 * 255
+        self._brightness = int(self._lj.get_load_level(self._index) / 99 * 255)

--- a/homeassistant/components/litejet/strings.json
+++ b/homeassistant/components/litejet/strings.json
@@ -15,5 +15,15 @@
     "error": {
       "open_failed": "Cannot open the specified serial port."
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Configure LiteJet",
+        "data": {
+          "default_transition": "Default Transition (seconds)"
+        }
+      }
+    }
   }
 }

--- a/homeassistant/components/litejet/translations/en.json
+++ b/homeassistant/components/litejet/translations/en.json
@@ -15,5 +15,15 @@
                 "title": "Connect To LiteJet"
             }
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "default_transition": "Default Transition (seconds)"
+                },
+                "title": "Configure LiteJet"
+            }
+        }
     }
 }

--- a/tests/components/litejet/test_config_flow.py
+++ b/tests/components/litejet/test_config_flow.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 
 from serial import SerialException
 
-from homeassistant import config_entries
-from homeassistant.components.litejet.const import DOMAIN
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.litejet.const import CONF_DEFAULT_TRANSITION, DOMAIN
 from homeassistant.const import CONF_PORT
 
 from tests.common import MockConfigEntry
@@ -76,3 +76,22 @@ async def test_import_step(hass):
     assert result["type"] == "create_entry"
     assert result["title"] == test_data[CONF_PORT]
     assert result["data"] == test_data
+
+
+async def test_options(hass):
+    """Test updating options."""
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_PORT: "/dev/test"})
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_DEFAULT_TRANSITION: 12},
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {CONF_DEFAULT_TRANSITION: 12}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The LiteJet light platform now supports the transition parameter for light.turn_on and light.turn_off.

When a brightness parameter is specified without a transition parameter, the default transition time is pulled from the options flow. This is a limitation of the LiteJet API which does not provide a way to specify only one of these parameters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: n/a
- This PR is related to issue: n/a
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
