### PR TITLE
Deconz websocket fixture

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -1,2 +1,29 @@
 """deconz conftest."""
+
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def mock_deconz_websocket():
+    """No real websocket allowed."""
+    with patch("pydeconz.gateway.WSClient") as mock:
+
+        async def make_websocket_call(data: Optional[dict] = None, state: str = ""):
+            """Generate a websocket call."""
+            async_callback = mock.call_args[0][3]
+
+            if data:
+                mock.return_value.data = data
+                await async_callback("data")
+            elif state:
+                mock.return_value.state = state
+                await async_callback("state")
+            else:
+                raise NotImplementedError
+
+        yield make_websocket_call

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -35,7 +35,6 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
     data = {
         "sensors": {
             "1": {
-                "id": "Presence sensor id",
                 "name": "Presence sensor",
                 "type": "ZHAPresence",
                 "state": {"dark": False, "presence": False},
@@ -43,7 +42,6 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             },
             "2": {
-                "id": "Temperature sensor id",
                 "name": "Temperature sensor",
                 "type": "ZHATemperature",
                 "state": {"temperature": False},
@@ -51,7 +49,6 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             },
             "3": {
-                "id": "CLIP presence sensor id",
                 "name": "CLIP presence sensor",
                 "type": "CLIPPresence",
                 "state": {"presence": False},
@@ -59,7 +56,6 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:02-00",
             },
             "4": {
-                "id": "Vibration sensor id",
                 "name": "Vibration sensor",
                 "type": "ZHAVibration",
                 "state": {
@@ -113,7 +109,6 @@ async def test_allow_clip_sensor(hass, aioclient_mock):
     data = {
         "sensors": {
             "1": {
-                "id": "Presence sensor id",
                 "name": "Presence sensor",
                 "type": "ZHAPresence",
                 "state": {"presence": False},
@@ -121,7 +116,6 @@ async def test_allow_clip_sensor(hass, aioclient_mock):
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             },
             "2": {
-                "id": "CLIP presence sensor id",
                 "name": "CLIP presence sensor",
                 "type": "CLIPPresence",
                 "state": {"presence": False},
@@ -193,7 +187,6 @@ async def test_add_new_binary_sensor_ignored(
 ):
     """Test that adding a new binary sensor is not allowed."""
     sensor = {
-        "id": "Presence sensor id",
         "name": "Presence sensor",
         "type": "ZHAPresence",
         "state": {"presence": False},

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """deCONZ binary sensor platform tests."""
-from copy import deepcopy
+
+from unittest.mock import patch
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_MOTION,
@@ -11,7 +12,6 @@ from homeassistant.components.deconz.const import (
     CONF_MASTER_GATEWAY,
     DOMAIN as DECONZ_DOMAIN,
 )
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.deconz.services import SERVICE_DEVICE_REFRESH
 from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.helpers import entity_registry as er
@@ -23,46 +23,6 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
-SENSORS = {
-    "1": {
-        "id": "Presence sensor id",
-        "name": "Presence sensor",
-        "type": "ZHAPresence",
-        "state": {"dark": False, "presence": False},
-        "config": {"on": True, "reachable": True, "temperature": 10},
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "Temperature sensor id",
-        "name": "Temperature sensor",
-        "type": "ZHATemperature",
-        "state": {"temperature": False},
-        "config": {},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-    "3": {
-        "id": "CLIP presence sensor id",
-        "name": "CLIP presence sensor",
-        "type": "CLIPPresence",
-        "state": {"presence": False},
-        "config": {},
-        "uniqueid": "00:00:00:00:00:00:00:02-00",
-    },
-    "4": {
-        "id": "Vibration sensor id",
-        "name": "Vibration sensor",
-        "type": "ZHAVibration",
-        "state": {
-            "orientation": [1, 2, 3],
-            "tiltangle": 36,
-            "vibration": True,
-            "vibrationstrength": 10,
-        },
-        "config": {"on": True, "reachable": True, "temperature": 10},
-        "uniqueid": "00:00:00:00:00:00:00:03-00",
-    },
-}
-
 
 async def test_no_binary_sensors(hass, aioclient_mock):
     """Test that no sensors in deconz results in no sensor entities."""
@@ -70,14 +30,51 @@ async def test_no_binary_sensors(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_binary_sensors(hass, aioclient_mock):
+async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
     """Test successful creation of binary sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Presence sensor id",
+                "name": "Presence sensor",
+                "type": "ZHAPresence",
+                "state": {"dark": False, "presence": False},
+                "config": {"on": True, "reachable": True, "temperature": 10},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "id": "Temperature sensor id",
+                "name": "Temperature sensor",
+                "type": "ZHATemperature",
+                "state": {"temperature": False},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "3": {
+                "id": "CLIP presence sensor id",
+                "name": "CLIP presence sensor",
+                "type": "CLIPPresence",
+                "state": {"presence": False},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+            "4": {
+                "id": "Vibration sensor id",
+                "name": "Vibration sensor",
+                "type": "ZHAVibration",
+                "state": {
+                    "orientation": [1, 2, 3],
+                    "tiltangle": 36,
+                    "vibration": True,
+                    "vibrationstrength": 10,
+                },
+                "config": {"on": True, "reachable": True, "temperature": 10},
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 3
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
@@ -89,14 +86,14 @@ async def test_binary_sensors(hass, aioclient_mock):
     assert vibration_sensor.state == STATE_ON
     assert vibration_sensor.attributes["device_class"] == DEVICE_CLASS_VIBRATION
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"presence": True},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.presence_sensor").state == STATE_ON
@@ -107,25 +104,41 @@ async def test_binary_sensors(hass, aioclient_mock):
 
     await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
+
     assert len(hass.states.async_all()) == 0
 
 
 async def test_allow_clip_sensor(hass, aioclient_mock):
     """Test that CLIP sensors can be allowed."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass,
-        aioclient_mock,
-        options={CONF_ALLOW_CLIP_SENSOR: True},
-        get_state_response=data,
-    )
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Presence sensor id",
+                "name": "Presence sensor",
+                "type": "ZHAPresence",
+                "state": {"presence": False},
+                "config": {"on": True, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "id": "CLIP presence sensor id",
+                "name": "CLIP presence sensor",
+                "type": "CLIPPresence",
+                "state": {"presence": False},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+        }
+    }
 
-    assert len(hass.states.async_all()) == 4
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(
+            hass, aioclient_mock, options={CONF_ALLOW_CLIP_SENSOR: True}
+        )
+
+    assert len(hass.states.async_all()) == 2
     assert hass.states.get("binary_sensor.presence_sensor").state == STATE_OFF
-    assert hass.states.get("binary_sensor.temperature_sensor") is None
     assert hass.states.get("binary_sensor.clip_presence_sensor").state == STATE_OFF
-    assert hass.states.get("binary_sensor.vibration_sensor").state == STATE_ON
 
     # Disallow clip sensors
 
@@ -134,8 +147,8 @@ async def test_allow_clip_sensor(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 3
-    assert hass.states.get("binary_sensor.clip_presence_sensor") is None
+    assert len(hass.states.async_all()) == 1
+    assert not hass.states.get("binary_sensor.clip_presence_sensor")
 
     # Allow clip sensors
 
@@ -144,48 +157,66 @@ async def test_allow_clip_sensor(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 4
+    assert len(hass.states.async_all()) == 2
     assert hass.states.get("binary_sensor.clip_presence_sensor").state == STATE_OFF
 
 
-async def test_add_new_binary_sensor(hass, aioclient_mock):
+async def test_add_new_binary_sensor(hass, aioclient_mock, mock_deconz_websocket):
     """Test that adding a new binary sensor works."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = get_gateway_from_config_entry(hass, config_entry)
-    assert len(hass.states.async_all()) == 0
-
-    state_added_event = {
+    event_added_sensor = {
         "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
-        "sensor": deepcopy(SENSORS["1"]),
+        "sensor": {
+            "id": "Presence sensor id",
+            "name": "Presence sensor",
+            "type": "ZHAPresence",
+            "state": {"presence": False},
+            "config": {"on": True, "reachable": True},
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
+        },
     }
-    gateway.api.event_handler(state_added_event)
+
+    await setup_deconz_integration(hass, aioclient_mock)
+    assert len(hass.states.async_all()) == 0
+
+    await mock_deconz_websocket(data=event_added_sensor)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("binary_sensor.presence_sensor").state == STATE_OFF
 
 
-async def test_add_new_binary_sensor_ignored(hass, aioclient_mock):
+async def test_add_new_binary_sensor_ignored(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Test that adding a new binary sensor is not allowed."""
+    sensor = {
+        "id": "Presence sensor id",
+        "name": "Presence sensor",
+        "type": "ZHAPresence",
+        "state": {"presence": False},
+        "config": {"on": True, "reachable": True},
+        "uniqueid": "00:00:00:00:00:00:00:00-00",
+    }
+    event_added_sensor = {
+        "t": "event",
+        "e": "added",
+        "r": "sensors",
+        "id": "1",
+        "sensor": sensor,
+    }
+
     config_entry = await setup_deconz_integration(
         hass,
         aioclient_mock,
         options={CONF_MASTER_GATEWAY: True, CONF_ALLOW_NEW_DEVICES: False},
     )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+
     assert len(hass.states.async_all()) == 0
 
-    state_added_event = {
-        "t": "event",
-        "e": "added",
-        "r": "sensors",
-        "id": "1",
-        "sensor": deepcopy(SENSORS["1"]),
-    }
-    gateway.api.event_handler(state_added_event)
+    await mock_deconz_websocket(data=event_added_sensor)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 0
@@ -197,11 +228,7 @@ async def test_add_new_binary_sensor_ignored(hass, aioclient_mock):
     )
 
     aioclient_mock.clear_requests()
-    data = {
-        "groups": {},
-        "lights": {},
-        "sensors": {"1": deepcopy(SENSORS["1"])},
-    }
+    data = {"groups": {}, "lights": {}, "sensors": {"1": sensor}}
     mock_deconz_request(aioclient_mock, config_entry.data, data)
 
     await hass.services.async_call(DECONZ_DOMAIN, SERVICE_DEVICE_REFRESH)

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -1,6 +1,6 @@
 """deCONZ climate platform tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 
@@ -27,14 +27,18 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
+    PRESET_BOOST,
     PRESET_COMFORT,
+    PRESET_ECO,
 )
 from homeassistant.components.deconz.climate import (
     DECONZ_FAN_SMART,
+    DECONZ_PRESET_AUTO,
+    DECONZ_PRESET_COMPLEX,
+    DECONZ_PRESET_HOLIDAY,
     DECONZ_PRESET_MANUAL,
 )
 from homeassistant.components.deconz.const import CONF_ALLOW_CLIP_SENSOR
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_TEMPERATURE,
@@ -48,31 +52,6 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
-SENSORS = {
-    "1": {
-        "id": "Thermostat id",
-        "name": "Thermostat",
-        "type": "ZHAThermostat",
-        "state": {"on": True, "temperature": 2260, "valve": 30},
-        "config": {
-            "battery": 100,
-            "heatsetpoint": 2200,
-            "mode": "auto",
-            "offset": 10,
-            "reachable": True,
-        },
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "CLIP thermostat id",
-        "name": "CLIP thermostat",
-        "type": "CLIPThermostat",
-        "state": {"on": True, "temperature": 2260, "valve": 30},
-        "config": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:02-00",
-    },
-}
-
 
 async def test_no_sensors(hass, aioclient_mock):
     """Test that no sensors in deconz results in no climate entities."""
@@ -80,48 +59,47 @@ async def test_no_sensors(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_simple_climate_device(hass, aioclient_mock):
+async def test_simple_climate_device(hass, aioclient_mock, mock_deconz_websocket):
     """Test successful creation of climate entities.
 
     This is a simple water heater that only supports setting temperature and on and off.
     """
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "config": {
-                "battery": 59,
-                "displayflipped": None,
-                "heatsetpoint": 2100,
-                "locked": True,
-                "mountingmode": None,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "6130553ac247174809bae47144ee23f8",
-            "lastseen": "2020-11-29T19:31Z",
-            "manufacturername": "Danfoss",
-            "modelid": "eTRV0100",
-            "name": "thermostat",
-            "state": {
-                "errorcode": None,
-                "lastupdated": "2020-11-29T19:28:40.665",
-                "mountingmodeactive": False,
-                "on": True,
-                "temperature": 2102,
-                "valve": 24,
-                "windowopen": "Closed",
-            },
-            "swversion": "01.02.0008 01.02",
-            "type": "ZHAThermostat",
-            "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
+    data = {
+        "sensors": {
+            "0": {
+                "config": {
+                    "battery": 59,
+                    "displayflipped": None,
+                    "heatsetpoint": 2100,
+                    "locked": True,
+                    "mountingmode": None,
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "6130553ac247174809bae47144ee23f8",
+                "lastseen": "2020-11-29T19:31Z",
+                "manufacturername": "Danfoss",
+                "modelid": "eTRV0100",
+                "name": "thermostat",
+                "state": {
+                    "errorcode": None,
+                    "lastupdated": "2020-11-29T19:28:40.665",
+                    "mountingmodeactive": False,
+                    "on": True,
+                    "temperature": 2102,
+                    "valve": 24,
+                    "windowopen": "Closed",
+                },
+                "swversion": "01.02.0008 01.02",
+                "type": "ZHAThermostat",
+                "uniqueid": "14:b4:57:ff:fe:d5:4e:77-01-0201",
+            }
         }
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
     climate_thermostat = hass.states.get("climate.thermostat")
@@ -137,28 +115,28 @@ async def test_simple_climate_device(hass, aioclient_mock):
 
     # Event signals thermostat configured off
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "state": {"on": False},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.thermostat").state == STATE_OFF
 
     # Event signals thermostat state on
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "state": {"on": True},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.thermostat").state == HVAC_MODE_HEAT
@@ -198,14 +176,30 @@ async def test_simple_climate_device(hass, aioclient_mock):
         )
 
 
-async def test_climate_device_without_cooling_support(hass, aioclient_mock):
+async def test_climate_device_without_cooling_support(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Test successful creation of sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Thermostat id",
+                "name": "Thermostat",
+                "type": "ZHAThermostat",
+                "state": {"on": True, "temperature": 2260, "valve": 30},
+                "config": {
+                    "battery": 100,
+                    "heatsetpoint": 2200,
+                    "mode": "auto",
+                    "offset": 10,
+                    "reachable": True,
+                },
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
     climate_thermostat = hass.states.get("climate.thermostat")
@@ -224,21 +218,21 @@ async def test_climate_device_without_cooling_support(hass, aioclient_mock):
 
     # Event signals thermostat configured off
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
         "config": {"mode": "off"},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.thermostat").state == STATE_OFF
 
     # Event signals thermostat state on
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
@@ -246,21 +240,21 @@ async def test_climate_device_without_cooling_support(hass, aioclient_mock):
         "config": {"mode": "other"},
         "state": {"on": True},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.thermostat").state == HVAC_MODE_HEAT
 
     # Event signals thermostat state off
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"on": False},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.thermostat").state == STATE_OFF
@@ -336,7 +330,7 @@ async def test_climate_device_without_cooling_support(hass, aioclient_mock):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 2
+    assert len(states) == 2
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
@@ -345,40 +339,41 @@ async def test_climate_device_without_cooling_support(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_climate_device_with_cooling_support(hass, aioclient_mock):
+async def test_climate_device_with_cooling_support(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Test successful creation of sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "config": {
-                "battery": 25,
-                "coolsetpoint": None,
-                "fanmode": None,
-                "heatsetpoint": 2222,
-                "mode": "heat",
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "074549903686a77a12ef0f06c499b1ef",
-            "lastseen": "2020-11-27T13:45Z",
-            "manufacturername": "Zen Within",
-            "modelid": "Zen-01",
-            "name": "Zen-01",
-            "state": {
-                "lastupdated": "2020-11-27T13:42:40.863",
-                "on": False,
-                "temperature": 2320,
-            },
-            "type": "ZHAThermostat",
-            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
+    data = {
+        "sensors": {
+            "0": {
+                "config": {
+                    "battery": 25,
+                    "coolsetpoint": None,
+                    "fanmode": None,
+                    "heatsetpoint": 2222,
+                    "mode": "heat",
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "074549903686a77a12ef0f06c499b1ef",
+                "lastseen": "2020-11-27T13:45Z",
+                "manufacturername": "Zen Within",
+                "modelid": "Zen-01",
+                "name": "Zen-01",
+                "state": {
+                    "lastupdated": "2020-11-27T13:42:40.863",
+                    "on": False,
+                    "temperature": 2320,
+                },
+                "type": "ZHAThermostat",
+                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
+            }
         }
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
     climate_thermostat = hass.states.get("climate.zen_01")
@@ -395,14 +390,14 @@ async def test_climate_device_with_cooling_support(hass, aioclient_mock):
 
     # Event signals thermostat state cool
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "config": {"mode": "cool"},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.zen_01").state == HVAC_MODE_COOL
@@ -422,40 +417,41 @@ async def test_climate_device_with_cooling_support(hass, aioclient_mock):
     assert aioclient_mock.mock_calls[1][2] == {"coolsetpoint": 2000.0}
 
 
-async def test_climate_device_with_fan_support(hass, aioclient_mock):
+async def test_climate_device_with_fan_support(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Test successful creation of sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "config": {
-                "battery": 25,
-                "coolsetpoint": None,
-                "fanmode": "auto",
-                "heatsetpoint": 2222,
-                "mode": "heat",
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "074549903686a77a12ef0f06c499b1ef",
-            "lastseen": "2020-11-27T13:45Z",
-            "manufacturername": "Zen Within",
-            "modelid": "Zen-01",
-            "name": "Zen-01",
-            "state": {
-                "lastupdated": "2020-11-27T13:42:40.863",
-                "on": False,
-                "temperature": 2320,
-            },
-            "type": "ZHAThermostat",
-            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
+    data = {
+        "sensors": {
+            "0": {
+                "config": {
+                    "battery": 25,
+                    "coolsetpoint": None,
+                    "fanmode": "auto",
+                    "heatsetpoint": 2222,
+                    "mode": "heat",
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "074549903686a77a12ef0f06c499b1ef",
+                "lastseen": "2020-11-27T13:45Z",
+                "manufacturername": "Zen Within",
+                "modelid": "Zen-01",
+                "name": "Zen-01",
+                "state": {
+                    "lastupdated": "2020-11-27T13:42:40.863",
+                    "on": False,
+                    "temperature": 2320,
+                },
+                "type": "ZHAThermostat",
+                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
+            }
         }
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
     climate_thermostat = hass.states.get("climate.zen_01")
@@ -473,21 +469,21 @@ async def test_climate_device_with_fan_support(hass, aioclient_mock):
 
     # Event signals fan mode defaults to off
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "config": {"fanmode": "unsupported"},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.zen_01").attributes["fan_mode"] == FAN_OFF
 
     # Event signals unsupported fan mode
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
@@ -495,21 +491,21 @@ async def test_climate_device_with_fan_support(hass, aioclient_mock):
         "config": {"fanmode": "unsupported"},
         "state": {"on": True},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.zen_01").attributes["fan_mode"] == FAN_ON
 
     # Event signals unsupported fan mode
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "config": {"fanmode": "unsupported"},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.zen_01").attributes["fan_mode"] == FAN_ON
@@ -549,41 +545,40 @@ async def test_climate_device_with_fan_support(hass, aioclient_mock):
         )
 
 
-async def test_climate_device_with_preset(hass, aioclient_mock):
+async def test_climate_device_with_preset(hass, aioclient_mock, mock_deconz_websocket):
     """Test successful creation of sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "config": {
-                "battery": 25,
-                "coolsetpoint": None,
-                "fanmode": None,
-                "heatsetpoint": 2222,
-                "mode": "heat",
-                "preset": "auto",
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-            },
-            "ep": 1,
-            "etag": "074549903686a77a12ef0f06c499b1ef",
-            "lastseen": "2020-11-27T13:45Z",
-            "manufacturername": "Zen Within",
-            "modelid": "Zen-01",
-            "name": "Zen-01",
-            "state": {
-                "lastupdated": "2020-11-27T13:42:40.863",
-                "on": False,
-                "temperature": 2320,
-            },
-            "type": "ZHAThermostat",
-            "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
+    data = {
+        "sensors": {
+            "0": {
+                "config": {
+                    "battery": 25,
+                    "coolsetpoint": None,
+                    "fanmode": None,
+                    "heatsetpoint": 2222,
+                    "mode": "heat",
+                    "preset": "auto",
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "074549903686a77a12ef0f06c499b1ef",
+                "lastseen": "2020-11-27T13:45Z",
+                "manufacturername": "Zen Within",
+                "modelid": "Zen-01",
+                "name": "Zen-01",
+                "state": {
+                    "lastupdated": "2020-11-27T13:42:40.863",
+                    "on": False,
+                    "temperature": 2320,
+                },
+                "type": "ZHAThermostat",
+                "uniqueid": "00:24:46:00:00:11:6f:56-01-0201",
+            }
         }
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
 
@@ -591,27 +586,27 @@ async def test_climate_device_with_preset(hass, aioclient_mock):
     assert climate_zen_01.state == HVAC_MODE_HEAT
     assert climate_zen_01.attributes["current_temperature"] == 23.2
     assert climate_zen_01.attributes["temperature"] == 22.2
-    assert climate_zen_01.attributes["preset_mode"] == "auto"
+    assert climate_zen_01.attributes["preset_mode"] == DECONZ_PRESET_AUTO
     assert climate_zen_01.attributes["preset_modes"] == [
-        "auto",
-        "boost",
-        "comfort",
-        "complex",
-        "eco",
-        "holiday",
-        "manual",
+        DECONZ_PRESET_AUTO,
+        PRESET_BOOST,
+        PRESET_COMFORT,
+        DECONZ_PRESET_COMPLEX,
+        PRESET_ECO,
+        DECONZ_PRESET_HOLIDAY,
+        DECONZ_PRESET_MANUAL,
     ]
 
     # Event signals deCONZ preset
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "config": {"preset": "manual"},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert (
@@ -621,14 +616,14 @@ async def test_climate_device_with_preset(hass, aioclient_mock):
 
     # Event signals unknown preset
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "0",
         "config": {"preset": "unsupported"},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.zen_01").attributes["preset_mode"] is None
@@ -670,19 +665,38 @@ async def test_climate_device_with_preset(hass, aioclient_mock):
 
 async def test_clip_climate_device(hass, aioclient_mock):
     """Test successful creation of sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass,
-        aioclient_mock,
-        options={CONF_ALLOW_CLIP_SENSOR: True},
-        get_state_response=data,
-    )
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Thermostat id",
+                "name": "Thermostat",
+                "type": "ZHAThermostat",
+                "state": {"on": True, "temperature": 2260, "valve": 30},
+                "config": {
+                    "battery": 100,
+                    "heatsetpoint": 2200,
+                    "mode": "auto",
+                    "offset": 10,
+                    "reachable": True,
+                },
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "id": "CLIP thermostat id",
+                "name": "CLIP thermostat",
+                "type": "CLIPThermostat",
+                "state": {"on": True, "temperature": 2260, "valve": 30},
+                "config": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(
+            hass, aioclient_mock, options={CONF_ALLOW_CLIP_SENSOR: True}
+        )
 
     assert len(hass.states.async_all()) == 3
-    assert hass.states.get("climate.thermostat").state == HVAC_MODE_AUTO
-    assert hass.states.get("sensor.thermostat") is None
-    assert hass.states.get("sensor.thermostat_battery_level").state == "100"
     assert hass.states.get("climate.clip_thermostat").state == HVAC_MODE_HEAT
 
     # Disallow clip sensors
@@ -693,7 +707,7 @@ async def test_clip_climate_device(hass, aioclient_mock):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 2
-    assert hass.states.get("climate.clip_thermostat") is None
+    assert not hass.states.get("climate.clip_thermostat")
 
     # Allow clip sensors
 
@@ -706,45 +720,71 @@ async def test_clip_climate_device(hass, aioclient_mock):
     assert hass.states.get("climate.clip_thermostat").state == HVAC_MODE_HEAT
 
 
-async def test_verify_state_update(hass, aioclient_mock):
+async def test_verify_state_update(hass, aioclient_mock, mock_deconz_websocket):
     """Test that state update properly."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Thermostat id",
+                "name": "Thermostat",
+                "type": "ZHAThermostat",
+                "state": {"on": True, "temperature": 2260, "valve": 30},
+                "config": {
+                    "battery": 100,
+                    "heatsetpoint": 2200,
+                    "mode": "auto",
+                    "offset": 10,
+                    "reachable": True,
+                },
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert hass.states.get("climate.thermostat").state == HVAC_MODE_AUTO
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"on": False},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("climate.thermostat").state == HVAC_MODE_AUTO
-    assert gateway.api.sensors["1"].changed_keys == {"state", "r", "t", "on", "e", "id"}
 
 
-async def test_add_new_climate_device(hass, aioclient_mock):
+async def test_add_new_climate_device(hass, aioclient_mock, mock_deconz_websocket):
     """Test that adding a new climate device works."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = get_gateway_from_config_entry(hass, config_entry)
-    assert len(hass.states.async_all()) == 0
-
-    state_added_event = {
+    event_sensor_added = {
         "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
-        "sensor": deepcopy(SENSORS["1"]),
+        "sensor": {
+            "id": "Thermostat id",
+            "name": "Thermostat",
+            "type": "ZHAThermostat",
+            "state": {"on": True, "temperature": 2260, "valve": 30},
+            "config": {
+                "battery": 100,
+                "heatsetpoint": 2200,
+                "mode": "auto",
+                "offset": 10,
+                "reachable": True,
+            },
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
+        },
     }
-    gateway.api.event_handler(state_added_event)
+
+    await setup_deconz_integration(hass, aioclient_mock)
+    assert len(hass.states.async_all()) == 0
+
+    await mock_deconz_websocket(data=event_sensor_added)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 2

--- a/tests/components/deconz/test_climate.py
+++ b/tests/components/deconz/test_climate.py
@@ -183,7 +183,6 @@ async def test_climate_device_without_cooling_support(
     data = {
         "sensors": {
             "1": {
-                "id": "Thermostat id",
                 "name": "Thermostat",
                 "type": "ZHAThermostat",
                 "state": {"on": True, "temperature": 2260, "valve": 30},
@@ -668,7 +667,6 @@ async def test_clip_climate_device(hass, aioclient_mock):
     data = {
         "sensors": {
             "1": {
-                "id": "Thermostat id",
                 "name": "Thermostat",
                 "type": "ZHAThermostat",
                 "state": {"on": True, "temperature": 2260, "valve": 30},
@@ -682,7 +680,6 @@ async def test_clip_climate_device(hass, aioclient_mock):
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             },
             "2": {
-                "id": "CLIP thermostat id",
                 "name": "CLIP thermostat",
                 "type": "CLIPThermostat",
                 "state": {"on": True, "temperature": 2260, "valve": 30},
@@ -725,7 +722,6 @@ async def test_verify_state_update(hass, aioclient_mock, mock_deconz_websocket):
     data = {
         "sensors": {
             "1": {
-                "id": "Thermostat id",
                 "name": "Thermostat",
                 "type": "ZHAThermostat",
                 "state": {"on": True, "temperature": 2260, "valve": 30},
@@ -760,7 +756,7 @@ async def test_verify_state_update(hass, aioclient_mock, mock_deconz_websocket):
 
 async def test_add_new_climate_device(hass, aioclient_mock, mock_deconz_websocket):
     """Test that adding a new climate device works."""
-    event_sensor_added = {
+    event_added_sensor = {
         "t": "event",
         "e": "added",
         "r": "sensors",
@@ -784,7 +780,7 @@ async def test_add_new_climate_device(hass, aioclient_mock, mock_deconz_websocke
     await setup_deconz_integration(hass, aioclient_mock)
     assert len(hass.states.async_all()) == 0
 
-    await mock_deconz_websocket(data=event_sensor_added)
+    await mock_deconz_websocket(data=event_added_sensor)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 2

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -17,7 +17,6 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
     data = {
         "sensors": {
             "1": {
-                "id": "Switch 1 id",
                 "name": "Switch 1",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},
@@ -25,7 +24,6 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             },
             "2": {
-                "id": "Switch 2 id",
                 "name": "Switch 2",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},
@@ -33,7 +31,6 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:02-00",
             },
             "3": {
-                "id": "Switch 3 id",
                 "name": "Switch 3",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000, "gesture": 1},
@@ -41,7 +38,6 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:03-00",
             },
             "4": {
-                "id": "Switch 4 id",
                 "name": "Switch 4",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000, "gesture": 1},
@@ -49,7 +45,6 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:04-00",
             },
             "5": {
-                "id": "ZHA remote 1 id",
                 "name": "ZHA remote 1",
                 "type": "ZHASwitch",
                 "state": {"angle": 0, "buttonevent": 1000, "xy": [0.0, 0.0]},

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -1,125 +1,169 @@
 """Test deCONZ remote events."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
+from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.helpers.device_registry import async_entries_for_config_entry
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
 from tests.common import async_capture_events
 
-SENSORS = {
-    "1": {
-        "id": "Switch 1 id",
-        "name": "Switch 1",
-        "type": "ZHASwitch",
-        "state": {"buttonevent": 1000},
-        "config": {},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-    "2": {
-        "id": "Switch 2 id",
-        "name": "Switch 2",
-        "type": "ZHASwitch",
-        "state": {"buttonevent": 1000},
-        "config": {"battery": 100},
-        "uniqueid": "00:00:00:00:00:00:00:02-00",
-    },
-    "3": {
-        "id": "Switch 3 id",
-        "name": "Switch 3",
-        "type": "ZHASwitch",
-        "state": {"buttonevent": 1000, "gesture": 1},
-        "config": {"battery": 100},
-        "uniqueid": "00:00:00:00:00:00:00:03-00",
-    },
-    "4": {
-        "id": "Switch 4 id",
-        "name": "Switch 4",
-        "type": "ZHASwitch",
-        "state": {"buttonevent": 1000, "gesture": 1},
-        "config": {"battery": 100},
-        "uniqueid": "00:00:00:00:00:00:00:04-00",
-    },
-    "5": {
-        "id": "ZHA remote 1 id",
-        "name": "ZHA remote 1",
-        "type": "ZHASwitch",
-        "state": {"angle": 0, "buttonevent": 1000, "xy": [0.0, 0.0]},
-        "config": {"group": "4,5,6", "reachable": True, "on": True},
-        "uniqueid": "00:00:00:00:00:00:00:05-00",
-    },
-}
 
-
-async def test_deconz_events(hass, aioclient_mock):
+async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
     """Test successful creation of deconz events."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Switch 1 id",
+                "name": "Switch 1",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "2": {
+                "id": "Switch 2 id",
+                "name": "Switch 2",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000},
+                "config": {"battery": 100},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+            "3": {
+                "id": "Switch 3 id",
+                "name": "Switch 3",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000, "gesture": 1},
+                "config": {"battery": 100},
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+            "4": {
+                "id": "Switch 4 id",
+                "name": "Switch 4",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000, "gesture": 1},
+                "config": {"battery": 100},
+                "uniqueid": "00:00:00:00:00:00:00:04-00",
+            },
+            "5": {
+                "id": "ZHA remote 1 id",
+                "name": "ZHA remote 1",
+                "type": "ZHASwitch",
+                "state": {"angle": 0, "buttonevent": 1000, "xy": [0.0, 0.0]},
+                "config": {"group": "4,5,6", "reachable": True, "on": True},
+                "uniqueid": "00:00:00:00:00:00:00:05-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
 
     assert len(hass.states.async_all()) == 3
-    assert len(gateway.events) == 5
-    assert hass.states.get("sensor.switch_1") is None
-    assert hass.states.get("sensor.switch_1_battery_level") is None
-    assert hass.states.get("sensor.switch_2") is None
+    # 5 switches + 2 additional devices for deconz service and host
+    assert (
+        len(async_entries_for_config_entry(device_registry, config_entry.entry_id)) == 7
+    )
     assert hass.states.get("sensor.switch_2_battery_level").state == "100"
+    assert hass.states.get("sensor.switch_3_battery_level").state == "100"
+    assert hass.states.get("sensor.switch_4_battery_level").state == "100"
 
-    events = async_capture_events(hass, CONF_DECONZ_EVENT)
+    captured_events = async_capture_events(hass, CONF_DECONZ_EVENT)
 
-    gateway.api.sensors["1"].update({"state": {"buttonevent": 2000}})
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"buttonevent": 2000},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
-    assert len(events) == 1
-    assert events[0].data == {
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
+    )
+
+    assert len(captured_events) == 1
+    assert captured_events[0].data == {
         "id": "switch_1",
         "unique_id": "00:00:00:00:00:00:00:01",
         "event": 2000,
-        "device_id": gateway.events[0].device_id,
+        "device_id": device.id,
     }
 
-    gateway.api.sensors["3"].update({"state": {"buttonevent": 2000}})
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "3",
+        "state": {"buttonevent": 2000},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
-    assert len(events) == 2
-    assert events[1].data == {
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:03")}
+    )
+
+    assert len(captured_events) == 2
+    assert captured_events[1].data == {
         "id": "switch_3",
         "unique_id": "00:00:00:00:00:00:00:03",
         "event": 2000,
         "gesture": 1,
-        "device_id": gateway.events[2].device_id,
+        "device_id": device.id,
     }
 
-    gateway.api.sensors["4"].update({"state": {"gesture": 0}})
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "4",
+        "state": {"gesture": 0},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
-    assert len(events) == 3
-    assert events[2].data == {
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:04")}
+    )
+
+    assert len(captured_events) == 3
+    assert captured_events[2].data == {
         "id": "switch_4",
         "unique_id": "00:00:00:00:00:00:00:04",
         "event": 1000,
         "gesture": 0,
-        "device_id": gateway.events[3].device_id,
+        "device_id": device.id,
     }
 
-    gateway.api.sensors["5"].update(
-        {"state": {"buttonevent": 6002, "angle": 110, "xy": [0.5982, 0.3897]}}
-    )
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "5",
+        "state": {"buttonevent": 6002, "angle": 110, "xy": [0.5982, 0.3897]},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
-    assert len(events) == 4
-    assert events[3].data == {
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:05")}
+    )
+
+    assert len(captured_events) == 4
+    assert captured_events[3].data == {
         "id": "zha_remote_1",
         "unique_id": "00:00:00:00:00:00:00:05",
         "event": 6002,
         "angle": 110,
         "xy": [0.5982, 0.3897],
-        "device_id": gateway.events[4].device_id,
+        "device_id": device.id,
     }
 
     await hass.config_entries.async_unload(config_entry.entry_id)
@@ -128,9 +172,7 @@ async def test_deconz_events(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 3
     for state in states:
         assert state.state == STATE_UNAVAILABLE
-    assert len(gateway.events) == 0
 
     await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 0
-    assert len(gateway.events) == 0

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -1,11 +1,10 @@
 """deCONZ device automation tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
 from homeassistant.components.deconz import device_trigger
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.device_trigger import CONF_SUBTYPE
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -38,7 +37,7 @@ SENSORS = {
         "name": "TRÅDFRI on/off switch ",
         "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
         "swversion": "1.4.018",
-        CONF_TYPE: "ZHASwitch",
+        "type": "ZHASwitch",
         "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
     }
 }
@@ -46,60 +45,86 @@ SENSORS = {
 
 async def test_get_triggers(hass, aioclient_mock):
     """Test triggers work."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "alert": "none",
+                    "battery": 60,
+                    "group": "10",
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "1b355c0b6d2af28febd7ca9165881952",
+                "manufacturername": "IKEA of Sweden",
+                "mode": 1,
+                "modelid": "TRADFRI on/off switch",
+                "name": "TRÅDFRI on/off switch ",
+                "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
+                "swversion": "1.4.018",
+                "type": "ZHASwitch",
+                "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
     )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
-    device_id = gateway.events[0].device_id
-    triggers = await async_get_device_automations(hass, "trigger", device_id)
+
+    assert device_trigger._get_deconz_event_from_device_id(hass, device.id)
+
+    triggers = await async_get_device_automations(hass, "trigger", device.id)
 
     expected_triggers = [
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DECONZ_DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
         },
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DECONZ_DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
         },
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DECONZ_DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_RELEASE,
             CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
         },
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DECONZ_DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_OFF,
         },
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DECONZ_DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_PRESS,
             CONF_SUBTYPE: device_trigger.CONF_TURN_OFF,
         },
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: DECONZ_DOMAIN,
             CONF_PLATFORM: "device",
             CONF_TYPE: device_trigger.CONF_LONG_RELEASE,
             CONF_SUBTYPE: device_trigger.CONF_TURN_OFF,
         },
         {
-            CONF_DEVICE_ID: device_id,
+            CONF_DEVICE_ID: device.id,
             CONF_DOMAIN: SENSOR_DOMAIN,
             ATTR_ENTITY_ID: "sensor.tradfri_on_off_switch_battery_level",
             CONF_PLATFORM: "device",
@@ -110,27 +135,14 @@ async def test_get_triggers(hass, aioclient_mock):
     assert_lists_same(triggers, expected_triggers)
 
 
-async def test_helper_successful(hass, aioclient_mock):
-    """Verify trigger helper."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
-    device_id = gateway.events[0].device_id
-    deconz_event = device_trigger._get_deconz_event_from_device_id(hass, device_id)
-    assert deconz_event == gateway.events[0]
-
-
 async def test_helper_no_match(hass, aioclient_mock):
     """Verify trigger helper returns None when no event could be matched."""
     await setup_deconz_integration(hass, aioclient_mock)
     deconz_event = device_trigger._get_deconz_event_from_device_id(hass, "mock-id")
-    assert deconz_event is None
+    assert not deconz_event
 
 
 async def test_helper_no_gateway_exist(hass):
     """Verify trigger helper returns None when no gateway exist."""
     deconz_event = device_trigger._get_deconz_event_from_device_id(hass, "mock-id")
-    assert deconz_event is None
+    assert not deconz_event

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -186,7 +186,6 @@ async def test_connection_status_signalling(
     data = {
         "sensors": {
             "1": {
-                "id": "id",
                 "name": "presence",
                 "type": "ZHAPresence",
                 "state": {"presence": False},

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -103,7 +103,6 @@ async def setup_deconz_integration(
     *,
     config=ENTRY_CONFIG,
     options=ENTRY_OPTIONS,
-    get_state_response=DECONZ_WEB_REQUEST,
     entry_id="1",
     unique_id=BRIDGEID,
     source="user",
@@ -121,7 +120,7 @@ async def setup_deconz_integration(
     config_entry.add_to_hass(hass)
 
     if aioclient_mock:
-        mock_deconz_request(aioclient_mock, config, get_state_response)
+        mock_deconz_request(aioclient_mock, config, DECONZ_WEB_REQUEST)
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest.mock import Mock, patch
 
 import pydeconz
+from pydeconz.websocket import STATE_RUNNING, STATE_STARTING
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -29,8 +30,14 @@ from homeassistant.components.ssdp import (
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, SOURCE_SSDP
-from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PORT,
+    CONTENT_TYPE_JSON,
+    STATE_OFF,
+    STATE_UNAVAILABLE,
+)
 
 from tests.common import MockConfigEntry
 
@@ -116,8 +123,7 @@ async def setup_deconz_integration(
     if aioclient_mock:
         mock_deconz_request(aioclient_mock, config, get_state_response)
 
-    with patch("pydeconz.DeconzSession.start", return_value=True):
-        await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     return config_entry
@@ -173,21 +179,36 @@ async def test_gateway_setup_fails(hass):
     assert not hass.data[DECONZ_DOMAIN]
 
 
-async def test_connection_status_signalling(hass, aioclient_mock):
+async def test_connection_status_signalling(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Make sure that connection status triggers a dispatcher send."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "id": "id",
+                "name": "presence",
+                "type": "ZHAPresence",
+                "state": {"presence": False},
+                "config": {"on": True, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
-    event_call = Mock()
-    unsub = async_dispatcher_connect(hass, gateway.signal_reachable, event_call)
+    assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
-    gateway.async_connection_status_callback(False)
+    await mock_deconz_websocket(state=STATE_STARTING)
     await hass.async_block_till_done()
 
-    assert gateway.available is False
-    assert len(event_call.mock_calls) == 1
+    assert hass.states.get("binary_sensor.presence").state == STATE_UNAVAILABLE
 
-    unsub()
+    await mock_deconz_websocket(state=STATE_RUNNING)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
 
 async def test_update_address(hass, aioclient_mock):

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -1,7 +1,6 @@
 """Test deCONZ component setup process."""
 
 import asyncio
-from copy import deepcopy
 from unittest.mock import patch
 
 from homeassistant.components.deconz import (
@@ -71,15 +70,14 @@ async def test_setup_entry_multiple_gateways(hass, aioclient_mock):
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
 
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["config"]["bridgeid"] = "01234E56789B"
-    config_entry2 = await setup_deconz_integration(
-        hass,
-        aioclient_mock,
-        get_state_response=data,
-        entry_id="2",
-        unique_id="01234E56789B",
-    )
+    data = {"config": {"bridgeid": "01234E56789B"}}
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry2 = await setup_deconz_integration(
+            hass,
+            aioclient_mock,
+            entry_id="2",
+            unique_id="01234E56789B",
+        )
 
     assert len(hass.data[DECONZ_DOMAIN]) == 2
     assert hass.data[DECONZ_DOMAIN][config_entry.unique_id].master
@@ -100,15 +98,14 @@ async def test_unload_entry_multiple_gateways(hass, aioclient_mock):
     config_entry = await setup_deconz_integration(hass, aioclient_mock)
     aioclient_mock.clear_requests()
 
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["config"]["bridgeid"] = "01234E56789B"
-    config_entry2 = await setup_deconz_integration(
-        hass,
-        aioclient_mock,
-        get_state_response=data,
-        entry_id="2",
-        unique_id="01234E56789B",
-    )
+    data = {"config": {"bridgeid": "01234E56789B"}}
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry2 = await setup_deconz_integration(
+            hass,
+            aioclient_mock,
+            entry_id="2",
+            unique_id="01234E56789B",
+        )
 
     assert len(hass.data[DECONZ_DOMAIN]) == 2
 

--- a/tests/components/deconz/test_init.py
+++ b/tests/components/deconz/test_init.py
@@ -151,12 +151,8 @@ async def test_update_group_unique_id(hass):
     await async_update_group_unique_id(hass, entry)
 
     assert entry.data == {CONF_API_KEY: "1", CONF_HOST: "2", CONF_PORT: "3"}
-
-    old_entity = registry.async_get(f"{LIGHT_DOMAIN}.old")
-    assert old_entity.unique_id == f"{new_unique_id}-OLD"
-
-    new_entity = registry.async_get(f"{LIGHT_DOMAIN}.new")
-    assert new_entity.unique_id == f"{new_unique_id}-NEW"
+    assert registry.async_get(f"{LIGHT_DOMAIN}.old").unique_id == f"{new_unique_id}-OLD"
+    assert registry.async_get(f"{LIGHT_DOMAIN}.new").unique_id == f"{new_unique_id}-NEW"
 
 
 async def test_update_group_unique_id_no_legacy_group_id(hass):
@@ -181,5 +177,4 @@ async def test_update_group_unique_id_no_legacy_group_id(hass):
 
     await async_update_group_unique_id(hass, entry)
 
-    old_entity = registry.async_get(f"{LIGHT_DOMAIN}.old")
-    assert old_entity.unique_id == f"{old_unique_id}-OLD"
+    assert registry.async_get(f"{LIGHT_DOMAIN}.old").unique_id == f"{old_unique_id}-OLD"

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -1,11 +1,10 @@
 """deCONZ light platform tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
 import pytest
 
 from homeassistant.components.deconz.const import CONF_ALLOW_DECONZ_GROUPS
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
@@ -36,75 +35,6 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
-GROUPS = {
-    "1": {
-        "id": "Light group id",
-        "name": "Light group",
-        "type": "LightGroup",
-        "state": {"all_on": False, "any_on": True},
-        "action": {},
-        "scenes": [],
-        "lights": ["1", "2"],
-    },
-    "2": {
-        "id": "Empty group id",
-        "name": "Empty group",
-        "type": "LightGroup",
-        "state": {},
-        "action": {},
-        "scenes": [],
-        "lights": [],
-    },
-}
-
-LIGHTS = {
-    "1": {
-        "id": "RGB light id",
-        "name": "RGB light",
-        "state": {
-            "on": True,
-            "bri": 255,
-            "colormode": "xy",
-            "effect": "colorloop",
-            "xy": (500, 500),
-            "reachable": True,
-        },
-        "type": "Extended color light",
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "ctmax": 454,
-        "ctmin": 155,
-        "id": "Tunable white light id",
-        "name": "Tunable white light",
-        "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
-        "type": "Tunable white light",
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-    "3": {
-        "id": "On off switch id",
-        "name": "On off switch",
-        "type": "On/Off plug-in unit",
-        "state": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:02-00",
-    },
-    "4": {
-        "name": "On off light",
-        "state": {"on": True, "reachable": True},
-        "type": "On and Off light",
-        "uniqueid": "00:00:00:00:00:00:00:03-00",
-    },
-    "5": {
-        "ctmax": 1000,
-        "ctmin": 0,
-        "id": "Tunable white light with bad maxmin values id",
-        "name": "Tunable white light with bad maxmin values",
-        "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
-        "type": "Tunable white light",
-        "uniqueid": "00:00:00:00:00:00:00:04-00",
-    },
-}
-
 
 async def test_no_lights_or_groups(hass, aioclient_mock):
     """Test that no lights or groups entities are created."""
@@ -112,15 +42,75 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_lights_and_groups(hass, aioclient_mock):
+async def test_lights_and_groups(hass, aioclient_mock, mock_deconz_websocket):
     """Test that lights or groups entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["groups"] = deepcopy(GROUPS)
-    data["lights"] = deepcopy(LIGHTS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "groups": {
+            "1": {
+                "id": "Light group id",
+                "name": "Light group",
+                "type": "LightGroup",
+                "state": {"all_on": False, "any_on": True},
+                "action": {},
+                "scenes": [],
+                "lights": ["1", "2"],
+            },
+            "2": {
+                "id": "Empty group id",
+                "name": "Empty group",
+                "type": "LightGroup",
+                "state": {},
+                "action": {},
+                "scenes": [],
+                "lights": [],
+            },
+        },
+        "lights": {
+            "1": {
+                "name": "RGB light",
+                "state": {
+                    "on": True,
+                    "bri": 255,
+                    "colormode": "xy",
+                    "effect": "colorloop",
+                    "xy": (500, 500),
+                    "reachable": True,
+                },
+                "type": "Extended color light",
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "ctmax": 454,
+                "ctmin": 155,
+                "name": "Tunable white light",
+                "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
+                "type": "Tunable white light",
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "3": {
+                "name": "On off switch",
+                "type": "On/Off plug-in unit",
+                "state": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+            "4": {
+                "name": "On off light",
+                "state": {"on": True, "reachable": True},
+                "type": "On and Off light",
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+            "5": {
+                "ctmax": 1000,
+                "ctmin": 0,
+                "name": "Tunable white light with bad maxmin values",
+                "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
+                "type": "Tunable white light",
+                "uniqueid": "00:00:00:00:00:00:00:04-00",
+            },
+        },
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 6
 
@@ -151,25 +141,23 @@ async def test_lights_and_groups(hass, aioclient_mock):
     assert on_off_light.state == STATE_ON
     assert on_off_light.attributes[ATTR_SUPPORTED_FEATURES] == 0
 
-    light_group = hass.states.get("light.light_group")
-    assert light_group.state == STATE_ON
-    assert light_group.attributes["all_on"] is False
+    assert hass.states.get("light.light_group").state == STATE_ON
+    assert hass.states.get("light.light_group").attributes["all_on"] is False
 
     empty_group = hass.states.get("light.empty_group")
     assert empty_group is None
 
-    state_changed_event = {
+    event_changed_light = {
         "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"on": False},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
     await hass.async_block_till_done()
 
-    rgb_light = hass.states.get("light.rgb_light")
-    assert rgb_light.state == STATE_OFF
+    assert hass.states.get("light.rgb_light").state == STATE_OFF
 
     # Verify service calls
 
@@ -231,14 +219,14 @@ async def test_lights_and_groups(hass, aioclient_mock):
     )
     assert len(aioclient_mock.mock_calls) == 3  # Not called
 
-    state_changed_event = {
+    event_changed_light = {
         "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"on": True},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
     await hass.async_block_till_done()
 
     # Service turn off light with short flashing
@@ -272,7 +260,7 @@ async def test_lights_and_groups(hass, aioclient_mock):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 6
+    assert len(states) == 6
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
@@ -283,28 +271,56 @@ async def test_lights_and_groups(hass, aioclient_mock):
 
 async def test_disable_light_groups(hass, aioclient_mock):
     """Test disallowing light groups work."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["groups"] = deepcopy(GROUPS)
-    data["lights"] = deepcopy(LIGHTS)
-    config_entry = await setup_deconz_integration(
-        hass,
-        aioclient_mock,
-        options={CONF_ALLOW_DECONZ_GROUPS: False},
-        get_state_response=data,
-    )
+    data = {
+        "groups": {
+            "1": {
+                "id": "Light group id",
+                "name": "Light group",
+                "type": "LightGroup",
+                "state": {"all_on": False, "any_on": True},
+                "action": {},
+                "scenes": [],
+                "lights": ["1"],
+            },
+            "2": {
+                "id": "Empty group id",
+                "name": "Empty group",
+                "type": "LightGroup",
+                "state": {},
+                "action": {},
+                "scenes": [],
+                "lights": [],
+            },
+        },
+        "lights": {
+            "1": {
+                "ctmax": 454,
+                "ctmin": 155,
+                "name": "Tunable white light",
+                "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
+                "type": "Tunable white light",
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+        },
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(
+            hass,
+            aioclient_mock,
+            options={CONF_ALLOW_DECONZ_GROUPS: False},
+        )
 
-    assert len(hass.states.async_all()) == 5
-    assert hass.states.get("light.rgb_light")
+    assert len(hass.states.async_all()) == 1
     assert hass.states.get("light.tunable_white_light")
-    assert hass.states.get("light.light_group") is None
-    assert hass.states.get("light.empty_group") is None
+    assert not hass.states.get("light.light_group")
+    assert not hass.states.get("light.empty_group")
 
     hass.config_entries.async_update_entry(
         config_entry, options={CONF_ALLOW_DECONZ_GROUPS: True}
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 2
     assert hass.states.get("light.light_group")
 
     hass.config_entries.async_update_entry(
@@ -312,62 +328,96 @@ async def test_disable_light_groups(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 5
-    assert hass.states.get("light.light_group") is None
+    assert len(hass.states.async_all()) == 1
+    assert not hass.states.get("light.light_group")
 
 
 async def test_configuration_tool(hass, aioclient_mock):
-    """Test that lights or groups entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["lights"] = {
-        "0": {
-            "etag": "26839cb118f5bf7ba1f2108256644010",
-            "hascolor": False,
-            "lastannounced": None,
-            "lastseen": "2020-11-22T11:27Z",
-            "manufacturername": "dresden elektronik",
-            "modelid": "ConBee II",
-            "name": "Configuration tool 1",
-            "state": {"reachable": True},
-            "swversion": "0x264a0700",
-            "type": "Configuration tool",
-            "uniqueid": "00:21:2e:ff:ff:05:a7:a3-01",
+    """Test that configuration tool is not created."""
+    data = {
+        "lights": {
+            "0": {
+                "etag": "26839cb118f5bf7ba1f2108256644010",
+                "hascolor": False,
+                "lastannounced": None,
+                "lastseen": "2020-11-22T11:27Z",
+                "manufacturername": "dresden elektronik",
+                "modelid": "ConBee II",
+                "name": "Configuration tool 1",
+                "state": {"reachable": True},
+                "swversion": "0x264a0700",
+                "type": "Configuration tool",
+                "uniqueid": "00:21:2e:ff:ff:05:a7:a3-01",
+            }
         }
     }
-    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 0
 
 
+async def test_ikea_default_transition_time(hass, aioclient_mock):
+    """Verify that service calls to IKEA lights always extend with transition tinme 0 if absent."""
+    data = {
+        "lights": {
+            "1": {
+                "manufacturername": "IKEA",
+                "name": "Dimmable light",
+                "state": {"on": True, "bri": 255, "reachable": True},
+                "type": "Dimmable light",
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+        },
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/1/state")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "light.dimmable_light", ATTR_BRIGHTNESS: 100},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[1][2] == {
+        "bri": 100,
+        "on": True,
+        "transitiontime": 0,
+    }
+
+
 async def test_lidl_christmas_light(hass, aioclient_mock):
     """Test that lights or groups entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["lights"] = {
-        "0": {
-            "etag": "87a89542bf9b9d0aa8134919056844f8",
-            "hascolor": True,
-            "lastannounced": None,
-            "lastseen": "2020-12-05T22:57Z",
-            "manufacturername": "_TZE200_s8gkrkxk",
-            "modelid": "TS0601",
-            "name": "xmas light",
-            "state": {
-                "bri": 25,
-                "colormode": "hs",
-                "effect": "none",
-                "hue": 53691,
-                "on": True,
-                "reachable": True,
-                "sat": 141,
-            },
-            "swversion": None,
-            "type": "Color dimmable light",
-            "uniqueid": "58:8e:81:ff:fe:db:7b:be-01",
+    data = {
+        "lights": {
+            "0": {
+                "etag": "87a89542bf9b9d0aa8134919056844f8",
+                "hascolor": True,
+                "lastannounced": None,
+                "lastseen": "2020-12-05T22:57Z",
+                "manufacturername": "_TZE200_s8gkrkxk",
+                "modelid": "TS0601",
+                "name": "xmas light",
+                "state": {
+                    "bri": 25,
+                    "colormode": "hs",
+                    "effect": "none",
+                    "hue": 53691,
+                    "on": True,
+                    "reachable": True,
+                    "sat": 141,
+                },
+                "swversion": None,
+                "type": "Color dimmable light",
+                "uniqueid": "58:8e:81:ff:fe:db:7b:be-01",
+            }
         }
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
+
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     mock_deconz_put_request(aioclient_mock, config_entry.data, "/lights/0/state")
 
@@ -385,100 +435,98 @@ async def test_lidl_christmas_light(hass, aioclient_mock):
     assert hass.states.get("light.xmas_light")
 
 
-async def test_non_color_light_reports_color(hass, aioclient_mock):
+async def test_non_color_light_reports_color(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Verify hs_color does not crash when a group gets updated with a bad color value.
 
     After calling a scene color temp light of certain manufacturers
     report color temp in color space.
     """
-    data = deepcopy(DECONZ_WEB_REQUEST)
-
-    data["groups"] = {
-        "0": {
-            "action": {
-                "alert": "none",
-                "bri": 127,
-                "colormode": "hs",
-                "ct": 0,
-                "effect": "none",
-                "hue": 0,
-                "on": True,
-                "sat": 127,
-                "scene": None,
-                "xy": [0, 0],
-            },
-            "devicemembership": [],
-            "etag": "81e42cf1b47affb72fa72bc2e25ba8bf",
-            "id": "0",
-            "lights": ["0", "1"],
-            "name": "All",
-            "scenes": [],
-            "state": {"all_on": False, "any_on": True},
-            "type": "LightGroup",
-        }
-    }
-
-    data["lights"] = {
-        "0": {
-            "ctmax": 500,
-            "ctmin": 153,
-            "etag": "026bcfe544ad76c7534e5ca8ed39047c",
-            "hascolor": True,
-            "manufacturername": "dresden elektronik",
-            "modelid": "FLS-PP3",
-            "name": "Light 1",
-            "pointsymbol": {},
-            "state": {
-                "alert": None,
-                "bri": 111,
-                "colormode": "ct",
-                "ct": 307,
-                "effect": None,
+    data = {
+        "groups": {
+            "0": {
+                "action": {
+                    "alert": "none",
+                    "bri": 127,
+                    "colormode": "hs",
+                    "ct": 0,
+                    "effect": "none",
+                    "hue": 0,
+                    "on": True,
+                    "sat": 127,
+                    "scene": None,
+                    "xy": [0, 0],
+                },
+                "devicemembership": [],
+                "etag": "81e42cf1b47affb72fa72bc2e25ba8bf",
+                "lights": ["0", "1"],
+                "name": "All",
+                "scenes": [],
+                "state": {"all_on": False, "any_on": True},
+                "type": "LightGroup",
+            }
+        },
+        "lights": {
+            "0": {
+                "ctmax": 500,
+                "ctmin": 153,
+                "etag": "026bcfe544ad76c7534e5ca8ed39047c",
                 "hascolor": True,
-                "hue": 7998,
-                "on": False,
-                "reachable": True,
-                "sat": 172,
-                "xy": [0.421253, 0.39921],
+                "manufacturername": "dresden elektronik",
+                "modelid": "FLS-PP3",
+                "name": "Light 1",
+                "pointsymbol": {},
+                "state": {
+                    "alert": None,
+                    "bri": 111,
+                    "colormode": "ct",
+                    "ct": 307,
+                    "effect": None,
+                    "hascolor": True,
+                    "hue": 7998,
+                    "on": False,
+                    "reachable": True,
+                    "sat": 172,
+                    "xy": [0.421253, 0.39921],
+                },
+                "swversion": "020C.201000A0",
+                "type": "Extended color light",
+                "uniqueid": "00:21:2E:FF:FF:EE:DD:CC-0A",
             },
-            "swversion": "020C.201000A0",
-            "type": "Extended color light",
-            "uniqueid": "00:21:2E:FF:FF:EE:DD:CC-0A",
-        },
-        "1": {
-            "colorcapabilities": 0,
-            "ctmax": 65535,
-            "ctmin": 0,
-            "etag": "9dd510cd474791481f189d2a68a3c7f1",
-            "hascolor": True,
-            "lastannounced": "2020-12-17T17:44:38Z",
-            "lastseen": "2021-01-11T18:36Z",
-            "manufacturername": "IKEA of Sweden",
-            "modelid": "TRADFRI bulb E27 WS opal 1000lm",
-            "name": "Küchenlicht",
-            "state": {
-                "alert": "none",
-                "bri": 156,
-                "colormode": "ct",
-                "ct": 250,
-                "on": True,
-                "reachable": True,
+            "1": {
+                "colorcapabilities": 0,
+                "ctmax": 65535,
+                "ctmin": 0,
+                "etag": "9dd510cd474791481f189d2a68a3c7f1",
+                "hascolor": True,
+                "lastannounced": "2020-12-17T17:44:38Z",
+                "lastseen": "2021-01-11T18:36Z",
+                "manufacturername": "IKEA of Sweden",
+                "modelid": "TRADFRI bulb E27 WS opal 1000lm",
+                "name": "Küchenlicht",
+                "state": {
+                    "alert": "none",
+                    "bri": 156,
+                    "colormode": "ct",
+                    "ct": 250,
+                    "on": True,
+                    "reachable": True,
+                },
+                "swversion": "2.0.022",
+                "type": "Color temperature light",
+                "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
             },
-            "swversion": "2.0.022",
-            "type": "Color temperature light",
-            "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
         },
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 3
     assert hass.states.get("light.all").attributes[ATTR_COLOR_TEMP] == 307
 
     # Updating a scene will return a faulty color value for a non-color light causing an exception in hs_color
-    state_changed_event = {
+    event_changed_light = {
         "e": "changed",
         "id": "1",
         "r": "lights",
@@ -493,7 +541,7 @@ async def test_non_color_light_reports_color(hass, aioclient_mock):
         "t": "event",
         "uniqueid": "ec:1b:bd:ff:fe:ee:ed:dd-01",
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
     await hass.async_block_till_done()
 
     # Bug is fixed if we reach this point, but device won't have neither color temp nor color
@@ -504,9 +552,8 @@ async def test_non_color_light_reports_color(hass, aioclient_mock):
 
 async def test_verify_group_supported_features(hass, aioclient_mock):
     """Test that group supported features reflect what included lights support."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["groups"] = deepcopy(
-        {
+    data = {
+        "groups": {
             "1": {
                 "id": "Group1",
                 "name": "group",
@@ -516,19 +563,15 @@ async def test_verify_group_supported_features(hass, aioclient_mock):
                 "scenes": [],
                 "lights": ["1", "2", "3"],
             },
-        }
-    )
-    data["lights"] = deepcopy(
-        {
+        },
+        "lights": {
             "1": {
-                "id": "light1",
                 "name": "Dimmable light",
                 "state": {"on": True, "bri": 255, "reachable": True},
                 "type": "Light",
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             },
             "2": {
-                "id": "light2",
                 "name": "Color light",
                 "state": {
                     "on": True,
@@ -544,18 +587,17 @@ async def test_verify_group_supported_features(hass, aioclient_mock):
             "3": {
                 "ctmax": 454,
                 "ctmin": 155,
-                "id": "light3",
                 "name": "Tunable light",
                 "state": {"on": True, "colormode": "ct", "ct": 2500, "reachable": True},
                 "type": "Tunable white light",
                 "uniqueid": "00:00:00:00:00:00:00:03-00",
             },
-        }
-    )
-    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+        },
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 4
 
-    group = hass.states.get("light.group")
-    assert group.state == STATE_ON
-    assert group.attributes[ATTR_SUPPORTED_FEATURES] == 63
+    assert hass.states.get("light.group").state == STATE_ON
+    assert hass.states.get("light.group").attributes[ATTR_SUPPORTED_FEATURES] == 63

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -19,7 +19,6 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
     data = {
         "sensors": {
             "1": {
-                "id": "Switch 1 id",
                 "name": "Switch 1",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},
@@ -27,7 +26,6 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             },
             "2": {
-                "id": "Hue remote id",
                 "name": "Hue remote",
                 "type": "ZHASwitch",
                 "modelid": "RWL021",
@@ -36,7 +34,6 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
                 "uniqueid": "00:00:00:00:00:00:00:02-00",
             },
             "3": {
-                "id": "Xiaomi cube id",
                 "name": "Xiaomi cube",
                 "type": "ZHASwitch",
                 "modelid": "lumi.sensor_cube",
@@ -45,7 +42,6 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
                 "uniqueid": "00:00:00:00:00:00:00:03-00",
             },
             "4": {
-                "id": "faulty",
                 "name": "Faulty event",
                 "type": "ZHASwitch",
                 "state": {},

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -1,13 +1,13 @@
 """The tests for deCONZ logbook."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
 from homeassistant.components import logbook
-from homeassistant.components.deconz.const import CONF_GESTURE
+from homeassistant.components.deconz.const import CONF_GESTURE, DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.setup import async_setup_component
+from homeassistant.util import slugify
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
@@ -16,47 +16,72 @@ from tests.components.logbook.test_init import MockLazyEventPartialState
 
 async def test_humanifying_deconz_event(hass, aioclient_mock):
     """Test humanifying deCONZ event."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "id": "Switch 1 id",
-            "name": "Switch 1",
-            "type": "ZHASwitch",
-            "state": {"buttonevent": 1000},
-            "config": {},
-            "uniqueid": "00:00:00:00:00:00:00:01-00",
-        },
-        "1": {
-            "id": "Hue remote id",
-            "name": "Hue remote",
-            "type": "ZHASwitch",
-            "modelid": "RWL021",
-            "state": {"buttonevent": 1000},
-            "config": {},
-            "uniqueid": "00:00:00:00:00:00:00:02-00",
-        },
-        "2": {
-            "id": "Xiaomi cube id",
-            "name": "Xiaomi cube",
-            "type": "ZHASwitch",
-            "modelid": "lumi.sensor_cube",
-            "state": {"buttonevent": 1000, "gesture": 1},
-            "config": {},
-            "uniqueid": "00:00:00:00:00:00:00:03-00",
-        },
-        "3": {
-            "id": "faulty",
-            "name": "Faulty event",
-            "type": "ZHASwitch",
-            "state": {},
-            "config": {},
-            "uniqueid": "00:00:00:00:00:00:00:04-00",
-        },
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Switch 1 id",
+                "name": "Switch 1",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "2": {
+                "id": "Hue remote id",
+                "name": "Hue remote",
+                "type": "ZHASwitch",
+                "modelid": "RWL021",
+                "state": {"buttonevent": 1000},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+            "3": {
+                "id": "Xiaomi cube id",
+                "name": "Xiaomi cube",
+                "type": "ZHASwitch",
+                "modelid": "lumi.sensor_cube",
+                "state": {"buttonevent": 1000, "gesture": 1},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+            "4": {
+                "id": "faulty",
+                "name": "Faulty event",
+                "type": "ZHASwitch",
+                "state": {},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:04-00",
+            },
+        }
     }
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+
+    switch_event_id = slugify(data["sensors"]["1"]["name"])
+    switch_serial = data["sensors"]["1"]["uniqueid"].split("-", 1)[0]
+    switch_entry = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, switch_serial)}
     )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+
+    hue_remote_event_id = slugify(data["sensors"]["2"]["name"])
+    hue_remote_serial = data["sensors"]["2"]["uniqueid"].split("-", 1)[0]
+    hue_remote_entry = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, hue_remote_serial)}
+    )
+
+    xiaomi_cube_event_id = slugify(data["sensors"]["3"]["name"])
+    xiaomi_cube_serial = data["sensors"]["3"]["uniqueid"].split("-", 1)[0]
+    xiaomi_cube_entry = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, xiaomi_cube_serial)}
+    )
+
+    faulty_event_id = slugify(data["sensors"]["4"]["name"])
+    faulty_serial = data["sensors"]["4"]["uniqueid"].split("-", 1)[0]
+    faulty_entry = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, faulty_serial)}
+    )
 
     hass.config.components.add("recorder")
     assert await async_setup_component(hass, "logbook", {})
@@ -70,50 +95,50 @@ async def test_humanifying_deconz_event(hass, aioclient_mock):
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
-                        CONF_DEVICE_ID: gateway.events[0].device_id,
+                        CONF_DEVICE_ID: switch_entry.id,
                         CONF_EVENT: 2000,
-                        CONF_ID: gateway.events[0].event_id,
-                        CONF_UNIQUE_ID: gateway.events[0].serial,
+                        CONF_ID: switch_event_id,
+                        CONF_UNIQUE_ID: switch_serial,
                     },
                 ),
                 # Event with matching device trigger
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
-                        CONF_DEVICE_ID: gateway.events[1].device_id,
+                        CONF_DEVICE_ID: hue_remote_entry.id,
                         CONF_EVENT: 2001,
-                        CONF_ID: gateway.events[1].event_id,
-                        CONF_UNIQUE_ID: gateway.events[1].serial,
+                        CONF_ID: hue_remote_event_id,
+                        CONF_UNIQUE_ID: hue_remote_serial,
                     },
                 ),
                 # Gesture with matching device trigger
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
-                        CONF_DEVICE_ID: gateway.events[2].device_id,
+                        CONF_DEVICE_ID: xiaomi_cube_entry.id,
                         CONF_GESTURE: 1,
-                        CONF_ID: gateway.events[2].event_id,
-                        CONF_UNIQUE_ID: gateway.events[2].serial,
+                        CONF_ID: xiaomi_cube_event_id,
+                        CONF_UNIQUE_ID: xiaomi_cube_serial,
                     },
                 ),
                 # Unsupported device trigger
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
-                        CONF_DEVICE_ID: gateway.events[2].device_id,
+                        CONF_DEVICE_ID: xiaomi_cube_entry.id,
                         CONF_GESTURE: "unsupported_gesture",
-                        CONF_ID: gateway.events[2].event_id,
-                        CONF_UNIQUE_ID: gateway.events[2].serial,
+                        CONF_ID: xiaomi_cube_event_id,
+                        CONF_UNIQUE_ID: xiaomi_cube_serial,
                     },
                 ),
                 # Unknown event
                 MockLazyEventPartialState(
                     CONF_DECONZ_EVENT,
                     {
-                        CONF_DEVICE_ID: gateway.events[3].device_id,
+                        CONF_DEVICE_ID: faulty_entry.id,
                         "unknown_event": None,
-                        CONF_ID: gateway.events[3].event_id,
-                        CONF_UNIQUE_ID: gateway.events[3].serial,
+                        CONF_ID: faulty_event_id,
+                        CONF_UNIQUE_ID: faulty_serial,
                     },
                 ),
             ],

--- a/tests/components/deconz/test_scene.py
+++ b/tests/components/deconz/test_scene.py
@@ -1,6 +1,6 @@
 """deCONZ scene platform tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
 from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN, SERVICE_TURN_ON
 from homeassistant.const import ATTR_ENTITY_ID
@@ -11,18 +11,6 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
-GROUPS = {
-    "1": {
-        "id": "Light group id",
-        "name": "Light group",
-        "type": "LightGroup",
-        "state": {"all_on": False, "any_on": True},
-        "action": {},
-        "scenes": [{"id": "1", "name": "Scene"}],
-        "lights": [],
-    }
-}
-
 
 async def test_no_scenes(hass, aioclient_mock):
     """Test that scenes can be loaded without scenes being available."""
@@ -32,11 +20,21 @@ async def test_no_scenes(hass, aioclient_mock):
 
 async def test_scenes(hass, aioclient_mock):
     """Test that scenes works."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["groups"] = deepcopy(GROUPS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
+    data = {
+        "groups": {
+            "1": {
+                "id": "Light group id",
+                "name": "Light group",
+                "type": "LightGroup",
+                "state": {"all_on": False, "any_on": True},
+                "action": {},
+                "scenes": [{"id": "1", "name": "Scene"}],
+                "lights": [],
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("scene.light_group_scene")

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -1,85 +1,20 @@
 """deCONZ sensor platform tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
 from homeassistant.components.deconz.const import CONF_ALLOW_CLIP_SENSOR
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
+from homeassistant.components.deconz.sensor import ATTR_DAYLIGHT
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
     STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
-
-SENSORS = {
-    "1": {
-        "id": "Light sensor id",
-        "name": "Light level sensor",
-        "type": "ZHALightLevel",
-        "state": {"lightlevel": 30000, "dark": False},
-        "config": {"on": True, "reachable": True, "temperature": 10},
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "Presence sensor id",
-        "name": "Presence sensor",
-        "type": "ZHAPresence",
-        "state": {"presence": False},
-        "config": {},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-    "3": {
-        "id": "Switch 1 id",
-        "name": "Switch 1",
-        "type": "ZHASwitch",
-        "state": {"buttonevent": 1000},
-        "config": {},
-        "uniqueid": "00:00:00:00:00:00:00:02-00",
-    },
-    "4": {
-        "id": "Switch 2 id",
-        "name": "Switch 2",
-        "type": "ZHASwitch",
-        "state": {"buttonevent": 1000},
-        "config": {"battery": 100},
-        "uniqueid": "00:00:00:00:00:00:00:03-00",
-    },
-    "5": {
-        "id": "Daylight sensor id",
-        "name": "Daylight sensor",
-        "type": "Daylight",
-        "state": {"daylight": True, "status": 130},
-        "config": {},
-        "uniqueid": "00:00:00:00:00:00:00:04-00",
-    },
-    "6": {
-        "id": "Power sensor id",
-        "name": "Power sensor",
-        "type": "ZHAPower",
-        "state": {"current": 2, "power": 6, "voltage": 3},
-        "config": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:05-00",
-    },
-    "7": {
-        "id": "Consumption id",
-        "name": "Consumption sensor",
-        "type": "ZHAConsumption",
-        "state": {"consumption": 2, "power": 6},
-        "config": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:06-00",
-    },
-    "8": {
-        "id": "CLIP light sensor id",
-        "name": "CLIP light level sensor",
-        "type": "CLIPLightLevel",
-        "state": {"lightlevel": 30000},
-        "config": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:07-00",
-    },
-}
 
 
 async def test_no_sensors(hass, aioclient_mock):
@@ -88,75 +23,144 @@ async def test_no_sensors(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_sensors(hass, aioclient_mock):
+async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
     """Test successful creation of sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Light sensor id",
+                "name": "Light level sensor",
+                "type": "ZHALightLevel",
+                "state": {"daylight": 6955, "lightlevel": 30000, "dark": False},
+                "config": {"on": True, "reachable": True, "temperature": 10},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "id": "Presence sensor id",
+                "name": "Presence sensor",
+                "type": "ZHAPresence",
+                "state": {"presence": False},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "3": {
+                "id": "Switch 1 id",
+                "name": "Switch 1",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:02-00",
+            },
+            "4": {
+                "id": "Switch 2 id",
+                "name": "Switch 2",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000},
+                "config": {"battery": 100},
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+            "5": {
+                "id": "Daylight sensor id",
+                "name": "Daylight sensor",
+                "type": "Daylight",
+                "state": {"daylight": True, "status": 130},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:04-00",
+            },
+            "6": {
+                "id": "Power sensor id",
+                "name": "Power sensor",
+                "type": "ZHAPower",
+                "state": {"current": 2, "power": 6, "voltage": 3},
+                "config": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:05-00",
+            },
+            "7": {
+                "id": "Consumption id",
+                "name": "Consumption sensor",
+                "type": "ZHAConsumption",
+                "state": {"consumption": 2, "power": 6},
+                "config": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:06-00",
+            },
+            "8": {
+                "id": "CLIP light sensor id",
+                "name": "CLIP light level sensor",
+                "type": "CLIPLightLevel",
+                "state": {"lightlevel": 30000},
+                "config": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:07-00",
+            },
+        }
+    }
+
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 5
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
-    assert light_level_sensor.attributes["device_class"] == DEVICE_CLASS_ILLUMINANCE
+    assert light_level_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ILLUMINANCE
+    assert light_level_sensor.attributes[ATTR_DAYLIGHT] == 6955
 
-    assert hass.states.get("sensor.presence_sensor") is None
-    assert hass.states.get("sensor.switch_1") is None
-    assert hass.states.get("sensor.switch_1_battery_level") is None
-    assert hass.states.get("sensor.switch_2") is None
+    assert not hass.states.get("sensor.presence_sensor")
+    assert not hass.states.get("sensor.switch_1")
+    assert not hass.states.get("sensor.switch_1_battery_level")
+    assert not hass.states.get("sensor.switch_2")
 
     switch_2_battery_level = hass.states.get("sensor.switch_2_battery_level")
     assert switch_2_battery_level.state == "100"
-    assert switch_2_battery_level.attributes["device_class"] == DEVICE_CLASS_BATTERY
+    assert switch_2_battery_level.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_BATTERY
 
-    assert hass.states.get("sensor.daylight_sensor") is None
+    assert not hass.states.get("sensor.daylight_sensor")
 
     power_sensor = hass.states.get("sensor.power_sensor")
     assert power_sensor.state == "6"
-    assert power_sensor.attributes["device_class"] == DEVICE_CLASS_POWER
+    assert power_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_POWER
 
     consumption_sensor = hass.states.get("sensor.consumption_sensor")
     assert consumption_sensor.state == "0.002"
-    assert "device_class" not in consumption_sensor.attributes
+    assert ATTR_DEVICE_CLASS not in consumption_sensor.attributes
 
-    assert hass.states.get("sensor.clip_light_level_sensor") is None
+    assert not hass.states.get("sensor.clip_light_level_sensor")
 
     # Event signals new light level
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "1",
         "state": {"lightlevel": 2000},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_sensor)
 
     assert hass.states.get("sensor.light_level_sensor").state == "1.6"
 
     # Event signals new battery level
 
-    state_changed_event = {
+    event_changed_sensor = {
         "t": "event",
         "e": "changed",
         "r": "sensors",
         "id": "4",
         "config": {"battery": 75},
     }
-    gateway.api.event_handler(state_changed_event)
-    await hass.async_block_till_done()
+    await mock_deconz_websocket(data=event_changed_sensor)
 
     assert hass.states.get("sensor.switch_2_battery_level").state == "75"
+
+    # Unload entry
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 5
+    assert len(states) == 5
     for state in states:
         assert state.state == STATE_UNAVAILABLE
+
+    # Remove entry
 
     await hass.config_entries.async_remove(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -165,16 +169,34 @@ async def test_sensors(hass, aioclient_mock):
 
 async def test_allow_clip_sensors(hass, aioclient_mock):
     """Test that CLIP sensors can be allowed."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = deepcopy(SENSORS)
-    config_entry = await setup_deconz_integration(
-        hass,
-        aioclient_mock,
-        options={CONF_ALLOW_CLIP_SENSOR: True},
-        get_state_response=data,
-    )
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Light sensor id",
+                "name": "Light level sensor",
+                "type": "ZHALightLevel",
+                "state": {"lightlevel": 30000, "dark": False},
+                "config": {"on": True, "reachable": True, "temperature": 10},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "id": "CLIP light sensor id",
+                "name": "CLIP light level sensor",
+                "type": "CLIPLightLevel",
+                "state": {"lightlevel": 30000},
+                "config": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(
+            hass,
+            aioclient_mock,
+            options={CONF_ALLOW_CLIP_SENSOR: True},
+        )
 
-    assert len(hass.states.async_all()) == 6
+    assert len(hass.states.async_all()) == 2
     assert hass.states.get("sensor.clip_light_level_sensor").state == "999.8"
 
     # Disallow clip sensors
@@ -184,8 +206,8 @@ async def test_allow_clip_sensors(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 5
-    assert hass.states.get("sensor.clip_light_level_sensor") is None
+    assert len(hass.states.async_all()) == 1
+    assert not hass.states.get("sensor.clip_light_level_sensor")
 
     # Allow clip sensors
 
@@ -194,52 +216,71 @@ async def test_allow_clip_sensors(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 6
-    assert hass.states.get("sensor.clip_light_level_sensor")
+    assert len(hass.states.async_all()) == 2
+    assert hass.states.get("sensor.clip_light_level_sensor").state == "999.8"
 
 
-async def test_add_new_sensor(hass, aioclient_mock):
+async def test_add_new_sensor(hass, aioclient_mock, mock_deconz_websocket):
     """Test that adding a new sensor works."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = get_gateway_from_config_entry(hass, config_entry)
-    assert len(hass.states.async_all()) == 0
-
-    state_added_event = {
+    event_added_sensor = {
         "t": "event",
         "e": "added",
         "r": "sensors",
         "id": "1",
-        "sensor": deepcopy(SENSORS["1"]),
+        "sensor": {
+            "id": "Light sensor id",
+            "name": "Light level sensor",
+            "type": "ZHALightLevel",
+            "state": {"lightlevel": 30000, "dark": False},
+            "config": {"on": True, "reachable": True, "temperature": 10},
+            "uniqueid": "00:00:00:00:00:00:00:00-00",
+        },
     }
-    gateway.api.event_handler(state_added_event)
+
+    await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 0
+
+    await mock_deconz_websocket(data=event_added_sensor)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("sensor.light_level_sensor").state == "999.8"
 
 
-async def test_add_battery_later(hass, aioclient_mock):
+async def test_add_battery_later(hass, aioclient_mock, mock_deconz_websocket):
     """Test that a sensor without an initial battery state creates a battery sensor once state exist."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {"1": deepcopy(SENSORS["3"])}
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
-    remote = gateway.api.sensors["1"]
+    data = {
+        "sensors": {
+            "1": {
+                "id": "Switch 1 id",
+                "name": "Switch 1",
+                "type": "ZHASwitch",
+                "state": {"buttonevent": 1000},
+                "config": {},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 0
-    assert len(gateway.events) == 1
-    assert len(remote._callbacks) == 2  # Event and battery tracker
+    assert not hass.states.get("sensor.switch_1_battery_level")
 
-    remote.update({"config": {"battery": 50}})
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "config": {"battery": 50},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
-    assert len(gateway.events) == 1
-    assert len(remote._callbacks) == 2  # Event and battery entity
 
-    assert hass.states.get("sensor.switch_1_battery_level")
+    assert hass.states.get("sensor.switch_1_battery_level").state == "50"
 
 
 async def test_special_danfoss_battery_creation(hass, aioclient_mock):
@@ -248,131 +289,133 @@ async def test_special_danfoss_battery_creation(hass, aioclient_mock):
     Normally there should only be one battery sensor per device from deCONZ.
     With specific Danfoss devices each endpoint can report its own battery state.
     """
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "1": {
-            "config": {
-                "battery": 70,
-                "heatsetpoint": 2300,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-                "schedule": {},
-                "schedule_on": False,
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "battery": 70,
+                    "heatsetpoint": 2300,
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                    "schedule": {},
+                    "schedule_on": False,
+                },
+                "ep": 1,
+                "etag": "982d9acc38bee5b251e24a9be26558e4",
+                "lastseen": "2021-02-15T12:23Z",
+                "manufacturername": "Danfoss",
+                "modelid": "0x8030",
+                "name": "0x8030",
+                "state": {
+                    "lastupdated": "2021-02-15T12:23:07.994",
+                    "on": False,
+                    "temperature": 2307,
+                },
+                "swversion": "YYYYMMDD",
+                "type": "ZHAThermostat",
+                "uniqueid": "58:8e:81:ff:fe:00:11:22-01-0201",
             },
-            "ep": 1,
-            "etag": "982d9acc38bee5b251e24a9be26558e4",
-            "lastseen": "2021-02-15T12:23Z",
-            "manufacturername": "Danfoss",
-            "modelid": "0x8030",
-            "name": "0x8030",
-            "state": {
-                "lastupdated": "2021-02-15T12:23:07.994",
-                "on": False,
-                "temperature": 2307,
+            "2": {
+                "config": {
+                    "battery": 86,
+                    "heatsetpoint": 2300,
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                    "schedule": {},
+                    "schedule_on": False,
+                },
+                "ep": 2,
+                "etag": "62f12749f9f51c950086aff37dd02b61",
+                "lastseen": "2021-02-15T12:23Z",
+                "manufacturername": "Danfoss",
+                "modelid": "0x8030",
+                "name": "0x8030",
+                "state": {
+                    "lastupdated": "2021-02-15T12:23:22.399",
+                    "on": False,
+                    "temperature": 2316,
+                },
+                "swversion": "YYYYMMDD",
+                "type": "ZHAThermostat",
+                "uniqueid": "58:8e:81:ff:fe:00:11:22-02-0201",
             },
-            "swversion": "YYYYMMDD",
-            "type": "ZHAThermostat",
-            "uniqueid": "58:8e:81:ff:fe:00:11:22-01-0201",
-        },
-        "2": {
-            "config": {
-                "battery": 86,
-                "heatsetpoint": 2300,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-                "schedule": {},
-                "schedule_on": False,
+            "3": {
+                "config": {
+                    "battery": 86,
+                    "heatsetpoint": 2350,
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                    "schedule": {},
+                    "schedule_on": False,
+                },
+                "ep": 3,
+                "etag": "f50061174bb7f18a3d95789bab8b646d",
+                "lastseen": "2021-02-15T12:23Z",
+                "manufacturername": "Danfoss",
+                "modelid": "0x8030",
+                "name": "0x8030",
+                "state": {
+                    "lastupdated": "2021-02-15T12:23:25.466",
+                    "on": False,
+                    "temperature": 2337,
+                },
+                "swversion": "YYYYMMDD",
+                "type": "ZHAThermostat",
+                "uniqueid": "58:8e:81:ff:fe:00:11:22-03-0201",
             },
-            "ep": 2,
-            "etag": "62f12749f9f51c950086aff37dd02b61",
-            "lastseen": "2021-02-15T12:23Z",
-            "manufacturername": "Danfoss",
-            "modelid": "0x8030",
-            "name": "0x8030",
-            "state": {
-                "lastupdated": "2021-02-15T12:23:22.399",
-                "on": False,
-                "temperature": 2316,
+            "4": {
+                "config": {
+                    "battery": 85,
+                    "heatsetpoint": 2300,
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                    "schedule": {},
+                    "schedule_on": False,
+                },
+                "ep": 4,
+                "etag": "eea97adf8ce1b971b8b6a3a31793f96b",
+                "lastseen": "2021-02-15T12:23Z",
+                "manufacturername": "Danfoss",
+                "modelid": "0x8030",
+                "name": "0x8030",
+                "state": {
+                    "lastupdated": "2021-02-15T12:23:41.939",
+                    "on": False,
+                    "temperature": 2333,
+                },
+                "swversion": "YYYYMMDD",
+                "type": "ZHAThermostat",
+                "uniqueid": "58:8e:81:ff:fe:00:11:22-04-0201",
             },
-            "swversion": "YYYYMMDD",
-            "type": "ZHAThermostat",
-            "uniqueid": "58:8e:81:ff:fe:00:11:22-02-0201",
-        },
-        "3": {
-            "config": {
-                "battery": 86,
-                "heatsetpoint": 2350,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-                "schedule": {},
-                "schedule_on": False,
+            "5": {
+                "config": {
+                    "battery": 83,
+                    "heatsetpoint": 2300,
+                    "offset": 0,
+                    "on": True,
+                    "reachable": True,
+                    "schedule": {},
+                    "schedule_on": False,
+                },
+                "ep": 5,
+                "etag": "1f7cd1a5d66dc27ac5eb44b8c47362fb",
+                "lastseen": "2021-02-15T12:23Z",
+                "manufacturername": "Danfoss",
+                "modelid": "0x8030",
+                "name": "0x8030",
+                "state": {"lastupdated": "none", "on": False, "temperature": 2325},
+                "swversion": "YYYYMMDD",
+                "type": "ZHAThermostat",
+                "uniqueid": "58:8e:81:ff:fe:00:11:22-05-0201",
             },
-            "ep": 3,
-            "etag": "f50061174bb7f18a3d95789bab8b646d",
-            "lastseen": "2021-02-15T12:23Z",
-            "manufacturername": "Danfoss",
-            "modelid": "0x8030",
-            "name": "0x8030",
-            "state": {
-                "lastupdated": "2021-02-15T12:23:25.466",
-                "on": False,
-                "temperature": 2337,
-            },
-            "swversion": "YYYYMMDD",
-            "type": "ZHAThermostat",
-            "uniqueid": "58:8e:81:ff:fe:00:11:22-03-0201",
-        },
-        "4": {
-            "config": {
-                "battery": 85,
-                "heatsetpoint": 2300,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-                "schedule": {},
-                "schedule_on": False,
-            },
-            "ep": 4,
-            "etag": "eea97adf8ce1b971b8b6a3a31793f96b",
-            "lastseen": "2021-02-15T12:23Z",
-            "manufacturername": "Danfoss",
-            "modelid": "0x8030",
-            "name": "0x8030",
-            "state": {
-                "lastupdated": "2021-02-15T12:23:41.939",
-                "on": False,
-                "temperature": 2333,
-            },
-            "swversion": "YYYYMMDD",
-            "type": "ZHAThermostat",
-            "uniqueid": "58:8e:81:ff:fe:00:11:22-04-0201",
-        },
-        "5": {
-            "config": {
-                "battery": 83,
-                "heatsetpoint": 2300,
-                "offset": 0,
-                "on": True,
-                "reachable": True,
-                "schedule": {},
-                "schedule_on": False,
-            },
-            "ep": 5,
-            "etag": "1f7cd1a5d66dc27ac5eb44b8c47362fb",
-            "lastseen": "2021-02-15T12:23Z",
-            "manufacturername": "Danfoss",
-            "modelid": "0x8030",
-            "name": "0x8030",
-            "state": {"lastupdated": "none", "on": False, "temperature": 2325},
-            "swversion": "YYYYMMDD",
-            "type": "ZHAThermostat",
-            "uniqueid": "58:8e:81:ff:fe:00:11:22-05-0201",
-        },
+        }
     }
-    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 10
     assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 5
@@ -380,77 +423,75 @@ async def test_special_danfoss_battery_creation(hass, aioclient_mock):
 
 async def test_air_quality_sensor(hass, aioclient_mock):
     """Test successful creation of air quality sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "config": {"on": True, "reachable": True},
-            "ep": 2,
-            "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
-            "lastseen": "2020-11-20T22:48Z",
-            "manufacturername": "BOSCH",
-            "modelid": "AIR",
-            "name": "Air quality",
-            "state": {
-                "airquality": "poor",
-                "airqualityppb": 809,
-                "lastupdated": "2020-11-20T22:48:00.209",
-            },
-            "swversion": "20200402",
-            "type": "ZHAAirQuality",
-            "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
+    data = {
+        "sensors": {
+            "0": {
+                "config": {"on": True, "reachable": True},
+                "ep": 2,
+                "etag": "c2d2e42396f7c78e11e46c66e2ec0200",
+                "lastseen": "2020-11-20T22:48Z",
+                "manufacturername": "BOSCH",
+                "modelid": "AIR",
+                "name": "Air quality",
+                "state": {
+                    "airquality": "poor",
+                    "airqualityppb": 809,
+                    "lastupdated": "2020-11-20T22:48:00.209",
+                },
+                "swversion": "20200402",
+                "type": "ZHAAirQuality",
+                "uniqueid": "00:12:4b:00:14:4d:00:07-02-fdef",
+            }
         }
     }
-    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 1
-
-    air_quality = hass.states.get("sensor.air_quality")
-    assert air_quality.state == "poor"
+    assert hass.states.get("sensor.air_quality").state == "poor"
 
 
 async def test_time_sensor(hass, aioclient_mock):
     """Test successful creation of time sensor entities."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {
-            "config": {"battery": 40, "on": True, "reachable": True},
-            "ep": 1,
-            "etag": "28e796678d9a24712feef59294343bb6",
-            "lastseen": "2020-11-22T11:26Z",
-            "manufacturername": "Danfoss",
-            "modelid": "eTRV0100",
-            "name": "Time",
-            "state": {
-                "lastset": "2020-11-19T08:07:08Z",
-                "lastupdated": "2020-11-22T10:51:03.444",
-                "localtime": "2020-11-22T10:51:01",
-                "utc": "2020-11-22T10:51:01Z",
-            },
-            "swversion": "20200429",
-            "type": "ZHATime",
-            "uniqueid": "cc:cc:cc:ff:fe:38:4d:b3-01-000a",
+    data = {
+        "sensors": {
+            "0": {
+                "config": {"battery": 40, "on": True, "reachable": True},
+                "ep": 1,
+                "etag": "28e796678d9a24712feef59294343bb6",
+                "lastseen": "2020-11-22T11:26Z",
+                "manufacturername": "Danfoss",
+                "modelid": "eTRV0100",
+                "name": "Time",
+                "state": {
+                    "lastset": "2020-11-19T08:07:08Z",
+                    "lastupdated": "2020-11-22T10:51:03.444",
+                    "localtime": "2020-11-22T10:51:01",
+                    "utc": "2020-11-22T10:51:01Z",
+                },
+                "swversion": "20200429",
+                "type": "ZHATime",
+                "uniqueid": "cc:cc:cc:ff:fe:38:4d:b3-01-000a",
+            }
         }
     }
-    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
-
-    time = hass.states.get("sensor.time")
-    assert time.state == "2020-11-19T08:07:08Z"
-
-    time_battery = hass.states.get("sensor.time_battery_level")
-    assert time_battery.state == "40"
+    assert hass.states.get("sensor.time").state == "2020-11-19T08:07:08Z"
+    assert hass.states.get("sensor.time_battery_level").state == "40"
 
 
 async def test_unsupported_sensor(hass, aioclient_mock):
     """Test that unsupported sensors doesn't break anything."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["sensors"] = {
-        "0": {"type": "not supported", "name": "name", "state": {}, "config": {}}
+    data = {
+        "sensors": {
+            "0": {"type": "not supported", "name": "name", "state": {}, "config": {}}
+        }
     }
-    await setup_deconz_integration(hass, aioclient_mock, get_state_response=data)
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 1
-
-    unsupported_sensor = hass.states.get("sensor.name")
-    assert unsupported_sensor.state == "unknown"
+    assert hass.states.get("sensor.name").state == STATE_UNKNOWN

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -28,7 +28,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
     data = {
         "sensors": {
             "1": {
-                "id": "Light sensor id",
                 "name": "Light level sensor",
                 "type": "ZHALightLevel",
                 "state": {"daylight": 6955, "lightlevel": 30000, "dark": False},
@@ -36,7 +35,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:00-00",
             },
             "2": {
-                "id": "Presence sensor id",
                 "name": "Presence sensor",
                 "type": "ZHAPresence",
                 "state": {"presence": False},
@@ -44,7 +42,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:01-00",
             },
             "3": {
-                "id": "Switch 1 id",
                 "name": "Switch 1",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},
@@ -52,7 +49,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:02-00",
             },
             "4": {
-                "id": "Switch 2 id",
                 "name": "Switch 2",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},
@@ -60,7 +56,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:03-00",
             },
             "5": {
-                "id": "Daylight sensor id",
                 "name": "Daylight sensor",
                 "type": "Daylight",
                 "state": {"daylight": True, "status": 130},
@@ -68,7 +63,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:04-00",
             },
             "6": {
-                "id": "Power sensor id",
                 "name": "Power sensor",
                 "type": "ZHAPower",
                 "state": {"current": 2, "power": 6, "voltage": 3},
@@ -76,7 +70,6 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:05-00",
             },
             "7": {
-                "id": "Consumption id",
                 "name": "Consumption sensor",
                 "type": "ZHAConsumption",
                 "state": {"consumption": 2, "power": 6},
@@ -172,7 +165,6 @@ async def test_allow_clip_sensors(hass, aioclient_mock):
     data = {
         "sensors": {
             "1": {
-                "id": "Light sensor id",
                 "name": "Light level sensor",
                 "type": "ZHALightLevel",
                 "state": {"lightlevel": 30000, "dark": False},
@@ -253,7 +245,6 @@ async def test_add_battery_later(hass, aioclient_mock, mock_deconz_websocket):
     data = {
         "sensors": {
             "1": {
-                "id": "Switch 1 id",
                 "name": "Switch 1",
                 "type": "ZHASwitch",
                 "state": {"buttonevent": 1000},

--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -1,8 +1,7 @@
 """deCONZ switch platform tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
@@ -16,54 +15,6 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
-POWER_PLUGS = {
-    "1": {
-        "id": "On off switch id",
-        "name": "On off switch",
-        "type": "On/Off plug-in unit",
-        "state": {"on": True, "reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "Smart plug id",
-        "name": "Smart plug",
-        "type": "Smart plug",
-        "state": {"on": False, "reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-    "3": {
-        "id": "Unsupported switch id",
-        "name": "Unsupported switch",
-        "type": "Not a switch",
-        "state": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:03-00",
-    },
-    "4": {
-        "id": "On off relay id",
-        "name": "On off relay",
-        "state": {"on": True, "reachable": True},
-        "type": "On/Off light",
-        "uniqueid": "00:00:00:00:00:00:00:04-00",
-    },
-}
-
-SIRENS = {
-    "1": {
-        "id": "Warning device id",
-        "name": "Warning device",
-        "type": "Warning device",
-        "state": {"alert": "lselect", "reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "Unsupported switch id",
-        "name": "Unsupported switch",
-        "type": "Not a switch",
-        "state": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-}
-
 
 async def test_no_switches(hass, aioclient_mock):
     """Test that no switch entities are created."""
@@ -71,14 +22,38 @@ async def test_no_switches(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_power_plugs(hass, aioclient_mock):
+async def test_power_plugs(hass, aioclient_mock, mock_deconz_websocket):
     """Test that all supported switch entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["lights"] = deepcopy(POWER_PLUGS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "lights": {
+            "1": {
+                "name": "On off switch",
+                "type": "On/Off plug-in unit",
+                "state": {"on": True, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "name": "Smart plug",
+                "type": "Smart plug",
+                "state": {"on": False, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "3": {
+                "name": "Unsupported switch",
+                "type": "Not a switch",
+                "state": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+            "4": {
+                "name": "On off relay",
+                "state": {"on": True, "reachable": True},
+                "type": "On/Off light",
+                "uniqueid": "00:00:00:00:00:00:00:04-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 4
     assert hass.states.get("switch.on_off_switch").state == STATE_ON
@@ -86,14 +61,15 @@ async def test_power_plugs(hass, aioclient_mock):
     assert hass.states.get("switch.on_off_relay").state == STATE_ON
     assert hass.states.get("switch.unsupported_switch") is None
 
-    state_changed_event = {
+    event_changed_light = {
         "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"on": False},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
+    await hass.async_block_till_done()
 
     assert hass.states.get("switch.on_off_switch").state == STATE_OFF
 
@@ -124,7 +100,7 @@ async def test_power_plugs(hass, aioclient_mock):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 4
+    assert len(states) == 4
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
@@ -133,27 +109,40 @@ async def test_power_plugs(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_sirens(hass, aioclient_mock):
+async def test_sirens(hass, aioclient_mock, mock_deconz_websocket):
     """Test that siren entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["lights"] = deepcopy(SIRENS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "lights": {
+            "1": {
+                "name": "Warning device",
+                "type": "Warning device",
+                "state": {"alert": "lselect", "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "name": "Unsupported switch",
+                "type": "Not a switch",
+                "state": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
     assert hass.states.get("switch.warning_device").state == STATE_ON
-    assert hass.states.get("switch.unsupported_switch") is None
+    assert not hass.states.get("switch.unsupported_switch")
 
-    state_changed_event = {
+    event_changed_light = {
         "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"alert": None},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
+    await hass.async_block_till_done()
 
     assert hass.states.get("switch.warning_device").state == STATE_OFF
 
@@ -184,7 +173,7 @@ async def test_sirens(hass, aioclient_mock):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 2
+    assert len(states) == 2
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Goal here was to become less dependent of integration specific mechanisms to verify states in the tests. Most is really about cosmetics and the core of tests have usually not been altered.

- Add a fixture for websocket events
- Replace deepcopy of DECONZ_WEB_REQUEST with using a patch.dict
- Minor changes in how asserts are formulated
- Minor changes to improve code coverage

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
