### PR TITLE
Improve bad JSON data reporting

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -112,12 +112,15 @@ def find_paths_unserializable_data(
         except (ValueError, TypeError):
             pass
 
-        # We convert states and events to dict so we can find bad data inside it
-        if isinstance(obj, State):
-            obj_path += f"(state: {obj.entity_id})"
-            obj = obj.as_dict()
-        elif isinstance(obj, Event):
-            obj_path += f"(event: {obj.event_type})"
+        # We convert objects with as_dict to their dict values so we can find bad data inside it
+        if hasattr(obj, "as_dict"):
+            desc = obj.__class__.__name__
+            if isinstance(obj, State):
+                desc += f": {obj.entity_id}"
+            elif isinstance(obj, Event):
+                desc += f": {obj.event_type}"
+
+            obj_path += f"({desc})"
             obj = obj.as_dict()
 
         if isinstance(obj, dict):

--- a/tests/components/websocket_api/test_http.py
+++ b/tests/components/websocket_api/test_http.py
@@ -67,7 +67,7 @@ async def test_pending_msg_peak(hass, mock_low_peak, hass_ws_client, caplog):
 
 
 async def test_non_json_message(hass, websocket_client, caplog):
-    """Test trying to serialze non JSON objects."""
+    """Test trying to serialize non JSON objects."""
     bad_data = object()
     hass.states.async_set("test_domain.entity", "testing", {"bad": bad_data})
     await websocket_client.send_json({"id": 5, "type": "get_states"})
@@ -77,6 +77,6 @@ async def test_non_json_message(hass, websocket_client, caplog):
     assert msg["type"] == const.TYPE_RESULT
     assert not msg["success"]
     assert (
-        f"Unable to serialize to JSON. Bad data found at $.result[0](state: test_domain.entity).attributes.bad={bad_data}(<class 'object'>"
+        f"Unable to serialize to JSON. Bad data found at $.result[0](State: test_domain.entity).attributes.bad={bad_data}(<class 'object'>"
         in caplog.text
     )

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -153,7 +153,7 @@ def test_find_unserializable_data():
             [State("mock_domain.mock_entity", "on", {"bad": bad_data})],
             dump=partial(dumps, cls=MockJSONEncoder),
         )
-        == {"$[0](state: mock_domain.mock_entity).attributes.bad": bad_data}
+        == {"$[0](State: mock_domain.mock_entity).attributes.bad": bad_data}
     )
 
     assert (
@@ -161,5 +161,20 @@ def test_find_unserializable_data():
             [Event("bad_event", {"bad_attribute": bad_data})],
             dump=partial(dumps, cls=MockJSONEncoder),
         )
-        == {"$[0](event: bad_event).data.bad_attribute": bad_data}
+        == {"$[0](Event: bad_event).data.bad_attribute": bad_data}
+    )
+
+    class BadData:
+        def __init__(self):
+            self.bla = bad_data
+
+        def as_dict(self):
+            return {"bla": self.bla}
+
+    assert (
+        find_paths_unserializable_data(
+            BadData(),
+            dump=partial(dumps, cls=MockJSONEncoder),
+        )
+        == {"$(BadData).bla": bad_data}
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

@bdraco got an unusable error message when we couldn't serialize the return value of an `as_dict` function. This fix will improve our bad data reporting finder to help track it down in the future.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
