### PR TITLE
Going async with denonavr

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -174,6 +174,7 @@ omit =
     homeassistant/components/deluge/sensor.py
     homeassistant/components/deluge/switch.py
     homeassistant/components/denon/media_player.py
+    homeassistant/components/denonavr/__init__.py
     homeassistant/components/denonavr/media_player.py
     homeassistant/components/denonavr/receiver.py
     homeassistant/components/deutsche_bahn/sensor.py

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers.httpx_client import get_async_client
 
 from .config_flow import (
     CONF_SHOW_ALL_SOURCES,
@@ -66,6 +67,7 @@ async def async_setup_entry(
         entry.options.get(CONF_SHOW_ALL_SOURCES, DEFAULT_SHOW_SOURCES),
         entry.options.get(CONF_ZONE2, DEFAULT_ZONE2),
         entry.options.get(CONF_ZONE3, DEFAULT_ZONE3),
+        get_async_client(hass),
     )
     if not await connect_denonavr.async_connect_receiver():
         raise ConfigEntryNotReady

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -3,7 +3,6 @@ import logging
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.httpx_client import get_async_client
 
@@ -44,8 +43,7 @@ async def async_setup_entry(
         get_denon_async_client,
         entry.state,
     )
-    if not await connect_denonavr.async_connect_receiver():
-        raise ConfigEntryNotReady
+    await connect_denonavr.async_connect_receiver()
     receiver = connect_denonavr.receiver
 
     undo_listener = entry.add_update_listener(update_listener)

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -30,9 +30,6 @@ async def async_setup_entry(
     """Set up the denonavr components from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    def get_denon_async_client():
-        return get_async_client(hass)
-
     # Connect to receiver
     connect_denonavr = ConnectDenonAVR(
         entry.data[CONF_HOST],
@@ -40,7 +37,7 @@ async def async_setup_entry(
         entry.options.get(CONF_SHOW_ALL_SOURCES, DEFAULT_SHOW_SOURCES),
         entry.options.get(CONF_ZONE2, DEFAULT_ZONE2),
         entry.options.get(CONF_ZONE3, DEFAULT_ZONE3),
-        get_denon_async_client,
+        lambda: get_async_client(hass),
         entry.state,
     )
     await connect_denonavr.async_connect_receiver()

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,6 +1,5 @@
 """The denonavr component."""
 import logging
-from typing import Dict
 
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST
@@ -24,11 +23,6 @@ CONF_RECEIVER = "receiver"
 UNDO_UPDATE_LISTENER = "undo_update_listener"
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: core.HomeAssistant, config: Dict):
-    """Set up the denonavr platform."""
-    return True
 
 
 async def async_setup_entry(

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -2,13 +2,10 @@
 import logging
 from typing import Dict
 
-import voluptuous as vol
-
 from homeassistant import config_entries, core
-from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST
+from homeassistant.const import CONF_HOST
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .config_flow import (
@@ -25,32 +22,12 @@ from .receiver import ConnectDenonAVR
 
 CONF_RECEIVER = "receiver"
 UNDO_UPDATE_LISTENER = "undo_update_listener"
-SERVICE_GET_COMMAND = "get_command"
 
 _LOGGER = logging.getLogger(__name__)
-
-CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
-
-GET_COMMAND_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_COMMAND): cv.string})
-
-SERVICE_TO_METHOD = {
-    SERVICE_GET_COMMAND: {"method": "async_get_command", "schema": GET_COMMAND_SCHEMA}
-}
 
 
 async def async_setup(hass: core.HomeAssistant, config: Dict):
     """Set up the denonavr platform."""
-
-    def service_handler(service):
-        method = SERVICE_TO_METHOD.get(service.service)
-        data = service.data.copy()
-        data["method"] = method["method"]
-        async_dispatcher_send(hass, DOMAIN, data)
-
-    for service in SERVICE_TO_METHOD:
-        schema = SERVICE_TO_METHOD[service]["schema"]
-        hass.services.async_register(DOMAIN, service, service_handler, schema=schema)
-
     return True
 
 

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,5 +1,6 @@
 """The denonavr component."""
 import logging
+from typing import Dict
 
 import voluptuous as vol
 
@@ -36,7 +37,7 @@ SERVICE_TO_METHOD = {
 }
 
 
-def setup(hass: core.HomeAssistant, config: dict):
+def setup(hass: core.HomeAssistant, config: Dict):
     """Set up the denonavr platform."""
 
     def service_handler(service):
@@ -60,7 +61,6 @@ async def async_setup_entry(
 
     # Connect to receiver
     connect_denonavr = ConnectDenonAVR(
-        hass,
         entry.data[CONF_HOST],
         DEFAULT_TIMEOUT,
         entry.options.get(CONF_SHOW_ALL_SOURCES, DEFAULT_SHOW_SOURCES),

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -1,8 +1,11 @@
 """The denonavr component."""
 import logging
 
+from denonavr.exceptions import AvrNetworkError, AvrTimoutError
+
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.httpx_client import get_async_client
 
@@ -40,7 +43,10 @@ async def async_setup_entry(
         lambda: get_async_client(hass),
         entry.state,
     )
-    await connect_denonavr.async_connect_receiver()
+    try:
+        await connect_denonavr.async_connect_receiver()
+    except (AvrNetworkError, AvrTimoutError) as ex:
+        raise ConfigEntryNotReady from ex
     receiver = connect_denonavr.receiver
 
     undo_listener = entry.add_update_listener(update_listener)

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries, core
 from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID, CONF_HOST
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, entity_registry as er
-from homeassistant.helpers.dispatcher import dispatcher_send
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .config_flow import (
     CONF_SHOW_ALL_SOURCES,
@@ -33,22 +33,22 @@ CALL_SCHEMA = vol.Schema({vol.Required(ATTR_ENTITY_ID): cv.comp_entity_ids})
 GET_COMMAND_SCHEMA = CALL_SCHEMA.extend({vol.Required(ATTR_COMMAND): cv.string})
 
 SERVICE_TO_METHOD = {
-    SERVICE_GET_COMMAND: {"method": "get_command", "schema": GET_COMMAND_SCHEMA}
+    SERVICE_GET_COMMAND: {"method": "async_get_command", "schema": GET_COMMAND_SCHEMA}
 }
 
 
-def setup(hass: core.HomeAssistant, config: Dict):
+async def async_setup(hass: core.HomeAssistant, config: Dict):
     """Set up the denonavr platform."""
 
     def service_handler(service):
         method = SERVICE_TO_METHOD.get(service.service)
         data = service.data.copy()
         data["method"] = method["method"]
-        dispatcher_send(hass, DOMAIN, data)
+        async_dispatcher_send(hass, DOMAIN, data)
 
     for service in SERVICE_TO_METHOD:
         schema = SERVICE_TO_METHOD[service]["schema"]
-        hass.services.register(DOMAIN, service, service_handler, schema=schema)
+        hass.services.async_register(DOMAIN, service, service_handler, schema=schema)
 
     return True
 

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -31,6 +31,9 @@ async def async_setup_entry(
     """Set up the denonavr components from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
+    def get_denon_async_client():
+        return get_async_client(hass)
+
     # Connect to receiver
     connect_denonavr = ConnectDenonAVR(
         entry.data[CONF_HOST],
@@ -38,7 +41,7 @@ async def async_setup_entry(
         entry.options.get(CONF_SHOW_ALL_SOURCES, DEFAULT_SHOW_SOURCES),
         entry.options.get(CONF_ZONE2, DEFAULT_ZONE2),
         entry.options.get(CONF_ZONE3, DEFAULT_ZONE3),
-        get_async_client(hass),
+        get_denon_async_client,
         entry.state,
     )
     if not await connect_denonavr.async_connect_receiver():

--- a/homeassistant/components/denonavr/__init__.py
+++ b/homeassistant/components/denonavr/__init__.py
@@ -45,6 +45,7 @@ async def async_setup_entry(
         entry.options.get(CONF_ZONE2, DEFAULT_ZONE2),
         entry.options.get(CONF_ZONE3, DEFAULT_ZONE3),
         get_async_client(hass),
+        entry.state,
     )
     if not await connect_denonavr.async_connect_receiver():
         raise ConfigEntryNotReady
@@ -77,8 +78,9 @@ async def async_unload_entry(
     # Remove zone2 and zone3 entities if needed
     entity_registry = await er.async_get_registry(hass)
     entries = er.async_entries_for_config_entry(entity_registry, config_entry.entry_id)
-    zone2_id = f"{config_entry.unique_id}-Zone2"
-    zone3_id = f"{config_entry.unique_id}-Zone3"
+    unique_id = config_entry.unique_id or config_entry.entry_id
+    zone2_id = f"{unique_id}-Zone2"
+    zone3_id = f"{unique_id}-Zone3"
     for entry in entries:
         if entry.unique_id == zone2_id and not config_entry.options.get(CONF_ZONE2):
             entity_registry.async_remove(entry.entity_id)

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -4,13 +4,13 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
 import denonavr
+from denonavr.exceptions import AvrNetworkError, AvrTimoutError
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .receiver import ConnectDenonAVR
@@ -168,7 +168,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             success = await connect_denonavr.async_connect_receiver()
-        except ConfigEntryNotReady:
+        except (AvrNetworkError, AvrTimoutError):
             success = False
         if not success:
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -10,6 +10,7 @@ from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .receiver import ConnectDenonAVR
@@ -164,7 +165,12 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             self.zone3,
             lambda: get_async_client(self.hass),
         )
-        if not await connect_denonavr.async_connect_receiver():
+
+        try:
+            success = await connect_denonavr.async_connect_receiver()
+        except ConfigEntryNotReady:
+            success = False
+        if not success:
             return self.async_abort(reason="cannot_connect")
         receiver = connect_denonavr.receiver
 

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -156,17 +156,13 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Connect to the receiver."""
-
-        def get_denon_async_client():
-            return get_async_client(self.hass)
-
         connect_denonavr = ConnectDenonAVR(
             self.host,
             self.timeout,
             self.show_all_sources,
             self.zone2,
             self.zone3,
-            get_denon_async_client,
+            lambda: get_async_client(self.hass),
         )
         if not await connect_denonavr.async_connect_receiver():
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -156,13 +156,17 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
         """Connect to the receiver."""
+
+        def get_denon_async_client():
+            return get_async_client(self.hass)
+
         connect_denonavr = ConnectDenonAVR(
             self.host,
             self.timeout,
             self.show_all_sources,
             self.zone2,
             self.zone3,
-            get_async_client(self.hass),
+            get_denon_async_client,
         )
         if not await connect_denonavr.async_connect_receiver():
             return self.async_abort(reason="cannot_connect")

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -149,6 +149,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return await self.async_step_connect()
 
+        self._set_confirm_only()
         return self.async_show_form(step_id="confirm")
 
     async def async_step_connect(

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon AVR Network Receivers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "requirements": ["denonavr==0.9.10", "getmac==0.8.2"],
+  "requirements": ["denonavr==0.10.1", "getmac==0.8.2"],
   "codeowners": ["@scarface-4711", "@starkillerOG"],
   "ssdp": [
     {

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon AVR Network Receivers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "requirements": ["denonavr==0.10.1", "getmac==0.8.2"],
+  "requirements": ["denonavr==0.10.3", "getmac==0.8.2"],
   "codeowners": ["@scarface-4711", "@starkillerOG"],
   "ssdp": [
     {

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon AVR Network Receivers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "requirements": ["denonavr==0.10.3", "getmac==0.8.2"],
+  "requirements": ["denonavr==0.10.3"],
   "codeowners": ["@scarface-4711", "@starkillerOG"],
   "ssdp": [
     {

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon AVR Network Receivers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "requirements": ["denonavr==0.10.4"],
+  "requirements": ["denonavr==0.10.5"],
   "codeowners": ["@scarface-4711", "@starkillerOG"],
   "ssdp": [
     {

--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon AVR Network Receivers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "requirements": ["denonavr==0.10.3"],
+  "requirements": ["denonavr==0.10.4"],
   "codeowners": ["@scarface-4711", "@starkillerOG"],
   "ssdp": [
     {

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -1,5 +1,6 @@
 """Support for Denon AVR receivers using their HTTP interface."""
 
+from datetime import timedelta
 from functools import wraps
 import logging
 from typing import Coroutine
@@ -76,6 +77,9 @@ SUPPORT_MEDIA_MODES = (
     | SUPPORT_VOLUME_SET
     | SUPPORT_PLAY
 )
+
+SCAN_INTERVAL = timedelta(seconds=10)
+PARALLEL_UPDATES = 2
 
 
 async def async_setup_entry(
@@ -408,7 +412,7 @@ class DenonDevice(MediaPlayerEntity):
     @async_log_errors
     async def async_select_sound_mode(self, sound_mode: str):
         """Select sound mode."""
-        await self._receiver.soundmode.async_set_sound_mode(sound_mode)
+        await self._receiver.async_set_sound_mode(sound_mode)
 
     @async_log_errors
     async def async_turn_on(self):

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -10,6 +10,7 @@ from denonavr.const import POWER_ON
 from denonavr.exceptions import (
     AvrCommandError,
     AvrForbiddenError,
+    AvrNetworkError,
     AvrTimoutError,
     DenonAvrError,
 )
@@ -146,6 +147,14 @@ class DenonDevice(MediaPlayerEntity):
                 if self._available is True:
                     _LOGGER.warning(
                         "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
+                        self._receiver.host,
+                    )
+                    self._available = False
+            except AvrNetworkError:
+                available = False
+                if self._available is True:
+                    _LOGGER.warning(
+                        "Network error connecting to Denon AVR receiver at host %s. Device is unavailable",
                         self._receiver.host,
                     )
                     self._available = False

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -33,7 +33,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.const import ATTR_COMMAND, STATE_PAUSED, STATE_PLAYING, STATE_UNKNOWN
+from homeassistant.const import ATTR_COMMAND, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
 
@@ -219,8 +219,6 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def state(self):
         """Return the state of the device."""
-        if self._receiver.state is None:
-            return STATE_UNKNOWN
         return self._receiver.state
 
     @property

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
         if config_entry.data[CONF_SERIAL_NUMBER] is not None:
             unique_id = f"{config_entry.unique_id}-{receiver_zone.zone}"
         else:
-            unique_id = None
+            unique_id = f"{config_entry.entry_id}-{receiver_zone.zone}"
         await receiver_zone.async_setup()
         entities.append(DenonDevice(receiver_zone, unique_id, config_entry))
     _LOGGER.debug(

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -139,15 +139,15 @@ class DenonDevice(MediaPlayerEntity):
                 if self._available is True:  # pylint: disable=protected-access
                     _LOGGER.warning(
                         "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
-                        self._receiver.host,
+                        self._receiver.host,  # pylint: disable=protected-access
                     )
-                    self._available = False
+                    self._available = False  # pylint: disable=protected-access
             except AvrForbiddenError:
                 available = False
                 if self._available is True:  # pylint: disable=protected-access
                     _LOGGER.warning(
                         "Denon AVR receiver at host %s responded with HTTP 403 error. Device is unavailable. Please consider power cycling your receiver",
-                        self._receiver.host,
+                        self._receiver.host,  # pylint: disable=protected-access
                     )
                     self._available = False  # pylint: disable=protected-access
             except AvrCommandError as err:
@@ -164,13 +164,15 @@ class DenonDevice(MediaPlayerEntity):
                     exc_info=True,
                 )
             finally:
-                if available is True:
-                    if self._available is False:  # pylint: disable=protected-access
-                        _LOGGER.info(
-                            "Denon AVR receiver at host %s is available again",
-                            self._receiver.host,
-                        )
-                        self._available = True  # pylint: disable=protected-access
+                if (
+                    available is True
+                    and self._available is False  # pylint: disable=protected-access
+                ):
+                    _LOGGER.info(
+                        "Denon AVR receiver at host %s is available again",
+                        self._receiver.host,  # pylint: disable=protected-access
+                    )
+                    self._available = True  # pylint: disable=protected-access
 
         return wrapper
 

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -1,8 +1,19 @@
 """Support for Denon AVR receivers using their HTTP interface."""
 
-from contextlib import suppress
+from functools import wraps
 import logging
+from typing import Coroutine
 
+from denonavr import DenonAVR
+from denonavr.const import POWER_ON
+from denonavr.exceptions import (
+    AvrCommandError,
+    AvrForbiddenError,
+    AvrTimoutError,
+    DenonAvrError,
+)
+
+from homeassistant import config_entries
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     MEDIA_TYPE_CHANNEL,
@@ -25,13 +36,15 @@ from homeassistant.const import (
     CONF_MAC,
     ENTITY_MATCH_ALL,
     ENTITY_MATCH_NONE,
-    STATE_OFF,
-    STATE_ON,
     STATE_PAUSED,
     STATE_PLAYING,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import EntityPlatform
 
 from . import CONF_RECEIVER
 from .config_flow import (
@@ -65,7 +78,11 @@ SUPPORT_MEDIA_MODES = (
 )
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: config_entries.ConfigEntry,
+    async_add_entities: EntityPlatform.async_add_entities,
+):
     """Set up the DenonAVR receiver from a config entry."""
     entities = []
     receiver = hass.data[DOMAIN][config_entry.entry_id][CONF_RECEIVER]
@@ -74,50 +91,88 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             unique_id = f"{config_entry.unique_id}-{receiver_zone.zone}"
         else:
             unique_id = None
+        await receiver_zone.async_setup()
         entities.append(DenonDevice(receiver_zone, unique_id, config_entry))
     _LOGGER.debug(
         "%s receiver at host %s initialized", receiver.manufacturer, receiver.host
     )
-    async_add_entities(entities)
+    async_add_entities(entities, update_before_add=True)
 
 
 class DenonDevice(MediaPlayerEntity):
     """Representation of a Denon Media Player Device."""
 
-    def __init__(self, receiver, unique_id, config_entry):
+    def __init__(
+        self,
+        receiver: DenonAVR,
+        unique_id: str,
+        config_entry: config_entries.ConfigEntry,
+    ):
         """Initialize the device."""
         self._receiver = receiver
-        self._name = self._receiver.name
         self._unique_id = unique_id
         self._config_entry = config_entry
-        self._muted = self._receiver.muted
-        self._volume = self._receiver.volume
-        self._current_source = self._receiver.input_func
-        self._source_list = self._receiver.input_func_list
-        self._state = self._receiver.state
-        self._power = self._receiver.power
-        self._media_image_url = self._receiver.image_url
-        self._title = self._receiver.title
-        self._artist = self._receiver.artist
-        self._album = self._receiver.album
-        self._band = self._receiver.band
-        self._frequency = self._receiver.frequency
-        self._station = self._receiver.station
-
-        self._sound_mode_support = self._receiver.support_sound_mode
-        if self._sound_mode_support:
-            self._sound_mode = self._receiver.sound_mode
-            self._sound_mode_raw = self._receiver.sound_mode_raw
-            self._sound_mode_list = self._receiver.sound_mode_list
-        else:
-            self._sound_mode = None
-            self._sound_mode_raw = None
-            self._sound_mode_list = None
 
         self._supported_features_base = SUPPORT_DENON
         self._supported_features_base |= (
-            self._sound_mode_support and SUPPORT_SELECT_SOUND_MODE
+            self._receiver.support_sound_mode and SUPPORT_SELECT_SOUND_MODE
         )
+        self._available = True
+
+    def async_log_errors(  # pylint: disable=no-self-argument
+        func: Coroutine,
+    ) -> Coroutine:
+        """
+        Log errors occurred when calling a Denon AVR receiver.
+
+        Decorates methods of DenonDevice class.
+        Declaration of staticmethod for this method is at the end of this class.
+        """
+
+        @wraps(func)
+        async def wrapper(self, *args, **kwargs):
+            available = True
+            try:
+                return await func(self, *args, **kwargs)  # pylint: disable=not-callable
+            except AvrTimoutError:
+                available = False
+                if self._available is True:
+                    _LOGGER.warning(
+                        "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
+                        self._receiver.host,
+                    )
+                    self._available = False
+            except AvrForbiddenError:
+                available = False
+                if self._available is True:
+                    _LOGGER.warning(
+                        "Denon AVR receiver at host %s responded with HTTP 403 error. Device is unavailable. Please consider power cycling your receiver",
+                        self._receiver.host,
+                    )
+                    self._available = False
+            except AvrCommandError as err:
+                _LOGGER.error(
+                    "Command %s failed with error: %s",
+                    func.__name__,  # pylint: disable=no-member
+                    err,
+                )
+            except DenonAvrError as err:
+                _LOGGER.error(
+                    "Error %s occurred in method %s for Denon AVR receiver",
+                    err,
+                    func._name__,  # pylint: disable=no-member
+                    exc_info=True,
+                )
+            finally:
+                if available is True:
+                    if self._available is False:
+                        _LOGGER.info(
+                            "Denon AVR receiver at host %s is available again",
+                            self._receiver.host,
+                        )
+                        self._available = True
+
+        return wrapper
 
     async def async_added_to_hass(self):
         """Register signal handler."""
@@ -140,26 +195,15 @@ class DenonDevice(MediaPlayerEntity):
             }
             getattr(self, data["method"])(**params)
 
-    def update(self):
+    @async_log_errors
+    async def async_update(self) -> None:
         """Get the latest status information from device."""
-        self._receiver.update()
-        self._name = self._receiver.name
-        self._muted = self._receiver.muted
-        self._volume = self._receiver.volume
-        self._current_source = self._receiver.input_func
-        self._source_list = self._receiver.input_func_list
-        self._state = self._receiver.state
-        self._power = self._receiver.power
-        self._media_image_url = self._receiver.image_url
-        self._title = self._receiver.title
-        self._artist = self._receiver.artist
-        self._album = self._receiver.album
-        self._band = self._receiver.band
-        self._frequency = self._receiver.frequency
-        self._station = self._receiver.station
-        if self._sound_mode_support:
-            self._sound_mode = self._receiver.sound_mode
-            self._sound_mode_raw = self._receiver.sound_mode_raw
+        await self._receiver.async_update()
+
+    @property
+    def available(self):
+        """Return True if entity is available."""
+        return self._available
 
     @property
     def unique_id(self):
@@ -188,49 +232,55 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def name(self):
         """Return the name of the device."""
-        return self._name
+        return self._receiver.name
 
     @property
     def state(self):
         """Return the state of the device."""
-        return self._state
+        if self._available is False:
+            return STATE_UNAVAILABLE
+        elif self._receiver.state is None:
+            return STATE_UNKNOWN
+        return self._receiver.state
 
     @property
     def is_volume_muted(self):
         """Return boolean if volume is currently muted."""
-        return self._muted
+        return self._receiver.muted
 
     @property
     def volume_level(self):
         """Volume level of the media player (0..1)."""
         # Volume is sent in a format like -50.0. Minimum is -80.0,
         # maximum is 18.0
-        return (float(self._volume) + 80) / 100
+        if self._receiver.volume is None:
+            return None
+        return (float(self._receiver.volume) + 80) / 100
 
     @property
     def source(self):
         """Return the current input source."""
-        return self._current_source
+        return self._receiver.input_func
 
     @property
     def source_list(self):
         """Return a list of available input sources."""
-        return self._source_list
+        return self._receiver.input_func_list
 
     @property
     def sound_mode(self):
         """Return the current matched sound mode."""
-        return self._sound_mode
+        return self._receiver.sound_mode
 
     @property
     def sound_mode_list(self):
         """Return a list of available sound modes."""
-        return self._sound_mode_list
+        return self._receiver.sound_mode_list
 
     @property
     def supported_features(self):
         """Flag media player features that are supported."""
-        if self._current_source in self._receiver.netaudio_func_list:
+        if self._receiver.input_func in self._receiver.netaudio_func_list:
             return self._supported_features_base | SUPPORT_MEDIA_MODES
         return self._supported_features_base
 
@@ -242,7 +292,10 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def media_content_type(self):
         """Content type of current playing media."""
-        if self._state == STATE_PLAYING or self._state == STATE_PAUSED:
+        if (
+            self._receiver.state == STATE_PLAYING
+            or self._receiver.state == STATE_PAUSED
+        ):
             return MEDIA_TYPE_MUSIC
         return MEDIA_TYPE_CHANNEL
 
@@ -254,32 +307,32 @@ class DenonDevice(MediaPlayerEntity):
     @property
     def media_image_url(self):
         """Image url of current playing media."""
-        if self._current_source in self._receiver.playing_func_list:
-            return self._media_image_url
+        if self._receiver.input_func in self._receiver.playing_func_list:
+            return self._receiver.image_url
         return None
 
     @property
     def media_title(self):
         """Title of current playing media."""
-        if self._current_source not in self._receiver.playing_func_list:
-            return self._current_source
-        if self._title is not None:
-            return self._title
-        return self._frequency
+        if self._receiver.input_func not in self._receiver.playing_func_list:
+            return self._receiver.input_func
+        if self._receiver.title is not None:
+            return self._receiver.title
+        return self._receiver.frequency
 
     @property
     def media_artist(self):
         """Artist of current playing media, music track only."""
-        if self._artist is not None:
-            return self._artist
-        return self._band
+        if self._receiver.artist is not None:
+            return self._receiver.artist
+        return self._receiver.band
 
     @property
     def media_album_name(self):
         """Album name of current playing media, music track only."""
-        if self._album is not None:
-            return self._album
-        return self._station
+        if self._receiver.album is not None:
+            return self._receiver.album
+        return self._receiver.station
 
     @property
     def media_album_artist(self):
@@ -310,77 +363,91 @@ class DenonDevice(MediaPlayerEntity):
     def extra_state_attributes(self):
         """Return device specific state attributes."""
         if (
-            self._sound_mode_raw is not None
-            and self._sound_mode_support
-            and self._power == "ON"
+            self._receiver.sound_mode_raw is not None
+            and self._receiver.support_sound_mode
+            and self._receiver.power == POWER_ON
         ):
-            return {ATTR_SOUND_MODE_RAW: self._sound_mode_raw}
+            return {ATTR_SOUND_MODE_RAW: self._receiver.sound_mode_raw}
         return {}
 
-    def media_play_pause(self):
+    @async_log_errors
+    async def async_media_play_pause(self):
         """Play or pause the media player."""
-        return self._receiver.toggle_play_pause()
+        await self._receiver.async_toggle_play_pause()
 
-    def media_play(self):
+    @async_log_errors
+    async def async_media_play(self):
         """Send play command."""
-        return self._receiver.play()
+        await self._receiver.async_play()
 
-    def media_pause(self):
+    @async_log_errors
+    async def async_media_pause(self):
         """Send pause command."""
-        return self._receiver.pause()
+        await self._receiver.async_pause()
 
-    def media_previous_track(self):
+    @async_log_errors
+    async def async_media_previous_track(self):
         """Send previous track command."""
-        return self._receiver.previous_track()
+        await self._receiver.async_previous_track()
 
-    def media_next_track(self):
+    @async_log_errors
+    async def async_media_next_track(self):
         """Send next track command."""
-        return self._receiver.next_track()
+        await self._receiver.async_next_track()
 
-    def select_source(self, source):
+    @async_log_errors
+    async def async_select_source(self, source: str):
         """Select input source."""
         # Ensure that the AVR is turned on, which is necessary for input
         # switch to work.
-        self.turn_on()
-        return self._receiver.set_input_func(source)
+        await self.async_turn_on()
+        await self._receiver.async_set_input_func(source)
 
-    def select_sound_mode(self, sound_mode):
+    @async_log_errors
+    async def async_select_sound_mode(self, sound_mode: str):
         """Select sound mode."""
-        return self._receiver.set_sound_mode(sound_mode)
+        # TODO: push fix in denonavr
+        await self._receiver.soundmode.async_set_sound_mode(sound_mode)
 
-    def turn_on(self):
+    @async_log_errors
+    async def async_turn_on(self):
         """Turn on media player."""
-        if self._receiver.power_on():
-            self._state = STATE_ON
+        await self._receiver.async_power_on()
 
-    def turn_off(self):
+    @async_log_errors
+    async def async_turn_off(self):
         """Turn off media player."""
-        if self._receiver.power_off():
-            self._state = STATE_OFF
+        await self._receiver.async_power_off()
 
-    def volume_up(self):
+    @async_log_errors
+    async def async_volume_up(self):
         """Volume up the media player."""
-        return self._receiver.volume_up()
+        await self._receiver.async_volume_up()
 
-    def volume_down(self):
+    @async_log_errors
+    async def async_volume_down(self):
         """Volume down media player."""
-        return self._receiver.volume_down()
+        await self._receiver.async_volume_down()
 
-    def set_volume_level(self, volume):
+    @async_log_errors
+    async def async_set_volume_level(self, volume: int):
         """Set volume level, range 0..1."""
         # Volume has to be sent in a format like -50.0. Minimum is -80.0,
         # maximum is 18.0
         volume_denon = float((volume * 100) - 80)
         if volume_denon > 18:
             volume_denon = float(18)
-        with suppress(ValueError):
-            if self._receiver.set_volume(volume_denon):
-                self._volume = volume_denon
+        await self._receiver.async_set_volume(volume_denon)
 
-    def mute_volume(self, mute):
+    @async_log_errors
+    async def async_mute_volume(self, mute: bool):
         """Send mute command."""
-        return self._receiver.mute(mute)
+        await self._receiver.async_mute(mute)
 
-    def get_command(self, command, **kwargs):
+    @async_log_errors
+    async def async_get_command(self, command: str, **kwargs):
         """Send generic command."""
-        self._receiver.send_get_command(command)
+        return await self._receiver.async_get_command(command)
+
+    # Decorator defined before is a staticmethod
+    async_log_erros = staticmethod(async_log_errors)

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -179,10 +179,10 @@ class DenonDevice(MediaPlayerEntity):
     async def async_added_to_hass(self):
         """Register signal handler."""
         self.async_on_remove(
-            async_dispatcher_connect(self.hass, DOMAIN, self.signal_handler)
+            async_dispatcher_connect(self.hass, DOMAIN, self.async_signal_handler)
         )
 
-    def signal_handler(self, data):
+    async def async_signal_handler(self, data):
         """Handle domain-specific signal by calling appropriate method."""
         entity_ids = data[ATTR_ENTITY_ID]
 
@@ -195,7 +195,7 @@ class DenonDevice(MediaPlayerEntity):
                 for key, value in data.items()
                 if key not in ["entity_id", "method"]
             }
-            getattr(self, data["method"])(**params)
+            await getattr(self, data["method"])(**params)
 
     @async_log_errors
     async def async_update(self) -> None:

--- a/homeassistant/components/denonavr/media_player.py
+++ b/homeassistant/components/denonavr/media_player.py
@@ -136,7 +136,7 @@ class DenonDevice(MediaPlayerEntity):
                 return await func(self, *args, **kwargs)  # pylint: disable=not-callable
             except AvrTimoutError:
                 available = False
-                if self._available is True:
+                if self._available is True:  # pylint: disable=protected-access
                     _LOGGER.warning(
                         "Timeout connecting to Denon AVR receiver at host %s. Device is unavailable",
                         self._receiver.host,
@@ -144,12 +144,12 @@ class DenonDevice(MediaPlayerEntity):
                     self._available = False
             except AvrForbiddenError:
                 available = False
-                if self._available is True:
+                if self._available is True:  # pylint: disable=protected-access
                     _LOGGER.warning(
                         "Denon AVR receiver at host %s responded with HTTP 403 error. Device is unavailable. Please consider power cycling your receiver",
                         self._receiver.host,
                     )
-                    self._available = False
+                    self._available = False  # pylint: disable=protected-access
             except AvrCommandError as err:
                 _LOGGER.error(
                     "Command %s failed with error: %s",
@@ -160,17 +160,17 @@ class DenonDevice(MediaPlayerEntity):
                 _LOGGER.error(
                     "Error %s occurred in method %s for Denon AVR receiver",
                     err,
-                    func._name__,  # pylint: disable=no-member
+                    func.__name__,  # pylint: disable=no-member
                     exc_info=True,
                 )
             finally:
                 if available is True:
-                    if self._available is False:
+                    if self._available is False:  # pylint: disable=protected-access
                         _LOGGER.info(
                             "Denon AVR receiver at host %s is available again",
                             self._receiver.host,
                         )
-                        self._available = True
+                        self._available = True  # pylint: disable=protected-access
 
         return wrapper
 
@@ -239,7 +239,7 @@ class DenonDevice(MediaPlayerEntity):
         """Return the state of the device."""
         if self._available is False:
             return STATE_UNAVAILABLE
-        elif self._receiver.state is None:
+        if self._receiver.state is None:
             return STATE_UNKNOWN
         return self._receiver.state
 
@@ -406,7 +406,6 @@ class DenonDevice(MediaPlayerEntity):
     @async_log_errors
     async def async_select_sound_mode(self, sound_mode: str):
         """Select sound mode."""
-        # TODO: push fix in denonavr
         await self._receiver.soundmode.async_set_sound_mode(sound_mode)
 
     @async_log_errors
@@ -450,4 +449,6 @@ class DenonDevice(MediaPlayerEntity):
         return await self._receiver.async_get_command(command)
 
     # Decorator defined before is a staticmethod
-    async_log_erros = staticmethod(async_log_errors)
+    async_log_erros = staticmethod(  # pylint: disable=no-staticmethod-decorator
+        async_log_errors
+    )

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -1,5 +1,6 @@
 """Code to handle a DenonAVR receiver."""
 import logging
+from typing import Optional
 
 from denonavr import DenonAVR
 from denonavr.exceptions import AvrTimoutError
@@ -34,11 +35,11 @@ class ConnectDenonAVR:
             self._zones["Zone3"] = None
 
     @property
-    def receiver(self):
+    def receiver(self) -> Optional[DenonAVR]:
         """Return the class containing all connections to the receiver."""
         return self._receiver
 
-    async def async_connect_receiver(self):
+    async def async_connect_receiver(self) -> bool:
         """Connect to the DenonAVR receiver."""
         if not await self.async_init_receiver_class():
             return False
@@ -70,7 +71,7 @@ class ConnectDenonAVR:
 
         return True
 
-    async def async_init_receiver_class(self):
+    async def async_init_receiver_class(self) -> bool:
         """Initialize the DenonAVR class asynchronously."""
         self._receiver = DenonAVR(
             host=self._host,

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -3,7 +3,7 @@ import logging
 from typing import Optional
 
 from denonavr import DenonAVR
-from denonavr.exceptions import AvrTimoutError
+from denonavr.exceptions import AvrNetworkError, AvrTimoutError
 import httpx
 
 _LOGGER = logging.getLogger(__name__)
@@ -86,6 +86,11 @@ class ConnectDenonAVR:
         except AvrTimoutError:
             _LOGGER.error(
                 "Timeout error during setup of denonavr on host %s", self._host
+            )
+            return False
+        except AvrNetworkError:
+            _LOGGER.error(
+                "Network error during setup of denonavr on host %s", self._host
             )
             return False
 

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -3,9 +3,6 @@ import logging
 from typing import Callable, Optional
 
 from denonavr import DenonAVR
-from denonavr.exceptions import AvrNetworkError, AvrTimoutError
-
-from homeassistant.exceptions import ConfigEntryNotReady
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,9 +80,6 @@ class ConnectDenonAVR:
         )
         # Use httpx.AsyncClient getter provided by Home Assistant
         receiver.set_async_client_getter(self._async_client_getter)
-        try:
-            await receiver.async_setup()
-        except (AvrNetworkError, AvrTimoutError) as ex:
-            raise ConfigEntryNotReady from ex
+        await receiver.async_setup()
 
         self._receiver = receiver

--- a/homeassistant/components/denonavr/receiver.py
+++ b/homeassistant/components/denonavr/receiver.py
@@ -3,6 +3,7 @@ import logging
 
 from denonavr import DenonAVR
 from denonavr.exceptions import AvrTimoutError
+import httpx
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -17,8 +18,10 @@ class ConnectDenonAVR:
         show_all_inputs: bool,
         zone2: bool,
         zone3: bool,
+        async_client: httpx.AsyncClient,
     ):
         """Initialize the class."""
+        self._async_client = async_client
         self._receiver = None
         self._host = host
         self._show_all_inputs = show_all_inputs
@@ -75,6 +78,8 @@ class ConnectDenonAVR:
             timeout=self._timeout,
             add_zones=self._zones,
         )
+        # Use httpx.AsyncClient provided by Home Assistant
+        self._receiver.set_async_client(self._async_client)
         try:
             await self._receiver.async_setup()
         except AvrTimoutError:

--- a/homeassistant/components/denonavr/services.yaml
+++ b/homeassistant/components/denonavr/services.yaml
@@ -1,4 +1,4 @@
-# Describes the format for available webostv services
+# Describes the format for available denonavr services
 
 get_command:
   description: "Send a generic HTTP get command."

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -476,7 +476,7 @@ defusedxml==0.6.0
 deluge-client==1.7.1
 
 # homeassistant.components.denonavr
-denonavr==0.10.3
+denonavr==0.10.4
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -476,7 +476,7 @@ defusedxml==0.6.0
 deluge-client==1.7.1
 
 # homeassistant.components.denonavr
-denonavr==0.10.1
+denonavr==0.10.3
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -476,7 +476,7 @@ defusedxml==0.6.0
 deluge-client==1.7.1
 
 # homeassistant.components.denonavr
-denonavr==0.9.10
+denonavr==0.10.1
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -650,7 +650,6 @@ georss_ign_sismologia_client==0.2
 # homeassistant.components.qld_bushfire
 georss_qld_bushfire_alert_client==0.3
 
-# homeassistant.components.denonavr
 # homeassistant.components.huawei_lte
 # homeassistant.components.kef
 # homeassistant.components.minecraft_server

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -476,7 +476,7 @@ defusedxml==0.6.0
 deluge-client==1.7.1
 
 # homeassistant.components.denonavr
-denonavr==0.10.4
+denonavr==0.10.5
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ debugpy==1.2.1
 defusedxml==0.6.0
 
 # homeassistant.components.denonavr
-denonavr==0.9.10
+denonavr==0.10.1
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ debugpy==1.2.1
 defusedxml==0.6.0
 
 # homeassistant.components.denonavr
-denonavr==0.10.3
+denonavr==0.10.4
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ debugpy==1.2.1
 defusedxml==0.6.0
 
 # homeassistant.components.denonavr
-denonavr==0.10.4
+denonavr==0.10.5
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -344,7 +344,6 @@ georss_ign_sismologia_client==0.2
 # homeassistant.components.qld_bushfire
 georss_qld_bushfire_alert_client==0.3
 
-# homeassistant.components.denonavr
 # homeassistant.components.huawei_lte
 # homeassistant.components.kef
 # homeassistant.components.minecraft_server

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -258,7 +258,7 @@ debugpy==1.2.1
 defusedxml==0.6.0
 
 # homeassistant.components.denonavr
-denonavr==0.10.1
+denonavr==0.10.3
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.1

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -14,8 +14,8 @@ from homeassistant.components.denonavr.config_flow import (
     CONF_ZONE2,
     CONF_ZONE3,
     DOMAIN,
+    AvrTimoutError,
 )
-from homeassistant.components.denonavr.receiver import AvrTimoutError
 from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry

--- a/tests/components/denonavr/test_config_flow.py
+++ b/tests/components/denonavr/test_config_flow.py
@@ -16,12 +16,11 @@ from homeassistant.components.denonavr.config_flow import (
     DOMAIN,
 )
 from homeassistant.components.denonavr.receiver import AvrTimoutError
-from homeassistant.const import CONF_HOST, CONF_MAC
+from homeassistant.const import CONF_HOST
 
 from tests.common import MockConfigEntry
 
 TEST_HOST = "1.2.3.4"
-TEST_MAC = "ab:cd:ef:gh"
 TEST_HOST2 = "5.6.7.8"
 TEST_NAME = "Test_Receiver"
 TEST_MODEL = "model5"
@@ -63,9 +62,6 @@ def denonavr_connect_fixture():
         "homeassistant.components.denonavr.receiver.DenonAVR.receiver_type",
         TEST_RECEIVER_TYPE,
     ), patch(
-        "homeassistant.components.denonavr.config_flow.get_mac_address",
-        return_value=TEST_MAC,
-    ), patch(
         "homeassistant.components.denonavr.async_setup_entry", return_value=True
     ):
         yield
@@ -94,7 +90,6 @@ async def test_config_flow_manual_host_success(hass):
     assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
-        CONF_MAC: TEST_MAC,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,
@@ -129,7 +124,6 @@ async def test_config_flow_manual_discover_1_success(hass):
     assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
-        CONF_MAC: TEST_MAC,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,
@@ -173,7 +167,6 @@ async def test_config_flow_manual_discover_2_success(hass):
     assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST2,
-        CONF_MAC: TEST_MAC,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,
@@ -236,118 +229,6 @@ async def test_config_flow_manual_host_no_serial(hass):
     assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
-        CONF_MAC: TEST_MAC,
-        CONF_MODEL: TEST_MODEL,
-        CONF_TYPE: TEST_RECEIVER_TYPE,
-        CONF_MANUFACTURER: TEST_MANUFACTURER,
-        CONF_SERIAL_NUMBER: None,
-    }
-
-
-async def test_config_flow_manual_host_no_mac(hass):
-    """
-    Successful flow manually initialized by the user.
-
-    Host specified and an error getting the mac address.
-    """
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.denonavr.config_flow.get_mac_address",
-        return_value=None,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_HOST: TEST_HOST},
-        )
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == TEST_NAME
-    assert result["data"] == {
-        CONF_HOST: TEST_HOST,
-        CONF_MAC: None,
-        CONF_MODEL: TEST_MODEL,
-        CONF_TYPE: TEST_RECEIVER_TYPE,
-        CONF_MANUFACTURER: TEST_MANUFACTURER,
-        CONF_SERIAL_NUMBER: TEST_SERIALNUMBER,
-    }
-
-
-async def test_config_flow_manual_host_no_serial_no_mac(hass):
-    """
-    Successful flow manually initialized by the user.
-
-    Host specified and an error getting the serial number and mac address.
-    """
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.denonavr.receiver.DenonAVR.serial_number",
-        None,
-    ), patch(
-        "homeassistant.components.denonavr.config_flow.get_mac_address",
-        return_value=None,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_HOST: TEST_HOST},
-        )
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == TEST_NAME
-    assert result["data"] == {
-        CONF_HOST: TEST_HOST,
-        CONF_MAC: None,
-        CONF_MODEL: TEST_MODEL,
-        CONF_TYPE: TEST_RECEIVER_TYPE,
-        CONF_MANUFACTURER: TEST_MANUFACTURER,
-        CONF_SERIAL_NUMBER: None,
-    }
-
-
-async def test_config_flow_manual_host_no_serial_no_mac_exception(hass):
-    """
-    Successful flow manually initialized by the user.
-
-    Host specified and an error getting the serial number and exception getting mac address.
-    """
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "user"
-    assert result["errors"] == {}
-
-    with patch(
-        "homeassistant.components.denonavr.receiver.DenonAVR.serial_number",
-        None,
-    ), patch(
-        "homeassistant.components.denonavr.config_flow.get_mac_address",
-        side_effect=OSError,
-    ):
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {CONF_HOST: TEST_HOST},
-        )
-
-    assert result["type"] == "create_entry"
-    assert result["title"] == TEST_NAME
-    assert result["data"] == {
-        CONF_HOST: TEST_HOST,
-        CONF_MAC: None,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,
@@ -437,7 +318,6 @@ async def test_config_flow_ssdp(hass):
     assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
-        CONF_MAC: TEST_MAC,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,
@@ -513,7 +393,6 @@ async def test_options_flow(hass):
         unique_id=TEST_UNIQUE_ID,
         data={
             CONF_HOST: TEST_HOST,
-            CONF_MAC: TEST_MAC,
             CONF_MODEL: TEST_MODEL,
             CONF_TYPE: TEST_RECEIVER_TYPE,
             CONF_MANUFACTURER: TEST_MANUFACTURER,
@@ -571,7 +450,6 @@ async def test_config_flow_manual_host_no_serial_double_config(hass):
     assert result["title"] == TEST_NAME
     assert result["data"] == {
         CONF_HOST: TEST_HOST,
-        CONF_MAC: TEST_MAC,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -92,4 +92,4 @@ async def test_get_command(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_GET_COMMAND, data)
     await hass.async_block_till_done()
 
-    client.send_get_command.assert_called_with("test_command")
+    await client.async_get_command.assert_awaited_with("test_command")

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -36,7 +36,7 @@ ENTITY_ID = f"{media_player.DOMAIN}.{TEST_NAME}"
 def client_fixture():
     """Patch of client library for tests."""
     with patch(
-        "homeassistant.components.denonavr.receiver.denonavr.DenonAVR",
+        "homeassistant.components.denonavr.receiver.DenonAVR",
         autospec=True,
     ) as mock_client_class, patch(
         "homeassistant.components.denonavr.receiver.denonavr.async_discover"

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -39,7 +39,7 @@ def client_fixture():
         "homeassistant.components.denonavr.receiver.denonavr.DenonAVR",
         autospec=True,
     ) as mock_client_class, patch(
-        "homeassistant.components.denonavr.receiver.denonavr.discover"
+        "homeassistant.components.denonavr.receiver.denonavr.async_discover"
     ):
         mock_client_class.return_value.name = TEST_NAME
         mock_client_class.return_value.model_name = TEST_MODEL

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -4,7 +4,6 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components import media_player
-from homeassistant.components.denonavr import ATTR_COMMAND, SERVICE_GET_COMMAND
 from homeassistant.components.denonavr.config_flow import (
     CONF_MANUFACTURER,
     CONF_MODEL,
@@ -12,12 +11,15 @@ from homeassistant.components.denonavr.config_flow import (
     CONF_TYPE,
     DOMAIN,
 )
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, CONF_MAC
+from homeassistant.components.denonavr.media_player import (
+    ATTR_COMMAND,
+    SERVICE_GET_COMMAND,
+)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST
 
 from tests.common import MockConfigEntry
 
 TEST_HOST = "1.2.3.4"
-TEST_MAC = "ab:cd:ef:gh"
 TEST_NAME = "Test_Receiver"
 TEST_MODEL = "model5"
 TEST_SERIALNUMBER = "123456789"
@@ -57,7 +59,6 @@ async def setup_denonavr(hass):
     """Initialize media_player for tests."""
     entry_data = {
         CONF_HOST: TEST_HOST,
-        CONF_MAC: TEST_MAC,
         CONF_MODEL: TEST_MODEL,
         CONF_TYPE: TEST_RECEIVER_TYPE,
         CONF_MANUFACTURER: TEST_MANUFACTURER,

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -92,4 +92,4 @@ async def test_get_command(hass, client):
     await hass.services.async_call(DOMAIN, SERVICE_GET_COMMAND, data)
     await hass.async_block_till_done()
 
-    await client.async_get_command.assert_awaited_with("test_command")
+    client.async_get_command.assert_awaited_with("test_command")

--- a/tests/components/denonavr/test_media_player.py
+++ b/tests/components/denonavr/test_media_player.py
@@ -39,7 +39,7 @@ def client_fixture():
         "homeassistant.components.denonavr.receiver.DenonAVR",
         autospec=True,
     ) as mock_client_class, patch(
-        "homeassistant.components.denonavr.receiver.denonavr.async_discover"
+        "homeassistant.components.denonavr.config_flow.denonavr.async_discover"
     ):
         mock_client_class.return_value.name = TEST_NAME
         mock_client_class.return_value.model_name = TEST_MODEL


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With this update `denonavr` is going async. It is using httpx instead of requests now and is 100% async.

~~There are a few bugs which are already identified and fixed in dev version of denonavr or in progress:~~
~~- non functional play-pause toggle~~
~~- improvement of 403 error handling of AVR-X 2016 receivers~~

~~I would like to collect some fixes and add fixes for potential issues discovered here during review.~~
~~That's why I did not set the "local tests pass" flag yet. Please start reviewing the changes anyhow. There is a bunch of them.~~

Known bugs are fixed, ready to proceed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
