### PR TITLE
Implement flexpool as an integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1170,6 +1170,7 @@ omit =
     homeassistant/components/zwave_js/discovery.py
     homeassistant/components/zwave_js/light.py
     homeassistant/components/zwave_js/sensor.py
+    homeassistant/components/flexpool/*
 
 [report]
 # Regexes for lines to exclude from consideration

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -153,6 +153,7 @@ homeassistant/components/filter/* @dgomes
 homeassistant/components/fireservicerota/* @cyberjunky
 homeassistant/components/firmata/* @DaAwesomeP
 homeassistant/components/fixer/* @fabaff
+homeassistant/components/flexpool/* @DatDraggy
 homeassistant/components/flick_electric/* @ZephireNZ
 homeassistant/components/flo/* @dmulcahey
 homeassistant/components/flock/* @fabaff

--- a/homeassistant/components/flexpool/__init__.py
+++ b/homeassistant/components/flexpool/__init__.py
@@ -1,0 +1,1 @@
+"""The flexpool component."""

--- a/homeassistant/components/flexpool/const.py
+++ b/homeassistant/components/flexpool/const.py
@@ -1,0 +1,54 @@
+"""Constants for the Flexpool integration."""
+SENSOR_DICT = {
+    "flexpool_unpaid_balance": [
+        "Flexpool Unpaid Balance",
+        "mdi:wallet",
+    ],
+    "flexpool_current_reported": [
+        "Flexpool Current Reported Hashrate",
+        "mdi:pound",
+        "reported",
+    ],
+    "flexpool_current_effective": [
+        "Flexpool Current Effective Hashrate",
+        "mdi:pound",
+        "effective",
+    ],
+    "flexpool_daily_average": [
+        "Flexpool Daily Average Hashrate",
+        "mdi:pound",
+        "average",
+    ],
+    "flexpool_worker_reported": [
+        "Flexpool Worker Reported Hashrate",
+        "mdi:pound",
+        "reported",
+    ],
+    "flexpool_worker_effective": [
+        "Flexpool Worker Effective Hashrate",
+        "mdi:pound",
+        "effective",
+    ],
+    "flexpool_worker_daily_valid": [
+        "Flexpool Worker Daily Valid Shares",
+        "mdi:share-variant",
+        "valid",
+    ],
+    "flexpool_worker_daily_total": [
+        "Flexpool Worker Daily Valid Shares",
+        "mdi:share-variant",
+        "total",
+    ],
+    "flexpool_effective": [
+        "Flexpool Hashrate",
+        "mdi:pound",
+    ],
+    "flexpool_workers": [
+        "Flexpool Workers",
+        "mdi:pickaxe",
+    ],
+    "flexpool_luck": [
+        "Flexpool Current Luck",
+        "mdi:clover",
+    ],
+}

--- a/homeassistant/components/flexpool/helper.py
+++ b/homeassistant/components/flexpool/helper.py
@@ -1,0 +1,12 @@
+"""Helper function for the Flexpool integration."""
+units = ["H/s", "KH/s", "MH/s", "GH/s", "TH/s"]
+
+
+def getHashrate(hashrate):
+    """Convert hashrate to kilohash, megahash etc."""
+    unit = 0
+    while hashrate > 1000:
+        unit += 1
+        hashrate = round(hashrate / 1000, 4)
+
+    return round(hashrate, 1), units[unit]

--- a/homeassistant/components/flexpool/manifest.json
+++ b/homeassistant/components/flexpool/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "flexpool",
+  "name": "Flexpool",
+  "documentation": "https://github.com/datdraggy/flexpool-homeassistant",
+  "requirements": ["flexpoolapi==1.2.7.post2"],
+  "codeowners": ["@DatDraggy"]
+}

--- a/homeassistant/components/flexpool/sensor.py
+++ b/homeassistant/components/flexpool/sensor.py
@@ -1,0 +1,74 @@
+"""Support for Etherscan sensors."""
+from datetime import timedelta
+
+import flexpoolapi
+import voluptuous as vol
+
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_ADDRESS, CONF_DEVICES, CONF_SERVICE_DATA
+import homeassistant.helpers.config_validation as cv
+
+from .sensors import (
+    FlexpoolBalanceSensor,
+    FlexpoolHashrateSensor,
+    FlexpoolPoolHashrateSensor,
+    FlexpoolPoolLuckSensor,
+    FlexpoolPoolWorkersSensor,
+    FlexpoolWorkerHashrateSensor,
+    FlexpoolWorkerShareSensor,
+)
+
+SCAN_INTERVAL = timedelta(minutes=5)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_ADDRESS): cv.string,
+        vol.Optional(CONF_DEVICES): cv.boolean,
+        vol.Optional(CONF_SERVICE_DATA): cv.boolean,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the Etherscan.io sensors."""
+    address = config.get(CONF_ADDRESS)
+    workers = config.get(CONF_DEVICES)
+    poolStats = config.get(CONF_SERVICE_DATA)
+
+    sensors = [
+        FlexpoolBalanceSensor("flexpool_unpaid_balance", address),
+        FlexpoolHashrateSensor("flexpool_current_reported", address),
+        FlexpoolHashrateSensor("flexpool_current_effective", address),
+        FlexpoolHashrateSensor("flexpool_daily_average", address),
+    ]
+
+    if workers:
+        workers = flexpoolapi.miner(address).workers()
+        for worker in workers:
+            sensors.append(
+                FlexpoolWorkerHashrateSensor(
+                    "flexpool_worker_reported", address, worker.worker_name
+                )
+            )
+            sensors.append(
+                FlexpoolWorkerHashrateSensor(
+                    "flexpool_worker_effective", address, worker.worker_name
+                )
+            )
+            sensors.append(
+                FlexpoolWorkerShareSensor(
+                    "flexpool_worker_daily_valid", address, worker.worker_name
+                )
+            )
+            sensors.append(
+                FlexpoolWorkerShareSensor(
+                    "flexpool_worker_daily_total", address, worker.worker_name
+                )
+            )
+
+    if poolStats:
+        sensors.append(FlexpoolPoolHashrateSensor("flexpool_effective"))
+        sensors.append(FlexpoolPoolWorkersSensor("flexpool_workers"))
+        sensors.append(FlexpoolPoolLuckSensor("flexpool_luck"))
+
+    add_entities(sensors, True)

--- a/homeassistant/components/flexpool/sensors.py
+++ b/homeassistant/components/flexpool/sensors.py
@@ -1,0 +1,314 @@
+"""Sensor classes for the Flexpool integration."""
+import flexpoolapi
+
+from homeassistant.const import PERCENTAGE
+from homeassistant.helpers.entity import Entity
+
+from .const import SENSOR_DICT
+from .helper import getHashrate
+
+
+class FlexpoolBalanceSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name, address):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._name = info[0]
+        self._icon = info[1]
+        self._address = address
+        self._state = None
+        self._unit_of_measurement = "ETH"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of measurement this sensor expresses itself in."""
+        return self._unit_of_measurement
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        miner = flexpoolapi.miner(self._address)
+        balance = round(miner.balance() / 1000000000000000000, 4)
+
+        self._state = balance
+
+
+class FlexpoolHashrateSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name, address):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._name = info[0]
+        self._icon = info[1]
+        self._type = info[2]
+        self._address = address
+        self._state = None
+        self._unit = "H/s"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the sensor."""
+        return self._unit
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        stats = flexpoolapi.miner(self._address).stats()
+
+        hashrate = 0
+        if self._type == "average":
+            hashrate = stats.average_effective_hashrate
+        elif self._type == "effective":
+            hashrate = stats.current_effective_hashrate
+        elif self._type == "reported":
+            hashrate = stats.current_reported_hashrate
+
+        self._state, self._unit = getHashrate(hashrate)
+
+
+class FlexpoolWorkerHashrateSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name, address, worker):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._worker_name = worker
+        self._icon = info[1]
+        self._type = info[2]
+        self._address = address
+        self._state = None
+        self._unit = "H/s"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "Flexpool {} {} Hashrate".format(
+            self._worker_name, self._type.capitalize()
+        )
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the sensor."""
+        return self._unit
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        workers = flexpoolapi.miner(self._address).workers()
+
+        hashrate = 0
+        # Ugly but I don't think there is another way
+        for worker in workers:
+            if worker.worker_name != self._worker_name:
+                continue
+
+            if self._type == "effective":
+                hashrate, _ = worker.current_hashrate()
+            elif self._type == "reported":
+                _, hashrate = worker.current_hashrate()
+
+            break
+
+        self._state, self._unit = getHashrate(hashrate)
+
+
+class FlexpoolWorkerShareSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name, address, worker):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._worker_name = worker
+        self._icon = info[1]
+        self._type = info[2]
+        self._address = address
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "Flexpool {} Daily {} Shares".format(
+            self._worker_name, self._type.capitalize()
+        )
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the sensor."""
+        return "Shares"
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        workers = flexpoolapi.miner(self._address).workers()
+
+        shares = 0
+        # Ugly but I don't think there is another way
+        for worker in workers:
+            if worker.worker_name != self._worker_name:
+                continue
+
+            if self._type == "total":
+                stats = worker.stats()
+                shares = stats.valid_shares + stats.stale_shares + stats.invalid_shares
+            elif self._type == "valid":
+                shares = worker.stats().valid_shares
+
+            break
+
+        self._state = shares
+
+
+class FlexpoolPoolHashrateSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._name = info[0]
+        self._icon = info[1]
+        self._state = None
+        self._unit = "H/s"
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the sensor."""
+        return self._unit
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        hashrate = flexpoolapi.pool.hashrate()
+
+        self._state, self._unit = getHashrate(hashrate["total"])
+
+
+class FlexpoolPoolWorkersSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._name = info[0]
+        self._icon = info[1]
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the sensor."""
+        return "Workers"
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        self._state = flexpoolapi.pool.workers_online()
+
+
+class FlexpoolPoolLuckSensor(Entity):
+    """Representation of an Etherscan.io sensor."""
+
+    def __init__(self, name):
+        """Initialize the sensor."""
+        info = SENSOR_DICT[name]
+        self._name = info[0]
+        self._icon = info[1]
+        self._state = None
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return self._name
+
+    @property
+    def icon(self):
+        """Return the icon of the sensor."""
+        return self._icon
+
+    @property
+    def state(self):
+        """Return the state of the sensor."""
+        return self._state
+
+    @property
+    def unit_of_measurement(self):
+        """Return the unit of the sensor."""
+        return PERCENTAGE
+
+    def update(self):
+        """Get the latest state of the sensor."""
+        self._state = round(flexpoolapi.pool.current_luck() * 100)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -596,6 +596,9 @@ fitbit==0.3.1
 # homeassistant.components.fixer
 fixerio==1.0.0a0
 
+# homeassistant.components.flexpool
+flexpoolapi==1.2.7.post2
+
 # homeassistant.components.flux_led
 flux_led==0.22
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I am adding a few sensors for the Ethereum mining pool Flexpool.io to homeassistant as my first integration.
I've been asked by other HA users to try my luck at an integration for this pool. 
As mentioned, this is the first time working on HA for me. I've looked at other sensor integrations to get a grasp of how that could look like, but I'm not sure if what I've done makes sense or could be done better.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->


```yaml
# Example configuration.yaml
sensor:
  - platform: flexpool
    address: "0x4b39187EBBb674Fb659A81a433D8e8AfbE3aA32b"
    data: true
    devices: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
