### PR TITLE
Add operation mode sensor to lyric

### DIFF
--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -31,6 +31,12 @@ LYRIC_SETPOINT_STATUS_NAMES = {
     PRESET_VACATION_HOLD: "Holiday",
 }
 
+LYRIC_OPERATION_MODES = {
+    "Cool": "Cooling",
+    "EquipmentOff": "Equipment Off",
+    "Heat": "Heating",
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistantType, entry: ConfigEntry, async_add_entities
@@ -54,6 +60,8 @@ async def async_setup_entry(
                     cls_list.append(LyricNextPeriodSensor)
                 if device.changeableValues.thermostatSetpointStatus:
                     cls_list.append(LyricSetpointStatusSensor)
+            if device.operationStatus and device.operationStatus.mode:
+                cls_list.append(LyricOperationModeSensor)
             for cls in cls_list:
                 entities.append(
                     cls(
@@ -248,4 +256,35 @@ class LyricSetpointStatusSensor(LyricSensor):
             return f"Held until {device.changeableValues.nextPeriodTime}"
         return LYRIC_SETPOINT_STATUS_NAMES.get(
             device.changeableValues.thermostatSetpointStatus, "Unknown"
+        )
+
+
+class LyricOperationModeSensor(LyricSensor):
+    """Defines a Honeywell Lyric sensor."""
+
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        location: LyricLocation,
+        device: LyricDevice,
+        unit_of_measurement: str = None,
+    ) -> None:
+        """Initialize Honeywell Lyric sensor."""
+
+        super().__init__(
+            coordinator,
+            location,
+            device,
+            f"{device.macID}_opeation_mode",
+            "Operation Mode",
+            "mdi:hvac",
+            None,
+        )
+
+    @property
+    def state(self) -> str:
+        """Return the state of the sensor."""
+        device = self.device
+        return LYRIC_OPERATION_MODES.get(
+            device.operationStatus.mode, device.operationStatus.mode
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds operation mode sensor to lyric integration. This shows whether the equipment is running or not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] New feature (which adds functionality to an existing integration)

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
lyric:
  client_id: !secret lyric_client_id
  client_secret: !secret lyric_client_secret
```

<!--
## Additional information
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
-->

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] 🥈 Silver

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
