### PR TITLE
Guard extra call in ZHA lights

### DIFF
--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -114,6 +114,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class BaseLight(LogMixin, light.LightEntity):
     """Operations common to all light entities."""
 
+    _FORCE_ON = False
+
     def __init__(self, *args, **kwargs):
         """Initialize the light."""
         super().__init__(*args, **kwargs)
@@ -228,7 +230,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if level:
                 self._brightness = level
 
-        if brightness is None or brightness:
+        if self._FORCE_ON and (brightness is None or brightness):
             # since some lights don't always turn on with move_to_level_with_on_off,
             # we should call the on command on the on_off cluster if brightness is not 0.
             result = await self._on_off_channel.on()
@@ -510,6 +512,17 @@ class HueLight(Light):
     """Representation of a HUE light which does not report attributes."""
 
     _REFRESH_INTERVAL = (3, 5)
+
+
+@STRICT_MATCH(
+    channel_names=CHANNEL_ON_OFF,
+    aux_channels={CHANNEL_COLOR, CHANNEL_LEVEL},
+    manufacturers="Jasco",
+)
+class ForceOnLight(Light):
+    """Representation of a light which does not respect move_to_level_with_on_off."""
+
+    _FORCE_ON = True
 
 
 @GROUP_MATCH()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -230,7 +230,7 @@ class BaseLight(LogMixin, light.LightEntity):
             if level:
                 self._brightness = level
 
-        if self._FORCE_ON and (brightness is None or brightness):
+        if brightness is None or (self._FORCE_ON and brightness):
             # since some lights don't always turn on with move_to_level_with_on_off,
             # we should call the on command on the on_off cluster if brightness is not 0.
             result = await self._on_off_channel.on()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -101,40 +101,33 @@ class LightColorMode(enum.IntEnum):
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Zigbee Home Automation light from config entry."""
-    entities_to_create = [
-        ent_cls(*args) for ent_cls, args in hass.data[DATA_ZHA][light.DOMAIN]
-    ]
 
-    normal_light_entities = [
-        light_entity
-        for light_entity in entities_to_create
-        if isinstance(light_entity, Light)
-    ]
+    async def _async_add_light_entities():
+        entities_to_create = [
+            ent_cls(*args) for ent_cls, args in hass.data[DATA_ZHA][light.DOMAIN]
+        ]
 
-    group_light_entities = [
-        light_entity
-        for light_entity in entities_to_create
-        if isinstance(light_entity, LightGroup)
-    ]
+        normal_light_entities = [
+            light_entity
+            for light_entity in entities_to_create
+            if isinstance(light_entity, Light)
+        ]
 
-    async def _async_add_light_entities(
-        _async_add_entities, _normal_light_entities, _group_light_entities
-    ):
-        if _normal_light_entities:
-            _async_add_entities(normal_light_entities, update_before_add=True)
-        if _group_light_entities:
-            _async_add_entities(group_light_entities, update_before_add=True)
+        group_light_entities = [
+            light_entity
+            for light_entity in entities_to_create
+            if isinstance(light_entity, LightGroup)
+        ]
+        if normal_light_entities:
+            async_add_entities(normal_light_entities, update_before_add=True)
+        if group_light_entities:
+            async_add_entities(group_light_entities, update_before_add=True)
         hass.data[DATA_ZHA][light.DOMAIN].clear()
 
     unsub = async_dispatcher_connect(
         hass,
         SIGNAL_ADD_ENTITIES,
-        functools.partial(
-            _async_add_light_entities,
-            async_add_entities,
-            normal_light_entities,
-            group_light_entities,
-        ),
+        _async_add_light_entities,
     )
     hass.data[DATA_ZHA][DATA_ZHA_DISPATCHERS].append(unsub)
 

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -524,7 +524,7 @@ class HueLight(Light):
 class ForceOnLight(Light):
     """Representation of a light which does not respect move_to_level_with_on_off."""
 
-    force_on = True
+    _FORCE_ON = True
 
 
 @GROUP_MATCH()

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -546,6 +546,10 @@ class LightGroup(BaseLight, ZhaGroupEntity):
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""
         await super().async_added_to_hass()
+        self._FORCE_ON = any(
+            self.platform.entities[member_entity_id]._FORCE_ON
+            for member_entity_id in self._entity_ids
+        )
         if self._debounced_member_refresh is None:
             force_refresh_debouncer = Debouncer(
                 self.hass,

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -65,6 +65,8 @@ CAPABILITIES_COLOR_LOOP = 0x4
 CAPABILITIES_COLOR_XY = 0x08
 CAPABILITIES_COLOR_TEMP = 0x10
 
+DEFAULT_TRANSITION = 1
+
 UPDATE_COLORLOOP_ACTION = 0x1
 UPDATE_COLORLOOP_DIRECTION = 0x2
 UPDATE_COLORLOOP_TIME = 0x4
@@ -203,7 +205,7 @@ class BaseLight(LogMixin, light.LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
         transition = kwargs.get(light.ATTR_TRANSITION)
-        duration = transition * 10 if transition else 1
+        duration = transition * 10 if transition else DEFAULT_TRANSITION
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)
         flash = kwargs.get(light.ATTR_FLASH)

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -392,13 +392,11 @@ async def async_test_level_on_off_from_hass(
     await hass.services.async_call(
         DOMAIN, "turn_on", {"entity_id": entity_id, "brightness": 10}, blocking=True
     )
-    assert on_off_cluster.request.call_count == 1
-    assert on_off_cluster.request.await_count == 1
+    # the onoff cluster is now not used when brightness is present by default
+    assert on_off_cluster.request.call_count == 0
+    assert on_off_cluster.request.await_count == 0
     assert level_cluster.request.call_count == 1
     assert level_cluster.request.await_count == 1
-    assert on_off_cluster.request.call_args == call(
-        False, ON, (), expect_reply=True, manufacturer=None, tries=1, tsn=None
-    )
     assert level_cluster.request.call_args == call(
         False,
         4,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR guards an extra call for ZHA light entities that is only needed for certain bulbs. This is one of a couple changes to address issues like #47714

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
