### PR TITLE
Add support for bar to pressure unit util

### DIFF
--- a/homeassistant/util/pressure.py
+++ b/homeassistant/util/pressure.py
@@ -3,6 +3,7 @@ from numbers import Number
 
 from homeassistant.const import (
     PRESSURE,
+    PRESSURE_BAR,
     PRESSURE_HPA,
     PRESSURE_INHG,
     PRESSURE_MBAR,
@@ -11,7 +12,14 @@ from homeassistant.const import (
     UNIT_NOT_RECOGNIZED_TEMPLATE,
 )
 
-VALID_UNITS = [PRESSURE_PA, PRESSURE_HPA, PRESSURE_MBAR, PRESSURE_INHG, PRESSURE_PSI]
+VALID_UNITS = [
+    PRESSURE_PA,
+    PRESSURE_HPA,
+    PRESSURE_MBAR,
+    PRESSURE_INHG,
+    PRESSURE_PSI,
+    PRESSURE_BAR,
+]
 
 UNIT_CONVERSION = {
     PRESSURE_PA: 1,
@@ -19,6 +27,7 @@ UNIT_CONVERSION = {
     PRESSURE_MBAR: 1 / 100,
     PRESSURE_INHG: 1 / 3386.389,
     PRESSURE_PSI: 1 / 6894.757,
+    PRESSURE_BAR: 1 / 100000,
 }
 
 

--- a/tests/util/test_pressure.py
+++ b/tests/util/test_pressure.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.const import (
+    PRESSURE_BAR,
     PRESSURE_HPA,
     PRESSURE_INHG,
     PRESSURE_MBAR,
@@ -20,6 +21,7 @@ def test_convert_same_unit():
     assert pressure_util.convert(3, PRESSURE_HPA, PRESSURE_HPA) == 3
     assert pressure_util.convert(4, PRESSURE_MBAR, PRESSURE_MBAR) == 4
     assert pressure_util.convert(5, PRESSURE_INHG, PRESSURE_INHG) == 5
+    assert pressure_util.convert(6, PRESSURE_BAR, PRESSURE_BAR) == 6
 
 
 def test_convert_invalid_unit():
@@ -52,6 +54,9 @@ def test_convert_from_hpascals():
     assert pressure_util.convert(
         hpascals, PRESSURE_HPA, PRESSURE_MBAR
     ) == pytest.approx(1000)
+    assert pressure_util.convert(hpascals, PRESSURE_HPA, PRESSURE_BAR) == pytest.approx(
+        1
+    )
 
 
 def test_convert_from_inhg():
@@ -68,4 +73,7 @@ def test_convert_from_inhg():
     )
     assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_MBAR) == pytest.approx(
         1015.9167
+    )
+    assert pressure_util.convert(inhg, PRESSURE_INHG, PRESSURE_BAR) == pytest.approx(
+        1.0159167
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In `homeassistant.const` we have the `PRESSURE_BAR` unit, but `homeassistant.util.pressure` does not support converting to/from this unit. This PR updates `homeassistant.util.pressure` to support converting to/from bar.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
