### PR TITLE
Verisure: Remove JSONPath, unique IDs, small cleanups

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -1,30 +1,27 @@
 """Support for Verisure devices."""
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import Any, Literal
-
-from jsonpath import jsonpath
-from verisure import (
-    Error as VerisureError,
-    ResponseError as VerisureResponseError,
-    Session as Verisure,
-)
+from verisure import Error as VerisureError
 import voluptuous as vol
 
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     CONF_PASSWORD,
     CONF_SCAN_INTERVAL,
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
-    HTTP_SERVICE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util import Throttle
 
 from .const import (
     ATTR_DEVICE_SERIAL,
@@ -47,14 +44,15 @@ from .const import (
     SERVICE_DISABLE_AUTOLOCK,
     SERVICE_ENABLE_AUTOLOCK,
 )
+from .coordinator import VerisureDataUpdateCoordinator
 
 PLATFORMS = [
-    "sensor",
-    "switch",
-    "alarm_control_panel",
-    "lock",
-    "camera",
-    "binary_sensor",
+    ALARM_CONTROL_PANEL_DOMAIN,
+    BINARY_SENSOR_DOMAIN,
+    CAMERA_DOMAIN,
+    LOCK_DOMAIN,
+    SENSOR_DOMAIN,
+    SWITCH_DOMAIN,
 ]
 
 CONFIG_SCHEMA = vol.Schema(
@@ -88,18 +86,13 @@ DEVICE_SERIAL_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_SERIAL): cv.string})
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Verisure integration."""
-    verisure = Verisure(config[DOMAIN][CONF_USERNAME], config[DOMAIN][CONF_PASSWORD])
-    coordinator = VerisureDataUpdateCoordinator(
-        hass, session=verisure, domain_config=config[DOMAIN]
-    )
+    coordinator = VerisureDataUpdateCoordinator(hass, config=config[DOMAIN])
 
-    if not await hass.async_add_executor_job(coordinator.login):
+    if not await coordinator.async_login():
         LOGGER.error("Login failed")
         return False
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STOP, lambda event: coordinator.logout()
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_logout)
 
     await coordinator.async_refresh()
     if not coordinator.last_update_success:
@@ -152,95 +145,3 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DOMAIN, SERVICE_ENABLE_AUTOLOCK, enable_autolock, schema=DEVICE_SERIAL_SCHEMA
     )
     return True
-
-
-class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
-    """A Verisure Data Update Coordinator."""
-
-    def __init__(
-        self, hass: HomeAssistant, domain_config: ConfigType, session: Verisure
-    ) -> None:
-        """Initialize the Verisure hub."""
-        self.imageseries = {}
-        self.config = domain_config
-        self.giid = domain_config.get(CONF_GIID)
-
-        self.session = session
-
-        super().__init__(
-            hass, LOGGER, name=DOMAIN, update_interval=domain_config[CONF_SCAN_INTERVAL]
-        )
-
-    def login(self) -> bool:
-        """Login to Verisure."""
-        try:
-            self.session.login()
-        except VerisureError as ex:
-            LOGGER.error("Could not log in to verisure, %s", ex)
-            return False
-        if self.giid:
-            return self.set_giid()
-        return True
-
-    def logout(self) -> bool:
-        """Logout from Verisure."""
-        try:
-            self.session.logout()
-        except VerisureError as ex:
-            LOGGER.error("Could not log out from verisure, %s", ex)
-            return False
-        return True
-
-    def set_giid(self) -> bool:
-        """Set installation GIID."""
-        try:
-            self.session.set_giid(self.giid)
-        except VerisureError as ex:
-            LOGGER.error("Could not set installation GIID, %s", ex)
-            return False
-        return True
-
-    async def _async_update_data(self) -> dict:
-        """Fetch data from Verisure."""
-        try:
-            return await self.hass.async_add_executor_job(self.session.get_overview)
-        except VerisureResponseError as ex:
-            LOGGER.error("Could not read overview, %s", ex)
-            if ex.status_code == HTTP_SERVICE_UNAVAILABLE:  # Service unavailable
-                LOGGER.info("Trying to log in again")
-                await self.hass.async_add_executor_job(self.login)
-                return {}
-            raise
-
-    @Throttle(timedelta(seconds=60))
-    def update_smartcam_imageseries(self) -> None:
-        """Update the image series."""
-        self.imageseries = self.session.get_camera_imageseries()
-
-    @Throttle(timedelta(seconds=30))
-    def smartcam_capture(self, device_id: str) -> None:
-        """Capture a new image from a smartcam."""
-        self.session.capture_image(device_id)
-
-    def disable_autolock(self, device_id: str) -> None:
-        """Disable autolock."""
-        self.session.set_lock_config(device_id, auto_lock_enabled=False)
-
-    def enable_autolock(self, device_id: str) -> None:
-        """Enable autolock."""
-        self.session.set_lock_config(device_id, auto_lock_enabled=True)
-
-    def get(self, jpath: str, *args) -> list[Any] | Literal[False]:
-        """Get values from the overview that matches the jsonpath."""
-        res = jsonpath(self.data, jpath % args)
-        return res or []
-
-    def get_first(self, jpath: str, *args) -> Any | None:
-        """Get first value from the overview that matches the jsonpath."""
-        res = self.get(jpath, *args)
-        return res[0] if res else None
-
-    def get_image_info(self, jpath: str, *args) -> list[Any] | Literal[False]:
-        """Get values from the imageseries that matches the jsonpath."""
-        res = jsonpath(self.imageseries, jpath % args)
-        return res or []

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -70,7 +70,7 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
         self.coordinator.update_smartcam_imageseries()
 
         images = self.coordinator.imageseries.get("imageSeries", [])
-        new_image_id = False
+        new_image_id = None
         for image in images:
             if image["deviceLabel"] == self.serial_number:
                 new_image_id = image["image"][0]["imageId"]

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -8,33 +8,28 @@ from typing import Any, Callable
 from homeassistant.components.camera import Camera
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import VerisureDataUpdateCoordinator
 from .const import CONF_SMARTCAM, DOMAIN, LOGGER
+from .coordinator import VerisureDataUpdateCoordinator
 
 
 def setup_platform(
     hass: HomeAssistant,
     config: dict[str, Any],
-    add_entities: Callable[[list[Entity], bool], None],
+    add_entities: Callable[[list[VerisureSmartcam]], None],
     discovery_info: dict[str, Any] | None = None,
 ) -> None:
     """Set up the Verisure Camera."""
-    coordinator = hass.data[DOMAIN]
+    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN]
     if not int(coordinator.config.get(CONF_SMARTCAM, 1)):
         return
 
-    directory_path = hass.config.config_dir
-    if not os.access(directory_path, os.R_OK):
-        LOGGER.error("file path %s is not readable", directory_path)
-        return
-
+    assert hass.config.config_dir
     add_entities(
         [
-            VerisureSmartcam(hass, coordinator, device_label, directory_path)
-            for device_label in coordinator.get("$.customerImageCameras[*].deviceLabel")
+            VerisureSmartcam(hass, coordinator, serial_number, hass.config.config_dir)
+            for serial_number in coordinator.data["cameras"]
         ]
     )
 
@@ -48,13 +43,13 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
         self,
         hass: HomeAssistant,
         coordinator: VerisureDataUpdateCoordinator,
-        device_label: str,
+        serial_number: str,
         directory_path: str,
     ):
         """Initialize Verisure File Camera component."""
         super().__init__(coordinator)
 
-        self._device_label = device_label
+        self.serial_number = serial_number
         self._directory_path = directory_path
         self._image = None
         self._image_id = None
@@ -73,21 +68,27 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
     def check_imagelist(self) -> None:
         """Check the contents of the image list."""
         self.coordinator.update_smartcam_imageseries()
-        image_ids = self.coordinator.get_image_info(
-            "$.imageSeries[?(@.deviceLabel=='%s')].image[0].imageId", self._device_label
-        )
-        if not image_ids:
+
+        images = self.coordinator.imageseries.get("imageSeries", [])
+        new_image_id = False
+        for image in images:
+            if image["deviceLabel"] == self.serial_number:
+                new_image_id = image["image"][0]["imageId"]
+                break
+
+        if not new_image_id:
             return
-        new_image_id = image_ids[0]
+
         if new_image_id in ("-1", self._image_id):
             LOGGER.debug("The image is the same, or loading image_id")
             return
+
         LOGGER.debug("Download new image %s", new_image_id)
         new_image_path = os.path.join(
             self._directory_path, "{}{}".format(new_image_id, ".jpg")
         )
-        self.coordinator.session.download_image(
-            self._device_label, new_image_id, new_image_path
+        self.coordinator.verisure.download_image(
+            self.serial_number, new_image_id, new_image_path
         )
         LOGGER.debug("Old image_id=%s", self._image_id)
         self.delete_image()
@@ -110,6 +111,9 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
     @property
     def name(self) -> str:
         """Return the name of this camera."""
-        return self.coordinator.get_first(
-            "$.customerImageCameras[?(@.deviceLabel=='%s')].area", self._device_label
-        )
+        return self.coordinator.data["cameras"][self.serial_number]["area"]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this camera."""
+        return self.serial_number

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -2,9 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
-from typing import Any, Literal
 
-from jsonpath import jsonpath
 from verisure import (
     Error as VerisureError,
     ResponseError as VerisureResponseError,
@@ -126,8 +124,3 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
     def enable_autolock(self, device_id: str) -> None:
         """Enable autolock."""
         self.verisure.set_lock_config(device_id, auto_lock_enabled=True)
-
-    def get_image_info(self, jpath: str, *args) -> list[Any] | Literal[False]:
-        """Get values from the imageseries that matches the jsonpath."""
-        res = jsonpath(self.imageseries, jpath % args)
-        return res or []

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -1,0 +1,133 @@
+"""DataUpdateCoordinator for the Verisure integration."""
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any, Literal
+
+from jsonpath import jsonpath
+from verisure import (
+    Error as VerisureError,
+    ResponseError as VerisureResponseError,
+    Session as Verisure,
+)
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, HTTP_SERVICE_UNAVAILABLE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util import Throttle
+
+from .const import CONF_GIID, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
+
+
+class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
+    """A Verisure Data Update Coordinator."""
+
+    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+        """Initialize the Verisure hub."""
+        self.imageseries = {}
+        self.config = config
+        self.giid = config.get(CONF_GIID)
+
+        self.verisure = Verisure(
+            username=config[CONF_USERNAME], password=config[CONF_PASSWORD]
+        )
+
+        super().__init__(
+            hass, LOGGER, name=DOMAIN, update_interval=DEFAULT_SCAN_INTERVAL
+        )
+
+    async def async_login(self) -> bool:
+        """Login to Verisure."""
+        try:
+            await self.hass.async_add_executor_job(self.verisure.login)
+        except VerisureError as ex:
+            LOGGER.error("Could not log in to verisure, %s", ex)
+            return False
+        if self.giid:
+            return await self.async_set_giid()
+        return True
+
+    async def async_logout(self) -> bool:
+        """Logout from Verisure."""
+        try:
+            await self.hass.async_add_executor_job(self.verisure.logout)
+        except VerisureError as ex:
+            LOGGER.error("Could not log out from verisure, %s", ex)
+            return False
+        return True
+
+    async def async_set_giid(self) -> bool:
+        """Set installation GIID."""
+        try:
+            await self.hass.async_add_executor_job(self.verisure.set_giid, self.giid)
+        except VerisureError as ex:
+            LOGGER.error("Could not set installation GIID, %s", ex)
+            return False
+        return True
+
+    async def _async_update_data(self) -> dict:
+        """Fetch data from Verisure."""
+        try:
+            overview = await self.hass.async_add_executor_job(
+                self.verisure.get_overview
+            )
+        except VerisureResponseError as ex:
+            LOGGER.error("Could not read overview, %s", ex)
+            if ex.status_code == HTTP_SERVICE_UNAVAILABLE:  # Service unavailable
+                LOGGER.info("Trying to log in again")
+                await self.async_login()
+                return {}
+            raise
+
+        # Store data in a way Home Assistant can easily consume it
+        return {
+            "alarm": overview["armState"],
+            "ethernet": overview.get("ethernetConnectedNow"),
+            "cameras": {
+                device["deviceLabel"]: device
+                for device in overview["customerImageCameras"]
+            },
+            "climate": {
+                device["deviceLabel"]: device for device in overview["climateValues"]
+            },
+            "door_window": {
+                device["deviceLabel"]: device
+                for device in overview["doorWindow"]["doorWindowDevice"]
+            },
+            "locks": {
+                device["deviceLabel"]: device
+                for device in overview["doorLockStatusList"]
+            },
+            "mice": {
+                device["deviceLabel"]: device
+                for device in overview["eventCounts"]
+                if device["deviceType"] == "MOUSE1"
+            },
+            "smart_plugs": {
+                device["deviceLabel"]: device for device in overview["smartPlugs"]
+            },
+        }
+
+    @Throttle(timedelta(seconds=60))
+    def update_smartcam_imageseries(self) -> None:
+        """Update the image series."""
+        self.imageseries = self.verisure.get_camera_imageseries()
+
+    @Throttle(timedelta(seconds=30))
+    def smartcam_capture(self, device_id: str) -> None:
+        """Capture a new image from a smartcam."""
+        self.verisure.capture_image(device_id)
+
+    def disable_autolock(self, device_id: str) -> None:
+        """Disable autolock."""
+        self.verisure.set_lock_config(device_id, auto_lock_enabled=False)
+
+    def enable_autolock(self, device_id: str) -> None:
+        """Enable autolock."""
+        self.verisure.set_lock_config(device_id, auto_lock_enabled=True)
+
+    def get_image_info(self, jpath: str, *args) -> list[Any] | Literal[False]:
+        """Get values from the imageseries that matches the jsonpath."""
+        res = jsonpath(self.imageseries, jpath % args)
+        return res or []

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -7,17 +7,16 @@ from typing import Any, Callable
 from homeassistant.components.lock import LockEntity
 from homeassistant.const import ATTR_CODE, STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import VerisureDataUpdateCoordinator
 from .const import CONF_CODE_DIGITS, CONF_DEFAULT_LOCK_CODE, CONF_LOCKS, DOMAIN, LOGGER
+from .coordinator import VerisureDataUpdateCoordinator
 
 
 def setup_platform(
     hass: HomeAssistant,
     config: dict[str, Any],
-    add_entities: Callable[[list[Entity], bool], None],
+    add_entities: Callable[[list[VerisureDoorlock]], None],
     discovery_info: dict[str, Any] | None = None,
 ) -> None:
     """Set up the Verisure lock platform."""
@@ -26,10 +25,8 @@ def setup_platform(
     if int(coordinator.config.get(CONF_LOCKS, 1)):
         locks.extend(
             [
-                VerisureDoorlock(coordinator, device_label)
-                for device_label in coordinator.get(
-                    "$.doorLockStatusList[*].deviceLabel"
-                )
+                VerisureDoorlock(coordinator, serial_number)
+                for serial_number in coordinator.data["locks"]
             ]
         )
 
@@ -42,11 +39,11 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
     coordinator: VerisureDataUpdateCoordinator
 
     def __init__(
-        self, coordinator: VerisureDataUpdateCoordinator, device_label: str
+        self, coordinator: VerisureDataUpdateCoordinator, serial_number: str
     ) -> None:
         """Initialize the Verisure lock."""
         super().__init__(coordinator)
-        self._device_label = device_label
+        self.serial_number = serial_number
         self._state = None
         self._digits = coordinator.config.get(CONF_CODE_DIGITS)
         self._default_lock_code = coordinator.config.get(CONF_DEFAULT_LOCK_CODE)
@@ -54,27 +51,19 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
     @property
     def name(self) -> str:
         """Return the name of the lock."""
-        return self.coordinator.get_first(
-            "$.doorLockStatusList[?(@.deviceLabel=='%s')].area", self._device_label
-        )
+        return self.coordinator.data["locks"][self.serial_number]["area"]
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return (
-            self.coordinator.get_first(
-                "$.doorLockStatusList[?(@.deviceLabel=='%s')]", self._device_label
-            )
-            is not None
+            super().available and self.serial_number in self.coordinator.data["locks"]
         )
 
     @property
     def changed_by(self) -> str | None:
         """Last change triggered by."""
-        return self.coordinator.get_first(
-            "$.doorLockStatusList[?(@.deviceLabel=='%s')].userString",
-            self._device_label,
-        )
+        return self.coordinator.data["locks"][self.serial_number].get("userString")
 
     @property
     def code_format(self) -> str:
@@ -84,11 +73,10 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
     @property
     def is_locked(self) -> bool:
         """Return true if lock is locked."""
-        status = self.coordinator.get_first(
-            "$.doorLockStatusList[?(@.deviceLabel=='%s')].lockedState",
-            self._device_label,
+        return (
+            self.coordinator.data["locks"][self.serial_number]["lockedState"]
+            == "LOCKED"
         )
-        return status == "LOCKED"
 
     async def async_unlock(self, **kwargs) -> None:
         """Send unlock command."""
@@ -112,9 +100,9 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
         """Send set lock state command."""
         target_state = "lock" if state == STATE_LOCKED else "unlock"
         lock_state = await self.hass.async_add_executor_job(
-            self.coordinator.session.set_lock_state,
+            self.coordinator.verisure.set_lock_state,
             code,
-            self._device_label,
+            self.serial_number,
             target_state,
         )
 
@@ -123,7 +111,7 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
         attempts = 0
         while "result" not in transaction:
             transaction = await self.hass.async_add_executor_job(
-                self.coordinator.session.get_lock_state_transaction,
+                self.coordinator.verisure.get_lock_state_transaction,
                 lock_state["doorLockStateChangeTransactionId"],
             )
             attempts += 1

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -2,6 +2,6 @@
   "domain": "verisure",
   "name": "Verisure",
   "documentation": "https://www.home-assistant.io/integrations/verisure",
-  "requirements": ["jsonpath==0.82", "vsure==1.7.2"],
+  "requirements": ["vsure==1.7.2"],
   "codeowners": ["@frenck"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -829,7 +829,6 @@ influxdb==5.2.3
 iperf3==0.1.11
 
 # homeassistant.components.rest
-# homeassistant.components.verisure
 jsonpath==0.82
 
 # homeassistant.components.kaiterra

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -446,7 +446,6 @@ influxdb-client==1.14.0
 influxdb==5.2.3
 
 # homeassistant.components.rest
-# homeassistant.components.verisure
 jsonpath==0.82
 
 # homeassistant.components.konnected


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Another step in the Verisure integration cleanup/refactoring.

- Moves the DataUpdateCoordinator into its own file.
- Data is processed in the DataUpdateCoordinator, so it becomes easier to consume for Home Assistant.
- Removed the need/use of JSONPath.
- device_labels and such, are serial numbers (and referenced as such in Versisure now as well). Code adjusted to make that clear.
- Added Unique IDs based on the serial numbers (where possible at this point).
- Updated all `available` properties to take the DataUpdateCoordinator status into account.

This code is far from perfect, but is meant as a step forward. Got some more changes ready to go after this PR (e.g., Configuration flow with imports/discovery, devices, more unique IDs, lots more to clean up).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
verisure:
  username: test
  password: welcome1
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
