### PR TITLE
Rfxtrx device triggers and actions

### DIFF
--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -12,14 +12,10 @@ from .helpers import async_get_device_object
 
 CONF_DATA = "data"
 
-ACTION_TYPE_CHIME = "send_chime"
 ACTION_TYPE_COMMAND = "send_command"
-ACTION_TYPE_STATUS = "send_status"
 
 ACTION_TYPES = {
-    ACTION_TYPE_CHIME,
     ACTION_TYPE_COMMAND,
-    ACTION_TYPE_STATUS,
 }
 
 ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
@@ -53,14 +49,13 @@ async def async_get_action_capabilities(hass, config):
     """List action capabilities."""
 
     device = async_get_device_object(hass, config[CONF_DEVICE_ID])
-    if config[CONF_TYPE] == ACTION_TYPE_CHIME:
-        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA, default=1): int})}
     if config[CONF_TYPE] == ACTION_TYPE_COMMAND:
         values = getattr(device, "COMMANDS")
-        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): vol.In(values)})}
-    if config[CONF_TYPE] == ACTION_TYPE_STATUS:
-        values = getattr(device, "STATUS")
-        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): vol.In(values)})}
+        if values:
+            data_schema = vol.In(values)
+        else:
+            data_schema = vol.Range(0, 255)
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): data_schema})}
 
     return {}
 
@@ -76,9 +71,5 @@ async def async_call_action_from_config(
 
     send_fun = getattr(device, config[CONF_TYPE])
 
-    if config[CONF_TYPE] == ACTION_TYPE_CHIME:
-        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])
-    elif config[CONF_TYPE] == ACTION_TYPE_COMMAND:
-        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])
-    elif config[CONF_TYPE] == ACTION_TYPE_STATUS:
+    if config[CONF_TYPE] == ACTION_TYPE_COMMAND:
         await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -59,11 +59,11 @@ async def async_get_action_capabilities(hass, config):
     """List action capabilities."""
 
     device = async_get_device_object(hass, config[CONF_DEVICE_ID])
-    values = getattr(device, ACTION_SELECTION[ACTION_TYPE_COMMAND])
+    values = getattr(device, ACTION_SELECTION[config[CONF_TYPE]], None)
     if values:
         data_schema = vol.In(values)
     else:
-        data_schema = vol.Range(0, 255)
+        data_schema = int
     return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): data_schema})}
 
 

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -1,0 +1,84 @@
+"""Provides device automations for RFXCOM RFXtrx."""
+from typing import List, Optional
+
+import voluptuous as vol
+
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
+from homeassistant.core import Context, HomeAssistant
+import homeassistant.helpers.config_validation as cv
+
+from . import DATA_RFXOBJECT, DOMAIN
+from .helpers import async_get_device_object
+
+CONF_DATA = "data"
+
+ACTION_TYPE_CHIME = "send_chime"
+ACTION_TYPE_COMMAND = "send_command"
+ACTION_TYPE_STATUS = "send_status"
+
+ACTION_TYPES = {
+    ACTION_TYPE_CHIME,
+    ACTION_TYPE_COMMAND,
+    ACTION_TYPE_STATUS,
+}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_DATA): int,
+    }
+)
+
+
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device actions for RFXCOM RFXtrx devices."""
+    actions = []
+
+    device = async_get_device_object(hass, device_id)
+    if device:
+        for action_type in ACTION_TYPES:
+            if hasattr(device, action_type):
+                actions.append(
+                    {
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_TYPE: action_type,
+                    }
+                )
+
+    return actions
+
+
+async def async_get_action_capabilities(hass, config):
+    """List action capabilities."""
+
+    device = async_get_device_object(hass, config[CONF_DEVICE_ID])
+    if config[CONF_TYPE] == ACTION_TYPE_CHIME:
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA, default=1): int})}
+    if config[CONF_TYPE] == ACTION_TYPE_COMMAND:
+        values = getattr(device, "COMMANDS")
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): vol.In(values)})}
+    if config[CONF_TYPE] == ACTION_TYPE_STATUS:
+        values = getattr(device, "STATUS")
+        return {"extra_fields": vol.Schema({vol.Required(CONF_DATA): vol.In(values)})}
+
+    return {}
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Optional[Context]
+) -> None:
+    """Execute a device action."""
+    config = ACTION_SCHEMA(config)
+
+    rfx = hass.data[DOMAIN][DATA_RFXOBJECT]
+    device = async_get_device_object(hass, config[CONF_DEVICE_ID])
+
+    send_fun = getattr(device, config[CONF_TYPE])
+
+    if config[CONF_TYPE] == ACTION_TYPE_CHIME:
+        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])
+    elif config[CONF_TYPE] == ACTION_TYPE_COMMAND:
+        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])
+    elif config[CONF_TYPE] == ACTION_TYPE_STATUS:
+        await hass.async_add_executor_job(send_fun, rfx.transport, config[CONF_DATA])

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -13,18 +13,15 @@ from .helpers import async_get_device_object
 CONF_DATA = "data"
 CONF_SUBTYPE = "subtype"
 
-ACTION_TYPE_CHIME = "send_chime"
 ACTION_TYPE_COMMAND = "send_command"
 ACTION_TYPE_STATUS = "send_status"
 
 ACTION_TYPES = {
-    ACTION_TYPE_CHIME,
     ACTION_TYPE_COMMAND,
     ACTION_TYPE_STATUS,
 }
 
 ACTION_SELECTION = {
-    ACTION_TYPE_CHIME: "COMMANDS",
     ACTION_TYPE_COMMAND: "COMMANDS",
     ACTION_TYPE_STATUS: "STATUS",
 }

--- a/homeassistant/components/rfxtrx/device_action.py
+++ b/homeassistant/components/rfxtrx/device_action.py
@@ -1,5 +1,5 @@
 """Provides device automations for RFXCOM RFXtrx."""
-from typing import List, Optional
+from __future__ import annotations
 
 import voluptuous as vol
 
@@ -38,7 +38,7 @@ ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_actions(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
     """List device actions for RFXCOM RFXtrx devices."""
     actions = []
 
@@ -77,7 +77,7 @@ async def async_get_action_capabilities(hass, config):
 
 
 async def async_call_action_from_config(
-    hass: HomeAssistant, config: dict, variables: dict, context: Optional[Context]
+    hass: HomeAssistant, config: dict, variables: dict, context: Context | None
 ) -> None:
     """Execute a device action."""
     config = ACTION_SCHEMA(config)

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -77,8 +77,6 @@ async def async_attach_trigger(
         event_data["values"] = {"Command": config[CONF_SUBTYPE]}
     elif config[CONF_TYPE] == CONF_TYPE_STATUS:
         event_data["values"] = {"Status": config[CONF_SUBTYPE]}
-    else:
-        return None
 
     event_config = event_trigger.TRIGGER_SCHEMA(
         {

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -1,0 +1,93 @@
+"""Provides device automations for RFXCOM RFXtrx."""
+from typing import List
+
+import voluptuous as vol
+
+from homeassistant.components.automation import AutomationActionType
+from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers import event as event_trigger
+from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+from .helpers import async_get_device_object
+
+CONF_SUBTYPE = "subtype"
+
+TRIGGER_TYPES = {"command", "status"}
+TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Required(CONF_SUBTYPE): str,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+    """List device triggers for RFXCOM RFXtrx devices."""
+    triggers = []
+
+    device = async_get_device_object(hass, device_id)
+    if device:
+        if hasattr(device, "COMMANDS"):
+            for command in device.COMMANDS.values():
+                triggers.append(
+                    {
+                        CONF_PLATFORM: "device",
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_TYPE: "command",
+                        CONF_SUBTYPE: command,
+                    }
+                )
+        if hasattr(device, "STATUS"):
+            for status in device.STATUS.values():
+                triggers.append(
+                    {
+                        CONF_PLATFORM: "device",
+                        CONF_DEVICE_ID: device_id,
+                        CONF_DOMAIN: DOMAIN,
+                        CONF_TYPE: "status",
+                        CONF_SUBTYPE: status,
+                    }
+                )
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    config = TRIGGER_SCHEMA(config)
+
+    event_data = {ATTR_DEVICE_ID: config[CONF_DEVICE_ID]}
+
+    if config[CONF_TYPE] == "command":
+        event_data["values"] = {"Command": config[CONF_SUBTYPE]}
+    elif config[CONF_TYPE] == "status":
+        event_data["values"] = {"Status": config[CONF_SUBTYPE]}
+    else:
+        return None
+
+    event_config = event_trigger.TRIGGER_SCHEMA(
+        {
+            event_trigger.CONF_PLATFORM: "event",
+            event_trigger.CONF_EVENT_TYPE: EVENT_RFXTRX_EVENT,
+            event_trigger.CONF_EVENT_DATA: event_data,
+        }
+    )
+
+    return await event_trigger.async_attach_trigger(
+        hass, event_config, action, automation_info, platform_type="device"
+    )

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant.components.automation import AutomationActionType
-from homeassistant.components.device_automation import TRIGGER_BASE_SCHEMA
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
 from homeassistant.components.homeassistant.triggers import event as event_trigger
 from homeassistant.components.rfxtrx.const import EVENT_RFXTRX_EVENT
 from homeassistant.const import (
@@ -33,7 +33,7 @@ TRIGGER_TYPES = [
     CONF_TYPE_COMMAND,
     CONF_TYPE_STATUS,
 ]
-TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
         vol.Required(CONF_SUBTYPE): str,

--- a/homeassistant/components/rfxtrx/device_trigger.py
+++ b/homeassistant/components/rfxtrx/device_trigger.py
@@ -1,5 +1,5 @@
 """Provides device automations for RFXCOM RFXtrx."""
-from typing import List
+from __future__ import annotations
 
 import voluptuous as vol
 
@@ -41,7 +41,7 @@ TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
 )
 
 
-async def async_get_triggers(hass: HomeAssistant, device_id: str) -> List[dict]:
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
     """List device triggers for RFXCOM RFXtrx devices."""
     triggers = []
 

--- a/homeassistant/components/rfxtrx/helpers.py
+++ b/homeassistant/components/rfxtrx/helpers.py
@@ -1,0 +1,25 @@
+"""Provides helpers for RFXtrx."""
+
+
+from RFXtrx import get_device
+
+from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.typing import HomeAssistantType
+
+
+@callback
+def async_get_device_object(hass: HomeAssistantType, device_id):
+    """Get a device for the given device registry id."""
+    device_registry = dr.async_get(hass)
+    registry_device = device_registry.async_get(device_id)
+    if registry_device is None:
+        return None
+
+    device_tuple = list(list(registry_device.identifiers)[0])
+    try:
+        return get_device(
+            int(device_tuple[1], 16), int(device_tuple[2], 16), device_tuple[3]
+        )
+    except ValueError:
+        return None

--- a/homeassistant/components/rfxtrx/helpers.py
+++ b/homeassistant/components/rfxtrx/helpers.py
@@ -14,12 +14,9 @@ def async_get_device_object(hass: HomeAssistantType, device_id):
     device_registry = dr.async_get(hass)
     registry_device = device_registry.async_get(device_id)
     if registry_device is None:
-        return None
+        raise ValueError(f"Device {device_id} not found")
 
     device_tuple = list(list(registry_device.identifiers)[0])
-    try:
-        return get_device(
-            int(device_tuple[1], 16), int(device_tuple[2], 16), device_tuple[3]
-        )
-    except ValueError:
-        return None
+    return get_device(
+        int(device_tuple[1], 16), int(device_tuple[2], 16), device_tuple[3]
+    )

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -73,13 +73,13 @@
   },
   "device_automation": {
     "action_type": {
-      "send_status": "Trigger status update",
-      "send_chime": "Send a sound command",
-      "send_command": "Send a command"
+      "send_status": "Trigger status: {subtype}",
+      "send_chime": "Send command: {subtype}",
+      "send_command": "Send command: {subtype}"
     },
     "trigger_type": {
-      "status": "Received '{subtype}' status",
-      "command": "Received '{subtype}' command"
+      "status": "Received status: {subtype}",
+      "command": "Received command: {subtype}"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -73,16 +73,13 @@
   },
   "device_automation": {
     "action_type": {
-      "send_status": "Trigger status on device",
-      "send_sound": "Trigger a sound on device",
-      "send_command": "Trigger a command on device"
+      "send_status": "Trigger status update",
+      "send_chime": "Send a sound command",
+      "send_command": "Send a command"
     },
     "trigger_type": {
-      "status": "Device received {subtype} status",
-      "command": "Device received {subtype} command"
-    },
-    "trigger_subtype": {
-      "Panic": "Panic"
+      "status": "Received '{subtype}' status",
+      "command": "Received '{subtype}' command"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -70,5 +70,12 @@
       "invalid_input_off_delay": "Invalid input for off delay",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
+  },
+  "device_automation": {
+    "action_type": {
+      "send_status": "Trigger status on device",
+      "send_sound": "Trigger a sound on device",
+      "send_command": "Trigger a command on device"
+    }
   }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -76,6 +76,13 @@
       "send_status": "Trigger status on device",
       "send_sound": "Trigger a sound on device",
       "send_command": "Trigger a command on device"
+    },
+    "trigger_type": {
+      "status": "Device received {subtype} status",
+      "command": "Device received {subtype} command"
+    },
+    "trigger_subtype": {
+      "Panic": "Panic"
     }
   }
 }

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -73,7 +73,7 @@
   },
   "device_automation": {
     "action_type": {
-      "send_status": "Trigger status: {subtype}",
+      "send_status": "Send status update: {subtype}",
       "send_command": "Send command: {subtype}"
     },
     "trigger_type": {

--- a/homeassistant/components/rfxtrx/strings.json
+++ b/homeassistant/components/rfxtrx/strings.json
@@ -74,7 +74,6 @@
   "device_automation": {
     "action_type": {
       "send_status": "Trigger status: {subtype}",
-      "send_chime": "Send command: {subtype}",
       "send_command": "Send command: {subtype}"
     },
     "trigger_type": {

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -76,6 +76,13 @@
             "send_status": "Trigger status on device",
             "send_sound": "Trigger a sound on device",
             "send_command": "Trigger a command on device"
+        },
+        "trigger_type": {
+          "status": "Device received {subtype} status",
+          "command": "Device received {subtype} command"
+        },
+        "trigger_subtype": {
+          "Panic": "Panic"
         }
     },
     "title": "Rfxtrx"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -73,13 +73,13 @@
     },
     "device_automation": {
         "action_type": {
-            "send_status": "Trigger status update",
-            "send_chime": "Send a sound command",
-            "send_command": "Send a command"
+            "send_status": "Trigger status: {subtype}",
+            "send_chime": "Send command: {subtype}",
+            "send_command": "Send command: {subtype}"      
         },
         "trigger_type": {
-            "status": "Received '{subtype}' status",
-            "command": "Received '{subtype}' command"
+            "status": "Received status: {subtype}",
+            "command": "Received command: {subtype}"      
         }
     },
     "title": "Rfxtrx"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -73,16 +73,13 @@
     },
     "device_automation": {
         "action_type": {
-            "send_status": "Trigger status on device",
-            "send_sound": "Trigger a sound on device",
-            "send_command": "Trigger a command on device"
+            "send_status": "Trigger status update",
+            "send_chime": "Send a sound command",
+            "send_command": "Send a command"
         },
         "trigger_type": {
-          "status": "Device received {subtype} status",
-          "command": "Device received {subtype} command"
-        },
-        "trigger_subtype": {
-          "Panic": "Panic"
+            "status": "Received '{subtype}' status",
+            "command": "Received '{subtype}' command"
         }
     },
     "title": "Rfxtrx"

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -70,5 +70,13 @@
                 "title": "Configure device options"
             }
         }
-    }
+    },
+    "device_automation": {
+        "action_type": {
+            "send_status": "Trigger status on device",
+            "send_sound": "Trigger a sound on device",
+            "send_command": "Trigger a command on device"
+        }
+    },
+    "title": "Rfxtrx"
 }

--- a/homeassistant/components/rfxtrx/translations/en.json
+++ b/homeassistant/components/rfxtrx/translations/en.json
@@ -73,8 +73,7 @@
     },
     "device_automation": {
         "action_type": {
-            "send_status": "Trigger status: {subtype}",
-            "send_chime": "Send command: {subtype}",
+            "send_status": "Send status update: {subtype}",
             "send_command": "Send command: {subtype}"      
         },
         "trigger_type": {

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -1,0 +1,142 @@
+"""The tests for RFXCOM RFXtrx device actions."""
+from typing import NamedTuple, Set, Tuple
+
+import RFXtrx
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.helpers.device_registry import DeviceRegistry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    mock_device_registry,
+    mock_registry,
+)
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture(name="entity_reg")
+def entity_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+class DeviceTestData(NamedTuple):
+    """Test data linked to a device."""
+
+    code: str
+    device_identifiers: Set[Tuple[str]]
+
+
+DEVICE_SECURITY_1 = DeviceTestData(
+    "08200300a109000670", {("rfxtrx", "20", "3", "a10900:32")}
+)
+
+DEVICE_TEMPHUM_1 = DeviceTestData(
+    "0a52080705020095220269", {("rfxtrx", "52", "8", "05:02")}
+)
+
+DEVICE_CHIME_1 = DeviceTestData(
+    "0a16000000000000000000", {("rfxtrx", "16", "0", "00:00")}
+)
+
+
+@pytest.mark.parametrize(
+    "device", [DEVICE_SECURITY_1, DEVICE_TEMPHUM_1, DEVICE_CHIME_1]
+)
+async def test_device_test_data(rfxtrx, device: DeviceTestData):
+    """Verify that our testing data remains correct."""
+    pkt: RFXtrx.lowlevel.Packet = RFXtrx.lowlevel.parse(bytearray.fromhex(device.code))
+    assert device.device_identifiers == {
+        ("rfxtrx", f"{pkt.packettype:x}", f"{pkt.subtype:x}", pkt.id_string)
+    }
+
+
+async def setup_entry(hass, devices):
+    """Construct a config setup."""
+    entry_data = create_rfx_test_cfg(devices=devices)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+
+@pytest.mark.parametrize(
+    "device,expected",
+    [
+        [DEVICE_SECURITY_1, [{"type": "send_status"}]],
+        [DEVICE_TEMPHUM_1, []],
+        [DEVICE_CHIME_1, [{"type": "send_chime"}]],
+    ],
+)
+async def test_get_actions(hass, device_reg: DeviceRegistry, device, expected):
+    """Test we get the expected actions from a rfxtrx."""
+    await setup_entry(hass, {device.code: {}})
+
+    device_entry = device_reg.async_get_device(device.device_identifiers, set())
+
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+
+    expected_actions = [
+        {"domain": DOMAIN, "device_id": device_entry.id, **action_type}
+        for action_type in expected
+    ]
+
+    assert_lists_same(actions, expected_actions)
+
+
+@pytest.mark.parametrize(
+    "device,config,expected",
+    [
+        [DEVICE_SECURITY_1, {"type": "send_status", "data": 1}, "08200300a109000100"],
+        [DEVICE_SECURITY_1, {"type": "send_status", "data": 10}, "08200300a109000a00"],
+        [DEVICE_CHIME_1, {"type": "send_chime", "data": 1}, "0716000000000100"],
+        [DEVICE_CHIME_1, {"type": "send_chime", "data": 10}, "0716000000000a00"],
+    ],
+)
+async def test_action(
+    hass, device_reg: DeviceRegistry, rfxtrx: RFXtrx.Connect, device, config, expected
+):
+    """Test for turn_on and turn_off actions."""
+
+    await setup_entry(hass, {device.code: {}})
+
+    device_entry = device_reg.async_get_device(device.device_identifiers, set())
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": device_entry.id,
+                        **config,
+                    },
+                },
+            ]
+        },
+    )
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+
+    rfxtrx.transport.send.assert_called_once_with(bytearray.fromhex(expected))

--- a/tests/components/rfxtrx/test_device_action.py
+++ b/tests/components/rfxtrx/test_device_action.py
@@ -1,7 +1,7 @@
 """The tests for RFXCOM RFXtrx device actions."""
 from __future__ import annotations
 
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple
 
 import RFXtrx
 import pytest
@@ -173,7 +173,7 @@ async def test_invalid_action(hass, device_reg: DeviceRegistry):
 
     await setup_entry(hass, {device.code: {"signal_repetitions": 1}})
 
-    device_identifers = cast(set[tuple[str, str]], device.device_identifiers)
+    device_identifers: Any = device.device_identifiers
     device_entry = device_reg.async_get_device(device_identifers, set())
     assert device_entry
 

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -26,14 +26,12 @@ class EventTestData(NamedTuple):
     subtype: str
 
 
-DEVICE_SECURITY_1 = {("rfxtrx", "20", "3", "a10900:32")}
-EVENT_SECURITY_1 = EventTestData(
-    "08200300a109000670", DEVICE_SECURITY_1, "status", "Panic"
-)
+DEVICE_LIGHTING_1 = {("rfxtrx", "10", "0", "E5")}
+EVENT_LIGHTING_1 = EventTestData("0710002a45050170", DEVICE_LIGHTING_1, "command", "On")
 
-DEVICE_CHIME_1 = {("rfxtrx", "16", "0", "00:00")}
-EVENT_CHIME_1 = EventTestData(
-    "0a16000000000000000000", DEVICE_CHIME_1, "command", "Chime"
+DEVICE_ROLLERTROL_1 = {("rfxtrx", "19", "0", "009ba8:1")}
+EVENT_ROLLERTROL_1 = EventTestData(
+    "09190000009ba8010100", DEVICE_ROLLERTROL_1, "command", "Down"
 )
 
 
@@ -59,38 +57,18 @@ async def setup_entry(hass, devices):
     "event,expected",
     [
         [
-            EVENT_SECURITY_1,
+            EVENT_LIGHTING_1,
             [
-                {"type": "status", "subtype": subtype}
+                {"type": "command", "subtype": subtype}
                 for subtype in [
-                    "Normal",
-                    "Normal Delayed",
-                    "Alarm",
-                    "Alarm Delayed",
-                    "Motion",
-                    "No Motion",
-                    "Panic",
-                    "End Panic",
-                    "IR",
-                    "Arm Away",
-                    "Arm Away Delayed",
-                    "Arm Home",
-                    "Arm Home Delayed",
-                    "Disarm",
-                    "Light 1 Off",
-                    "Light 1 On",
-                    "Light 2 Off",
-                    "Light 2 On",
-                    "Dark Detected",
-                    "Light Detected",
-                    "Battery low",
-                    "Pairing KD101",
-                    "Normal Tamper",
-                    "Normal Delayed Tamper",
-                    "Alarm Tamper",
-                    "Alarm Delayed Tamper",
-                    "Motion Tamper",
-                    "No Motion Tamper",
+                    "Off",
+                    "On",
+                    "Dim",
+                    "Bright",
+                    "All/group Off",
+                    "All/group On",
+                    "Chime",
+                    "Illegal command",
                 ]
             ],
         ]
@@ -98,7 +76,7 @@ async def setup_entry(hass, devices):
 )
 async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
     """Test we get the expected triggers from a rfxtrx."""
-    await setup_entry(hass, {event.code: {}})
+    await setup_entry(hass, {event.code: {"signal_repetitions": 1}})
 
     device_entry = device_reg.async_get_device(event.device_identifiers, set())
 
@@ -115,14 +93,14 @@ async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
 @pytest.mark.parametrize(
     "event",
     [
-        EVENT_SECURITY_1,
-        EVENT_CHIME_1,
+        EVENT_LIGHTING_1,
+        EVENT_ROLLERTROL_1,
     ],
 )
 async def test_firing_event(hass, device_reg, rfxtrx, event):
     """Test for turn_on and turn_off triggers firing."""
 
-    await setup_entry(hass, {event.code: {"fire_event": True}})
+    await setup_entry(hass, {event.code: {"fire_event": True, "signal_repetitions": 1}})
 
     device_entry = device_reg.async_get_device(event.device_identifiers, set())
 

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -1,0 +1,157 @@
+"""The tests for RFXCOM RFXtrx device triggers."""
+from typing import NamedTuple, Set, Tuple
+
+import pytest
+
+import homeassistant.components.automation as automation
+from homeassistant.components.rfxtrx import DOMAIN
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+)
+from tests.components.rfxtrx.conftest import create_rfx_test_cfg
+
+
+class EventTestData(NamedTuple):
+    """Test data linked to a device."""
+
+    code: str
+    device_identifiers: Set[Tuple[str]]
+    type: str
+    subtype: str
+
+
+DEVICE_SECURITY_1 = {("rfxtrx", "20", "3", "a10900:32")}
+EVENT_SECURITY_1 = EventTestData(
+    "08200300a109000670", DEVICE_SECURITY_1, "status", "Panic"
+)
+
+DEVICE_CHIME_1 = {("rfxtrx", "16", "0", "00:00")}
+EVENT_CHIME_1 = EventTestData(
+    "0a16000000000000000000", DEVICE_CHIME_1, "command", "Chime"
+)
+
+
+@pytest.fixture(name="device_reg")
+def device_reg_fixture(hass):
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+async def setup_entry(hass, devices):
+    """Construct a config setup."""
+    entry_data = create_rfx_test_cfg(devices=devices)
+    mock_entry = MockConfigEntry(domain="rfxtrx", unique_id=DOMAIN, data=entry_data)
+
+    mock_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+
+
+@pytest.mark.parametrize(
+    "event,expected",
+    [
+        [
+            EVENT_SECURITY_1,
+            [
+                {"type": "status", "subtype": subtype}
+                for subtype in [
+                    "Normal",
+                    "Normal Delayed",
+                    "Alarm",
+                    "Alarm Delayed",
+                    "Motion",
+                    "No Motion",
+                    "Panic",
+                    "End Panic",
+                    "IR",
+                    "Arm Away",
+                    "Arm Away Delayed",
+                    "Arm Home",
+                    "Arm Home Delayed",
+                    "Disarm",
+                    "Light 1 Off",
+                    "Light 1 On",
+                    "Light 2 Off",
+                    "Light 2 On",
+                    "Dark Detected",
+                    "Light Detected",
+                    "Battery low",
+                    "Pairing KD101",
+                    "Normal Tamper",
+                    "Normal Delayed Tamper",
+                    "Alarm Tamper",
+                    "Alarm Delayed Tamper",
+                    "Motion Tamper",
+                    "No Motion Tamper",
+                ]
+            ],
+        ]
+    ],
+)
+async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
+    """Test we get the expected triggers from a rfxtrx."""
+    await setup_entry(hass, {event.code: {}})
+
+    device_entry = device_reg.async_get_device(event.device_identifiers, set())
+
+    expected_triggers = [
+        {"domain": DOMAIN, "device_id": device_entry.id, "platform": "device", **expect}
+        for expect in expected
+    ]
+
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    triggers = [value for value in triggers if value["domain"] == "rfxtrx"]
+    assert_lists_same(triggers, expected_triggers)
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        EVENT_SECURITY_1,
+        EVENT_CHIME_1,
+    ],
+)
+async def test_firing_event(hass, device_reg, rfxtrx, event):
+    """Test for turn_on and turn_off triggers firing."""
+
+    await setup_entry(hass, {event.code: {"fire_event": True}})
+
+    device_entry = device_reg.async_get_device(event.device_identifiers, set())
+
+    calls = async_mock_service(hass, "test", "automation")
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": device_entry.id,
+                        "type": event.type,
+                        "subtype": event.subtype,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": ("{{trigger.platform}}")},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    await rfxtrx.signal(event.code)
+
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "device"

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -1,7 +1,7 @@
 """The tests for RFXCOM RFXtrx device triggers."""
 from __future__ import annotations
 
-from typing import NamedTuple, cast
+from typing import Any, NamedTuple
 
 import pytest
 
@@ -152,7 +152,7 @@ async def test_invalid_trigger(hass, device_reg: DeviceRegistry):
 
     await setup_entry(hass, {event.code: {"fire_event": True, "signal_repetitions": 1}})
 
-    device_identifers = cast(set[tuple[str, str]], event.device_identifiers)
+    device_identifers: Any = event.device_identifiers
     device_entry = device_reg.async_get_device(device_identifers, set())
     assert device_entry
 

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -34,6 +34,11 @@ EVENT_ROLLERTROL_1 = EventTestData(
     "09190000009ba8010100", DEVICE_ROLLERTROL_1, "command", "Down"
 )
 
+DEVICE_FIREALARM_1 = {("rfxtrx", "20", "3", "a10900:32")}
+EVENT_FIREALARM_1 = EventTestData(
+    "08200300a109000670", DEVICE_FIREALARM_1, "status", "Panic"
+)
+
 
 @pytest.fixture(name="device_reg")
 def device_reg_fixture(hass):
@@ -95,6 +100,7 @@ async def test_get_triggers(hass, device_reg, event: EventTestData, expected):
     [
         EVENT_LIGHTING_1,
         EVENT_ROLLERTROL_1,
+        EVENT_FIREALARM_1,
     ],
 )
 async def test_firing_event(hass, device_reg, rfxtrx, event):

--- a/tests/components/rfxtrx/test_device_trigger.py
+++ b/tests/components/rfxtrx/test_device_trigger.py
@@ -1,5 +1,7 @@
 """The tests for RFXCOM RFXtrx device triggers."""
-from typing import NamedTuple, Set, Tuple
+from __future__ import annotations
+
+from typing import NamedTuple
 
 import pytest
 
@@ -21,7 +23,7 @@ class EventTestData(NamedTuple):
     """Test data linked to a device."""
 
     code: str
-    device_identifiers: Set[Tuple[str]]
+    device_identifiers: set[tuple[str, str, str, str]]
     type: str
     subtype: str
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for using device triggers and actions directly on rfxtrx devices. This way we can trigger any of the supported commands for devices like pairing group/on/off and such.

Device triggers allow reaction to any of the standard commands from remotes instead of triggering on changes in some last received sensor value.

### Open issues/questions
* This does require events to be turned on for the device as it is now. We'd need a way to do that automatically.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
- Link to documentation pull request: 
- Updated lib closes #49528

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
