### PR TITLE
Add support for light color modes

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -652,6 +652,10 @@ class LightEntity(ToggleEntity):
 
         if color_mode in COLOR_MODES_BRIGHTNESS:
             data[ATTR_BRIGHTNESS] = self.brightness
+        elif supported_features & SUPPORT_BRIGHTNESS:
+            # Backwards compatibility for ambiguous / incomplete states
+            # Add warning in 2021.6, remove in 2021.10
+            data[ATTR_BRIGHTNESS] = self.brightness
 
         if color_mode == COLOR_MODE_COLOR_TEMP:
             data[ATTR_COLOR_TEMP] = self.color_temp

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -52,7 +52,7 @@ ATTR_COLOR_MODE = "color_mode"
 ATTR_SUPPORTED_COLOR_MODES = "supported_color_modes"
 # Possible color modes
 COLOR_MODE_UNKNOWN = "color_mode_unknown"  # Ambiguous color mode
-COLOR_MODE_NONE = "color_mode_onoff"  # Must be the only supported mode
+COLOR_MODE_ONOFF = "color_mode_onoff"  # Must be the only supported mode
 COLOR_MODE_DIMMER = "color_mode_dimmer"  # Must be the only supported mode
 COLOR_MODE_COLOR_TEMP = "color_mode_color_temp"
 COLOR_MODE_HS = "color_mode_hs"
@@ -61,8 +61,8 @@ COLOR_MODE_RGB = "color_mode_rgb"
 COLOR_MODE_RGBW = "color_mode_rgbw"
 COLOR_MODE_RGBWW = "color_mode_rgbww"
 
-COLOR_MODES = {
-    COLOR_MODE_NONE,
+VALID_COLOR_MODES = {
+    COLOR_MODE_ONOFF,
     COLOR_MODE_DIMMER,
     COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_HS,
@@ -71,7 +71,7 @@ COLOR_MODES = {
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
 }
-COLOR_MODES_BRIGHTNESS = COLOR_MODES - {COLOR_MODE_NONE}
+COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {COLOR_MODE_ONOFF}
 COLOR_MODES_COLOR = {COLOR_MODE_HS, COLOR_MODE_RGB, COLOR_MODE_XY}
 
 # Float that represents transition time in seconds to make change.
@@ -508,8 +508,8 @@ class LightEntity(ToggleEntity):
                 return COLOR_MODE_COLOR_TEMP
             if COLOR_MODE_DIMMER in supported and self.brightness is not None:
                 return COLOR_MODE_DIMMER
-            if COLOR_MODE_NONE in supported:
-                return COLOR_MODE_NONE
+            if COLOR_MODE_ONOFF in supported:
+                return COLOR_MODE_ONOFF
             return COLOR_MODE_UNKNOWN
 
         return color_mode
@@ -707,7 +707,7 @@ class LightEntity(ToggleEntity):
                 supported_color_modes = {COLOR_MODE_DIMMER}
 
             if not supported_color_modes:
-                supported_color_modes = {COLOR_MODE_NONE}
+                supported_color_modes = {COLOR_MODE_ONOFF}
 
         return supported_color_modes
 

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -641,6 +641,7 @@ class LightEntity(ToggleEntity):
         color_mode = self._light_internal_color_mode
 
         if color_mode not in self._light_internal_supported_color_modes:
+            # Increase severity to warning in 2021.6, reject in 2021.10
             _LOGGER.debug(
                 "%s: set to unsupported color_mode: %s, supported_color_modes: %s",
                 self.entity_id,

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -253,7 +253,8 @@ async def async_setup(hass, config):
             preprocess_turn_on_alternatives(hass, params)
 
         supported_color_modes = light.supported_color_modes
-        # If an RGBWW color is specified, convert to RGB + W for legacy lights
+        # Backwards compatibility: if an RGBWW color is specified, convert to RGB + W
+        # for legacy lights
         if ATTR_RGBW_COLOR in params:
             legacy_supported_color_modes = light._light_internal_supported_color_modes
             if (
@@ -265,7 +266,8 @@ async def async_setup(hass, config):
                 params[ATTR_WHITE_VALUE] = rgbw_color[3]
 
         # If a color is specified, convert to the color space supported by the light
-        # Fall back to hs color if light.supported_color_modes is not implemented
+        # Backwards compatibility: Fall back to hs color if light.supported_color_modes
+        # is not implemented
         if ATTR_HS_COLOR or ATTR_RGB_COLOR or ATTR_XY_COLOR in params:
             if not supported_color_modes or COLOR_MODE_HS in supported_color_modes:
                 if (rgb_color := params.pop(ATTR_RGB_COLOR, None)) is not None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -298,6 +298,10 @@ async def async_setup(hass, config):
             elif COLOR_MODE_RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = color_util.color_xy_to_RGB(*xy_color)
 
+        # Remove deprecated white value if the light supports color mode
+        if supported_color_modes:
+            params.pop(ATTR_WHITE_VALUE, None)
+
         # Zero brightness: Light will be turned off
         if params.get(ATTR_BRIGHTNESS) == 0:
             await light.async_turn_off(**filter_turn_off_params(params))
@@ -670,12 +674,12 @@ class LightEntity(ToggleEntity):
         if color_mode == COLOR_MODE_RGBWW:
             data[ATTR_RGBWW_COLOR] = self.rgbww_color
 
-        if supported_features & SUPPORT_COLOR_TEMP:
+        if supported_features & SUPPORT_COLOR_TEMP and not self.supported_color_modes:
             # Backwards compatibility
             # Add warning in 2021.6, remove in 2021.10
             data[ATTR_COLOR_TEMP] = self.color_temp
 
-        if supported_features & SUPPORT_WHITE_VALUE:
+        if supported_features & SUPPORT_WHITE_VALUE and not self.supported_color_modes:
             # Backwards compatibility
             # Add warning in 2021.6, remove in 2021.10
             data[ATTR_WHITE_VALUE] = self.white_value

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -260,7 +260,9 @@ async def async_setup(hass, config):
         # Backwards compatibility: if an RGBWW color is specified, convert to RGB + W
         # for legacy lights
         if ATTR_RGBW_COLOR in params:
-            legacy_supported_color_modes = light._light_internal_supported_color_modes
+            legacy_supported_color_modes = (
+                light._light_internal_supported_color_modes  # pylint: disable=protected-access
+            )
             if (
                 COLOR_MODE_RGBW in legacy_supported_color_modes
                 and not supported_color_modes
@@ -543,8 +545,10 @@ class LightEntity(ToggleEntity):
         ):
             # Backwards compatibility for rgbw_color added in 2021.4
             # Add warning in 2021.6, remove in 2021.10
-            r, g, b = color_util.color_hs_to_RGB(*self.hs_color)
-            w = self.white_value
+            r, g, b = color_util.color_hs_to_RGB(  # pylint: disable=invalid-name
+                *self.hs_color
+            )
+            w = self.white_value  # pylint: disable=invalid-name
             rgbw_color = (r, g, b, w)
 
         return rgbw_color

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -51,19 +51,19 @@ ATTR_COLOR_MODE = "color_mode"
 # List of color modes supported by the light
 ATTR_SUPPORTED_COLOR_MODES = "supported_color_modes"
 # Possible color modes
-COLOR_MODE_UNKNOWN = "color_mode_unknown"  # Ambiguous color mode
-COLOR_MODE_ONOFF = "color_mode_onoff"  # Must be the only supported mode
-COLOR_MODE_DIMMER = "color_mode_dimmer"  # Must be the only supported mode
-COLOR_MODE_COLOR_TEMP = "color_mode_color_temp"
-COLOR_MODE_HS = "color_mode_hs"
-COLOR_MODE_XY = "color_mode_xy"
-COLOR_MODE_RGB = "color_mode_rgb"
-COLOR_MODE_RGBW = "color_mode_rgbw"
-COLOR_MODE_RGBWW = "color_mode_rgbww"
+COLOR_MODE_UNKNOWN = "unknown"  # Ambiguous color mode
+COLOR_MODE_ONOFF = "onoff"  # Must be the only supported mode
+COLOR_MODE_BRIGHTNESS = "brightness"  # Must be the only supported mode
+COLOR_MODE_COLOR_TEMP = "color_temp"
+COLOR_MODE_HS = "hs"
+COLOR_MODE_XY = "xy"
+COLOR_MODE_RGB = "rgb"
+COLOR_MODE_RGBW = "rgbw"
+COLOR_MODE_RGBWW = "rgbww"
 
 VALID_COLOR_MODES = {
     COLOR_MODE_ONOFF,
-    COLOR_MODE_DIMMER,
+    COLOR_MODE_BRIGHTNESS,
     COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_HS,
     COLOR_MODE_XY,
@@ -506,8 +506,8 @@ class LightEntity(ToggleEntity):
                 return COLOR_MODE_HS
             if COLOR_MODE_COLOR_TEMP in supported and self.color_temp is not None:
                 return COLOR_MODE_COLOR_TEMP
-            if COLOR_MODE_DIMMER in supported and self.brightness is not None:
-                return COLOR_MODE_DIMMER
+            if COLOR_MODE_BRIGHTNESS in supported and self.brightness is not None:
+                return COLOR_MODE_BRIGHTNESS
             if COLOR_MODE_ONOFF in supported:
                 return COLOR_MODE_ONOFF
             return COLOR_MODE_UNKNOWN
@@ -705,7 +705,7 @@ class LightEntity(ToggleEntity):
             if supported_features & SUPPORT_WHITE_VALUE:
                 supported_color_modes.add(COLOR_MODE_RGBW)
             if supported_features & SUPPORT_BRIGHTNESS and not supported_color_modes:
-                supported_color_modes = {COLOR_MODE_DIMMER}
+                supported_color_modes = {COLOR_MODE_BRIGHTNESS}
 
             if not supported_color_modes:
                 supported_color_modes = {COLOR_MODE_ONOFF}

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -17,6 +17,7 @@ from homeassistant.helpers.typing import HomeAssistantType
 from . import (
     ATTR_BRIGHTNESS,
     ATTR_BRIGHTNESS_PCT,
+    ATTR_COLOR_MODE,
     ATTR_COLOR_NAME,
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
@@ -25,9 +26,16 @@ from . import (
     ATTR_KELVIN,
     ATTR_PROFILE,
     ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
+    COLOR_MODE_HS,
+    COLOR_MODE_RGB,
+    COLOR_MODE_RGBW,
+    COLOR_MODE_RGBWW,
+    COLOR_MODE_XY,
     DOMAIN,
 )
 
@@ -48,12 +56,22 @@ COLOR_GROUP = [
     ATTR_HS_COLOR,
     ATTR_COLOR_TEMP,
     ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ATTR_RGBWW_COLOR,
     ATTR_XY_COLOR,
     # The following color attributes are deprecated
     ATTR_PROFILE,
     ATTR_COLOR_NAME,
     ATTR_KELVIN,
 ]
+
+COLOR_MODE_TO_ATTRIBUTE = {
+    COLOR_MODE_HS: ATTR_HS_COLOR,
+    COLOR_MODE_RGB: ATTR_RGB_COLOR,
+    COLOR_MODE_RGBW: ATTR_RGBW_COLOR,
+    COLOR_MODE_RGBWW: ATTR_RGBWW_COLOR,
+    COLOR_MODE_XY: ATTR_XY_COLOR,
+}
 
 DEPRECATED_GROUP = [
     ATTR_BRIGHTNESS_PCT,
@@ -114,11 +132,24 @@ async def _async_reproduce_state(
             if attr in state.attributes:
                 service_data[attr] = state.attributes[attr]
 
-        for color_attr in COLOR_GROUP:
-            # Choose the first color that is specified
-            if color_attr in state.attributes:
+        if ATTR_COLOR_MODE in state.attributes:
+            color_mode = state.attributes[ATTR_COLOR_MODE]
+            if color_attr := COLOR_MODE_TO_ATTRIBUTE.get(color_mode):
+                if color_attr not in state.attributes:
+                    _LOGGER.warning(
+                        "Color mode %s specified but attribute %s missing for: %s",
+                        color_mode,
+                        color_attr,
+                        state.entity_id,
+                    )
+                    return
                 service_data[color_attr] = state.attributes[color_attr]
-                break
+        else:
+            # Fall back to Choosing the first color that is specified
+            for color_attr in COLOR_GROUP:
+                if color_attr in state.attributes:
+                    service_data[color_attr] = state.attributes[color_attr]
+                    break
 
     elif state.state == STATE_OFF:
         service = SERVICE_TURN_OFF

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -31,10 +31,12 @@ from . import (
     ATTR_TRANSITION,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
+    COLOR_MODE_COLOR_TEMP,
     COLOR_MODE_HS,
     COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
+    COLOR_MODE_UNKNOWN,
     COLOR_MODE_XY,
     DOMAIN,
 )
@@ -66,6 +68,7 @@ COLOR_GROUP = [
 ]
 
 COLOR_MODE_TO_ATTRIBUTE = {
+    COLOR_MODE_COLOR_TEMP: ATTR_COLOR_TEMP,
     COLOR_MODE_HS: ATTR_HS_COLOR,
     COLOR_MODE_RGB: ATTR_RGB_COLOR,
     COLOR_MODE_RGBW: ATTR_RGBW_COLOR,
@@ -132,7 +135,12 @@ async def _async_reproduce_state(
             if attr in state.attributes:
                 service_data[attr] = state.attributes[attr]
 
-        if ATTR_COLOR_MODE in state.attributes:
+        if (
+            state.attributes.get(ATTR_COLOR_MODE, COLOR_MODE_UNKNOWN)
+            != COLOR_MODE_UNKNOWN
+        ):
+            # Remove deprecated white value if we got a valid color mode
+            service_data.pop(ATTR_WHITE_VALUE, None)
             color_mode = state.attributes[ATTR_COLOR_MODE]
             if color_attr := COLOR_MODE_TO_ATTRIBUTE.get(color_mode):
                 if color_attr not in state.attributes:

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -8,10 +8,15 @@ from homeassistant import setup
 from homeassistant.components.kulersky.light import DOMAIN
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
     ATTR_HS_COLOR,
     ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ATTR_SUPPORTED_COLOR_MODES,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
+    COLOR_MODE_HS,
+    COLOR_MODE_RGBW,
     SCAN_INTERVAL,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
@@ -65,6 +70,7 @@ async def test_init(hass, mock_light):
     assert state.state == STATE_OFF
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "Bedroom",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
         | SUPPORT_COLOR
         | SUPPORT_WHITE_VALUE,
@@ -168,6 +174,7 @@ async def test_light_update(hass, mock_light):
     assert state.state == STATE_OFF
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "Bedroom",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
         | SUPPORT_COLOR
         | SUPPORT_WHITE_VALUE,
@@ -183,6 +190,7 @@ async def test_light_update(hass, mock_light):
     assert state.state == STATE_UNAVAILABLE
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "Bedroom",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
         | SUPPORT_COLOR
         | SUPPORT_WHITE_VALUE,
@@ -198,12 +206,15 @@ async def test_light_update(hass, mock_light):
     assert state.state == STATE_ON
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "Bedroom",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
         | SUPPORT_COLOR
         | SUPPORT_WHITE_VALUE,
+        ATTR_COLOR_MODE: COLOR_MODE_RGBW,
         ATTR_BRIGHTNESS: 200,
         ATTR_HS_COLOR: (200, 60),
         ATTR_RGB_COLOR: (102, 203, 255),
+        ATTR_RGBW_COLOR: (102, 203, 255, 240),
         ATTR_WHITE_VALUE: 240,
         ATTR_XY_COLOR: (0.184, 0.261),
     }

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -971,7 +971,7 @@ async def test_light_backwards_compatibility_supported_color_modes(hass, light_s
         assert state.attributes["color_mode"] == light.COLOR_MODE_ONOFF
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_DIMMER]
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_BRIGHTNESS]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
@@ -1072,8 +1072,8 @@ async def test_light_backwards_compatibility_color_mode(hass):
     assert state.attributes["color_mode"] == light.COLOR_MODE_ONOFF
 
     state = hass.states.get(entity1.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_DIMMER]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_DIMMER
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_BRIGHTNESS]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_BRIGHTNESS
 
     state = hass.states.get(entity2.entity_id)
     assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_COLOR_TEMP]

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -964,11 +964,11 @@ async def test_light_backwards_compatibility_supported_color_modes(hass, light_s
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_NONE]
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_ONOFF]
     if light_state == STATE_OFF:
         assert "color_mode" not in state.attributes
     else:
-        assert state.attributes["color_mode"] == light.COLOR_MODE_NONE
+        assert state.attributes["color_mode"] == light.COLOR_MODE_ONOFF
 
     state = hass.states.get(entity1.entity_id)
     assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_DIMMER]
@@ -1068,8 +1068,8 @@ async def test_light_backwards_compatibility_color_mode(hass):
     await hass.async_block_till_done()
 
     state = hass.states.get(entity0.entity_id)
-    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_NONE]
-    assert state.attributes["color_mode"] == light.COLOR_MODE_NONE
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_ONOFF]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_ONOFF
 
     state = hass.states.get(entity1.entity_id)
     assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_DIMMER]

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -915,3 +915,482 @@ invalid_no_brightness_no_color_no_transition,,,
         "invalid_no_brightness_no_color_no_transition",
     ):
         assert invalid_profile_name not in profiles.data
+
+
+@pytest.mark.parametrize("light_state", (STATE_ON, STATE_OFF))
+async def test_light_backwards_compatibility_supported_color_modes(hass, light_state):
+    """Test supported_color_modes if not implemented by the entity."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_0", light_state))
+    platform.ENTITIES.append(platform.MockLight("Test_1", light_state))
+    platform.ENTITIES.append(platform.MockLight("Test_2", light_state))
+    platform.ENTITIES.append(platform.MockLight("Test_3", light_state))
+    platform.ENTITIES.append(platform.MockLight("Test_4", light_state))
+    platform.ENTITIES.append(platform.MockLight("Test_5", light_state))
+    platform.ENTITIES.append(platform.MockLight("Test_6", light_state))
+
+    entity0 = platform.ENTITIES[0]
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_features = light.SUPPORT_BRIGHTNESS
+
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
+
+    entity3 = platform.ENTITIES[3]
+    entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
+
+    entity4 = platform.ENTITIES[4]
+    entity4.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_WHITE_VALUE
+    )
+
+    entity5 = platform.ENTITIES[5]
+    entity5.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
+    )
+
+    entity6 = platform.ENTITIES[6]
+    entity6.supported_features = (
+        light.SUPPORT_BRIGHTNESS
+        | light.SUPPORT_COLOR
+        | light.SUPPORT_COLOR_TEMP
+        | light.SUPPORT_WHITE_VALUE
+    )
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_NONE]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_NONE
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_DIMMER]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+
+    state = hass.states.get(entity2.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_COLOR_TEMP]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+
+    state = hass.states.get(entity4.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGBW,
+    ]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+
+    state = hass.states.get(entity5.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_COLOR_TEMP,
+        light.COLOR_MODE_HS,
+    ]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+
+    state = hass.states.get(entity6.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_COLOR_TEMP,
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGBW,
+    ]
+    if light_state == STATE_OFF:
+        assert "color_mode" not in state.attributes
+    else:
+        assert state.attributes["color_mode"] == light.COLOR_MODE_UNKNOWN
+
+
+async def test_light_backwards_compatibility_color_mode(hass):
+    """Test color_mode if not implemented by the entity."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_0", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_1", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_2", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_3", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_4", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_5", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_6", STATE_ON))
+
+    entity0 = platform.ENTITIES[0]
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_features = light.SUPPORT_BRIGHTNESS
+    entity1.brightness = 100
+
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR_TEMP
+    entity2.color_temp = 100
+
+    entity3 = platform.ENTITIES[3]
+    entity3.supported_features = light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR
+    entity3.hs_color = (240, 100)
+
+    entity4 = platform.ENTITIES[4]
+    entity4.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_WHITE_VALUE
+    )
+    entity4.hs_color = (240, 100)
+    entity4.white_value = 100
+
+    entity5 = platform.ENTITIES[5]
+    entity5.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_COLOR_TEMP
+    )
+    entity5.hs_color = (240, 100)
+    entity5.color_temp = 100
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_NONE]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_NONE
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_DIMMER]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_DIMMER
+
+    state = hass.states.get(entity2.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_COLOR_TEMP]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_COLOR_TEMP
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+
+    state = hass.states.get(entity4.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGBW,
+    ]
+    assert state.attributes["color_mode"] == light.COLOR_MODE_RGBW
+
+    state = hass.states.get(entity5.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_COLOR_TEMP,
+        light.COLOR_MODE_HS,
+    ]
+    # hs color prioritized over color_temp, light should report mode COLOR_MODE_HS
+    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+
+
+async def test_light_service_call_rgbw(hass):
+    """Test backwards compatibility for rgbw functionality in service calls."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_legacy_white_value", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
+
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_WHITE_VALUE
+    )
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {light.COLOR_MODE_RGBW}
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGBW,
+    ]
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBW]
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [entity0.entity_id, entity1.entity_id],
+            "brightness_pct": 100,
+            "rgbw_color": (10, 20, 30, 40),
+        },
+        blocking=True,
+    )
+
+    _, data = entity0.last_call("turn_on")
+    assert data == {"brightness": 255, "hs_color": (210.0, 66.667), "white_value": 40}
+    _, data = entity1.last_call("turn_on")
+    assert data == {"brightness": 255, "rgbw_color": (10, 20, 30, 40)}
+
+
+async def test_light_state_rgbw(hass):
+    """Test rgbw color conversion in state updates."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_legacy_white_value", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
+
+    entity0 = platform.ENTITIES[0]
+    legacy_supported_features = (
+        light.SUPPORT_BRIGHTNESS | light.SUPPORT_COLOR | light.SUPPORT_WHITE_VALUE
+    )
+    entity0.supported_features = legacy_supported_features
+    entity0.hs_color = (210.0, 66.667)
+    entity0.rgb_color = "Invalid"  # Should be ignored
+    entity0.rgbww_color = "Invalid"  # Should be ignored
+    entity0.white_value = 40
+    entity0.xy_color = "Invalid"  # Should be ignored
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {light.COLOR_MODE_RGBW}
+    entity1.color_mode = light.COLOR_MODE_RGBW
+    entity1.hs_color = "Invalid"  # Should be ignored
+    entity1.rgb_color = "Invalid"  # Should be ignored
+    entity1.rgbw_color = (1, 2, 3, 4)
+    entity1.rgbww_color = "Invalid"  # Should be ignored
+    entity1.white_value = "Invalid"  # Should be ignored
+    entity1.xy_color = "Invalid"  # Should be ignored
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes == {
+        "color_mode": light.COLOR_MODE_RGBW,
+        "friendly_name": "Test_legacy_white_value",
+        "supported_color_modes": [light.COLOR_MODE_HS, light.COLOR_MODE_RGBW],
+        "supported_features": legacy_supported_features,
+        "hs_color": (210.0, 66.667),
+        "rgb_color": (84, 169, 255),
+        "rgbw_color": (84, 169, 255, 40),
+        "white_value": 40,
+        "xy_color": (0.173, 0.207),
+    }
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes == {
+        "color_mode": light.COLOR_MODE_RGBW,
+        "friendly_name": "Test_rgbw",
+        "supported_color_modes": [light.COLOR_MODE_RGBW],
+        "supported_features": 0,
+        "rgbw_color": (1, 2, 3, 4),
+    }
+
+
+async def test_light_service_call_color_conversion(hass):
+    """Test color conversion in service calls."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgb", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_all", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
+
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_color_modes = {light.COLOR_MODE_HS}
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {light.COLOR_MODE_RGB}
+
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_color_modes = {light.COLOR_MODE_XY}
+
+    entity3 = platform.ENTITIES[3]
+    entity3.supported_color_modes = {
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGB,
+        light.COLOR_MODE_XY,
+    }
+
+    entity4 = platform.ENTITIES[4]
+    entity4.supported_features = light.SUPPORT_COLOR
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGB]
+
+    state = hass.states.get(entity2.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_XY]
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_RGB,
+        light.COLOR_MODE_XY,
+    ]
+
+    state = hass.states.get(entity4.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+                entity1.entity_id,
+                entity2.entity_id,
+                entity3.entity_id,
+                entity4.entity_id,
+            ],
+            "brightness_pct": 100,
+            "hs_color": (240, 100),
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
+    _, data = entity1.last_call("turn_on")
+    assert data == {"brightness": 255, "rgb_color": (0, 0, 255)}
+    _, data = entity2.last_call("turn_on")
+    assert data == {"brightness": 255, "xy_color": (0.136, 0.04)}
+    _, data = entity3.last_call("turn_on")
+    assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
+    _, data = entity4.last_call("turn_on")
+    assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+                entity1.entity_id,
+                entity2.entity_id,
+                entity3.entity_id,
+                entity4.entity_id,
+            ],
+            "brightness_pct": 50,
+            "rgb_color": (128, 0, 0),
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+    _, data = entity1.last_call("turn_on")
+    assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
+    _, data = entity2.last_call("turn_on")
+    assert data == {"brightness": 128, "xy_color": (0.701, 0.299)}
+    _, data = entity3.last_call("turn_on")
+    assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
+    _, data = entity4.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+                entity1.entity_id,
+                entity2.entity_id,
+                entity3.entity_id,
+                entity4.entity_id,
+            ],
+            "brightness_pct": 50,
+            "xy_color": (0.1, 0.8),
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (125.176, 100.0)}
+    _, data = entity1.last_call("turn_on")
+    assert data == {"brightness": 128, "rgb_color": (0, 255, 22)}
+    _, data = entity2.last_call("turn_on")
+    assert data == {"brightness": 128, "xy_color": (0.1, 0.8)}
+    _, data = entity3.last_call("turn_on")
+    assert data == {"brightness": 128, "xy_color": (0.1, 0.8)}
+    _, data = entity4.last_call("turn_on")
+    assert data == {"brightness": 128, "hs_color": (125.176, 100.0)}
+
+
+async def test_light_state_color_conversion(hass):
+    """Test color conversion in state updates."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_hs", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgb", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
+
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_color_modes = {light.COLOR_MODE_HS}
+    entity0.color_mode = light.COLOR_MODE_HS
+    entity0.hs_color = (240, 100)
+    entity0.rgb_color = "Invalid"  # Should be ignored
+    entity0.xy_color = "Invalid"  # Should be ignored
+
+    entity1 = platform.ENTITIES[1]
+    entity1.supported_color_modes = {light.COLOR_MODE_RGB}
+    entity1.color_mode = light.COLOR_MODE_RGB
+    entity1.hs_color = "Invalid"  # Should be ignored
+    entity1.rgb_color = (128, 0, 0)
+    entity1.xy_color = "Invalid"  # Should be ignored
+
+    entity2 = platform.ENTITIES[2]
+    entity2.supported_color_modes = {light.COLOR_MODE_XY}
+    entity2.color_mode = light.COLOR_MODE_XY
+    entity2.hs_color = "Invalid"  # Should be ignored
+    entity2.rgb_color = "Invalid"  # Should be ignored
+    entity2.xy_color = (0.1, 0.8)
+
+    entity3 = platform.ENTITIES[3]
+    entity3.hs_color = (240, 100)
+    entity3.supported_features = light.SUPPORT_COLOR
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+    assert state.attributes["hs_color"] == (240, 100)
+    assert state.attributes["rgb_color"] == (0, 0, 255)
+    assert state.attributes["xy_color"] == (0.136, 0.04)
+
+    state = hass.states.get(entity1.entity_id)
+    assert state.attributes["color_mode"] == light.COLOR_MODE_RGB
+    assert state.attributes["hs_color"] == (0.0, 100.0)
+    assert state.attributes["rgb_color"] == (128, 0, 0)
+    assert state.attributes["xy_color"] == (0.701, 0.299)
+
+    state = hass.states.get(entity2.entity_id)
+    assert state.attributes["color_mode"] == light.COLOR_MODE_XY
+    assert state.attributes["hs_color"] == (125.176, 100.0)
+    assert state.attributes["rgb_color"] == (0, 255, 22)
+    assert state.attributes["xy_color"] == (0.1, 0.8)
+
+    state = hass.states.get(entity3.entity_id)
+    assert state.attributes["color_mode"] == light.COLOR_MODE_HS
+    assert state.attributes["hs_color"] == (240, 100)
+    assert state.attributes["rgb_color"] == (0, 0, 255)
+    assert state.attributes["xy_color"] == (0.136, 0.04)

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -1,4 +1,7 @@
 """Test reproduce state for Light."""
+import pytest
+
+from homeassistant.components import light
 from homeassistant.components.light.reproduce_state import DEPRECATION_WARNING
 from homeassistant.core import State
 
@@ -15,6 +18,8 @@ VALID_HS_COLOR = {"hs_color": (345, 75)}
 VALID_KELVIN = {"kelvin": 4000}
 VALID_PROFILE = {"profile": "relax"}
 VALID_RGB_COLOR = {"rgb_color": (255, 63, 111)}
+VALID_RGBW_COLOR = {"rgbw_color": (255, 63, 111, 10)}
+VALID_RGBWW_COLOR = {"rgbww_color": (255, 63, 111, 10, 20)}
 VALID_XY_COLOR = {"xy_color": (0.59, 0.274)}
 
 
@@ -91,51 +96,51 @@ async def test_reproducing_states(hass, caplog):
 
     expected_calls = []
 
-    expected_off = VALID_BRIGHTNESS
+    expected_off = dict(VALID_BRIGHTNESS)
     expected_off["entity_id"] = "light.entity_off"
     expected_calls.append(expected_off)
 
-    expected_bright = VALID_WHITE_VALUE
+    expected_bright = dict(VALID_WHITE_VALUE)
     expected_bright["entity_id"] = "light.entity_bright"
     expected_calls.append(expected_bright)
 
-    expected_white = VALID_FLASH
+    expected_white = dict(VALID_FLASH)
     expected_white["entity_id"] = "light.entity_white"
     expected_calls.append(expected_white)
 
-    expected_flash = VALID_EFFECT
+    expected_flash = dict(VALID_EFFECT)
     expected_flash["entity_id"] = "light.entity_flash"
     expected_calls.append(expected_flash)
 
-    expected_effect = VALID_TRANSITION
+    expected_effect = dict(VALID_TRANSITION)
     expected_effect["entity_id"] = "light.entity_effect"
     expected_calls.append(expected_effect)
 
-    expected_trans = VALID_COLOR_NAME
+    expected_trans = dict(VALID_COLOR_NAME)
     expected_trans["entity_id"] = "light.entity_trans"
     expected_calls.append(expected_trans)
 
-    expected_name = VALID_COLOR_TEMP
+    expected_name = dict(VALID_COLOR_TEMP)
     expected_name["entity_id"] = "light.entity_name"
     expected_calls.append(expected_name)
 
-    expected_temp = VALID_HS_COLOR
+    expected_temp = dict(VALID_HS_COLOR)
     expected_temp["entity_id"] = "light.entity_temp"
     expected_calls.append(expected_temp)
 
-    expected_hs = VALID_KELVIN
+    expected_hs = dict(VALID_KELVIN)
     expected_hs["entity_id"] = "light.entity_hs"
     expected_calls.append(expected_hs)
 
-    expected_kelvin = VALID_PROFILE
+    expected_kelvin = dict(VALID_PROFILE)
     expected_kelvin["entity_id"] = "light.entity_kelvin"
     expected_calls.append(expected_kelvin)
 
-    expected_profile = VALID_RGB_COLOR
+    expected_profile = dict(VALID_RGB_COLOR)
     expected_profile["entity_id"] = "light.entity_profile"
     expected_calls.append(expected_profile)
 
-    expected_rgb = VALID_XY_COLOR
+    expected_rgb = dict(VALID_XY_COLOR)
     expected_rgb["entity_id"] = "light.entity_rgb"
     expected_calls.append(expected_rgb)
 
@@ -154,6 +159,59 @@ async def test_reproducing_states(hass, caplog):
     assert len(turn_off_calls) == 1
     assert turn_off_calls[0].domain == "light"
     assert turn_off_calls[0].data == {"entity_id": "light.entity_xy"}
+
+
+@pytest.mark.parametrize(
+    "color_mode",
+    (
+        light.COLOR_MODE_COLOR_TEMP,
+        light.COLOR_MODE_DIMMER,
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_ONOFF,
+        light.COLOR_MODE_RGB,
+        light.COLOR_MODE_RGBW,
+        light.COLOR_MODE_RGBWW,
+        light.COLOR_MODE_UNKNOWN,
+        light.COLOR_MODE_XY,
+    ),
+)
+async def test_filter_color_modes(hass, caplog, color_mode):
+    """Test filtering of parameters according to color mode."""
+    hass.states.async_set("light.entity", "off", {})
+    all_colors = {
+        **VALID_WHITE_VALUE,
+        **VALID_COLOR_NAME,
+        **VALID_COLOR_TEMP,
+        **VALID_HS_COLOR,
+        **VALID_KELVIN,
+        **VALID_RGB_COLOR,
+        **VALID_RGBW_COLOR,
+        **VALID_RGBWW_COLOR,
+        **VALID_XY_COLOR,
+    }
+
+    turn_on_calls = async_mock_service(hass, "light", "turn_on")
+
+    await hass.helpers.state.async_reproduce_state(
+        [State("light.entity", "on", {**all_colors, "color_mode": color_mode})]
+    )
+
+    expected_map = {
+        light.COLOR_MODE_COLOR_TEMP: VALID_COLOR_TEMP,
+        light.COLOR_MODE_DIMMER: {},
+        light.COLOR_MODE_HS: VALID_HS_COLOR,
+        light.COLOR_MODE_ONOFF: {},
+        light.COLOR_MODE_RGB: VALID_RGB_COLOR,
+        light.COLOR_MODE_RGBW: VALID_RGBW_COLOR,
+        light.COLOR_MODE_RGBWW: VALID_RGBWW_COLOR,
+        light.COLOR_MODE_UNKNOWN: {**VALID_HS_COLOR, **VALID_WHITE_VALUE},
+        light.COLOR_MODE_XY: VALID_XY_COLOR,
+    }
+    expected = expected_map[color_mode]
+
+    assert len(turn_on_calls) == 1
+    assert turn_on_calls[0].domain == "light"
+    assert dict(turn_on_calls[0].data) == {"entity_id": "light.entity", **expected}
 
 
 async def test_deprecation_warning(hass, caplog):

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -165,7 +165,7 @@ async def test_reproducing_states(hass, caplog):
     "color_mode",
     (
         light.COLOR_MODE_COLOR_TEMP,
-        light.COLOR_MODE_DIMMER,
+        light.COLOR_MODE_BRIGHTNESS,
         light.COLOR_MODE_HS,
         light.COLOR_MODE_ONOFF,
         light.COLOR_MODE_RGB,
@@ -198,7 +198,7 @@ async def test_filter_color_modes(hass, caplog, color_mode):
 
     expected_map = {
         light.COLOR_MODE_COLOR_TEMP: VALID_COLOR_TEMP,
-        light.COLOR_MODE_DIMMER: {},
+        light.COLOR_MODE_BRIGHTNESS: {},
         light.COLOR_MODE_HS: VALID_HS_COLOR,
         light.COLOR_MODE_ONOFF: {},
         light.COLOR_MODE_RGB: VALID_RGB_COLOR,

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -430,8 +430,8 @@ async def test_device_types(hass: HomeAssistant):
             "effect_list": YEELIGHT_MONO_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": bright,
-            "color_mode": "color_mode_dimmer",
-            "supported_color_modes": ["color_mode_dimmer"],
+            "color_mode": "brightness",
+            "supported_color_modes": ["brightness"],
         },
     )
 
@@ -443,8 +443,8 @@ async def test_device_types(hass: HomeAssistant):
             "effect_list": YEELIGHT_MONO_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": bright,
-            "color_mode": "color_mode_dimmer",
-            "supported_color_modes": ["color_mode_dimmer"],
+            "color_mode": "brightness",
+            "supported_color_modes": ["brightness"],
         },
     )
 
@@ -467,13 +467,13 @@ async def test_device_types(hass: HomeAssistant):
             "hs_color": hs_color,
             "rgb_color": rgb_color,
             "xy_color": xy_color,
-            "color_mode": "color_mode_hs",
-            "supported_color_modes": ["color_mode_color_temp", "color_mode_hs"],
+            "color_mode": "hs",
+            "supported_color_modes": ["color_temp", "hs"],
         },
         {
             "supported_features": 0,
-            "color_mode": "color_mode_onoff",
-            "supported_color_modes": ["color_mode_onoff"],
+            "color_mode": "onoff",
+            "supported_color_modes": ["onoff"],
         },
     )
 
@@ -493,15 +493,15 @@ async def test_device_types(hass: HomeAssistant):
             ),
             "brightness": current_brightness,
             "color_temp": ct,
-            "color_mode": "color_mode_color_temp",
-            "supported_color_modes": ["color_mode_color_temp"],
+            "color_mode": "color_temp",
+            "supported_color_modes": ["color_temp"],
         },
         {
             "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": nl_br,
-            "color_mode": "color_mode_dimmer",
-            "supported_color_modes": ["color_mode_dimmer"],
+            "color_mode": "brightness",
+            "supported_color_modes": ["brightness"],
         },
     )
 
@@ -526,15 +526,15 @@ async def test_device_types(hass: HomeAssistant):
             ),
             "brightness": current_brightness,
             "color_temp": ct,
-            "color_mode": "color_mode_color_temp",
-            "supported_color_modes": ["color_mode_color_temp"],
+            "color_mode": "color_temp",
+            "supported_color_modes": ["color_temp"],
         },
         {
             "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": nl_br,
-            "color_mode": "color_mode_dimmer",
-            "supported_color_modes": ["color_mode_dimmer"],
+            "color_mode": "brightness",
+            "supported_color_modes": ["brightness"],
         },
     )
     await _async_test(
@@ -550,8 +550,8 @@ async def test_device_types(hass: HomeAssistant):
             "hs_color": bg_hs_color,
             "rgb_color": bg_rgb_color,
             "xy_color": bg_xy_color,
-            "color_mode": "color_mode_hs",
-            "supported_color_modes": ["color_mode_color_temp", "color_mode_hs"],
+            "color_mode": "hs",
+            "supported_color_modes": ["color_temp", "hs"],
         },
         name=f"{UNIQUE_NAME} ambilight",
         entity_id=f"{ENTITY_LIGHT}_ambilight",

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -430,6 +430,8 @@ async def test_device_types(hass: HomeAssistant):
             "effect_list": YEELIGHT_MONO_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": bright,
+            "color_mode": "color_mode_dimmer",
+            "supported_color_modes": ["color_mode_dimmer"],
         },
     )
 
@@ -441,6 +443,8 @@ async def test_device_types(hass: HomeAssistant):
             "effect_list": YEELIGHT_MONO_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": bright,
+            "color_mode": "color_mode_dimmer",
+            "supported_color_modes": ["color_mode_dimmer"],
         },
     )
 
@@ -463,8 +467,14 @@ async def test_device_types(hass: HomeAssistant):
             "hs_color": hs_color,
             "rgb_color": rgb_color,
             "xy_color": xy_color,
+            "color_mode": "color_mode_hs",
+            "supported_color_modes": ["color_mode_color_temp", "color_mode_hs"],
         },
-        {"supported_features": 0},
+        {
+            "supported_features": 0,
+            "color_mode": "color_mode_onoff",
+            "supported_color_modes": ["color_mode_onoff"],
+        },
     )
 
     # WhiteTemp
@@ -483,11 +493,15 @@ async def test_device_types(hass: HomeAssistant):
             ),
             "brightness": current_brightness,
             "color_temp": ct,
+            "color_mode": "color_mode_color_temp",
+            "supported_color_modes": ["color_mode_color_temp"],
         },
         {
             "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": nl_br,
+            "color_mode": "color_mode_dimmer",
+            "supported_color_modes": ["color_mode_dimmer"],
         },
     )
 
@@ -512,11 +526,15 @@ async def test_device_types(hass: HomeAssistant):
             ),
             "brightness": current_brightness,
             "color_temp": ct,
+            "color_mode": "color_mode_color_temp",
+            "supported_color_modes": ["color_mode_color_temp"],
         },
         {
             "effect_list": YEELIGHT_TEMP_ONLY_EFFECT_LIST,
             "supported_features": SUPPORT_YEELIGHT,
             "brightness": nl_br,
+            "color_mode": "color_mode_dimmer",
+            "supported_color_modes": ["color_mode_dimmer"],
         },
     )
     await _async_test(
@@ -532,6 +550,8 @@ async def test_device_types(hass: HomeAssistant):
             "hs_color": bg_hs_color,
             "rgb_color": bg_rgb_color,
             "xy_color": bg_xy_color,
+            "color_mode": "color_mode_hs",
+            "supported_color_modes": ["color_mode_color_temp", "color_mode_hs"],
         },
         name=f"{UNIQUE_NAME} ambilight",
         entity_id=f"{ENTITY_LIGHT}_ambilight",

--- a/tests/components/zerproc/test_light.py
+++ b/tests/components/zerproc/test_light.py
@@ -7,9 +7,12 @@ import pyzerproc
 from homeassistant import setup
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
     ATTR_HS_COLOR,
     ATTR_RGB_COLOR,
+    ATTR_SUPPORTED_COLOR_MODES,
     ATTR_XY_COLOR,
+    COLOR_MODE_HS,
     SCAN_INTERVAL,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR,
@@ -96,6 +99,7 @@ async def test_init(hass, mock_entry):
     assert state.state == STATE_OFF
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
         ATTR_ICON: "mdi:string-lights",
     }
@@ -104,8 +108,10 @@ async def test_init(hass, mock_entry):
     assert state.state == STATE_ON
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "LEDBlue-33445566",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
         ATTR_ICON: "mdi:string-lights",
+        ATTR_COLOR_MODE: COLOR_MODE_HS,
         ATTR_BRIGHTNESS: 255,
         ATTR_HS_COLOR: (221.176, 100.0),
         ATTR_RGB_COLOR: (0, 80, 255),
@@ -272,6 +278,7 @@ async def test_light_update(hass, mock_light):
     assert state.state == STATE_OFF
     assert state.attributes == {
         ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS],
         ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
         ATTR_ICON: "mdi:string-lights",
     }
@@ -290,6 +297,7 @@ async def test_light_update(hass, mock_light):
         assert state.state == STATE_UNAVAILABLE
         assert state.attributes == {
             ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
+            ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS],
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
             ATTR_ICON: "mdi:string-lights",
         }
@@ -307,6 +315,7 @@ async def test_light_update(hass, mock_light):
         assert state.state == STATE_OFF
         assert state.attributes == {
             ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
+            ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS],
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
             ATTR_ICON: "mdi:string-lights",
         }
@@ -324,8 +333,10 @@ async def test_light_update(hass, mock_light):
         assert state.state == STATE_ON
         assert state.attributes == {
             ATTR_FRIENDLY_NAME: "LEDBlue-CCDDEEFF",
+            ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS],
             ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS | SUPPORT_COLOR,
             ATTR_ICON: "mdi:string-lights",
+            ATTR_COLOR_MODE: COLOR_MODE_HS,
             ATTR_BRIGHTNESS: 220,
             ATTR_HS_COLOR: (261.429, 31.818),
             ATTR_RGB_COLOR: (202, 173, 255),

--- a/tests/testing_config/custom_components/test/light.py
+++ b/tests/testing_config/custom_components/test/light.py
@@ -37,4 +37,17 @@ class MockLight(MockToggleEntity, LightEntity):
     """Mock light class."""
 
     brightness = None
+    supported_color_modes = None
     supported_features = 0
+
+    color_mode = None
+
+    hs_color = None
+    xy_color = None
+    rgb_color = None
+    rgbw_color = None
+    rgbww_color = None
+
+    color_temp = None
+
+    white_value = None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for light color modes, background in https://github.com/home-assistant/architecture/discussions/519.
The color mode will be stored in the light's state, but should *not* be passed to the `turn_on` service call.
When turning on the light, the color mode is non ambiguous because only one color may be given.

Colors will no longer be force-converted through hs color space when updating state or in a `turn_on` call, instead the light's native color space will be respected.

New attributes:
```
ATTR_COLOR_MODE
ATTR_SUPPORTED_COLOR_MODES
ATTR_RGBW_COLOR
ATTR_RGBWW_COLOR
```

Defined color modes:
```
COLOR_MODES = {
    COLOR_MODE_ONOFF,  # The light can be turned on or off. This mode must be the only supported mode if supported by the light
    COLOR_MODE_DIMMER,  # The light can be dimmed. This mode must be the only supported mode if supported by the light
    COLOR_MODE_COLOR_TEMP,  # The light can be dimmed and its color temperature is present in the state.
    COLOR_MODE_HS,  # The light can be dimmed and its color is present in the state as an (h, s) tuple (no brightness).
    COLOR_MODE_XY,  # The light can be dimmed and its color is present in the state as an (x, y) tuple (no brightness).
    COLOR_MODE_RGB,  # The light can be dimmed and its color is present in the state as an (r, g, b) tuple (not normalized).
    COLOR_MODE_RGBW,  # The light can be dimmed and its color is present in the state as an (r, g, b, w) tuple (not normalized).
    COLOR_MODE_RGBWW,  # The light can be dimmed and its color is present in the state as an (r, g, b, cw, ww) tuple (not normalized).
    COLOR_MODE_UNKNOWN,  # The light has reported an ambiguous state (e.g. no brightness for a light which supports `COLOR_MODE_DIMMER`)
}
```

New methods added to the base component `LightEntity`:
- `color_mode`
- `supported_color_modes`
- `rgb_color`
- `rgbw_color`
- `rgbww_color`
- `xy_color`

For backwards compatibility:
- If the light does not implement `supported_color_modes`, it will be calculeted based on `supported_features`
- If the light does not implement `color_mode`, current `color_mode` will be guessed in the following order:
   - `COLOR_MODE_RGBW` if the light's `white_value` and `hs_color` are not `None`
   - `COLOR_MODE_HS` if the light's `hs_color` is not `None`
   - `COLOR_MODE_COLOR_TEMP` if the light's `color_temp` is not None
   - `COLOR_MODE_DIMMER` if the light's `brihtness` is not None
   - `COLOR_MODE_NONE` otherwise
- If the light does not implement `supported_color_modes`, a `turn_on` service call with `ATTR_RGBW_COLOR` will be converted to `ATTR_HS_COLOR` + `ATTR_WHITE_VALUE`.

Deprecated:
```
SUPPORT_BRIGHTNESS = 1
SUPPORT_COLOR_TEMP = 2
SUPPORT_COLOR = 16
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
