### PR TITLE
Move Verisure services to entity services

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -5,7 +5,6 @@ import asyncio
 import os
 from typing import Any
 
-from verisure import Error as VerisureError
 import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import (
@@ -29,7 +28,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.storage import STORAGE_DIR
 
 from .const import (
-    ATTR_DEVICE_SERIAL,
     CONF_CODE_DIGITS,
     CONF_DEFAULT_LOCK_CODE,
     CONF_GIID,
@@ -38,9 +36,6 @@ from .const import (
     DEFAULT_LOCK_CODE_DIGITS,
     DOMAIN,
     LOGGER,
-    SERVICE_CAPTURE_SMARTCAM,
-    SERVICE_DISABLE_AUTOLOCK,
-    SERVICE_ENABLE_AUTOLOCK,
 )
 from .coordinator import VerisureDataUpdateCoordinator
 
@@ -71,9 +66,6 @@ CONFIG_SCHEMA = vol.Schema(
     ),
     extra=vol.ALLOW_EXTRA,
 )
-
-
-DEVICE_SERIAL_SCHEMA = vol.Schema({vol.Required(ATTR_DEVICE_SERIAL): cv.string})
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
@@ -151,44 +143,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.config_entries.async_forward_entry_setup(entry, platform)
         )
 
-    async def capture_smartcam(service):
-        """Capture a new picture from a smartcam."""
-        device_id = service.data[ATTR_DEVICE_SERIAL]
-        try:
-            await hass.async_add_executor_job(coordinator.smartcam_capture, device_id)
-            LOGGER.debug("Capturing new image from %s", ATTR_DEVICE_SERIAL)
-        except VerisureError as ex:
-            LOGGER.error("Could not capture image, %s", ex)
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_CAPTURE_SMARTCAM, capture_smartcam, schema=DEVICE_SERIAL_SCHEMA
-    )
-
-    async def disable_autolock(service):
-        """Disable autolock on a doorlock."""
-        device_id = service.data[ATTR_DEVICE_SERIAL]
-        try:
-            await hass.async_add_executor_job(coordinator.disable_autolock, device_id)
-            LOGGER.debug("Disabling autolock on%s", ATTR_DEVICE_SERIAL)
-        except VerisureError as ex:
-            LOGGER.error("Could not disable autolock, %s", ex)
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_DISABLE_AUTOLOCK, disable_autolock, schema=DEVICE_SERIAL_SCHEMA
-    )
-
-    async def enable_autolock(service):
-        """Enable autolock on a doorlock."""
-        device_id = service.data[ATTR_DEVICE_SERIAL]
-        try:
-            await hass.async_add_executor_job(coordinator.enable_autolock, device_id)
-            LOGGER.debug("Enabling autolock on %s", ATTR_DEVICE_SERIAL)
-        except VerisureError as ex:
-            LOGGER.error("Could not enable autolock, %s", ex)
-
-    hass.services.async_register(
-        DOMAIN, SERVICE_ENABLE_AUTOLOCK, enable_autolock, schema=DEVICE_SERIAL_SCHEMA
-    )
     return True
 
 

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -5,14 +5,17 @@ import errno
 import os
 from typing import Callable, Iterable
 
+from verisure import Error as VerisureError
+
 from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import current_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, SERVICE_CAPTURE_SMARTCAM
 from .coordinator import VerisureDataUpdateCoordinator
 
 
@@ -23,6 +26,13 @@ async def async_setup_entry(
 ) -> None:
     """Set up Verisure sensors based on a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    platform = current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_CAPTURE_SMARTCAM,
+        {},
+        VerisureSmartcam.capture_smartcam.__name__,
+    )
 
     assert hass.config.config_dir
     async_add_entities(
@@ -114,3 +124,11 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
     def unique_id(self) -> str:
         """Return the unique ID for this camera."""
         return self.serial_number
+
+    def capture_smartcam(self) -> None:
+        """Capture a new picture from a smartcam."""
+        try:
+            self.coordinator.smartcam_capture(self.serial_number)
+            LOGGER.debug("Capturing new image from %s", self.serial_number)
+        except VerisureError as ex:
+            LOGGER.error("Could not capture image, %s", ex)

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -6,8 +6,6 @@ DOMAIN = "verisure"
 
 LOGGER = logging.getLogger(__package__)
 
-ATTR_DEVICE_SERIAL = "device_serial"
-
 CONF_GIID = "giid"
 CONF_LOCK_CODE_DIGITS = "lock_code_digits"
 CONF_LOCK_DEFAULT_CODE = "lock_default_code"

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -112,11 +112,3 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
     def smartcam_capture(self, device_id: str) -> None:
         """Capture a new image from a smartcam."""
         self.verisure.capture_image(device_id)
-
-    def disable_autolock(self, device_id: str) -> None:
-        """Disable autolock."""
-        self.verisure.set_lock_config(device_id, auto_lock_enabled=False)
-
-    def enable_autolock(self, device_id: str) -> None:
-        """Enable autolock."""
-        self.verisure.set_lock_config(device_id, auto_lock_enabled=True)

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 import asyncio
 from typing import Callable, Iterable
 
+from verisure import Error as VerisureError
+
 from homeassistant.components.lock import LockEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_CODE, STATE_LOCKED, STATE_UNLOCKED
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import current_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
@@ -17,6 +20,8 @@ from .const import (
     DEFAULT_LOCK_CODE_DIGITS,
     DOMAIN,
     LOGGER,
+    SERVICE_DISABLE_AUTOLOCK,
+    SERVICE_ENABLE_AUTOLOCK,
 )
 from .coordinator import VerisureDataUpdateCoordinator
 
@@ -28,6 +33,19 @@ async def async_setup_entry(
 ) -> None:
     """Set up Verisure alarm control panel from a config entry."""
     coordinator: VerisureDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    platform = current_platform.get()
+    platform.async_register_entity_service(
+        SERVICE_DISABLE_AUTOLOCK,
+        {},
+        VerisureDoorlock.disable_autolock.__name__,
+    )
+    platform.async_register_entity_service(
+        SERVICE_ENABLE_AUTOLOCK,
+        {},
+        VerisureDoorlock.enable_autolock.__name__,
+    )
+
     async_add_entities(
         VerisureDoorlock(coordinator, serial_number)
         for serial_number in coordinator.data["locks"]
@@ -127,3 +145,23 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
                 await asyncio.sleep(0.5)
         if transaction["result"] == "OK":
             self._state = state
+
+    def disable_autolock(self) -> None:
+        """Disable autolock on a doorlock."""
+        try:
+            self.coordinator.verisure.set_lock_config(
+                self.serial_number, auto_lock_enabled=False
+            )
+            LOGGER.debug("Disabling autolock on %s", self.serial_number)
+        except VerisureError as ex:
+            LOGGER.error("Could not disable autolock, %s", ex)
+
+    def enable_autolock(self) -> None:
+        """Enable autolock on a doorlock."""
+        try:
+            self.coordinator.verisure.set_lock_config(
+                self.serial_number, auto_lock_enabled=True
+            )
+            LOGGER.debug("Enabling autolock on %s", self.serial_number)
+        except VerisureError as ex:
+            LOGGER.error("Could not enable autolock, %s", ex)

--- a/homeassistant/components/verisure/services.yaml
+++ b/homeassistant/components/verisure/services.yaml
@@ -1,6 +1,23 @@
 capture_smartcam:
-  description: Capture a new image from a smartcam.
-  fields:
-    device_serial:
-      description: The serial number of the smartcam you want to capture an image from.
-      example: 2DEU AT5Z
+  name: Capture SmartCam image
+  description: Capture a new image from a Verisure SmartCam
+  target:
+    entity:
+      integration: verisure
+      domain: camera
+
+enable_autolock:
+  name: Enable autolock
+  description: Enable autolock of a Verisure Lockguard Smartlock
+  target:
+    entity:
+      integration: verisure
+      domain: lock
+
+disable_autolock:
+  name: Disable autolock
+  description: Disable autolock of a Verisure Lockguard Smartlock
+  target:
+    entity:
+      integration: verisure
+      domain: lock


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The services provided by the Verisure integration have changed to match the standard way of how Home Assistant handles services. The following services are affected by this change:

- [`verisure.capture_smartcam`](https://my.home-assistant.io/redirect/developer_call_service/?service=verisure.capture_smartcam)
- [`verisure.disable_autolock`](https://my.home-assistant.io/redirect/developer_call_service/?service=verisure.disable_autolock)
- [`verisure.enable_autolock`](https://my.home-assistant.io/redirect/developer_call_service/?service=verisure.enable_autolock)

Previously these services required a `device_serial` parameter, they have now changed to accept a regular Home Assistant entity, device or area as a target. For example:

```yaml
- service: verisure.enable_autolock
  target:
     entity_id: lock.my_verisure_lock
```

If you used any of these services in your automations or scripts, please make sure you update them after updating to Home Assistant Core 2021.4.0.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Depends on #47880 and needs to rebase after that is merged.

ℹ️  See the above breaking change section for a description of this PR.

Still open / to do before marking ready for review:

- [x] Move existing additional integration services to entity services
- [x] Update services descriptions
- [x] Rebase when #47880 is merged

Next steps (after this PR):

- Put entities into devices
- Check if installation still exists on startup
- Even more cleanup!
- Pre-determine property values, instead of calculating them in property methods themselves (as much as possible)
- Start setting up tests for platforms
- Check if we can detect unsupported 2FA enabled on Verisure My Pages account (to help with #47397)
- Re-auth handling (awaits: https://github.com/persandstrom/python-verisure/pull/129)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
