### PR TITLE
Add support for Roomba 980 discovery

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--network", "host"]
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--network=host"]
   "extensions": [
     "ms-python.vscode-pylance",
     "visualstudioexptteam.vscodeintellicode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
+  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--network", "host"]
   "extensions": [
     "ms-python.vscode-pylance",
     "visualstudioexptteam.vscodeintellicode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait",
+  "runArgs": ["-e", "GIT_EDITOR=code --wait"],
   "extensions": [
     "ms-python.vscode-pylance",
     "visualstudioexptteam.vscodeintellicode",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   "postStartCommand": "script/bootstrap",
   "containerEnv": { "DEVCONTAINER": "1" },
   "appPort": 8123,
-  "runArgs": ["-e", "GIT_EDITOR=code --wait", "--network=host"]
+  "runArgs": ["-e", "GIT_EDITOR=code --wait",
   "extensions": [
     "ms-python.vscode-pylance",
     "visualstudioexptteam.vscodeintellicode",

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -80,7 +80,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_host_already_configured(dhcp_discovery[IP_ADDRESS]):
             return self.async_abort(reason="already_configured")
 
-        if not dhcp_discovery[HOSTNAME].startswith("iRobot-"):
+        if not dhcp_discovery[HOSTNAME].startswith(("iRobot-","Roomba-")):
             return self.async_abort(reason="not_irobot_device")
 
         blid = _async_blid_from_hostname(dhcp_discovery[HOSTNAME])

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -80,7 +80,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_host_already_configured(dhcp_discovery[IP_ADDRESS]):
             return self.async_abort(reason="already_configured")
 
-        if not dhcp_discovery[HOSTNAME].startswith(("iRobot-","Roomba-")):
+        if not dhcp_discovery[HOSTNAME].startswith(("iRobot-", "Roomba-")):
             return self.async_abort(reason="not_irobot_device")
 
         blid = _async_blid_from_hostname(dhcp_discovery[HOSTNAME])

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -1,18 +1,19 @@
 {
-    "domain": "roomba",
-    "name": "iRobot Roomba and Braava",
-    "config_flow": true,
-    "documentation": "https://www.home-assistant.io/integrations/roomba",
-    "requirements": ["roombapy==1.6.2"],
-    "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"],
-    "dhcp": [
+  "domain": "roomba",
+  "name": "iRobot Roomba and Braava",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/roomba",
+  "requirements": ["roombapy==1.6.2"],
+  "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"],
+  "dhcp": [
       {
-        "hostname": "irobot-*", 
-        "macaddress": "501479*"
+        "hostname" : "irobot-*",
+        "macaddress" : "501479*"
       },
       {
-        "hostname": "roomba-*",
-        "macaddress": "80A589*"
+        "hostname" : "roomba-*",
+        "macaddress" : "80A589*"
       }
-    ]
+   ]
 }
+

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -5,5 +5,14 @@
   "documentation": "https://www.home-assistant.io/integrations/roomba",
   "requirements": ["roombapy==1.6.2"],
   "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"],
-  "dhcp": [{"hostname":"irobot-*","macaddress":"501479*"}]
+  "dhcp": [
+    {
+      "hostname":"irobot-*",
+      "macaddress":"501479*"
+    },
+    {
+      "hostname":"Roomba-*",
+      "macaddress":"80a589*"
+    }
+  ]
 }

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -1,18 +1,18 @@
 {
-  "domain": "roomba",
-  "name": "iRobot Roomba and Braava",
-  "config_flow": true,
-  "documentation": "https://www.home-assistant.io/integrations/roomba",
-  "requirements": ["roombapy==1.6.2"],
-  "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"],
-  "dhcp": [
-    {
-      "hostname":"irobot-*",
-      "macaddress":"501479*"
-    },
-    {
-      "hostname":"roomba-*",
-      "macaddress":"80A589*"
-    }
-  ]
+    "domain": "roomba",
+    "name": "iRobot Roomba and Braava",
+    "config_flow": true,
+    "documentation": "https://www.home-assistant.io/integrations/roomba",
+    "requirements": ["roombapy==1.6.2"],
+    "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"],
+    "dhcp": [
+      {
+        "hostname": "irobot-*", 
+        "macaddress": "501479*"
+      },
+      {
+        "hostname": "roomba-*",
+        "macaddress": "80A589*"
+      }
+    ]
 }

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -11,8 +11,8 @@
       "macaddress":"501479*"
     },
     {
-      "hostname":"Roomba-*",
-      "macaddress":"80a589*"
+      "hostname":"roomba-*",
+      "macaddress":"80A589*"
     }
   ]
 }

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -120,6 +120,11 @@ DHCP = [
         "macaddress": "501479*"
     },
     {
+        "domain": "roomba",
+        "hostname": "roomba-*",
+        "macaddress": "80A589*"
+    },
+    {
         "domain": "screenlogic",
         "hostname": "pentair: *",
         "macaddress": "00C033*"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add Roomba 980 models host name and mac to dhcp discovery in manifest.json for the roomba integration

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

none

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #16931
- This PR is related to issue:  https://github.com/home-assistant/home-assistant.io/issues/16931
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
