### PR TITLE
Add "timestamp" attribute to seventeentrack

### DIFF
--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -2,6 +2,6 @@
   "domain": "seventeentrack",
   "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["py17track==2.2.2"],
+  "requirements": ["py17track==3.0.1"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -2,6 +2,6 @@
   "domain": "seventeentrack",
   "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["py17track==3.0.1"],
+  "requirements": ["py17track==3.1.0"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -2,6 +2,6 @@
   "domain": "seventeentrack",
   "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["py17track==3.1.0"],
+  "requirements": ["py17track==3.2.0"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -2,6 +2,6 @@
   "domain": "seventeentrack",
   "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["py17track==3.2.0"],
+  "requirements": ["git+https://github.com/bachya/py17track.git@dev#py17track==3.2.1"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/seventeentrack/manifest.json
+++ b/homeassistant/components/seventeentrack/manifest.json
@@ -2,6 +2,6 @@
   "domain": "seventeentrack",
   "name": "17TRACK",
   "documentation": "https://www.home-assistant.io/integrations/seventeentrack",
-  "requirements": ["git+https://github.com/bachya/py17track.git@dev#py17track==3.2.1"],
+  "requirements": ["py17track==3.2.1"],
   "codeowners": ["@bachya"]
 }

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -240,7 +240,11 @@ class SeventeenTrackPackageSensor(Entity):
             return
 
         self._attrs.update(
-            {ATTR_INFO_TEXT: package.info_text, ATTR_TIMESTAMP: package.timestamp, ATTR_LOCATION: package.location}
+            {
+                ATTR_INFO_TEXT: package.info_text,
+                ATTR_TIMESTAMP: package.timestamp,
+                ATTR_LOCATION: package.location
+            }
         )
         self._state = package.status
         self._friendly_name = package.friendly_name

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -243,7 +243,7 @@ class SeventeenTrackPackageSensor(Entity):
             {
                 ATTR_INFO_TEXT: package.info_text,
                 ATTR_TIMESTAMP: package.timestamp,
-                ATTR_LOCATION: package.location
+                ATTR_LOCATION: package.location,
             }
         )
         self._state = package.status

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -24,6 +24,7 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_DESTINATION_COUNTRY = "destination_country"
 ATTR_INFO_TEXT = "info_text"
+ATTR_TIMESTAMP = "timestamp"
 ATTR_ORIGIN_COUNTRY = "origin_country"
 ATTR_PACKAGES = "packages"
 ATTR_PACKAGE_TYPE = "package_type"
@@ -151,6 +152,7 @@ class SeventeenTrackSummarySensor(Entity):
                 {
                     ATTR_FRIENDLY_NAME: package.friendly_name,
                     ATTR_INFO_TEXT: package.info_text,
+                    ATTR_TIMESTAMP: package.timestamp,
                     ATTR_STATUS: package.status,
                     ATTR_LOCATION: package.location,
                     ATTR_TRACKING_NUMBER: package.tracking_number,
@@ -172,6 +174,7 @@ class SeventeenTrackPackageSensor(Entity):
             ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION,
             ATTR_DESTINATION_COUNTRY: package.destination_country,
             ATTR_INFO_TEXT: package.info_text,
+            ATTR_TIMESTAMP: package.timestamp,
             ATTR_LOCATION: package.location,
             ATTR_ORIGIN_COUNTRY: package.origin_country,
             ATTR_PACKAGE_TYPE: package.package_type,
@@ -237,7 +240,7 @@ class SeventeenTrackPackageSensor(Entity):
             return
 
         self._attrs.update(
-            {ATTR_INFO_TEXT: package.info_text, ATTR_LOCATION: package.location}
+            {ATTR_INFO_TEXT: package.info_text, ATTR_TIMESTAMP: package.timestamp, ATTR_LOCATION: package.location}
         )
         self._state = package.status
         self._friendly_name = package.friendly_name

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -291,7 +291,7 @@ class SeventeenTrackData:
         scan_interval,
         show_archived,
         show_delivered,
-        timezone
+        timezone,
     ):
         """Initialize."""
         self._async_add_entities = async_add_entities

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -287,7 +287,13 @@ class SeventeenTrackData:
     """Define a data handler for 17track.net."""
 
     def __init__(
-        self, client, async_add_entities, scan_interval, show_archived, show_delivered, timezone
+        self,
+        client,
+        async_add_entities,
+        scan_interval,
+        show_archived,
+        show_delivered,
+        timezone
     ):
         """Initialize."""
         self._async_add_entities = async_add_entities
@@ -308,8 +314,7 @@ class SeventeenTrackData:
 
         try:
             packages = await self._client.profile.packages(
-                show_archived=self._show_archived,
-                tz=self.timezone
+                show_archived=self._show_archived, tz=self.timezone
             )
             _LOGGER.debug("New package data received: %s", packages)
 

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -65,9 +65,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Configure the platform and add the sensors."""
 
-    websession = aiohttp_client.async_get_clientsession(hass)
+    session = aiohttp_client.async_get_clientsession(hass)
 
-    client = SeventeenTrackClient(websession)
+    client = SeventeenTrackClient(session=session)
 
     try:
         login_result = await client.profile.login(

--- a/homeassistant/components/seventeentrack/sensor.py
+++ b/homeassistant/components/seventeentrack/sensor.py
@@ -34,7 +34,6 @@ ATTR_TRACKING_NUMBER = "tracking_number"
 
 CONF_SHOW_ARCHIVED = "show_archived"
 CONF_SHOW_DELIVERED = "show_delivered"
-CONF_TIMEZONE = "timezone"
 
 DATA_PACKAGES = "package_data"
 DATA_SUMMARY = "summary_data"
@@ -60,7 +59,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Required(CONF_PASSWORD): cv.string,
         vol.Optional(CONF_SHOW_ARCHIVED, default=False): cv.boolean,
         vol.Optional(CONF_SHOW_DELIVERED, default=False): cv.boolean,
-        vol.Optional(CONF_TIMEZONE, default="UTC"): cv.string,
     }
 )
 
@@ -92,7 +90,7 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         scan_interval,
         config[CONF_SHOW_ARCHIVED],
         config[CONF_SHOW_DELIVERED],
-        config[CONF_TIMEZONE],
+        str(hass.config.time_zone),
     )
     await data.async_update()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 -c homeassistant/package_constraints.txt
 
 # Home Assistant Core
-aiohttp==3.7.4
+aiohttp==3.7.4.post0
 astral==1.10.1
 async_timeout==3.0.1
-attrs==19.3.0
+attrs==20.3.0
 awesomeversion==21.2.3
 bcrypt==3.1.7
 certifi>=2020.12.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 -c homeassistant/package_constraints.txt
 
 # Home Assistant Core
-aiohttp==3.7.4.post0
+aiohttp==3.7.4
 astral==1.10.1
 async_timeout==3.0.1
-attrs==20.3.0
+attrs==19.3.0
 awesomeversion==21.2.3
 bcrypt==3.1.7
 certifi>=2020.12.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1213,7 +1213,7 @@ py-schluter==0.1.7
 py-zabbix==1.1.7
 
 # homeassistant.components.seventeentrack
-py17track==2.2.2
+py17track==3.1.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1213,7 +1213,7 @@ py-schluter==0.1.7
 py-zabbix==1.1.7
 
 # homeassistant.components.seventeentrack
-py17track==3.2.0
+git+https://github.com/bachya/py17track.git@dev#py17track==3.2.1
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1213,7 +1213,7 @@ py-schluter==0.1.7
 py-zabbix==1.1.7
 
 # homeassistant.components.seventeentrack
-py17track==3.1.0
+py17track==3.2.0
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1213,7 +1213,7 @@ py-schluter==0.1.7
 py-zabbix==1.1.7
 
 # homeassistant.components.seventeentrack
-git+https://github.com/bachya/py17track.git@dev#py17track==3.2.1
+py17track==3.2.1
 
 # homeassistant.components.hdmi_cec
 pyCEC==0.5.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,7 +629,7 @@ py-melissa-climate==2.1.4
 py-nightscout==1.2.2
 
 # homeassistant.components.seventeentrack
-py17track==3.1.0
+py17track==3.2.0
 
 # homeassistant.components.control4
 pyControl4==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,7 +629,7 @@ py-melissa-climate==2.1.4
 py-nightscout==1.2.2
 
 # homeassistant.components.seventeentrack
-git+https://github.com/bachya/py17track.git@dev#py17track==3.2.1
+py17track==3.2.1
 
 # homeassistant.components.control4
 pyControl4==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,7 +629,7 @@ py-melissa-climate==2.1.4
 py-nightscout==1.2.2
 
 # homeassistant.components.seventeentrack
-py17track==2.2.2
+py17track==3.1.0
 
 # homeassistant.components.control4
 pyControl4==0.0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -629,7 +629,7 @@ py-melissa-climate==2.1.4
 py-nightscout==1.2.2
 
 # homeassistant.components.seventeentrack
-py17track==3.2.0
+git+https://github.com/bachya/py17track.git@dev#py17track==3.2.1
 
 # homeassistant.components.control4
 pyControl4==0.0.6

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 import datetime
 from unittest.mock import MagicMock, patch
 
+from pytz import timezone
+
 from py17track.package import Package
 import pytest
 
@@ -386,3 +388,24 @@ async def test_summary_correctly_updated(hass):
     assert len(hass.states.async_entity_ids()) == 7
     for state in hass.states.async_all():
         assert state.state == "1"
+
+
+async def test_utc_timestamp(hass):
+    """Ensure package timestamp is converted correctly from HA-defined time zone to UTC."""
+    package = Package(
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
+        tz = "Asia/Jakarta"
+    )
+    ProfileMock.package_list = [package]
+    
+    await _setup_seventeentrack(hass)
+    assert hass.states.get("sensor.seventeentrack_package_456") is not None
+    assert len(hass.states.async_entity_ids()) == 1
+    assert str(hass.states.get("sensor.seventeentrack_package_456").attributes.get('timestamp')) == "2020-08-10 03:32:00+00:00"

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -172,7 +172,14 @@ async def test_invalid_config(hass):
 async def test_add_package(hass):
     """Ensure package is added correctly when user add a new package."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
     )
     ProfileMock.package_list = [package]
 
@@ -181,7 +188,14 @@ async def test_add_package(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
     package2 = Package(
-        "789", 206, "friendly name 2", "info text 2", "location 2", "2020-08-10 14:25", 206, 2
+        "789",
+        206,
+        "friendly name 2",
+        "info text 2",
+        "location 2",
+        "2020-08-10 14:25",
+        206,
+        2,
     )
     ProfileMock.package_list = [package, package2]
 
@@ -194,10 +208,24 @@ async def test_add_package(hass):
 async def test_remove_package(hass):
     """Ensure entity is not there anymore if package is not there."""
     package1 = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
     )
     package2 = Package(
-        "789", 206, "friendly name 2", "info text 2", "location 2", "2020-08-10 14:25", 206, 2
+        "789",
+        206,
+        "friendly name 2",
+        "info text 2",
+        "location 2",
+        "2020-08-10 14:25",
+        206,
+        2,
     )
 
     ProfileMock.package_list = [package1, package2]
@@ -220,7 +248,14 @@ async def test_remove_package(hass):
 async def test_friendly_name_changed(hass):
     """Test friendly name change."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
     )
     ProfileMock.package_list = [package]
 
@@ -230,7 +265,14 @@ async def test_friendly_name_changed(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
     package = Package(
-        "456", 206, "friendly name 2", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
+        "456",
+        206,
+        "friendly name 2",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
     )
     ProfileMock.package_list = [package]
 
@@ -247,7 +289,15 @@ async def test_friendly_name_changed(hass):
 async def test_delivered_not_shown(hass):
     """Ensure delivered packages are not shown."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2, 40
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
+        40,
     )
     ProfileMock.package_list = [package]
 
@@ -262,7 +312,15 @@ async def test_delivered_not_shown(hass):
 async def test_delivered_shown(hass):
     """Ensure delivered packages are show when user choose to show them."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2, 40
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
+        40,
     )
     ProfileMock.package_list = [package]
 
@@ -277,7 +335,14 @@ async def test_delivered_shown(hass):
 async def test_becomes_delivered_not_shown_notification(hass):
     """Ensure notification is triggered when package becomes delivered."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
     )
     ProfileMock.package_list = [package]
 
@@ -287,7 +352,15 @@ async def test_becomes_delivered_not_shown_notification(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
     package_delivered = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2, 40
+        "456",
+        206,
+        "friendly name 1",
+        "info text 1",
+        "location 1",
+        "2020-08-10 10:32",
+        206,
+        2,
+        40,
     )
     ProfileMock.package_list = [package_delivered]
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -101,7 +101,10 @@ class ProfileMock:
         return self.__class__.login_result
 
     async def packages(
-        self, package_state: int | str = "", show_archived: bool = False
+        self,
+        package_state: Union[int, str] = "",
+        show_archived: bool = False,
+        tz: str = "UTC",
     ) -> list:
         """Packages mock."""
         return self.__class__.package_list[:]

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 
 from py17track.package import Package
 import pytest
-from pytz import timezone
 
 from homeassistant.components.seventeentrack.sensor import (
     CONF_SHOW_ARCHIVED,
@@ -400,7 +399,7 @@ async def test_utc_timestamp(hass):
         "2020-08-10 10:32",
         206,
         2,
-        tz = "Asia/Jakarta",
+        tz="Asia/Jakarta",
     )
     ProfileMock.package_list = [package]
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 import datetime
 from unittest.mock import MagicMock, patch
 
-from pytz import timezone
-
 from py17track.package import Package
 import pytest
+from pytz import timezone
 
 from homeassistant.components.seventeentrack.sensor import (
     CONF_SHOW_ARCHIVED,

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -169,7 +169,7 @@ async def test_invalid_config(hass):
 async def test_add_package(hass):
     """Ensure package is added correctly when user add a new package."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
     )
     ProfileMock.package_list = [package]
 
@@ -178,7 +178,7 @@ async def test_add_package(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
     package2 = Package(
-        "789", 206, "friendly name 2", "info text 2", "location 2", 206, 2
+        "789", 206, "friendly name 2", "info text 2", "location 2", "2020-08-10 14:25", 206, 2
     )
     ProfileMock.package_list = [package, package2]
 
@@ -191,10 +191,10 @@ async def test_add_package(hass):
 async def test_remove_package(hass):
     """Ensure entity is not there anymore if package is not there."""
     package1 = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
     )
     package2 = Package(
-        "789", 206, "friendly name 2", "info text 2", "location 2", 206, 2
+        "789", 206, "friendly name 2", "info text 2", "location 2", "2020-08-10 14:25", 206, 2
     )
 
     ProfileMock.package_list = [package1, package2]
@@ -217,7 +217,7 @@ async def test_remove_package(hass):
 async def test_friendly_name_changed(hass):
     """Test friendly name change."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
     )
     ProfileMock.package_list = [package]
 
@@ -227,7 +227,7 @@ async def test_friendly_name_changed(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
     package = Package(
-        "456", 206, "friendly name 2", "info text 1", "location 1", 206, 2
+        "456", 206, "friendly name 2", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
     )
     ProfileMock.package_list = [package]
 
@@ -244,7 +244,7 @@ async def test_friendly_name_changed(hass):
 async def test_delivered_not_shown(hass):
     """Ensure delivered packages are not shown."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2, 40
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2, 40
     )
     ProfileMock.package_list = [package]
 
@@ -259,7 +259,7 @@ async def test_delivered_not_shown(hass):
 async def test_delivered_shown(hass):
     """Ensure delivered packages are show when user choose to show them."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2, 40
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2, 40
     )
     ProfileMock.package_list = [package]
 
@@ -274,7 +274,7 @@ async def test_delivered_shown(hass):
 async def test_becomes_delivered_not_shown_notification(hass):
     """Ensure notification is triggered when package becomes delivered."""
     package = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2
     )
     ProfileMock.package_list = [package]
 
@@ -284,7 +284,7 @@ async def test_becomes_delivered_not_shown_notification(hass):
     assert len(hass.states.async_entity_ids()) == 1
 
     package_delivered = Package(
-        "456", 206, "friendly name 1", "info text 1", "location 1", 206, 2, 40
+        "456", 206, "friendly name 1", "info text 1", "location 1", "2020-08-10 10:32", 206, 2, 40
     )
     ProfileMock.package_list = [package_delivered]
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -102,7 +102,7 @@ class ProfileMock:
 
     async def packages(
         self,
-        package_state: Union[int, str] = "",
+        package_state: int | str = "",
         show_archived: bool = False,
         tz: str = "UTC",
     ) -> list:

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -71,7 +71,7 @@ NEW_SUMMARY_DATA = {
 class ClientMock:
     """Mock the py17track client to inject the ProfileMock."""
 
-    def __init__(self, websession) -> None:
+    def __init__(self, session) -> None:
         """Mock the profile."""
         self.profile = ProfileMock()
 

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -400,11 +400,18 @@ async def test_utc_timestamp(hass):
         "2020-08-10 10:32",
         206,
         2,
-        tz = "Asia/Jakarta"
+        tz = "Asia/Jakarta",
     )
     ProfileMock.package_list = [package]
-    
+
     await _setup_seventeentrack(hass)
     assert hass.states.get("sensor.seventeentrack_package_456") is not None
     assert len(hass.states.async_entity_ids()) == 1
-    assert str(hass.states.get("sensor.seventeentrack_package_456").attributes.get('timestamp')) == "2020-08-10 03:32:00+00:00"
+    assert (
+        str(
+            hass.states.get("sensor.seventeentrack_package_456").attributes.get(
+                'timestamp'
+            )
+        )
+        == "2020-08-10 03:32:00+00:00"
+    )

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -409,7 +409,7 @@ async def test_utc_timestamp(hass):
     assert (
         str(
             hass.states.get("sensor.seventeentrack_package_456").attributes.get(
-                'timestamp'
+                "timestamp"
             )
         )
         == "2020-08-10 03:32:00+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump py17track to latest version 3.2.1 (from 2.2.2) and include the new attribute `timestamp` of the latest status of a package. Don't know how people used this sensor without knowing **when** the last status occured. As of now timestamp is not a date object but simply the date string provided by 17track.

- [Release notes for 3.2.1](https://github.com/bachya/py17track/releases/tag/3.2.1)
- [Release notes for 3.2.0](https://github.com/bachya/py17track/releases/tag/3.2.0)
- [Release notes for 3.1.0](https://github.com/bachya/py17track/releases/tag/3.1.0)
- [Release notes for 3.0.1](https://github.com/bachya/py17track/releases/tag/3.0.1)
- [Release notes for 3.0.0](https://github.com/bachya/py17track/releases/tag/3.0.0)
- [Release notes for 2.2.6](https://github.com/bachya/py17track/releases/tag/2.2.6)
- [Release notes for 2.2.5](https://github.com/bachya/py17track/releases/tag/2.2.5)
- [Release notes for 2.2.4](https://github.com/bachya/py17track/releases/tag/2.2.4)
- [Release notes for 2.2.3](https://github.com/bachya/py17track/releases/tag/2.2.3)
- [Changelog](https://github.com/bachya/py17track/releases)
- [Github Compare 2.2.2 <-> 3.2.1](https://github.com/bachya/py17track/compare/2.2.2...3.2.1)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
  - platform: seventeentrack
    username: EMAIL_ADDRESS
    password: YOUR_PASSWORD
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
nothing special with this PR, just added the new attribute "timestamp" from py17track to the entity attributes

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
