### PR TITLE
Add TYPE_CHECKING to coverage excludes

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1167,3 +1167,6 @@ exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise AssertionError
     raise NotImplementedError
+
+    # TYPE_CHECKING block is never executed during pytest run
+    if TYPE_CHECKING:


### PR DESCRIPTION
## Proposed change
Add `if TYPE_CHECKING:` to coverage `exclude_lines`. The `TYPE_CHECKING` block will never be executed by pytest.
https://github.com/nedbat/coveragepy/issues/831


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests
