### PR TITLE
Use websocket fixture in deCONZ switch tests

### DIFF
--- a/tests/components/deconz/test_switch.py
+++ b/tests/components/deconz/test_switch.py
@@ -1,8 +1,7 @@
 """deCONZ switch platform tests."""
 
-from copy import deepcopy
+from unittest.mock import patch
 
-from homeassistant.components.deconz.gateway import get_gateway_from_config_entry
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
@@ -16,54 +15,6 @@ from .test_gateway import (
     setup_deconz_integration,
 )
 
-POWER_PLUGS = {
-    "1": {
-        "id": "On off switch id",
-        "name": "On off switch",
-        "type": "On/Off plug-in unit",
-        "state": {"on": True, "reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "Smart plug id",
-        "name": "Smart plug",
-        "type": "Smart plug",
-        "state": {"on": False, "reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-    "3": {
-        "id": "Unsupported switch id",
-        "name": "Unsupported switch",
-        "type": "Not a switch",
-        "state": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:03-00",
-    },
-    "4": {
-        "id": "On off relay id",
-        "name": "On off relay",
-        "state": {"on": True, "reachable": True},
-        "type": "On/Off light",
-        "uniqueid": "00:00:00:00:00:00:00:04-00",
-    },
-}
-
-SIRENS = {
-    "1": {
-        "id": "Warning device id",
-        "name": "Warning device",
-        "type": "Warning device",
-        "state": {"alert": "lselect", "reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:00-00",
-    },
-    "2": {
-        "id": "Unsupported switch id",
-        "name": "Unsupported switch",
-        "type": "Not a switch",
-        "state": {"reachable": True},
-        "uniqueid": "00:00:00:00:00:00:00:01-00",
-    },
-}
-
 
 async def test_no_switches(hass, aioclient_mock):
     """Test that no switch entities are created."""
@@ -71,14 +22,38 @@ async def test_no_switches(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_power_plugs(hass, aioclient_mock):
+async def test_power_plugs(hass, aioclient_mock, mock_deconz_websocket):
     """Test that all supported switch entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["lights"] = deepcopy(POWER_PLUGS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "lights": {
+            "1": {
+                "name": "On off switch",
+                "type": "On/Off plug-in unit",
+                "state": {"on": True, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "name": "Smart plug",
+                "type": "Smart plug",
+                "state": {"on": False, "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+            "3": {
+                "name": "Unsupported switch",
+                "type": "Not a switch",
+                "state": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:03-00",
+            },
+            "4": {
+                "name": "On off relay",
+                "state": {"on": True, "reachable": True},
+                "type": "On/Off light",
+                "uniqueid": "00:00:00:00:00:00:00:04-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 4
     assert hass.states.get("switch.on_off_switch").state == STATE_ON
@@ -86,14 +61,15 @@ async def test_power_plugs(hass, aioclient_mock):
     assert hass.states.get("switch.on_off_relay").state == STATE_ON
     assert hass.states.get("switch.unsupported_switch") is None
 
-    state_changed_event = {
+    event_changed_light = {
         "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"on": False},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
+    await hass.async_block_till_done()
 
     assert hass.states.get("switch.on_off_switch").state == STATE_OFF
 
@@ -124,7 +100,7 @@ async def test_power_plugs(hass, aioclient_mock):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 4
+    assert len(states) == 4
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
@@ -133,27 +109,40 @@ async def test_power_plugs(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_sirens(hass, aioclient_mock):
+async def test_sirens(hass, aioclient_mock, mock_deconz_websocket):
     """Test that siren entities are created."""
-    data = deepcopy(DECONZ_WEB_REQUEST)
-    data["lights"] = deepcopy(SIRENS)
-    config_entry = await setup_deconz_integration(
-        hass, aioclient_mock, get_state_response=data
-    )
-    gateway = get_gateway_from_config_entry(hass, config_entry)
+    data = {
+        "lights": {
+            "1": {
+                "name": "Warning device",
+                "type": "Warning device",
+                "state": {"alert": "lselect", "reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            },
+            "2": {
+                "name": "Unsupported switch",
+                "type": "Not a switch",
+                "state": {"reachable": True},
+                "uniqueid": "00:00:00:00:00:00:00:01-00",
+            },
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
     assert len(hass.states.async_all()) == 2
     assert hass.states.get("switch.warning_device").state == STATE_ON
-    assert hass.states.get("switch.unsupported_switch") is None
+    assert not hass.states.get("switch.unsupported_switch")
 
-    state_changed_event = {
+    event_changed_light = {
         "t": "event",
         "e": "changed",
         "r": "lights",
         "id": "1",
         "state": {"alert": None},
     }
-    gateway.api.event_handler(state_changed_event)
+    await mock_deconz_websocket(data=event_changed_light)
+    await hass.async_block_till_done()
 
     assert hass.states.get("switch.warning_device").state == STATE_OFF
 
@@ -184,7 +173,7 @@ async def test_sirens(hass, aioclient_mock):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(hass.states.async_all()) == 2
+    assert len(states) == 2
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Depends on #47738
Use new websocket fixture
Localize test fixtures
Improve asserts

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #47738
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
