### PR TITLE
Add devices to Verisure integration

### DIFF
--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from homeassistant.components.alarm_control_panel import (
     FORMAT_NUMBER,
@@ -55,6 +55,16 @@ class VerisureAlarm(CoordinatorEntity, AlarmControlPanelEntity):
     def unique_id(self) -> str:
         """Return the unique ID for this alarm control panel."""
         return self.coordinator.entry.data[CONF_GIID]
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": "Verisure Alarm",
+            "manufacturer": "Verisure",
+            "model": "VBox",
+            "identifiers": {(DOMAIN, self.coordinator.entry.data[CONF_GIID])},
+        }
 
     @property
     def state(self) -> str | None:

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -60,8 +60,10 @@ class VerisureDoorWindowSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this entity."""
+        area = self.coordinator.data["door_window"][self.serial_number]["area"]
         return {
-            "name": self.coordinator.data["door_window"][self.serial_number]["area"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": "Shock Sensor Detector",
             "identifiers": {(DOMAIN, self.serial_number)},

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -1,7 +1,7 @@
 """Support for Verisure binary sensors."""
 from __future__ import annotations
 
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_CONNECTIVITY,
@@ -13,7 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import DOMAIN
+from .const import CONF_GIID, DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 
@@ -58,6 +58,17 @@ class VerisureDoorWindowSensor(CoordinatorEntity, BinarySensorEntity):
         return f"{self.serial_number}_door_window"
 
     @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": self.coordinator.data["door_window"][self.serial_number]["area"],
+            "manufacturer": "Verisure",
+            "model": "Shock Sensor Detector",
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
+
+    @property
     def device_class(self) -> str:
         """Return the class of this device, from component DEVICE_CLASSES."""
         return DEVICE_CLASS_OPENING
@@ -87,6 +98,21 @@ class VerisureEthernetStatus(CoordinatorEntity, BinarySensorEntity):
     def name(self) -> str:
         """Return the name of the binary sensor."""
         return "Verisure Ethernet status"
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this alarm control panel."""
+        return f"{self.coordinator.entry.data[CONF_GIID]}_ethernet"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": "Verisure Alarm",
+            "manufacturer": "Verisure",
+            "model": "VBox",
+            "identifiers": {(DOMAIN, self.coordinator.entry.data[CONF_GIID])},
+        }
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -101,7 +101,7 @@ class VerisureEthernetStatus(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def unique_id(self) -> str:
-        """Return the unique ID for this alarm control panel."""
+        """Return the unique ID for this binary sensor."""
         return f"{self.coordinator.entry.data[CONF_GIID]}_ethernet"
 
     @property

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -75,8 +75,10 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this entity."""
+        area = self.coordinator.data["cameras"][self.serial_number]["area"]
         return {
-            "name": self.coordinator.data["cameras"][self.serial_number]["area"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": "SmartCam",
             "identifiers": {(DOMAIN, self.serial_number)},

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import errno
 import os
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from verisure import Error as VerisureError
 
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import current_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, LOGGER, SERVICE_CAPTURE_SMARTCAM
+from .const import CONF_GIID, DOMAIN, LOGGER, SERVICE_CAPTURE_SMARTCAM
 from .coordinator import VerisureDataUpdateCoordinator
 
 
@@ -61,6 +61,27 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
         self._image = None
         self._image_id = None
         hass.bus.listen_once(EVENT_HOMEASSISTANT_STOP, self.delete_image)
+
+    @property
+    def name(self) -> str:
+        """Return the name of this camera."""
+        return self.coordinator.data["cameras"][self.serial_number]["area"]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this camera."""
+        return self.serial_number
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": self.coordinator.data["cameras"][self.serial_number]["area"],
+            "manufacturer": "Verisure",
+            "model": "SmartCam",
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
 
     def camera_image(self) -> bytes | None:
         """Return image response."""
@@ -114,16 +135,6 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
         except OSError as error:
             if error.errno != errno.ENOENT:
                 raise
-
-    @property
-    def name(self) -> str:
-        """Return the name of this camera."""
-        return self.coordinator.data["cameras"][self.serial_number]["area"]
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique ID for this camera."""
-        return self.serial_number
 
     def capture_smartcam(self) -> None:
         """Capture a new picture from a smartcam."""

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -17,6 +17,20 @@ SERVICE_CAPTURE_SMARTCAM = "capture_smartcam"
 SERVICE_DISABLE_AUTOLOCK = "disable_autolock"
 SERVICE_ENABLE_AUTOLOCK = "enable_autolock"
 
+# Mapping of device types to a human readable name
+DEVICE_TYPE_NAME = {
+    "CAMERAPIR2": "Camera detector",
+    "HOMEPAD1": "VoiceBox",
+    "HUMIDITY1": "Climate sensor",
+    "PIR2": "",
+    "SIREN1": "Siren",
+    "SMARTCAMERA1": "SmartCam",
+    "SMOKE2": "Smoke detector",
+    "SMOKE3": "Smoke detector",
+    "VOICEBOX1": "VoiceBox",
+    "WATER1": "Water detector",
+}
+
 # Legacy; to remove after YAML removal
 CONF_CODE_DIGITS = "code_digits"
 CONF_DEFAULT_LOCK_CODE = "default_lock_code"

--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -22,7 +22,7 @@ DEVICE_TYPE_NAME = {
     "CAMERAPIR2": "Camera detector",
     "HOMEPAD1": "VoiceBox",
     "HUMIDITY1": "Climate sensor",
-    "PIR2": "",
+    "PIR2": "Camera detector",
     "SIREN1": "Siren",
     "SMARTCAMERA1": "SmartCam",
     "SMOKE2": "Smoke detector",

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -82,8 +82,10 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this entity."""
+        area = self.coordinator.data["locks"][self.serial_number]["area"]
         return {
-            "name": self.coordinator.data["locks"][self.serial_number]["area"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": "Lockguard Smartlock",
             "identifiers": {(DOMAIN, self.serial_number)},

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -77,7 +77,7 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
     @property
     def unique_id(self) -> str:
         """Return the unique ID for this entity."""
-        return f"{self.serial_number}"
+        return self.serial_number
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from verisure import Error as VerisureError
 
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import current_platform
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
+    CONF_GIID,
     CONF_LOCK_CODE_DIGITS,
     CONF_LOCK_DEFAULT_CODE,
     DEFAULT_LOCK_CODE_DIGITS,
@@ -72,6 +73,22 @@ class VerisureDoorlock(CoordinatorEntity, LockEntity):
     def name(self) -> str:
         """Return the name of the lock."""
         return self.coordinator.data["locks"][self.serial_number]["area"]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        return f"{self.serial_number}"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": self.coordinator.data["locks"][self.serial_number]["area"],
+            "manufacturer": "Verisure",
+            "model": "Lockguard Smartlock",
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
 
     @property
     def available(self) -> bool:

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -70,8 +70,10 @@ class VerisureThermometer(CoordinatorEntity, Entity):
         device_type = self.coordinator.data["climate"][self.serial_number].get(
             "deviceType"
         )
+        area = self.coordinator.data["climate"][self.serial_number]["deviceArea"]
         return {
-            "name": self.coordinator.data["climate"][self.serial_number]["deviceArea"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": DEVICE_TYPE_NAME.get(device_type, device_type),
             "identifiers": {(DOMAIN, self.serial_number)},
@@ -127,8 +129,10 @@ class VerisureHygrometer(CoordinatorEntity, Entity):
         device_type = self.coordinator.data["climate"][self.serial_number].get(
             "deviceType"
         )
+        area = self.coordinator.data["climate"][self.serial_number]["deviceArea"]
         return {
-            "name": self.coordinator.data["climate"][self.serial_number]["deviceArea"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": DEVICE_TYPE_NAME.get(device_type, device_type),
             "identifiers": {(DOMAIN, self.serial_number)},
@@ -181,8 +185,10 @@ class VerisureMouseDetection(CoordinatorEntity, Entity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this entity."""
+        area = self.coordinator.data["mice"][self.serial_number]["area"]
         return {
-            "name": self.coordinator.data["mice"][self.serial_number]["area"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": "Mouse detector",
             "identifiers": {(DOMAIN, self.serial_number)},

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -1,7 +1,7 @@
 """Support for Verisure sensors."""
 from __future__ import annotations
 
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import PERCENTAGE, TEMP_CELSIUS
@@ -9,7 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_GIID, DEVICE_TYPE_NAME, DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 
@@ -65,6 +65,20 @@ class VerisureThermometer(CoordinatorEntity, Entity):
         return f"{self.serial_number}_temperature"
 
     @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        device_type = self.coordinator.data["climate"][self.serial_number].get(
+            "deviceType"
+        )
+        return {
+            "name": self.coordinator.data["climate"][self.serial_number]["deviceArea"],
+            "manufacturer": "Verisure",
+            "model": DEVICE_TYPE_NAME.get(device_type, device_type),
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
+
+    @property
     def state(self) -> str | None:
         """Return the state of the entity."""
         return self.coordinator.data["climate"][self.serial_number]["temperature"]
@@ -108,6 +122,20 @@ class VerisureHygrometer(CoordinatorEntity, Entity):
         return f"{self.serial_number}_humidity"
 
     @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        device_type = self.coordinator.data["climate"][self.serial_number].get(
+            "deviceType"
+        )
+        return {
+            "name": self.coordinator.data["climate"][self.serial_number]["deviceArea"],
+            "manufacturer": "Verisure",
+            "model": DEVICE_TYPE_NAME.get(device_type, device_type),
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
+
+    @property
     def state(self) -> str | None:
         """Return the state of the entity."""
         return self.coordinator.data["climate"][self.serial_number]["humidity"]
@@ -149,6 +177,17 @@ class VerisureMouseDetection(CoordinatorEntity, Entity):
     def unique_id(self) -> str:
         """Return the unique ID for this entity."""
         return f"{self.serial_number}_mice"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": self.coordinator.data["mice"][self.serial_number]["area"],
+            "manufacturer": "Verisure",
+            "model": "Mouse detector",
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
 
     @property
     def state(self) -> str | None:

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from time import monotonic
-from typing import Callable, Iterable
+from typing import Any, Callable, Iterable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_GIID, DOMAIN
 from .coordinator import VerisureDataUpdateCoordinator
 
 
@@ -50,6 +50,17 @@ class VerisureSmartplug(CoordinatorEntity, SwitchEntity):
     def unique_id(self) -> str:
         """Return the unique ID for this alarm control panel."""
         return self.serial_number
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return device information about this entity."""
+        return {
+            "name": self.coordinator.data["smart_plugs"][self.serial_number]["area"],
+            "manufacturer": "Verisure",
+            "model": "SmartPlug",
+            "identifiers": {(DOMAIN, self.serial_number)},
+            "via_device": (DOMAIN, self.coordinator.entry.data[CONF_GIID]),
+        }
 
     @property
     def is_on(self) -> bool:

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -48,7 +48,7 @@ class VerisureSmartplug(CoordinatorEntity, SwitchEntity):
 
     @property
     def unique_id(self) -> str:
-        """Return the unique ID for this alarm control panel."""
+        """Return the unique ID for this entity."""
         return self.serial_number
 
     @property

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -54,8 +54,10 @@ class VerisureSmartplug(CoordinatorEntity, SwitchEntity):
     @property
     def device_info(self) -> dict[str, Any]:
         """Return device information about this entity."""
+        area = self.coordinator.data["smart_plugs"][self.serial_number]["area"]
         return {
-            "name": self.coordinator.data["smart_plugs"][self.serial_number]["area"],
+            "name": area,
+            "suggested_area": area,
             "manufacturer": "Verisure",
             "model": "SmartPlug",
             "identifiers": {(DOMAIN, self.serial_number)},


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Depends on #47880 and #47905; needs to rebase after that is merged.

This PR adds device info to the Verisure entities, bringing in all the devices goodness from Home Assistant to this integration.

Still open / to do before marking ready for review:

- [x] Put entities into devices
- [x] Rebase when #47880 is merged
- [x] Rebase when #47905 is merged

Next steps (after this PR):

- Check if installation still exists on startup
- Even more cleanup!
- Pre-determine property values, instead of calculating them in property methods themselves (as much as possible)
- Start setting up tests for platforms
- Check if we can detect unsupported 2FA enabled on Verisure My Pages account (to help with #47397)
- Re-auth handling (awaits: https://github.com/persandstrom/python-verisure/pull/129)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
