### PR TITLE
Fix aemet temperatures with a value of 0

### DIFF
--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -98,6 +98,8 @@ def format_float(value) -> float:
     """Try converting string to float."""
     try:
         return float(value)
+    except TypeError:
+        return None
     except ValueError:
         return None
 
@@ -106,6 +108,8 @@ def format_int(value) -> int:
     """Try converting string to int."""
     try:
         return int(value)
+    except TypeError:
+        return None
     except ValueError:
         return None
 

--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -539,9 +539,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
     def _get_temperature(day_data, hour):
         """Get temperature (hour) from weather data."""
         val = get_forecast_hour_value(day_data[AEMET_ATTR_TEMPERATURE], hour)
-        if val:
-            return format_int(val)
-        return None
+        return format_int(val)
 
     @staticmethod
     def _get_temperature_day(day_data):
@@ -549,9 +547,7 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         val = get_forecast_day_value(
             day_data[AEMET_ATTR_TEMPERATURE], key=AEMET_ATTR_MAX
         )
-        if val:
-            return format_int(val)
-        return None
+        return format_int(val)
 
     @staticmethod
     def _get_temperature_low_day(day_data):
@@ -559,17 +555,13 @@ class WeatherUpdateCoordinator(DataUpdateCoordinator):
         val = get_forecast_day_value(
             day_data[AEMET_ATTR_TEMPERATURE], key=AEMET_ATTR_MIN
         )
-        if val:
-            return format_int(val)
-        return None
+        return format_int(val)
 
     @staticmethod
     def _get_temperature_feeling(day_data, hour):
         """Get temperature from weather data."""
         val = get_forecast_hour_value(day_data[AEMET_ATTR_TEMPERATURE_FEELING], hour)
-        if val:
-            return format_int(val)
-        return None
+        return format_int(val)
 
     def _get_town_id(self):
         """Get town ID from weather data."""

--- a/homeassistant/components/aemet/weather_update_coordinator.py
+++ b/homeassistant/components/aemet/weather_update_coordinator.py
@@ -98,9 +98,7 @@ def format_float(value) -> float:
     """Try converting string to float."""
     try:
         return float(value)
-    except TypeError:
-        return None
-    except ValueError:
+    except (TypeError, ValueError):
         return None
 
 
@@ -108,9 +106,7 @@ def format_int(value) -> int:
     """Try converting string to int."""
     try:
         return int(value)
-    except TypeError:
-        return None
-    except ValueError:
+    except (TypeError, ValueError):
         return None
 
 


### PR DESCRIPTION
## Proposed change
The current implementation of AEMET will return None when a temperature with a value of 0 is provided by the API, making that value invisible in the UI. We should return 0 instead of None in this case.


## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
```yaml
# Example configuration.yaml

```

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
