### PR TITLE
Add reauthentication to Verisure

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_REAUTH, ConfigEntry
 from homeassistant.const import (
     CONF_EMAIL,
     CONF_PASSWORD,
@@ -35,7 +35,6 @@ from .const import (
     CONF_LOCK_DEFAULT_CODE,
     DEFAULT_LOCK_CODE_DIGITS,
     DOMAIN,
-    LOGGER,
 )
 from .coordinator import VerisureDataUpdateCoordinator
 
@@ -125,7 +124,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = VerisureDataUpdateCoordinator(hass, entry=entry)
 
     if not await coordinator.async_login():
-        LOGGER.error("Could not login to Verisure, aborting setting up integration")
+        await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_REAUTH},
+            data={"entry": entry},
+        )
         return False
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, coordinator.async_logout)

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -36,8 +36,9 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
 
-    installations: dict[str, str]
     email: str
+    entry: ConfigEntry
+    installations: dict[str, str]
     password: str
 
     # These can be removed after YAML import has been removed.

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -124,7 +124,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_reauth(self, data=dict[str, Any]) -> dict[str, Any]:
+    async def async_step_reauth(self, data: dict[str, Any]) -> dict[str, Any]:
         """Handle initiation of re-authentication with Verisure."""
         self.entry = data["entry"]
         return await self.async_step_reauth_confirm()

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -123,6 +123,55 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_reauth(self, data=dict[str, Any]) -> dict[str, Any]:
+        """Handle initiation of re-authentication with Verisure."""
+        self.entry = data["entry"]
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Handle re-authentication with Verisure."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            verisure = Verisure(
+                username=user_input[CONF_EMAIL], password=user_input[CONF_PASSWORD]
+            )
+            try:
+                await self.hass.async_add_executor_job(verisure.login)
+            except VerisureLoginError as ex:
+                LOGGER.debug("Could not log in to Verisure, %s", ex)
+                errors["base"] = "invalid_auth"
+            except (VerisureError, VerisureResponseError) as ex:
+                LOGGER.debug("Unexpected response from Verisure, %s", ex)
+                errors["base"] = "unknown"
+            else:
+                data = self.entry.data.copy()
+                self.hass.config_entries.async_update_entry(
+                    self.entry,
+                    data={
+                        **data,
+                        CONF_EMAIL: user_input[CONF_EMAIL],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(self.entry.entry_id)
+                )
+                return self.async_abort(reason="reauth_successful")
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_EMAIL, default=self.entry.data[CONF_EMAIL]): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
     async def async_step_import(self, user_input: dict[str, Any]) -> dict[str, Any]:
         """Import Verisure YAML configuration."""
         if user_input[CONF_GIID]:

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -13,6 +13,13 @@
         "data": {
           "giid": "Installation"
         }
+      },
+      "reauth": {
+        "data": {
+          "description": "Re-authenticate with your Verisure My Pages account.",
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
@@ -20,7 +27,8 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "options": {

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -14,7 +14,7 @@
           "giid": "Installation"
         }
       },
-      "reauth": {
+      "reauth_confirm": {
         "data": {
           "description": "Re-authenticate with your Verisure My Pages account.",
           "email": "[%key:common::config_flow::data::email%]",

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Account is already configured"
+            "already_configured": "Account is already configured",
+            "reauth_successful": "Re-authentication was successful"
         },
         "error": {
             "invalid_auth": "Invalid authentication",
@@ -13,6 +14,13 @@
                     "giid": "Installation"
                 },
                 "description": "Home Assistant found multiple Verisure installations in your My Pages account. Please, select the installation to add to Home Assistant."
+            },
+            "reauth": {
+                "data": {
+                    "description": "Re-authenticate with your Verisure My Pages account.",
+                    "email": "Email",
+                    "password": "Password"
+                }
             },
             "user": {
                 "data": {

--- a/homeassistant/components/verisure/translations/en.json
+++ b/homeassistant/components/verisure/translations/en.json
@@ -15,7 +15,7 @@
                 },
                 "description": "Home Assistant found multiple Verisure installations in your My Pages account. Please, select the installation to add to Home Assistant."
             },
-            "reauth": {
+            "reauth_confirm": {
                 "data": {
                     "description": "Re-authenticate with your Verisure My Pages account.",
                     "email": "Email",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds re-authentication handling to the Verisure integration.
Now possible because of: https://github.com/persandstrom/python-verisure/pull/129
That PR has already been merged, released and bumped in our code base (in #47946).

![image](https://user-images.githubusercontent.com/195327/111231038-d78a3d00-85e8-11eb-8f5d-aac01cc13d81.png)

We currently cannot check if 2FA is an issue, so this is the best we can do at this point. It will give instant feedback now (so no late surprises). Documentation is adjusted to this as well (PR separate from this PR: https://github.com/home-assistant/home-assistant.io/pull/17013)

Next steps (after this PR):

- Check if installation still exists on startup
- Even more cleanup!
- Pre-determine property values, instead of calculating them in property methods themselves (as much as possible)
- Start setting up tests for platforms

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: closes #47397
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
