### PR TITLE
Implement iCloud GPS Accuracy Threshold

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -213,7 +213,7 @@ homeassistant/components/hydrawise/* @ptcryan
 homeassistant/components/hyperion/* @dermotduffy
 homeassistant/components/iammeter/* @lewei50
 homeassistant/components/iaqualink/* @flz
-homeassistant/components/icloud/* @Quentame @nzapponi
+homeassistant/components/icloud/* @Quentame @nzapponi @Justus502
 homeassistant/components/ign_sismologia/* @exxamalte
 homeassistant/components/image/* @home-assistant/core
 homeassistant/components/incomfort/* @zxdavb

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -197,7 +197,7 @@ class IcloudAccount:
             if self._devices.get(device_id) is not None:
                 # Seen device -> updating
                 _LOGGER.debug("Updating iCloud device: %s", device_name)
-                self._devices[device_id].update(status, self._config_entry)
+                self._devices[device_id].update(status)
             else:
                 # New device, should be unique
                 _LOGGER.debug(
@@ -205,10 +205,8 @@ class IcloudAccount:
                     device_name,
                     status[DEVICE_RAW_DEVICE_MODEL],
                 )
-                self._devices[device_id] = IcloudDevice(
-                    self, device, status, self._config_entry
-                )
-                self._devices[device_id].update(status, self._config_entry)
+                self._devices[device_id] = IcloudDevice(self, device, status)
+                self._devices[device_id].update(status)
                 new_device = True
 
         if (
@@ -376,19 +374,12 @@ class IcloudAccount:
 class IcloudDevice:
     """Representation of a iCloud device."""
 
-    def __init__(
-        self,
-        account: IcloudAccount,
-        device: AppleDevice,
-        status,
-        config_entry: ConfigEntry,
-    ):
+    def __init__(self, account: IcloudAccount, device: AppleDevice, status):
         """Initialize the iCloud device."""
         self._account = account
 
         self._device = device
         self._status = status
-        self._config_entry = config_entry
 
         self._name = self._status[DEVICE_NAME]
         self._device_id = self._status[DEVICE_ID]
@@ -414,7 +405,7 @@ class IcloudDevice:
             ATTR_OWNER_NAME: owner_fullname,
         }
 
-    def update(self, status, config_entry) -> None:
+    def update(self, status) -> None:
         """Update the iCloud device."""
         self._status = status
 
@@ -437,14 +428,15 @@ class IcloudDevice:
             ):
                 location = self._status[DEVICE_LOCATION]
                 if (
-                    self._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD] is not None
+                    self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                    is not None
                     and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
-                    > self._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                    > self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
                 ):
                     _LOGGER.info(
                         "Update of iCloud device %s: Ignoring update because expected GPS accuracy (%.0f) is not met: %.0f",
                         self.name,
-                        self._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD],
+                        self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD],
                         location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
                     )
                     return

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -426,6 +426,14 @@ class IcloudDevice:
                 and self._status[DEVICE_LOCATION][DEVICE_LOCATION_LATITUDE]
             ):
                 location = self._status[DEVICE_LOCATION]
+                if self._account._gps_accuracy_threshold is not None and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY] > self._account._gps_accuracy_threshold:
+                    _LOGGER.info(
+                        "Update of iCloud device %s: Ignoring update because expected GPS accuracy (%.0f) is not met: %.0f",
+                        self.name,
+                        self._account._gps_accuracy_threshold,
+                        location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
+                    )
+                    return
                 if self._location is None:
                     dispatcher_send(self._account.hass, self._account.signal_device_new)
                 self._location = location

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -433,8 +433,7 @@ class IcloudDevice:
             ):
                 location = self._status[DEVICE_LOCATION]
                 if (
-                    self._account.gps_accuracy_threshold
-                    is not None
+                    self._account.gps_accuracy_threshold is not None
                     and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
                     > self._account.gps_accuracy_threshold
                 ):

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -197,7 +197,7 @@ class IcloudAccount:
             if self._devices.get(device_id) is not None:
                 # Seen device -> updating
                 _LOGGER.debug("Updating iCloud device: %s", device_name)
-                self._devices[device_id].update(status)
+                self._devices[device_id].update(status, self._config_entry)
             else:
                 # New device, should be unique
                 _LOGGER.debug(
@@ -205,8 +205,10 @@ class IcloudAccount:
                     device_name,
                     status[DEVICE_RAW_DEVICE_MODEL],
                 )
-                self._devices[device_id] = IcloudDevice(self, device, status)
-                self._devices[device_id].update(status)
+                self._devices[device_id] = IcloudDevice(
+                    self, device, status, self._config_entry
+                )
+                self._devices[device_id].update(status, self._config_entry)
                 new_device = True
 
         if (
@@ -374,12 +376,19 @@ class IcloudAccount:
 class IcloudDevice:
     """Representation of a iCloud device."""
 
-    def __init__(self, account: IcloudAccount, device: AppleDevice, status):
+    def __init__(
+        self,
+        account: IcloudAccount,
+        device: AppleDevice,
+        status,
+        config_entry: ConfigEntry,
+    ):
         """Initialize the iCloud device."""
         self._account = account
 
         self._device = device
         self._status = status
+        self._config_entry = config_entry
 
         self._name = self._status[DEVICE_NAME]
         self._device_id = self._status[DEVICE_ID]
@@ -405,7 +414,7 @@ class IcloudDevice:
             ATTR_OWNER_NAME: owner_fullname,
         }
 
-    def update(self, status) -> None:
+    def update(self, status, config_entry) -> None:
         """Update the iCloud device."""
         self._status = status
 
@@ -428,15 +437,14 @@ class IcloudDevice:
             ):
                 location = self._status[DEVICE_LOCATION]
                 if (
-                    self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
-                    is not None
+                    self._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD] is not None
                     and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
-                    > self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                    > self._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
                 ):
                     _LOGGER.info(
                         "Update of iCloud device %s: Ignoring update because expected GPS accuracy (%.0f) is not met: %.0f",
                         self.name,
-                        self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD],
+                        self._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD],
                         location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
                     )
                     return

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -91,7 +91,7 @@ class IcloudAccount:
         self._with_family = with_family
         self._fetch_interval = max_interval
         self._max_interval = max_interval
-        self._gps_accuracy_threshold = gps_accuracy_threshold
+        self.gps_accuracy_threshold = gps_accuracy_threshold
 
         self._icloud_dir = icloud_dir
 
@@ -353,11 +353,6 @@ class IcloudAccount:
     def fetch_interval(self) -> int:
         """Return the account fetch interval."""
         return self._fetch_interval
-
-    @property
-    def gps_accuracy_threshold(self) -> int:
-        """Return configured GPS Accuracy Threshold."""
-        return self._gps_accuracy_threshold
 
     @property
     def devices(self) -> Dict[str, any]:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -26,6 +26,7 @@ from homeassistant.util.dt import utcnow
 from homeassistant.util.location import distance
 
 from .const import (
+    CONF_GPS_ACCURACY_THRESHOLD,
     DEVICE_BATTERY_LEVEL,
     DEVICE_BATTERY_STATUS,
     DEVICE_CLASS,
@@ -426,11 +427,16 @@ class IcloudDevice:
                 and self._status[DEVICE_LOCATION][DEVICE_LOCATION_LATITUDE]
             ):
                 location = self._status[DEVICE_LOCATION]
-                if self._account._gps_accuracy_threshold is not None and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY] > self._account._gps_accuracy_threshold:
+                if (
+                    self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                    is not None
+                    and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
+                    > self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                ):
                     _LOGGER.info(
                         "Update of iCloud device %s: Ignoring update because expected GPS accuracy (%.0f) is not met: %.0f",
                         self.name,
-                        self._account._gps_accuracy_threshold,
+                        self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD],
                         location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
                     )
                     return

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -26,7 +26,6 @@ from homeassistant.util.dt import utcnow
 from homeassistant.util.location import distance
 
 from .const import (
-    CONF_GPS_ACCURACY_THRESHOLD,
     DEVICE_BATTERY_LEVEL,
     DEVICE_BATTERY_STATUS,
     DEVICE_CLASS,

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -356,6 +356,11 @@ class IcloudAccount:
         return self._fetch_interval
 
     @property
+    def gps_accuracy_threshold(self) -> int:
+        """Return configured GPS Accuracy Threshold."""
+        return self._gps_accuracy_threshold
+
+    @property
     def devices(self) -> Dict[str, any]:
         """Return the account devices."""
         return self._devices
@@ -428,15 +433,15 @@ class IcloudDevice:
             ):
                 location = self._status[DEVICE_LOCATION]
                 if (
-                    self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                    self._account.gps_accuracy_threshold
                     is not None
                     and location[DEVICE_LOCATION_HORIZONTAL_ACCURACY]
-                    > self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD]
+                    > self._account.gps_accuracy_threshold
                 ):
                     _LOGGER.info(
                         "Update of iCloud device %s: Ignoring update because expected GPS accuracy (%.0f) is not met: %.0f",
                         self.name,
-                        self._account._config_entry.data[CONF_GPS_ACCURACY_THRESHOLD],
+                        self._account.gps_accuracy_threshold,
                         location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
                     )
                     return

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -73,7 +73,9 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 ): bool,
                 vol.Optional(
                     CONF_GPS_ACCURACY_THRESHOLD,
-                    default=user_input.get(CONF_GPS_ACCURACY_THRESHOLD, DEFAULT_GPS_ACCURACY_THRESHOLD),
+                    default=user_input.get(
+                        CONF_GPS_ACCURACY_THRESHOLD, DEFAULT_GPS_ACCURACY_THRESHOLD
+                    ),
                 ): int,
             }
         else:

--- a/homeassistant/components/icloud/config_flow.py
+++ b/homeassistant/components/icloud/config_flow.py
@@ -71,6 +71,10 @@ class IcloudFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_WITH_FAMILY,
                     default=user_input.get(CONF_WITH_FAMILY, DEFAULT_WITH_FAMILY),
                 ): bool,
+                vol.Optional(
+                    CONF_GPS_ACCURACY_THRESHOLD,
+                    default=user_input.get(CONF_GPS_ACCURACY_THRESHOLD, DEFAULT_GPS_ACCURACY_THRESHOLD),
+                ): int,
             }
         else:
             schema = {

--- a/homeassistant/components/icloud/manifest.json
+++ b/homeassistant/components/icloud/manifest.json
@@ -4,5 +4,5 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/icloud",
   "requirements": ["pyicloud==0.10.2"],
-  "codeowners": ["@Quentame", "@nzapponi"]
+  "codeowners": ["@Quentame", "@nzapponi", "@Justus502"]
 }

--- a/homeassistant/components/icloud/strings.json
+++ b/homeassistant/components/icloud/strings.json
@@ -7,7 +7,8 @@
         "data": {
           "username": "[%key:common::config_flow::data::email%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "with_family": "With family"
+          "with_family": "With family",
+          "gps_accuracy_threshold": "Discard inaccurate location updates above threshold (meters)"
         }
       },
       "reauth": {

--- a/homeassistant/components/icloud/translations/de.json
+++ b/homeassistant/components/icloud/translations/de.json
@@ -28,7 +28,8 @@
                 "data": {
                     "password": "Passwort",
                     "username": "Email",
-                    "with_family": "Mit Familie"
+                    "with_family": "Mit Familie",
+                    "gps_accuracy_threshold": "Ungenauere Ortungsdaten verwerfen (Radius in Meter)"
                 },
                 "description": "Gib deine Zugangsdaten ein",
                 "title": "iCloud-Anmeldeinformationen"

--- a/homeassistant/components/icloud/translations/de.json
+++ b/homeassistant/components/icloud/translations/de.json
@@ -28,8 +28,7 @@
                 "data": {
                     "password": "Passwort",
                     "username": "Email",
-                    "with_family": "Mit Familie",
-                    "gps_accuracy_threshold": "Ungenauere Ortungsdaten verwerfen (Radius in Meter)"
+                    "with_family": "Mit Familie"
                 },
                 "description": "Gib deine Zugangsdaten ein",
                 "title": "iCloud-Anmeldeinformationen"

--- a/homeassistant/components/icloud/translations/en.json
+++ b/homeassistant/components/icloud/translations/en.json
@@ -30,7 +30,7 @@
                     "password": "Password",
                     "username": "Email",
                     "with_family": "With family",
-                    "gps_accuracy_threshold": "Discard inaccurate location updates threshold (meters)"
+                    "gps_accuracy_threshold": "Discard inaccurate location updates above threshold (meters)"
                 },
                 "description": "Enter your credentials",
                 "title": "iCloud credentials"

--- a/homeassistant/components/icloud/translations/en.json
+++ b/homeassistant/components/icloud/translations/en.json
@@ -29,7 +29,8 @@
                 "data": {
                     "password": "Password",
                     "username": "Email",
-                    "with_family": "With family"
+                    "with_family": "With family",
+                    "gps_accuracy_threshold": "Discard inaccurate location updates threshold (meters)"
                 },
                 "description": "Enter your credentials",
                 "title": "iCloud credentials"


### PR DESCRIPTION
Discards iCloud device tracker updates if the accuracy is larger than the configured threshold. The other sensors are not affected.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wildly inaccurate location updates can often trigger things you don't want. Here's a fix for that.
The feature was supposedly implemented but the config-variables have stayed unused from what i could see. 
I just finished what was started a long time ago.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

This feature was supposed to be implemented all along, i think. Otherwise there wouldn't have been a (hidden) config-variable for it. So it could both be seen as a bugfix, as well as a new feature.

You could argue about the need of the option in the config-flow. If you want to keep it simple you could remove it, but the feature doesn't really add complexity and offers a real value, because if filters false-positive values.

- This PR fixes or closes issue: fixes #46261 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
