### PR TITLE
Add config flow to Verisure

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1064,7 +1064,14 @@ omit =
     homeassistant/components/velbus/switch.py
     homeassistant/components/velux/*
     homeassistant/components/venstar/climate.py
-    homeassistant/components/verisure/*
+    homeassistant/components/verisure/__init__.py
+    homeassistant/components/verisure/alarm_control_panel.py
+    homeassistant/components/verisure/binary_sensor.py
+    homeassistant/components/verisure/camera.py
+    homeassistant/components/verisure/coordinator.py
+    homeassistant/components/verisure/lock.py
+    homeassistant/components/verisure/sensor.py
+    homeassistant/components/verisure/switch.py
     homeassistant/components/versasense/*
     homeassistant/components/vesync/__init__.py
     homeassistant/components/vesync/common.py

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     CONF_EMAIL,
     CONF_PASSWORD,
@@ -133,12 +133,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = VerisureDataUpdateCoordinator(hass, entry=entry)
 
     if not await coordinator.async_login():
-        LOGGER.error("Login failed")
-        await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_REAUTH},
-            data=entry.data,
-        )
+        LOGGER.error("Could not login to Verisure, aborting setting up integration")
         return False
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_logout)

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -1,6 +1,10 @@
 """Support for Verisure devices."""
 from __future__ import annotations
 
+import asyncio
+import os
+from typing import Any
+
 from verisure import Error as VerisureError
 import voluptuous as vol
 
@@ -12,34 +16,24 @@ from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import (
+    CONF_EMAIL,
     CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
     CONF_USERNAME,
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import discovery
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.storage import STORAGE_DIR
 
 from .const import (
     ATTR_DEVICE_SERIAL,
-    CONF_ALARM,
     CONF_CODE_DIGITS,
     CONF_DEFAULT_LOCK_CODE,
-    CONF_DOOR_WINDOW,
     CONF_GIID,
-    CONF_HYDROMETERS,
-    CONF_LOCKS,
-    CONF_MOUSE,
-    CONF_SMARTCAM,
-    CONF_SMARTPLUGS,
-    CONF_THERMOMETERS,
-    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     LOGGER,
-    MIN_SCAN_INTERVAL,
     SERVICE_CAPTURE_SMARTCAM,
     SERVICE_DISABLE_AUTOLOCK,
     SERVICE_ENABLE_AUTOLOCK,
@@ -56,40 +50,57 @@ PLATFORMS = [
 ]
 
 CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_PASSWORD): cv.string,
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Optional(CONF_ALARM, default=True): cv.boolean,
-                vol.Optional(CONF_CODE_DIGITS, default=4): cv.positive_int,
-                vol.Optional(CONF_DOOR_WINDOW, default=True): cv.boolean,
-                vol.Optional(CONF_GIID): cv.string,
-                vol.Optional(CONF_HYDROMETERS, default=True): cv.boolean,
-                vol.Optional(CONF_LOCKS, default=True): cv.boolean,
-                vol.Optional(CONF_DEFAULT_LOCK_CODE): cv.string,
-                vol.Optional(CONF_MOUSE, default=True): cv.boolean,
-                vol.Optional(CONF_SMARTPLUGS, default=True): cv.boolean,
-                vol.Optional(CONF_THERMOMETERS, default=True): cv.boolean,
-                vol.Optional(CONF_SMARTCAM, default=True): cv.boolean,
-                vol.Optional(CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL): (
-                    vol.All(cv.time_period, vol.Clamp(min=MIN_SCAN_INTERVAL))
-                ),
-            }
-        )
-    },
+    vol.All(
+        cv.deprecated(DOMAIN),
+        {
+            DOMAIN: vol.Schema(
+                {
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Required(CONF_USERNAME): cv.string,
+                    vol.Optional(CONF_CODE_DIGITS, default=4): cv.positive_int,
+                    vol.Optional(CONF_GIID): cv.string,
+                    vol.Optional(CONF_DEFAULT_LOCK_CODE): cv.string,
+                },
+                extra=vol.ALLOW_EXTRA,
+            )
+        },
+    ),
     extra=vol.ALLOW_EXTRA,
 )
+
 
 DEVICE_SERIAL_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_SERIAL): cv.string})
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
     """Set up the Verisure integration."""
-    coordinator = VerisureDataUpdateCoordinator(hass, config=config[DOMAIN])
+    if DOMAIN in config:
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data={
+                    CONF_EMAIL: config[DOMAIN][CONF_USERNAME],
+                    CONF_PASSWORD: config[DOMAIN][CONF_PASSWORD],
+                    CONF_GIID: config[DOMAIN].get(CONF_GIID),
+                },
+            )
+        )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Verisure from a config entry."""
+    coordinator = VerisureDataUpdateCoordinator(hass, entry=entry)
 
     if not await coordinator.async_login():
         LOGGER.error("Login failed")
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH},
+            data=entry.data,
+        )
         return False
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_logout)
@@ -99,11 +110,13 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         LOGGER.error("Update failed")
         return False
 
-    hass.data[DOMAIN] = coordinator
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
+    # Set up all platforms for this device/entry.
     for platform in PLATFORMS:
         hass.async_create_task(
-            discovery.async_load_platform(hass, platform, DOMAIN, {}, config)
+            hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
     async def capture_smartcam(service):
@@ -145,3 +158,26 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         DOMAIN, SERVICE_ENABLE_AUTOLOCK, enable_autolock, schema=DEVICE_SERIAL_SCHEMA
     )
     return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload Verisure config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *(
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            )
+        )
+    )
+
+    if unload_ok:
+        cookie_file = hass.config.path(STORAGE_DIR, f"verisure_{entry.entry_id}")
+        if os.path.exists(cookie_file):
+            os.unlink(cookie_file)
+        del hass.data[DOMAIN][entry.entry_id]
+
+    if not hass.data[DOMAIN]:
+        del hass.data[DOMAIN]
+
+    return unload_ok

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
@@ -107,8 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await coordinator.async_refresh()
     if not coordinator.last_update_success:
-        LOGGER.error("Update failed")
-        return False
+        raise ConfigEntryNotReady
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -100,28 +100,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Verisure from a config entry."""
     # Migrate old YAML settings (hidden in the config entry),
     # to config entry options. Can be removed after YAML support is gone.
-    if (
-        CONF_LOCK_CODE_DIGITS not in entry.options
-        and CONF_LOCK_CODE_DIGITS in entry.data
-        and entry.data[CONF_LOCK_CODE_DIGITS] != DEFAULT_LOCK_CODE_DIGITS
-    ):
-        options = {
-            **entry.options,
-            CONF_LOCK_CODE_DIGITS: entry.data[CONF_LOCK_CODE_DIGITS],
-        }
+    if CONF_LOCK_CODE_DIGITS in entry.data or CONF_DEFAULT_LOCK_CODE in entry.data:
+        options = entry.options.copy()
+
+        if (
+            CONF_LOCK_CODE_DIGITS in entry.data
+            and CONF_LOCK_CODE_DIGITS not in entry.options
+            and entry.data[CONF_LOCK_CODE_DIGITS] != DEFAULT_LOCK_CODE_DIGITS
+        ):
+            options.update(
+                {
+                    CONF_LOCK_CODE_DIGITS: entry.data[CONF_LOCK_CODE_DIGITS],
+                }
+            )
+
+        if (
+            CONF_DEFAULT_LOCK_CODE in entry.data
+            and CONF_DEFAULT_LOCK_CODE not in entry.options
+        ):
+            options.update(
+                {
+                    CONF_DEFAULT_LOCK_CODE: entry.data[CONF_DEFAULT_LOCK_CODE],
+                }
+            )
+
         data = entry.data.copy()
         data.pop(CONF_LOCK_CODE_DIGITS)
-        hass.config_entries.async_update_entry(entry, data=data, options=options)
-
-    if (
-        CONF_DEFAULT_LOCK_CODE not in entry.options
-        and CONF_DEFAULT_LOCK_CODE in entry.data
-    ):
-        options = {
-            **entry.options,
-            CONF_DEFAULT_LOCK_CODE: entry.data[CONF_DEFAULT_LOCK_CODE],
-        }
-        data = entry.data.copy()
         data.pop(CONF_DEFAULT_LOCK_CODE)
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -203,13 +203,18 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
     )
 
-    if unload_ok:
-        cookie_file = hass.config.path(STORAGE_DIR, f"verisure_{entry.entry_id}")
-        if os.path.exists(cookie_file):
-            os.unlink(cookie_file)
-        del hass.data[DOMAIN][entry.entry_id]
+    if not unload_ok:
+        return False
+
+    cookie_file = hass.config.path(STORAGE_DIR, f"verisure_{entry.entry_id}")
+    try:
+        await hass.async_add_executor_job(os.unlink, cookie_file)
+    except FileNotFoundError:
+        pass
+
+    del hass.data[DOMAIN][entry.entry_id]
 
     if not hass.data[DOMAIN]:
         del hass.data[DOMAIN]
 
-    return unload_ok
+    return True

--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -125,8 +125,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             )
 
         data = entry.data.copy()
-        data.pop(CONF_LOCK_CODE_DIGITS)
-        data.pop(CONF_DEFAULT_LOCK_CODE)
+        data.pop(CONF_LOCK_CODE_DIGITS, None)
+        data.pop(CONF_DEFAULT_LOCK_CODE, None)
         hass.config_entries.async_update_entry(entry, data=data, options=options)
 
     # Continue as normal...

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Callable
+from typing import Callable
 
 from homeassistant.components.alarm_control_panel import (
     FORMAT_NUMBER,
@@ -12,6 +12,7 @@ from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
@@ -19,25 +20,19 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_ALARM, CONF_GIID, DOMAIN, LOGGER
+from .const import CONF_GIID, DOMAIN, LOGGER
 from .coordinator import VerisureDataUpdateCoordinator
 
 
-def setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: dict[str, Any],
-    add_entities: Callable[[list[Entity], bool], None],
-    discovery_info: dict[str, Any] | None = None,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[VerisureAlarm]], None],
 ) -> None:
-    """Set up the Verisure platform."""
-    coordinator = hass.data[DOMAIN]
-    alarms = []
-    if int(coordinator.config.get(CONF_ALARM, 1)):
-        alarms.append(VerisureAlarm(coordinator))
-    add_entities(alarms)
+    """Set up Verisure alarm control panel from a config entry."""
+    async_add_entities([VerisureAlarm(coordinator=hass.data[DOMAIN][entry.entry_id])])
 
 
 class VerisureAlarm(CoordinatorEntity, AlarmControlPanelEntity):
@@ -53,17 +48,12 @@ class VerisureAlarm(CoordinatorEntity, AlarmControlPanelEntity):
     @property
     def name(self) -> str:
         """Return the name of the device."""
-        giid = self.coordinator.config.get(CONF_GIID)
-        if giid is not None:
-            aliass = {
-                i["giid"]: i["alias"] for i in self.coordinator.verisure.installations
-            }
-            if giid in aliass:
-                return "{} alarm".format(aliass[giid])
+        return "Verisure Alarm"
 
-            LOGGER.error("Verisure installation giid not found: %s", giid)
-
-        return "{} alarm".format(self.coordinator.verisure.installations[0]["alias"])
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this alarm control panel."""
+        return self.coordinator.entry.data[CONF_GIID]
 
     @property
     def state(self) -> str | None:

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Callable
+from typing import Callable, Iterable
 
 from homeassistant.components.alarm_control_panel import (
     FORMAT_NUMBER,
@@ -20,6 +20,7 @@ from homeassistant.const import (
     STATE_ALARM_PENDING,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_GIID, DOMAIN, LOGGER
@@ -29,7 +30,7 @@ from .coordinator import VerisureDataUpdateCoordinator
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[list[VerisureAlarm]], None],
+    async_add_entities: Callable[[Iterable[Entity]], None],
 ) -> None:
     """Set up Verisure alarm control panel from a config entry."""
     async_add_entities([VerisureAlarm(coordinator=hass.data[DOMAIN][entry.entry_id])])

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -1,40 +1,39 @@
 """Support for Verisure binary sensors."""
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_OPENING,
     BinarySensorEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import CONF_DOOR_WINDOW, DOMAIN
+from . import DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 
-def setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: dict[str, Any],
-    add_entities: Callable[[list[CoordinatorEntity]], None],
-    discovery_info: dict[str, Any] | None = None,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[CoordinatorEntity]], None],
 ) -> None:
-    """Set up the Verisure binary sensors."""
-    coordinator = hass.data[DOMAIN]
+    """Set up Verisure sensors based on a config entry."""
+    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     sensors: list[CoordinatorEntity] = [VerisureEthernetStatus(coordinator)]
 
-    if int(coordinator.config.get(CONF_DOOR_WINDOW, 1)):
-        sensors.extend(
-            [
-                VerisureDoorWindowSensor(coordinator, serial_number)
-                for serial_number in coordinator.data["door_window"]
-            ]
-        )
+    sensors.extend(
+        [
+            VerisureDoorWindowSensor(coordinator, serial_number)
+            for serial_number in coordinator.data["door_window"]
+        ]
+    )
 
-    add_entities(sensors)
+    async_add_entities(sensors)
 
 
 class VerisureDoorWindowSensor(CoordinatorEntity, BinarySensorEntity):

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Verisure binary sensors."""
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Iterable
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
@@ -10,6 +10,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DOMAIN
@@ -19,18 +20,16 @@ from .coordinator import VerisureDataUpdateCoordinator
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[list[CoordinatorEntity]], None],
+    async_add_entities: Callable[[Iterable[Entity]], None],
 ) -> None:
     """Set up Verisure sensors based on a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    sensors: list[CoordinatorEntity] = [VerisureEthernetStatus(coordinator)]
+    sensors: list[Entity] = [VerisureEthernetStatus(coordinator)]
 
     sensors.extend(
-        [
-            VerisureDoorWindowSensor(coordinator, serial_number)
-            for serial_number in coordinator.data["door_window"]
-        ]
+        VerisureDoorWindowSensor(coordinator, serial_number)
+        for serial_number in coordinator.data["door_window"]
     )
 
     async_add_entities(sensors)

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -3,30 +3,28 @@ from __future__ import annotations
 
 import errno
 import os
-from typing import Any, Callable
+from typing import Callable
 
 from homeassistant.components.camera import Camera
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_SMARTCAM, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 from .coordinator import VerisureDataUpdateCoordinator
 
 
-def setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: dict[str, Any],
-    add_entities: Callable[[list[VerisureSmartcam]], None],
-    discovery_info: dict[str, Any] | None = None,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[VerisureSmartcam]], None],
 ) -> None:
-    """Set up the Verisure Camera."""
-    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN]
-    if not int(coordinator.config.get(CONF_SMARTCAM, 1)):
-        return
+    """Set up Verisure sensors based on a config entry."""
+    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     assert hass.config.config_dir
-    add_entities(
+    async_add_entities(
         [
             VerisureSmartcam(hass, coordinator, serial_number, hass.config.config_dir)
             for serial_number in coordinator.data["cameras"]

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -3,12 +3,13 @@ from __future__ import annotations
 
 import errno
 import os
-from typing import Callable
+from typing import Callable, Iterable
 
 from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LOGGER
@@ -18,17 +19,15 @@ from .coordinator import VerisureDataUpdateCoordinator
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[list[VerisureSmartcam]], None],
+    async_add_entities: Callable[[Iterable[Entity]], None],
 ) -> None:
     """Set up Verisure sensors based on a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     assert hass.config.config_dir
     async_add_entities(
-        [
-            VerisureSmartcam(hass, coordinator, serial_number, hass.config.config_dir)
-            for serial_number in coordinator.data["cameras"]
-        ]
+        VerisureSmartcam(hass, coordinator, serial_number, hass.config.config_dir)
+        for serial_number in coordinator.data["cameras"]
     )
 
 

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -46,9 +46,9 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     @staticmethod
     @callback
-    def async_get_options_flow(entry: ConfigEntry):
+    def async_get_options_flow(config_entry: ConfigEntry) -> VerisureOptionsFlowHandler:
         """Get the options flow for this handler."""
-        return VerisureOptionsFlowHandler(entry)
+        return VerisureOptionsFlowHandler(config_entry)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -150,7 +150,7 @@ class VerisureOptionsFlowHandler(OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
-        """Manage Hue options."""
+        """Manage Verisure options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
 

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -39,7 +39,10 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     installations: dict[str, str]
     email: str
     password: str
+
+    # These can be removed after YAML import has been removed.
     giid: str | None = None
+    settings: dict[str, int | str] = {}
 
     @staticmethod
     @callback
@@ -112,6 +115,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 CONF_EMAIL: self.email,
                 CONF_PASSWORD: self.password,
                 CONF_GIID: user_input[CONF_GIID],
+                **self.settings,
             },
         )
 
@@ -126,6 +130,12 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             # Therefore, if we don't know the GIID, we can use the discovery
             # without a unique ID logic, to prevent re-import/discovery.
             await self._async_handle_discovery_without_unique_id()
+
+        # Settings, later to be converted to config entry options
+        if user_input[CONF_LOCK_CODE_DIGITS]:
+            self.settings[CONF_LOCK_CODE_DIGITS] = user_input[CONF_LOCK_CODE_DIGITS]
+        if user_input[CONF_LOCK_DEFAULT_CODE]:
+            self.settings[CONF_LOCK_DEFAULT_CODE] = user_input[CONF_LOCK_DEFAULT_CODE]
 
         return await self.async_step_user(user_input)
 

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -42,7 +42,11 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     # These can be removed after YAML import has been removed.
     giid: str | None = None
-    settings: dict[str, int | str] = {}
+    settings: dict[str, int | str]
+
+    def __init__(self):
+        """Initialize."""
+        self.settings = {}
 
     @staticmethod
     @callback

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -1,0 +1,163 @@
+"""Config flow for Verisure integration."""
+from __future__ import annotations
+
+from typing import Any
+
+from verisure import (
+    Error as VerisureError,
+    LoginError as VerisureLoginError,
+    ResponseError as VerisureResponseError,
+    Session as Verisure,
+)
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    CONN_CLASS_CLOUD_POLL,
+    ConfigEntry,
+    ConfigFlow,
+    OptionsFlow,
+)
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import callback
+
+from .const import (  # pylint:disable=unused-import
+    CONF_GIID,
+    CONF_LOCK_CODE_DIGITS,
+    CONF_LOCK_DEFAULT_CODE,
+    DEFAULT_LOCK_CODE_DIGITS,
+    DOMAIN,
+    LOGGER,
+)
+
+
+class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Verisure."""
+
+    VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
+
+    installations: dict[str, str]
+    email: str
+    password: str
+    giid: str | None = None
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(entry: ConfigEntry):
+        """Get the options flow for this handler."""
+        return VerisureOptionsFlowHandler(entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            verisure = Verisure(
+                username=user_input[CONF_EMAIL], password=user_input[CONF_PASSWORD]
+            )
+            try:
+                await self.hass.async_add_executor_job(verisure.login)
+            except VerisureLoginError as ex:
+                LOGGER.debug("Could not log in to Verisure, %s", ex)
+                errors["base"] = "invalid_auth"
+            except (VerisureError, VerisureResponseError) as ex:
+                LOGGER.debug("Unexpected response from Verisure, %s", ex)
+                errors["base"] = "unknown"
+            else:
+                self.email = user_input[CONF_EMAIL]
+                self.password = user_input[CONF_PASSWORD]
+                self.installations = {
+                    inst["giid"]: f"{inst['alias']} ({inst['street']})"
+                    for inst in verisure.installations
+                }
+
+                return await self.async_step_installation()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_installation(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Select Verisure installation to add."""
+        if len(self.installations) == 1:
+            user_input = {CONF_GIID: list(self.installations)[0]}
+        elif self.giid and self.giid in self.installations:
+            user_input = {CONF_GIID: self.giid}
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="installation",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_GIID): vol.In(self.installations)}
+                ),
+            )
+
+        await self.async_set_unique_id(user_input[CONF_GIID])
+        self._abort_if_unique_id_configured()
+
+        return self.async_create_entry(
+            title=self.installations[user_input[CONF_GIID]],
+            data={
+                CONF_EMAIL: self.email,
+                CONF_PASSWORD: self.password,
+                CONF_GIID: user_input[CONF_GIID],
+            },
+        )
+
+    async def async_step_import(self, user_input: dict[str, Any]) -> dict[str, Any]:
+        """Import Verisure YAML configuration."""
+        if user_input[CONF_GIID]:
+            self.giid = user_input[CONF_GIID]
+            await self.async_set_unique_id(self.giid)
+            self._abort_if_unique_id_configured()
+        else:
+            # The old YAML configuration could handle 1 single Verisure instance.
+            # Therefore, if we don't know the GIID, we can use the discovery
+            # without a unique ID logic, to prevent re-import/discovery.
+            await self._async_handle_discovery_without_unique_id()
+
+        return await self.async_step_user(user_input)
+
+
+class VerisureOptionsFlowHandler(OptionsFlow):
+    """Handle Verisure options."""
+
+    def __init__(self, entry: ConfigEntry) -> None:
+        """Initialize Verisure options flow."""
+        self.entry = entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Manage Hue options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_LOCK_CODE_DIGITS,
+                        default=self.entry.options.get(
+                            CONF_LOCK_CODE_DIGITS, DEFAULT_LOCK_CODE_DIGITS
+                        ),
+                    ): int,
+                    vol.Optional(
+                        CONF_LOCK_DEFAULT_CODE,
+                        default=self.entry.options.get(CONF_LOCK_DEFAULT_CODE),
+                    ): str,
+                }
+            ),
+        )

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -155,8 +155,16 @@ class VerisureOptionsFlowHandler(OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> dict[str, Any]:
         """Manage Verisure options."""
+        errors = {}
+
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            if len(user_input[CONF_LOCK_DEFAULT_CODE]) not in [
+                0,
+                user_input[CONF_LOCK_CODE_DIGITS],
+            ]:
+                errors["base"] = "code_format_mismatch"
+            else:
+                return self.async_create_entry(title="", data=user_input)
 
         return self.async_show_form(
             step_id="init",
@@ -174,4 +182,5 @@ class VerisureOptionsFlowHandler(OptionsFlow):
                     ): str,
                 }
             ),
+            errors=errors,
         )

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -8,21 +8,17 @@ LOGGER = logging.getLogger(__package__)
 
 ATTR_DEVICE_SERIAL = "device_serial"
 
-CONF_ALARM = "alarm"
-CONF_CODE_DIGITS = "code_digits"
-CONF_DOOR_WINDOW = "door_window"
 CONF_GIID = "giid"
-CONF_HYDROMETERS = "hygrometers"
-CONF_LOCKS = "locks"
-CONF_DEFAULT_LOCK_CODE = "default_lock_code"
-CONF_MOUSE = "mouse"
-CONF_SMARTPLUGS = "smartplugs"
-CONF_THERMOMETERS = "thermometers"
-CONF_SMARTCAM = "smartcam"
+CONF_LOCK_CODE_DIGITS = "lock_code_digits"
+CONF_LOCK_DEFAULT_CODE = "lock_default_code"
 
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=1)
-MIN_SCAN_INTERVAL = timedelta(minutes=1)
+DEFAULT_LOCK_CODE_DIGITS = 4
 
 SERVICE_CAPTURE_SMARTCAM = "capture_smartcam"
 SERVICE_DISABLE_AUTOLOCK = "disable_autolock"
 SERVICE_ENABLE_AUTOLOCK = "enable_autolock"
+
+# Legacy; to remove after YAML removal
+CONF_CODE_DIGITS = "code_digits"
+CONF_DEFAULT_LOCK_CODE = "default_lock_code"

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -9,9 +9,10 @@ from verisure import (
     Session as Verisure,
 )
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, HTTP_SERVICE_UNAVAILABLE
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, HTTP_SERVICE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import Throttle
 
@@ -21,14 +22,15 @@ from .const import CONF_GIID, DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER
 class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
     """A Verisure Data Update Coordinator."""
 
-    def __init__(self, hass: HomeAssistant, config: ConfigType) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the Verisure hub."""
         self.imageseries = {}
-        self.config = config
-        self.giid = config.get(CONF_GIID)
+        self.entry = entry
 
         self.verisure = Verisure(
-            username=config[CONF_USERNAME], password=config[CONF_PASSWORD]
+            username=entry.data[CONF_EMAIL],
+            password=entry.data[CONF_PASSWORD],
+            cookieFileName=hass.config.path(STORAGE_DIR, f"verisure_{entry.entry_id}"),
         )
 
         super().__init__(
@@ -42,8 +44,12 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         except VerisureError as ex:
             LOGGER.error("Could not log in to verisure, %s", ex)
             return False
-        if self.giid:
-            return await self.async_set_giid()
+
+        # TODO: Check if installation still exists in the account
+        await self.hass.async_add_executor_job(
+            self.verisure.set_giid, self.entry.data[CONF_GIID]
+        )
+
         return True
 
     async def async_logout(self) -> bool:
@@ -52,15 +58,6 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             await self.hass.async_add_executor_job(self.verisure.logout)
         except VerisureError as ex:
             LOGGER.error("Could not log out from verisure, %s", ex)
-            return False
-        return True
-
-    async def async_set_giid(self) -> bool:
-        """Set installation GIID."""
-        try:
-            await self.hass.async_add_executor_job(self.verisure.set_giid, self.giid)
-        except VerisureError as ex:
-            LOGGER.error("Could not set installation GIID, %s", ex)
             return False
         return True
 

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -45,7 +45,6 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.error("Could not log in to verisure, %s", ex)
             return False
 
-        # TODO: Check if installation still exists in the account
         await self.hass.async_add_executor_job(
             self.verisure.set_giid, self.entry.data[CONF_GIID]
         )

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -11,7 +11,7 @@ from verisure import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, HTTP_SERVICE_UNAVAILABLE
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers.storage import STORAGE_DIR
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util import Throttle
@@ -51,7 +51,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
 
         return True
 
-    async def async_logout(self) -> bool:
+    async def async_logout(self, _event: Event) -> bool:
         """Logout from Verisure."""
         try:
             await self.hass.async_add_executor_job(self.verisure.logout)

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Callable
+from typing import Callable, Iterable
 
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_CODE, STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -23,15 +24,13 @@ from .coordinator import VerisureDataUpdateCoordinator
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[list[VerisureDoorlock]], None],
+    async_add_entities: Callable[[Iterable[Entity]], None],
 ) -> None:
     """Set up Verisure alarm control panel from a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            VerisureDoorlock(coordinator, serial_number)
-            for serial_number in coordinator.data["locks"]
-        ]
+        VerisureDoorlock(coordinator, serial_number)
+        for serial_number in coordinator.data["locks"]
     )
 
 
@@ -50,7 +49,6 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
         self._digits = coordinator.entry.options.get(
             CONF_LOCK_CODE_DIGITS, DEFAULT_LOCK_CODE_DIGITS
         )
-        self._default_lock_code = coordinator.entry.options.get(CONF_LOCK_DEFAULT_CODE)
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -84,7 +84,9 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
 
     async def async_unlock(self, **kwargs) -> None:
         """Send unlock command."""
-        code = kwargs.get(ATTR_CODE, self._default_lock_code)
+        code = kwargs.get(
+            ATTR_CODE, self.coordinator.entry.options.get(CONF_LOCK_DEFAULT_CODE)
+        )
         if code is None:
             LOGGER.error("Code required but none provided")
             return
@@ -93,7 +95,9 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
 
     async def async_lock(self, **kwargs) -> None:
         """Send lock command."""
-        code = kwargs.get(ATTR_CODE, self._default_lock_code)
+        code = kwargs.get(
+            ATTR_CODE, self.coordinator.entry.options.get(CONF_LOCK_DEFAULT_CODE)
+        )
         if code is None:
             LOGGER.error("Code required but none provided")
             return

--- a/homeassistant/components/verisure/manifest.json
+++ b/homeassistant/components/verisure/manifest.json
@@ -3,5 +3,7 @@
   "name": "Verisure",
   "documentation": "https://www.home-assistant.io/integrations/verisure",
   "requirements": ["vsure==1.7.3"],
-  "codeowners": ["@frenck"]
+  "codeowners": ["@frenck"],
+  "config_flow": true,
+  "dhcp": [{ "macaddress": "0023C1*" }]
 }

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -1,54 +1,48 @@
 """Support for Verisure sensors."""
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_HYDROMETERS, CONF_MOUSE, CONF_THERMOMETERS, DOMAIN
+from .const import DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 
-def setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: dict[str, Any],
-    add_entities: Callable[[list[CoordinatorEntity], bool], None],
-    discovery_info: dict[str, Any] | None = None,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[CoordinatorEntity]], None],
 ) -> None:
-    """Set up the Verisure platform."""
-    coordinator = hass.data[DOMAIN]
+    """Set up Verisure sensors based on a config entry."""
+    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    sensors: list[CoordinatorEntity] = []
-    if int(coordinator.config.get(CONF_THERMOMETERS, 1)):
-        sensors.extend(
-            [
-                VerisureThermometer(coordinator, serial_number)
-                for serial_number, values in coordinator.data["climate"].items()
-                if "temperature" in values
-            ]
-        )
+    sensors: list[CoordinatorEntity] = [
+        VerisureThermometer(coordinator, serial_number)
+        for serial_number, values in coordinator.data["climate"].items()
+        if "temperature" in values
+    ]
 
-    if int(coordinator.config.get(CONF_HYDROMETERS, 1)):
-        sensors.extend(
-            [
-                VerisureHygrometer(coordinator, serial_number)
-                for serial_number, values in coordinator.data["climate"].items()
-                if "humidity" in values
-            ]
-        )
+    sensors.extend(
+        [
+            VerisureHygrometer(coordinator, serial_number)
+            for serial_number, values in coordinator.data["climate"].items()
+            if "humidity" in values
+        ]
+    )
 
-    if int(coordinator.config.get(CONF_MOUSE, 1)):
-        sensors.extend(
-            [
-                VerisureMouseDetection(coordinator, serial_number)
-                for serial_number in coordinator.data["mice"]
-            ]
-        )
+    sensors.extend(
+        [
+            VerisureMouseDetection(coordinator, serial_number)
+            for serial_number in coordinator.data["mice"]
+        ]
+    )
 
-    add_entities(sensors)
+    async_add_entities(sensors)
 
 
 class VerisureThermometer(CoordinatorEntity, Entity):

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -1,7 +1,7 @@
 """Support for Verisure sensors."""
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, Iterable
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
@@ -16,30 +16,26 @@ from .coordinator import VerisureDataUpdateCoordinator
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[list[CoordinatorEntity]], None],
+    async_add_entities: Callable[[Iterable[Entity]], None],
 ) -> None:
     """Set up Verisure sensors based on a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    sensors: list[CoordinatorEntity] = [
+    sensors: list[Entity] = [
         VerisureThermometer(coordinator, serial_number)
         for serial_number, values in coordinator.data["climate"].items()
         if "temperature" in values
     ]
 
     sensors.extend(
-        [
-            VerisureHygrometer(coordinator, serial_number)
-            for serial_number, values in coordinator.data["climate"].items()
-            if "humidity" in values
-        ]
+        VerisureHygrometer(coordinator, serial_number)
+        for serial_number, values in coordinator.data["climate"].items()
+        if "humidity" in values
     )
 
     sensors.extend(
-        [
-            VerisureMouseDetection(coordinator, serial_number)
-            for serial_number in coordinator.data["mice"]
-        ]
+        VerisureMouseDetection(coordinator, serial_number)
+        for serial_number in coordinator.data["mice"]
     )
 
     async_add_entities(sensors)

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -1,0 +1,36 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "description": "Sign-in with your Verisure My Pages account.",
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      },
+      "installation": {
+        "description": "Home Assistant found multiple Verisure installations in your My Pages account. Please, select the installation to add to Home Assistant.",
+        "data": {
+          "giid": "Installation"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "lock_code_digits": "Number of digits in PIN code for locks",
+          "lock_default_code": "Default PIN code for locks, used if none is given"
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -20,7 +20,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   },
   "options": {

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -31,6 +31,9 @@
           "lock_default_code": "Default PIN code for locks, used if none is given"
         }
       }
+    },
+    "error": {
+      "code_format_mismatch": "The default PIN code does not match the required number of digits"
     }
   }
 }

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -2,29 +2,25 @@
 from __future__ import annotations
 
 from time import monotonic
-from typing import Any, Callable
+from typing import Callable
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_SMARTPLUGS, DOMAIN
+from .const import DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 
-def setup_platform(
+async def async_setup_entry(
     hass: HomeAssistant,
-    config: dict[str, Any],
-    add_entities: Callable[[list[CoordinatorEntity]], None],
-    discovery_info: dict[str, Any] | None = None,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[VerisureSmartplug]], None],
 ) -> None:
-    """Set up the Verisure switch platform."""
-    coordinator = hass.data[DOMAIN]
-
-    if not int(coordinator.config.get(CONF_SMARTPLUGS, 1)):
-        return
-
-    add_entities(
+    """Set up Verisure alarm control panel from a config entry."""
+    coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
         [
             VerisureSmartplug(coordinator, serial_number)
             for serial_number in coordinator.data["smart_plugs"]
@@ -50,6 +46,11 @@ class VerisureSmartplug(CoordinatorEntity, SwitchEntity):
     def name(self) -> str:
         """Return the name or location of the smartplug."""
         return self.coordinator.data["smart_plugs"][self.serial_number]["area"]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this alarm control panel."""
+        return self.serial_number
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 from time import monotonic
-from typing import Callable
+from typing import Callable, Iterable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -16,15 +17,13 @@ from .coordinator import VerisureDataUpdateCoordinator
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: Callable[[list[VerisureSmartplug]], None],
+    async_add_entities: Callable[[Iterable[Entity]], None],
 ) -> None:
     """Set up Verisure alarm control panel from a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            VerisureSmartplug(coordinator, serial_number)
-            for serial_number in coordinator.data["smart_plugs"]
-        ]
+        VerisureSmartplug(coordinator, serial_number)
+        for serial_number in coordinator.data["smart_plugs"]
     )
 
 

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Account is already configured"
         },
         "error": {
             "invalid_auth": "Invalid authentication",

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -1,0 +1,36 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "installation": {
+                "data": {
+                    "giid": "Installation"
+                },
+                "description": "Home Assistant found multiple Verisure installations in your My Pages account. Please, select the installation to add to Home Assistant."
+            },
+            "user": {
+                "data": {
+                    "description": "Sign-in with your Verisure My Pages account.",
+                    "email": "Email",
+                    "password": "Password"
+                }
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "lock_code_digits": "Number of digits in PIN code for locks",
+                    "lock_default_code": "Default PIN code for locks, used if none is given"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -24,6 +24,9 @@
         }
     },
     "options": {
+        "error": {
+            "code_format_mismatch": "The default PIN code does not match the required number of digits"
+        },
         "step": {
             "init": {
                 "data": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -247,6 +247,7 @@ FLOWS = [
     "upnp",
     "velbus",
     "vera",
+    "verisure",
     "vesync",
     "vilfo",
     "vizio",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -153,5 +153,9 @@ DHCP = [
         "domain": "toon",
         "hostname": "eneco-*",
         "macaddress": "74C63B*"
+    },
+    {
+        "domain": "verisure",
+        "macaddress": "0023C1*"
     }
 ]

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1171,6 +1171,9 @@ uvcclient==0.11.0
 # homeassistant.components.vilfo
 vilfo-api-client==0.3.2
 
+# homeassistant.components.verisure
+vsure==1.7.2
+
 # homeassistant.components.vultr
 vultr==0.1.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1172,7 +1172,7 @@ uvcclient==0.11.0
 vilfo-api-client==0.3.2
 
 # homeassistant.components.verisure
-vsure==1.7.2
+vsure==1.7.3
 
 # homeassistant.components.vultr
 vultr==0.1.2

--- a/tests/components/verisure/__init__.py
+++ b/tests/components/verisure/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Verisure integration."""

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -178,7 +178,7 @@ async def test_unknown_error(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "unknown"}
 
 
-async def test_dhcp(hass):
+async def test_dhcp(hass: HomeAssistant) -> None:
     """Test that DHCP discovery works."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -1,0 +1,349 @@
+"""Test the Verisure config flow."""
+from __future__ import annotations
+
+from unittest.mock import PropertyMock, patch
+
+import pytest
+from verisure import Error as VerisureError, LoginError as VerisureLoginError
+
+from homeassistant import config_entries
+from homeassistant.components.dhcp import MAC_ADDRESS
+from homeassistant.components.verisure.const import (
+    CONF_GIID,
+    CONF_LOCK_CODE_DIGITS,
+    CONF_LOCK_DEFAULT_CODE,
+    DEFAULT_LOCK_CODE_DIGITS,
+    DOMAIN,
+)
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
+
+from tests.common import MockConfigEntry
+
+TEST_INSTALLATIONS = [
+    {"giid": "12345", "alias": "ascending", "street": "12345th street"},
+    {"giid": "54321", "alias": "descending", "street": "54321th street"},
+]
+TEST_INSTALLATION = [TEST_INSTALLATIONS[0]]
+
+
+async def test_full_user_flow_single_installation(hass: HomeAssistant) -> None:
+    """Test a full user initiated configuration flow with a single installation."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure",
+    ) as mock_verisure, patch(
+        "homeassistant.components.verisure.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.verisure.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        type(mock_verisure.return_value).installations = PropertyMock(
+            return_value=TEST_INSTALLATION
+        )
+        mock_verisure.login.return_value = True
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "verisure_my_pages@example.com",
+                "password": "SuperS3cr3t!",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "ascending (12345th street)"
+    assert result2["data"] == {
+        CONF_GIID: "12345",
+        CONF_EMAIL: "verisure_my_pages@example.com",
+        CONF_PASSWORD: "SuperS3cr3t!",
+    }
+
+    assert len(mock_verisure.mock_calls) == 2
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_full_user_flow_multiple_installations(hass: HomeAssistant) -> None:
+    """Test a full user initiated configuration flow with multiple installations."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure",
+    ) as mock_verisure:
+        type(mock_verisure.return_value).installations = PropertyMock(
+            return_value=TEST_INSTALLATIONS
+        )
+        mock_verisure.login.return_value = True
+
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "verisure_my_pages@example.com",
+                "password": "SuperS3cr3t!",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["step_id"] == "installation"
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] is None
+
+    with patch(
+        "homeassistant.components.verisure.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.verisure.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"], {"giid": "54321"}
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result3["title"] == "descending (54321th street)"
+    assert result3["data"] == {
+        CONF_GIID: "54321",
+        CONF_EMAIL: "verisure_my_pages@example.com",
+        CONF_PASSWORD: "SuperS3cr3t!",
+    }
+
+    assert len(mock_verisure.mock_calls) == 2
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_invalid_login(hass: HomeAssistant) -> None:
+    """Test a flow with an invalid Verisure My Pages login."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure.login",
+        side_effect=VerisureLoginError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "verisure_my_pages@example.com",
+                "password": "SuperS3cr3t!",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_unknown_error(hass: HomeAssistant) -> None:
+    """Test a flow with an invalid Verisure My Pages login."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure.login",
+        side_effect=VerisureError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "email": "verisure_my_pages@example.com",
+                "password": "SuperS3cr3t!",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "unknown"}
+
+
+async def test_dhcp(hass):
+    """Test that DHCP discovery works."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        data={MAC_ADDRESS: "01:23:45:67:89:ab"},
+        context={"source": config_entries.SOURCE_DHCP},
+    )
+
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_options_flow(hass):
+    """Test options config flow."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="12345",
+        data={},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    schema = result["data_schema"].schema
+    assert (
+        _get_schema_default(schema, CONF_LOCK_CODE_DIGITS) == DEFAULT_LOCK_CODE_DIGITS
+    )
+    assert _get_schema_default(schema, CONF_LOCK_DEFAULT_CODE) is None
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_LOCK_CODE_DIGITS: 5,
+            CONF_LOCK_DEFAULT_CODE: "123456",
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        CONF_LOCK_CODE_DIGITS: 5,
+        CONF_LOCK_DEFAULT_CODE: "123456",
+    }
+
+
+def _get_schema_default(schema, key_name):
+    """Iterate schema to find a key."""
+    for schema_key in schema:
+        if schema_key == key_name:
+            return schema_key.default()
+    raise KeyError(f"{key_name} not found in schema")
+
+
+#
+# Below this line are tests that can be removed once the YAML configuration
+# has been removed from this integration.
+#
+@pytest.mark.parametrize(
+    "giid,installations",
+    [
+        ("12345", TEST_INSTALLATION),
+        ("12345", TEST_INSTALLATIONS),
+        (None, TEST_INSTALLATION),
+    ],
+)
+async def test_imports(
+    hass: HomeAssistant, giid: str | None, installations: dict[str, str]
+) -> None:
+    """Test a YAML import with/without known giid on single/multiple installations."""
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure",
+    ) as mock_verisure, patch(
+        "homeassistant.components.verisure.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.verisure.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        type(mock_verisure.return_value).installations = PropertyMock(
+            return_value=installations
+        )
+        mock_verisure.login.return_value = True
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                CONF_EMAIL: "verisure_my_pages@example.com",
+                CONF_PASSWORD: "SuperS3cr3t!",
+                CONF_GIID: giid,
+            },
+        )
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "ascending (12345th street)"
+    assert result["data"] == {
+        CONF_GIID: "12345",
+        CONF_EMAIL: "verisure_my_pages@example.com",
+        CONF_PASSWORD: "SuperS3cr3t!",
+    }
+
+    assert len(mock_verisure.mock_calls) == 2
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_imports_invalid_login(hass: HomeAssistant) -> None:
+    """Test a YAML import that results in a invalid login."""
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure.login",
+        side_effect=VerisureLoginError,
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                CONF_EMAIL: "verisure_my_pages@example.com",
+                CONF_PASSWORD: "SuperS3cr3t!",
+                CONF_GIID: None,
+            },
+        )
+
+    assert result["step_id"] == "user"
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_imports_needs_user_installation_choice(hass: HomeAssistant) -> None:
+    """Test a YAML import that needs to use to decide on the installation."""
+    with patch(
+        "homeassistant.components.verisure.config_flow.Verisure",
+    ) as mock_verisure:
+        type(mock_verisure.return_value).installations = PropertyMock(
+            return_value=TEST_INSTALLATIONS
+        )
+        mock_verisure.login.return_value = True
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={
+                CONF_EMAIL: "verisure_my_pages@example.com",
+                CONF_PASSWORD: "SuperS3cr3t!",
+                CONF_GIID: None,
+            },
+        )
+
+    assert result["step_id"] == "installation"
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+
+@pytest.mark.parametrize("giid", ["12345", None])
+async def test_import_already_exists(hass: HomeAssistant, giid: str | None) -> None:
+    """Test that import flow aborts if exists."""
+    MockConfigEntry(domain=DOMAIN, data={}, unique_id="12345").add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={
+            CONF_EMAIL: "verisure_my_pages@example.com",
+            CONF_PASSWORD: "SuperS3cr3t!",
+            CONF_GIID: giid,
+        },
+    )
+
+    assert result["type"] == RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -266,16 +266,20 @@ async def test_imports(
             context={"source": config_entries.SOURCE_IMPORT},
             data={
                 CONF_EMAIL: "verisure_my_pages@example.com",
-                CONF_PASSWORD: "SuperS3cr3t!",
                 CONF_GIID: giid,
+                CONF_LOCK_CODE_DIGITS: 10,
+                CONF_LOCK_DEFAULT_CODE: "123456",
+                CONF_PASSWORD: "SuperS3cr3t!",
             },
         )
 
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "ascending (12345th street)"
     assert result["data"] == {
-        CONF_GIID: "12345",
         CONF_EMAIL: "verisure_my_pages@example.com",
+        CONF_GIID: "12345",
+        CONF_LOCK_CODE_DIGITS: 10,
+        CONF_LOCK_DEFAULT_CODE: "123456",
         CONF_PASSWORD: "SuperS3cr3t!",
     }
 
@@ -296,8 +300,10 @@ async def test_imports_invalid_login(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_IMPORT},
             data={
                 CONF_EMAIL: "verisure_my_pages@example.com",
-                CONF_PASSWORD: "SuperS3cr3t!",
                 CONF_GIID: None,
+                CONF_LOCK_CODE_DIGITS: None,
+                CONF_LOCK_DEFAULT_CODE: None,
+                CONF_PASSWORD: "SuperS3cr3t!",
             },
         )
 
@@ -321,8 +327,10 @@ async def test_imports_needs_user_installation_choice(hass: HomeAssistant) -> No
             context={"source": config_entries.SOURCE_IMPORT},
             data={
                 CONF_EMAIL: "verisure_my_pages@example.com",
-                CONF_PASSWORD: "SuperS3cr3t!",
                 CONF_GIID: None,
+                CONF_LOCK_CODE_DIGITS: None,
+                CONF_LOCK_DEFAULT_CODE: None,
+                CONF_PASSWORD: "SuperS3cr3t!",
             },
         )
 

--- a/tests/components/verisure/test_config_flow.py
+++ b/tests/components/verisure/test_config_flow.py
@@ -225,6 +225,15 @@ async def test_options_flow(
     )
     entry.add_to_hass(hass)
 
+    with patch(
+        "homeassistant.components.verisure.async_setup", return_value=True
+    ), patch(
+        "homeassistant.components.verisure.async_setup_entry",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
     assert result["type"] == "form"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Verisure integration largely rewritten and is now configured via the Home Assistant user interface.
Your existing YAML configuration will be automatically imported when upgrading Home Assistant Core. After the upgrade completes, you can safely remove the existing Verisure YAML configuration.

If after upgrade your Verisure alarm system doesn't appear, please check your [integrations dashboard](https://my.home-assistant.io/redirect/integrations/). In rare cases (with accounts that have access to multiple Verisure alarm systems), it might be needed to select the specific Verisure alarm system to migrate.

This also means the YAML configuration for the Verisure integration is now deprecated and will be removed in Home Assitant Core 2021.6.0.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds a configuration flow to the Verisure integration. Additionally, cleans up a little more and adds unique IDs to the entities that didn't get one in #47870. Bonus: Now support multiple instances (entries) of the integration.

Still open / to do before marking ready for review:

- [x] Rebase when #47870 is merged
- [x] Migration of YAML config -> option flow
- [x] Throw ConfigEntryNotReady
- [x] Update documentation

Next steps (after this PR):

- Move existing additional integration services to entity services
- Update services descriptions
- Put entities into devices
- Check if installation still exists on startup
- Even more cleanup!
- Pre-determine property values, instead of calculating them in property methods themselves (as much as possible)
- Start setting up tests for platforms
- Check if we can detect unsupported 2FA enabled on Verisure My Pages account (to help with #47397)
- Re-auth handling (awaits: https://github.com/persandstrom/python-verisure/pull/129)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17000

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
