### PR TITLE
Let recorder deal with event names longer than 32 chars

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -206,6 +206,15 @@ def _add_columns(engine, table_name, columns_def):
 
 def _modify_columns(engine, table_name, columns_def):
     """Modify columns in a table."""
+    if engine.dialect.name == "sqlite":
+        _LOGGER.warning(
+            "Modifying columns in %s is not supported. "
+            "If you have issues with the database, "
+            "you can recreate the database or modify it manually.",
+            engine.dialect.name
+        )
+        return
+
     _LOGGER.warning(
         "Modifying columns %s in table %s. Note: this can take several "
         "minutes on large databases and slow computers. Please "
@@ -213,7 +222,13 @@ def _modify_columns(engine, table_name, columns_def):
         ", ".join(column.split(" ")[0] for column in columns_def),
         table_name,
     )
-    columns_def = [f"MODIFY {col_def}" for col_def in columns_def]
+
+    if engine.dialect.name == "postgresql":
+        columns_def = ["ALTER {column} TYPE {type}".format(**dict(zip(["column", "type"], col_def.split(" ", 1)))) for col_def in columns_def]
+    elif engine.dialect.name == "mssql":
+        columns_def = [f"ALTER COLUMN {col_def}" for col_def in columns_def]
+    else:
+        columns_def = [f"MODIFY {col_def}" for col_def in columns_def]
 
     try:
         engine.execute(

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -377,6 +377,8 @@ def _apply_update(engine, new_version, old_version):
                     "created DATETIME(6)",
                 ],
             )
+    elif new_version == 14:
+        _modify_columns(engine, "events", ["event_type VARCHAR(64)"])
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -208,7 +208,7 @@ def _modify_columns(engine, table_name, columns_def):
     """Modify columns in a table."""
     if engine.dialect.name == "sqlite":
         _LOGGER.debug(
-            "Skipping to modify columns %s in table %s. "
+            "Skipping to modify columns %s in table %s; "
             "Modifying column length in SQLite is unnecessary, "
             "it does not impose any length restrictions.",
             ", ".join(column.split(" ")[0] for column in columns_def),

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -211,7 +211,7 @@ def _modify_columns(engine, table_name, columns_def):
             "Modifying columns in %s is not supported. "
             "If you have issues with the database, "
             "you can recreate the database or modify it manually.",
-            engine.dialect.name
+            engine.dialect.name,
         )
         return
 
@@ -224,7 +224,12 @@ def _modify_columns(engine, table_name, columns_def):
     )
 
     if engine.dialect.name == "postgresql":
-        columns_def = ["ALTER {column} TYPE {type}".format(**dict(zip(["column", "type"], col_def.split(" ", 1)))) for col_def in columns_def]
+        columns_def = [
+            "ALTER {column} TYPE {type}".format(
+                **dict(zip(["column", "type"], col_def.split(" ", 1)))
+            )
+            for col_def in columns_def
+        ]
     elif engine.dialect.name == "mssql":
         columns_def = [f"ALTER COLUMN {col_def}" for col_def in columns_def]
     else:

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -207,11 +207,12 @@ def _add_columns(engine, table_name, columns_def):
 def _modify_columns(engine, table_name, columns_def):
     """Modify columns in a table."""
     if engine.dialect.name == "sqlite":
-        _LOGGER.warning(
-            "Modifying columns in %s is not supported. "
-            "If you have issues with the database, "
-            "you can recreate the database or modify it manually.",
-            engine.dialect.name,
+        _LOGGER.debug(
+            "Skipping to modify columns %s in table %s. "
+            "Modifying column length in SQLite is unnecessary, "
+            "it does not impose any length restrictions.",
+            ", ".join(column.split(" ")[0] for column in columns_def),
+            table_name,
         )
         return
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -210,7 +210,7 @@ def _modify_columns(engine, table_name, columns_def):
         _LOGGER.debug(
             "Skipping to modify columns %s in table %s; "
             "Modifying column length in SQLite is unnecessary, "
-            "it does not impose any length restrictions.",
+            "it does not impose any length restrictions",
             ", ".join(column.split(" ")[0] for column in columns_def),
             table_name,
         )

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -26,7 +26,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 13
+SCHEMA_VERSION = 14
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -53,7 +53,7 @@ class Events(Base):  # type: ignore
     }
     __tablename__ = TABLE_EVENTS
     event_id = Column(Integer, primary_key=True)
-    event_type = Column(String(32))
+    event_type = Column(String(64))
     event_data = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
     origin = Column(String(32))
     time_fired = Column(DATETIME_TYPE, index=True)

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -86,7 +86,7 @@ def test_invalid_update():
     ],
 )
 def test_modify_column(engine_type, substr):
-    """Test that add column will continue if column exists."""
+    """Test that modify column generates the expected query."""
     engine = Mock()
     engine.dialect.name = engine_type
     migration._modify_columns(engine, "events", ["event_type VARCHAR(64)"])

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -90,10 +90,10 @@ def test_modify_column(engine_type, substr):
     engine = Mock()
     engine.dialect.name = engine_type
     migration._modify_columns(engine, "events", ["event_type VARCHAR(64)"])
-    if substr is not None:
+    if substr:
         assert substr in engine.execute.call_args[0][0].text
     else:
-        not engine.execute.called
+        assert not engine.execute.called
 
 
 def test_forgiving_add_column():

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -76,6 +76,26 @@ def test_invalid_update():
         migration._apply_update(None, -1, 0)
 
 
+@pytest.mark.parametrize(
+    ["engine_type", "substr"],
+    [
+        ("postgresql", "ALTER event_type TYPE VARCHAR(64)"),
+        ("mssql", "ALTER COLUMN event_type VARCHAR(64)"),
+        ("mysql", "MODIFY event_type VARCHAR(64)"),
+        ("sqlite", None),
+    ],
+)
+def test_modify_column(engine_type, substr):
+    """Test that add column will continue if column exists."""
+    engine = Mock()
+    engine.dialect.name = engine_type
+    migration._modify_columns(engine, "events", ["event_type VARCHAR(64)"])
+    if substr is not None:
+        assert substr in engine.execute.call_args[0][0].text
+    else:
+        not engine.execute.called
+
+
 def test_forgiving_add_column():
     """Test that add column will continue if column exists."""
     engine = create_engine("sqlite://", poolclass=StaticPool)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `recorder` component's `events.event_type` column is too small for some events, causing SQL errors in the log. VARCHAR(32) increased to VARCHAR(64),  though it is still smaller than the similar `states.entity_id(255)`.

See #38917

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #38917
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
