### PR TITLE
Ensure startup can proceed when there is package metadata cruft

### DIFF
--- a/tests/util/test_package.py
+++ b/tests/util/test_package.py
@@ -239,10 +239,55 @@ async def test_async_get_user_site(mock_env_copy):
 
 def test_check_package_global():
     """Test for an installed package."""
-    installed_package = list(pkg_resources.working_set)[0].project_name
+    first_package = list(pkg_resources.working_set)[0]
+    installed_package = first_package.project_name
+    installed_version = first_package.version
+
     assert package.is_installed(installed_package)
+    assert package.is_installed(f"{installed_package}=={installed_version}")
+    assert package.is_installed(f"{installed_package}>={installed_version}")
+    assert package.is_installed(f"{installed_package}<={installed_version}")
+    assert not package.is_installed(f"{installed_package}<{installed_version}")
+
+
+def test_check_package_version_does_not_match():
+    """Test for version mismatch."""
+    installed_package = list(pkg_resources.working_set)[0].project_name
+    assert not package.is_installed(f"{installed_package}==999.999.999")
+    assert not package.is_installed(f"{installed_package}>=999.999.999")
 
 
 def test_check_package_zip():
     """Test for an installed zip package."""
     assert not package.is_installed(TEST_ZIP_REQ)
+
+
+def test_get_distribution_falls_back_to_version():
+    """Test for get_distribution failing and fallback to version."""
+    first_package = list(pkg_resources.working_set)[0]
+    installed_package = first_package.project_name
+    installed_version = first_package.version
+
+    with patch(
+        "homeassistant.util.package.pkg_resources.get_distribution",
+        side_effect=pkg_resources.ExtractionError,
+    ):
+        assert package.is_installed(installed_package)
+        assert package.is_installed(f"{installed_package}=={installed_version}")
+        assert package.is_installed(f"{installed_package}>={installed_version}")
+        assert package.is_installed(f"{installed_package}<={installed_version}")
+        assert not package.is_installed(f"{installed_package}<{installed_version}")
+
+
+def test_check_package_previous_failed_install():
+    """Test for when a previously install package failed and left cruft behind."""
+    first_package = list(pkg_resources.working_set)[0]
+    installed_package = first_package.project_name
+    installed_version = first_package.version
+
+    with patch(
+        "homeassistant.util.package.pkg_resources.get_distribution",
+        side_effect=pkg_resources.ExtractionError,
+    ), patch("homeassistant.util.package.version", return_value=None):
+        assert not package.is_installed(installed_package)
+        assert not package.is_installed(f"{installed_package}=={installed_version}")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If a package previously failed to install or partially installed and left behind metadata cruft, `importlib.metadata` version can return `None` even though it is typed to always return a `str`.

Even if the package is now up to date and working, `importlib.metadata` will return `None` because of the cruft left behind from previous versions.

We now try `pkg_resources` first, then try `importlib.metadata`, and handle the case where version unexpectedly returns `None`.


Fixes:
https://community.home-assistant.io/t/2021-3-my-oh-my/286346/467
https://community.home-assistant.io/t/home-assistant-does-not-start-after-upgrade-to-0-106/177160
https://community.home-assistant.io/t/expected-string-or-bytes-like-object-how-to-debug/247081/6
https://community.home-assistant.io/t/cant-access-frontend-but-can-still-access-file-system-help-please-v0-105-1/171507
https://community.home-assistant.io/t/unable-to-connect-to-home-assistant-after-clicking-update-not-sure-how-to-proceed-details-included/171282
https://community.home-assistant.io/t/0-102-official-android-app-almond-scene-editor/149639/90
https://community.home-assistant.io/t/home-assistant-does-not-start-after-upgrade-to-0-106/177160
https://community.home-assistant.io/t/unable-to-start-ha-after-0-109-upgrade/192859
https://community.home-assistant.io/t/upgrade-to-105-2-failed-restored-104-3-snapshot-and-home-assistant-still-wont-launch/169679

fixes #47704
fixes #47386
fixes #40821
fixes #41819
fixes #41205
fixes #43849
fixes #32106
fixes #36593
fixes #32062
fixes #27625
fixes #28504
fixes #25125

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47699
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
