### PR TITLE
Introduction of deCONZ websocket fixture

### DIFF
--- a/tests/components/deconz/conftest.py
+++ b/tests/components/deconz/conftest.py
@@ -1,2 +1,29 @@
 """deconz conftest."""
+
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def mock_deconz_websocket():
+    """No real websocket allowed."""
+    with patch("pydeconz.gateway.WSClient") as mock:
+
+        async def make_websocket_call(data: Optional[dict] = None, state: str = ""):
+            """Generate a websocket call."""
+            pydeconz_gateway_session_handler = mock.call_args[0][3]
+
+            if data:
+                mock.return_value.data = data
+                await pydeconz_gateway_session_handler(signal="data")
+            elif state:
+                mock.return_value.state = state
+                await pydeconz_gateway_session_handler(signal="state")
+            else:
+                raise NotImplementedError
+
+        yield make_websocket_call

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from unittest.mock import Mock, patch
 
 import pydeconz
+from pydeconz.websocket import STATE_RUNNING, STATE_STARTING
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -29,8 +30,14 @@ from homeassistant.components.ssdp import (
 )
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, SOURCE_SSDP
-from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_PORT, CONTENT_TYPE_JSON
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_HOST,
+    CONF_PORT,
+    CONTENT_TYPE_JSON,
+    STATE_OFF,
+    STATE_UNAVAILABLE,
+)
 
 from tests.common import MockConfigEntry
 
@@ -116,8 +123,7 @@ async def setup_deconz_integration(
     if aioclient_mock:
         mock_deconz_request(aioclient_mock, config, get_state_response)
 
-    with patch("pydeconz.DeconzSession.start", return_value=True):
-        await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
     return config_entry
@@ -173,21 +179,35 @@ async def test_gateway_setup_fails(hass):
     assert not hass.data[DECONZ_DOMAIN]
 
 
-async def test_connection_status_signalling(hass, aioclient_mock):
+async def test_connection_status_signalling(
+    hass, aioclient_mock, mock_deconz_websocket
+):
     """Make sure that connection status triggers a dispatcher send."""
-    config_entry = await setup_deconz_integration(hass, aioclient_mock)
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "sensors": {
+            "1": {
+                "name": "presence",
+                "type": "ZHAPresence",
+                "state": {"presence": False},
+                "config": {"on": True, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
 
-    event_call = Mock()
-    unsub = async_dispatcher_connect(hass, gateway.signal_reachable, event_call)
+    assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
-    gateway.async_connection_status_callback(False)
+    await mock_deconz_websocket(state=STATE_STARTING)
     await hass.async_block_till_done()
 
-    assert gateway.available is False
-    assert len(event_call.mock_calls) == 1
+    assert hass.states.get("binary_sensor.presence").state == STATE_UNAVAILABLE
 
-    unsub()
+    await mock_deconz_websocket(state=STATE_RUNNING)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
 
 async def test_update_address(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Smaller introductory PR for deCONZ websocket fixture. Multiple upcoming PRs that depend on this one.
First step towards reducing the usage of internal integration details in deCONZ tests.
Split from #47738

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #47738
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
