### PR TITLE
Make Xiaomi Miio unavailable device independent

### DIFF
--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -87,17 +87,22 @@ async def async_setup_gateway_entry(
         sw_version=gateway_info.firmware_version,
     )
 
-    async def async_update_data():
+    def update_data():
         """Fetch data from the subdevice."""
         data = {}
         for sub_device in gateway.gateway_device.devices.values():
             try:
-                await hass.async_add_executor_job(sub_device.update)
-                data[sub_device.sid] = {ATTR_AVAILABLE: True}
+                sub_device.update()
             except GatewayException as ex:
                 _LOGGER.error("Got exception while fetching the state: %s", ex)
                 data[sub_device.sid] = {ATTR_AVAILABLE: False}
+            else:
+                data[sub_device.sid] = {ATTR_AVAILABLE: True}
         return data
+
+    async def async_update_data():
+        """Fetch data from the subdevice using async_add_executor_job."""
+        return await hass.async_add_executor_job(update_data)
 
     # Create update coordinator
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/xiaomi_miio/__init__.py
+++ b/homeassistant/components/xiaomi_miio/__init__.py
@@ -7,9 +7,10 @@ from miio.gateway import GatewayException
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import (
+    ATTR_AVAILABLE,
     CONF_DEVICE,
     CONF_FLOW_TYPE,
     CONF_GATEWAY,
@@ -88,11 +89,15 @@ async def async_setup_gateway_entry(
 
     async def async_update_data():
         """Fetch data from the subdevice."""
-        try:
-            for sub_device in gateway.gateway_device.devices.values():
+        data = {}
+        for sub_device in gateway.gateway_device.devices.values():
+            try:
                 await hass.async_add_executor_job(sub_device.update)
-        except GatewayException as ex:
-            raise UpdateFailed("Got exception while fetching the state") from ex
+                data[sub_device.sid] = {ATTR_AVAILABLE: True}
+            except GatewayException as ex:
+                _LOGGER.error("Got exception while fetching the state: %s", ex)
+                data[sub_device.sid] = {ATTR_AVAILABLE: False}
+        return data
 
     # Create update coordinator
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/xiaomi_miio/const.py
+++ b/homeassistant/components/xiaomi_miio/const.py
@@ -9,6 +9,8 @@ CONF_MAC = "mac"
 
 KEY_COORDINATOR = "coordinator"
 
+ATTR_AVAILABLE = "available"
+
 # Fan Models
 MODEL_AIRPURIFIER_V1 = "zhimi.airpurifier.v1"
 MODEL_AIRPURIFIER_V2 = "zhimi.airpurifier.v2"

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -93,4 +93,7 @@ class XiaomiGatewayDevice(CoordinatorEntity, Entity):
     @property
     def available(self):
         """Return if entity is available."""
-        return self.coordinator.data.get(self._sub_device.sid, {}).get(ATTR_AVAILABLE, False)
+        if self.coordinator.data is None:
+            return False
+
+        return self.coordinator.data[self._sub_device.sid][ATTR_AVAILABLE]

--- a/homeassistant/components/xiaomi_miio/gateway.py
+++ b/homeassistant/components/xiaomi_miio/gateway.py
@@ -6,7 +6,7 @@ from miio import DeviceException, gateway
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import ATTR_AVAILABLE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -89,3 +89,8 @@ class XiaomiGatewayDevice(CoordinatorEntity, Entity):
             "model": self._sub_device.model,
             "sw_version": self._sub_device.firmware_version,
         }
+
+    @property
+    def available(self):
+        """Return if entity is available."""
+        return self.coordinator.data.get(self._sub_device.sid, {}).get(ATTR_AVAILABLE, False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the unavailable property independent of other subdevices.
Now if one device fails, all devices are unavailble, this PR ensures only the device that fails will be unavailable

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

Config flow

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #https://github.com/home-assistant/core/issues/47494
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
