### PR TITLE
Shield async httpx call in generic

### DIFF
--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -162,7 +162,7 @@ class GenericCamera(Camera):
             return self._last_url, self._last_image
         finally:
             if response:
-                response.close()
+                await response.aclose()
         return url, image
 
     @property

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -125,6 +125,11 @@ class GenericCamera(Camera):
         ).result()
 
     async def async_camera_image(self):
+        """Wrap _async_camera_image with an asyncio.shield."""
+        # Shield the request because of https://github.com/encode/httpx/issues/1461
+        return await asyncio.shield(self._async_camera_image())
+
+    async def _async_camera_image(self):
         """Return a still image response from the camera."""
         try:
             url = self._still_image_url.async_render(parse_result=False)
@@ -134,7 +139,7 @@ class GenericCamera(Camera):
 
         if url == self._last_url and self._limit_refetch:
             return self._last_image
-
+        response = None
         try:
             async_client = get_async_client(self.hass, verify_ssl=self.verify_ssl)
             response = await async_client.get(
@@ -142,14 +147,16 @@ class GenericCamera(Camera):
             )
             response.raise_for_status()
             self._last_image = response.content
+            self._last_url = url
         except httpx.TimeoutException:
             _LOGGER.error("Timeout getting camera image from %s", self._name)
             return self._last_image
         except (httpx.RequestError, httpx.HTTPStatusError) as err:
             _LOGGER.error("Error getting new camera image from %s: %s", self._name, err)
             return self._last_image
-
-        self._last_url = url
+        finally:
+            if response:
+                response.close()
         return self._last_image
 
     @property

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -131,9 +131,9 @@ class GenericCamera(Camera):
             self._last_url, self._last_image = await asyncio.shield(
                 self._async_camera_image()
             )
-        except asyncio.CancelledError as e:
+        except asyncio.CancelledError as err:
             _LOGGER.warning("Timeout getting camera image from %s", self._name)
-            raise e
+            raise err
         return self._last_image
 
     async def _async_camera_image(self):

--- a/homeassistant/components/generic/camera.py
+++ b/homeassistant/components/generic/camera.py
@@ -131,8 +131,9 @@ class GenericCamera(Camera):
             self._last_url, self._last_image = await asyncio.shield(
                 self._async_camera_image()
             )
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as e:
             _LOGGER.warning("Timeout getting camera image from %s", self._name)
+            raise e
         return self._last_image
 
     async def _async_camera_image(self):

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -3,6 +3,7 @@ import asyncio
 from os import path
 from unittest.mock import patch
 
+import httpx
 import respx
 
 from homeassistant import config as hass_config
@@ -405,6 +406,57 @@ async def test_reloading(hass, hass_client):
     assert respx.calls.call_count == 2
     body = await resp.text()
     assert body == "hello world"
+
+
+@respx.mock
+async def test_timeout_cancelled(hass, hass_client):
+    """Test that timeouts and cancellations return last image."""
+
+    respx.get("http://example.com").respond(text="hello world")
+
+    await async_setup_component(
+        hass,
+        "camera",
+        {
+            "camera": {
+                "name": "config_test",
+                "platform": "generic",
+                "still_image_url": "http://example.com",
+                "username": "user",
+                "password": "pass",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    client = await hass_client()
+
+    resp = await client.get("/api/camera_proxy/camera.config_test")
+
+    assert resp.status == 200
+    assert respx.calls.call_count == 1
+    assert await resp.text() == "hello world"
+
+    respx.get("http://example.com").respond(text="not hello world")
+
+    with patch(
+        "homeassistant.components.generic.camera.GenericCamera._async_camera_image",
+        side_effect=asyncio.CancelledError(),
+    ):
+        resp = await client.get("/api/camera_proxy/camera.config_test")
+        assert respx.calls.call_count == 1
+        assert await resp.text() == "hello world"
+
+    respx.get("http://example.com").side_effect = [
+        httpx.RequestError,
+        httpx.TimeoutException,
+    ]
+
+    for total_calls in range(2, 4):
+        resp = await client.get("/api/camera_proxy/camera.config_test")
+        assert respx.calls.call_count == total_calls
+        assert resp.status == 200
+        assert await resp.text() == "hello world"
 
 
 def _get_fixtures_base_path():

--- a/tests/components/generic/test_camera.py
+++ b/tests/components/generic/test_camera.py
@@ -445,7 +445,7 @@ async def test_timeout_cancelled(hass, hass_client):
     ):
         resp = await client.get("/api/camera_proxy/camera.config_test")
         assert respx.calls.call_count == 1
-        assert await resp.text() == "hello world"
+        assert resp.status == 500
 
     respx.get("http://example.com").side_effect = [
         httpx.RequestError,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/home-assistant/core/pull/46576 changed `generic` to use the `httpx` library. However, there are a few outstanding issues with `httpx`'s async api (e.g. https://github.com/encode/httpx/issues/1461) which seem to be causing https://github.com/home-assistant/core/issues/47624. This PR uses `asyncio.shield` as a workaround for the `httpx` issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/47624
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
