### PR TITLE
Add run_id to automation logbook event

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -281,6 +281,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         }
         if self.action_script.supports_max:
             attrs[ATTR_MAX] = self.action_script.max_runs
+        if self._id is not None:
+            attrs[CONF_ID] = self._id
         return attrs
 
     @property
@@ -533,14 +535,6 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             home_assistant_start,
             variables,
         )
-
-    @property
-    def extra_state_attributes(self):
-        """Return automation attributes."""
-        if self._id is None:
-            return None
-
-        return {CONF_ID: self._id}
 
 
 async def _async_process_config(

--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -1,26 +1,42 @@
 """Describe logbook events."""
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
-from homeassistant.core import callback
+from homeassistant.components.logbook import LazyEventPartialState
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, CONF_ID
+from homeassistant.core import HomeAssistant, callback
 
 from . import ATTR_SOURCE, DOMAIN, EVENT_AUTOMATION_TRIGGERED
+from .trace import DATA_AUTOMATION_TRACE
 
 
 @callback
-def async_describe_events(hass, async_describe_event):  # type: ignore
+def async_describe_events(hass: HomeAssistant, async_describe_event):  # type: ignore
     """Describe logbook events."""
 
     @callback
-    def async_describe_logbook_event(event):  # type: ignore
+    def async_describe_logbook_event(event: LazyEventPartialState):  # type: ignore
         """Describe a logbook event."""
         data = event.data
         message = "has been triggered"
         if ATTR_SOURCE in data:
             message = f"{message} by {data[ATTR_SOURCE]}"
+
+        run_id = None
+        if (
+            (entity_id := data.get(ATTR_ENTITY_ID))
+            and (cur_state := hass.states.get(entity_id))
+            and (automation_id := cur_state.attributes.get(CONF_ID))
+            and automation_id in hass.data[DATA_AUTOMATION_TRACE]
+        ):
+            for trace in hass.data[DATA_AUTOMATION_TRACE][automation_id].values():
+                if trace.context.id == event.context_id:
+                    run_id = trace.run_id
+                    break
+
         return {
             "name": data.get(ATTR_NAME),
             "message": message,
             "source": data.get(ATTR_SOURCE),
             "entity_id": data.get(ATTR_ENTITY_ID),
+            "run_id": run_id,
         }
 
     async_describe_event(

--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -1,10 +1,9 @@
 """Describe logbook events."""
 from homeassistant.components.logbook import LazyEventPartialState
-from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME, CONF_ID
+from homeassistant.const import ATTR_ENTITY_ID, ATTR_NAME
 from homeassistant.core import HomeAssistant, callback
 
 from . import ATTR_SOURCE, DOMAIN, EVENT_AUTOMATION_TRIGGERED
-from .trace import DATA_AUTOMATION_TRACE
 
 
 @callback
@@ -19,24 +18,12 @@ def async_describe_events(hass: HomeAssistant, async_describe_event):  # type: i
         if ATTR_SOURCE in data:
             message = f"{message} by {data[ATTR_SOURCE]}"
 
-        run_id = None
-        if (
-            (entity_id := data.get(ATTR_ENTITY_ID))
-            and (cur_state := hass.states.get(entity_id))
-            and (automation_id := cur_state.attributes.get(CONF_ID))
-            and automation_id in hass.data[DATA_AUTOMATION_TRACE]
-        ):
-            for trace in hass.data[DATA_AUTOMATION_TRACE][automation_id].values():
-                if trace.context.id == event.context_id:
-                    run_id = trace.run_id
-                    break
-
         return {
             "name": data.get(ATTR_NAME),
             "message": message,
             "source": data.get(ATTR_SOURCE),
             "entity_id": data.get(ATTR_ENTITY_ID),
-            "run_id": run_id,
+            "context_id": event.context_id,
         }
 
     async_describe_event(

--- a/homeassistant/components/automation/trace.py
+++ b/homeassistant/components/automation/trace.py
@@ -38,7 +38,7 @@ class AutomationTrace:
         self._action_trace: Optional[Dict[str, Deque[TraceElement]]] = None
         self._condition_trace: Optional[Dict[str, Deque[TraceElement]]] = None
         self._config: Dict[str, Any] = config
-        self._context: Context = context
+        self.context: Context = context
         self._error: Optional[Exception] = None
         self._state: str = "running"
         self.run_id: str = str(next(self._run_ids))
@@ -88,7 +88,7 @@ class AutomationTrace:
                 "action_trace": action_traces,
                 "condition_trace": condition_traces,
                 "config": self._config,
-                "context": self._context,
+                "context": self.context,
                 "variables": self._variables,
             }
         )

--- a/tests/components/automation/test_logbook.py
+++ b/tests/components/automation/test_logbook.py
@@ -1,0 +1,54 @@
+"""Test automation logbook."""
+from homeassistant.components import automation, logbook
+from homeassistant.core import Context
+from homeassistant.setup import async_setup_component
+
+from tests.components.logbook.test_init import MockLazyEventPartialState
+
+
+async def test_humanify_automation_trigger_event(hass):
+    """Test humanifying Shelly click event."""
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "automation", {})
+    assert await async_setup_component(hass, "logbook", {})
+    entity_attr_cache = logbook.EntityAttributeCache(hass)
+    context = Context()
+
+    event1, event2 = list(
+        logbook.humanify(
+            hass,
+            [
+                MockLazyEventPartialState(
+                    automation.EVENT_AUTOMATION_TRIGGERED,
+                    {
+                        "name": "Bla",
+                        "entity_id": "automation.bla",
+                        "source": "state change of input_boolean.yo",
+                    },
+                    context=context,
+                ),
+                MockLazyEventPartialState(
+                    automation.EVENT_AUTOMATION_TRIGGERED,
+                    {
+                        "name": "Bla",
+                        "entity_id": "automation.bla",
+                    },
+                    context=context,
+                ),
+            ],
+            entity_attr_cache,
+            {},
+        )
+    )
+
+    assert event1["name"] == "Bla"
+    assert event1["message"] == "has been triggered by state change of input_boolean.yo"
+    assert event1["source"] == "state change of input_boolean.yo"
+    assert event1["context_id"] == context.id
+    assert event1["entity_id"] == "automation.bla"
+
+    assert event2["name"] == "Bla"
+    assert event2["message"] == "has been triggered"
+    assert event2["source"] is None
+    assert event2["context_id"] == context.id
+    assert event2["entity_id"] == "automation.bla"

--- a/tests/components/automation/test_websocket_api.py
+++ b/tests/components/automation/test_websocket_api.py
@@ -65,6 +65,7 @@ async def test_get_automation_trace(hass, hass_ws_client):
         await async_setup_component(hass, "config", {})
 
     client = await hass_ws_client()
+    contexts = {}
 
     # Trigger "sun" automation
     context = Context()
@@ -102,6 +103,10 @@ async def test_get_automation_trace(hass, hass_ws_client):
     assert trace["trigger"] == "event 'test_event'"
     assert trace["unique_id"] == "sun"
     assert trace["variables"]
+    contexts[trace["context"]["id"]] = {
+        "run_id": trace["run_id"],
+        "automation_id": trace["automation_id"],
+    }
 
     # Trigger "moon" automation, with passing condition
     hass.bus.async_fire("test_event2")
@@ -139,6 +144,10 @@ async def test_get_automation_trace(hass, hass_ws_client):
     assert trace["trigger"] == "event 'test_event2'"
     assert trace["unique_id"] == "moon"
     assert trace["variables"]
+    contexts[trace["context"]["id"]] = {
+        "run_id": trace["run_id"],
+        "automation_id": trace["automation_id"],
+    }
 
     # Trigger "moon" automation, with failing condition
     hass.bus.async_fire("test_event3")
@@ -173,6 +182,10 @@ async def test_get_automation_trace(hass, hass_ws_client):
     assert trace["trigger"] == "event 'test_event3'"
     assert trace["unique_id"] == "moon"
     assert trace["variables"]
+    contexts[trace["context"]["id"]] = {
+        "run_id": trace["run_id"],
+        "automation_id": trace["automation_id"],
+    }
 
     # Trigger "moon" automation, with passing condition
     hass.bus.async_fire("test_event2")
@@ -210,6 +223,16 @@ async def test_get_automation_trace(hass, hass_ws_client):
     assert trace["trigger"] == "event 'test_event2'"
     assert trace["unique_id"] == "moon"
     assert trace["variables"]
+    contexts[trace["context"]["id"]] = {
+        "run_id": trace["run_id"],
+        "automation_id": trace["automation_id"],
+    }
+
+    # Check contexts
+    await client.send_json({"id": next_id(), "type": "automation/trace/contexts"})
+    response = await client.receive_json()
+    assert response["success"]
+    assert response["result"] == contexts
 
 
 async def test_automation_trace_overflow(hass, hass_ws_client):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `run_id` to the automation triggered logbook event so that we can link to traces from the logbook.

Marked as draft because I want to first check if this is a good idea + haven't added tests yet.

Run ID is looked up when describing the event because run_id is not unique across runs. Note, we could achieve a similar thing by putting the context ID in the generated data and map it up to available traces during render in the frontend. What would be the preference? While writing this I am _leaning_ to the latter, because it means we only match up events that are being shown.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
