### PR TITLE
Bump incomfort client to 0.4.4

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,35 +5,20 @@
   "version": "0.2.0",
   "configurations": [
     {
-      // Debug by attaching to remote Home Asistant server using Remote Python Debugger.
-      // See https://www.home-assistant.io/integrations/debugpy/
-      "name": "HASS: Attach Remote",
-      "type": "python",
-      "request": "attach",
-      "port": 5678,
-      "host": "vm-builder.home",
-      "pathMappings": [
-        {
-          "xlocalRoot": "${workspaceFolder}",
-          "remoteRoot": "/usr/dbonnes/home-assistant"
-        }
-      ],
-    },
-    {
-      "name": "HASS: Launch",
+      "name": "Home Assistant",
       "type": "python",
       "request": "launch",
       "module": "homeassistant",
       "args": [
         "--debug",
         "-c",
-        ".config"
+        "config"
       ]
     },
     {
       // Debug by attaching to local Home Asistant server using Remote Python Debugger.
       // See https://www.home-assistant.io/integrations/debugpy/
-      "name": "HASS: Attach Local",
+      "name": "Home Assistant: Attach Local",
       "type": "python",
       "request": "attach",
       "port": 5678,
@@ -42,6 +27,21 @@
         {
           "localRoot": "${workspaceFolder}",
           "remoteRoot": "."
+        }
+      ],
+    },
+    {
+      // Debug by attaching to remote Home Asistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      "name": "Home Assistant: Attach Remote",
+      "type": "python",
+      "request": "attach",
+      "port": 5678,
+      "host": "homeassistant.local",
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}",
+          "remoteRoot": "/usr/src/homeassistant"
         }
       ],
     }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,20 +5,35 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Home Assistant",
+      // Debug by attaching to remote Home Asistant server using Remote Python Debugger.
+      // See https://www.home-assistant.io/integrations/debugpy/
+      "name": "HASS: Attach Remote",
+      "type": "python",
+      "request": "attach",
+      "port": 5678,
+      "host": "vm-builder.home",
+      "pathMappings": [
+        {
+          "xlocalRoot": "${workspaceFolder}",
+          "remoteRoot": "/usr/dbonnes/home-assistant"
+        }
+      ],
+    },
+    {
+      "name": "HASS: Launch",
       "type": "python",
       "request": "launch",
       "module": "homeassistant",
       "args": [
         "--debug",
         "-c",
-        "config"
+        ".config"
       ]
     },
     {
       // Debug by attaching to local Home Asistant server using Remote Python Debugger.
       // See https://www.home-assistant.io/integrations/debugpy/
-      "name": "Home Assistant: Attach Local",
+      "name": "HASS: Attach Local",
       "type": "python",
       "request": "attach",
       "port": 5678,
@@ -27,21 +42,6 @@
         {
           "localRoot": "${workspaceFolder}",
           "remoteRoot": "."
-        }
-      ],
-    },
-    {
-      // Debug by attaching to remote Home Asistant server using Remote Python Debugger.
-      // See https://www.home-assistant.io/integrations/debugpy/
-      "name": "Home Assistant: Attach Remote",
-      "type": "python",
-      "request": "attach",
-      "port": 5678,
-      "host": "homeassistant.local",
-      "pathMappings": [
-        {
-          "localRoot": "${workspaceFolder}",
-          "remoteRoot": "/usr/src/homeassistant"
         }
       ],
     }

--- a/homeassistant/components/incomfort/manifest.json
+++ b/homeassistant/components/incomfort/manifest.json
@@ -2,6 +2,6 @@
   "domain": "incomfort",
   "name": "Intergas InComfort/Intouch Lan2RF gateway",
   "documentation": "https://www.home-assistant.io/integrations/incomfort",
-  "requirements": ["incomfort-client==0.4.0"],
+  "requirements": ["incomfort-client==0.4.4"],
   "codeowners": ["@zxdavb"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -817,7 +817,7 @@ iglo==1.2.7
 ihcsdk==2.7.0
 
 # homeassistant.components.incomfort
-incomfort-client==0.4.0
+incomfort-client==0.4.4
 
 # homeassistant.components.influxdb
 influxdb-client==1.14.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump the **incomfort** client library to version 0.4.4 
- main change is updated for aiohttp 3.7.4, including CI, requirements.txt, etc.
- see: https://pypi.org/project/incomfort-client/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
