### PR TITLE
Clean up AsusWRT

### DIFF
--- a/homeassistant/components/asuswrt/device_tracker.py
+++ b/homeassistant/components/asuswrt/device_tracker.py
@@ -56,41 +56,22 @@ class AsusWrtDevice(ScannerEntity):
     def __init__(self, router: AsusWrtRouter, device) -> None:
         """Initialize a AsusWrt device."""
         self._router = router
-        self._mac = device.mac
-        self._name = device.name or DEFAULT_DEVICE_NAME
-        self._active = False
-        self._icon = None
-        self._attrs = {}
-
-    @callback
-    def async_update_state(self) -> None:
-        """Update the AsusWrt device."""
-        device = self._router.devices[self._mac]
-        self._active = device.is_connected
-
-        self._attrs = {
-            "mac": device.mac,
-            "ip_address": device.ip_address,
-        }
-        if device.last_activity:
-            self._attrs["last_time_reachable"] = device.last_activity.isoformat(
-                timespec="seconds"
-            )
+        self._device = device
 
     @property
     def unique_id(self) -> str:
         """Return a unique ID."""
-        return self._mac
+        return self._device.mac
 
     @property
     def name(self) -> str:
         """Return the name."""
-        return self._name
+        return self._device.name or DEFAULT_DEVICE_NAME
 
     @property
     def is_connected(self):
         """Return true if the device is connected to the network."""
-        return self._active
+        return self._device.is_connected
 
     @property
     def source_type(self) -> str:
@@ -98,24 +79,28 @@ class AsusWrtDevice(ScannerEntity):
         return SOURCE_TYPE_ROUTER
 
     @property
-    def icon(self) -> str:
-        """Return the icon."""
-        return self._icon
-
-    @property
     def extra_state_attributes(self) -> dict[str, any]:
         """Return the attributes."""
-        return self._attrs
+        attrs = {
+            "mac": self._device.mac,
+            "ip_address": self._device.ip_address,
+        }
+        if self._device.last_activity:
+            attrs["last_time_reachable"] = self._device.last_activity.isoformat(
+                timespec="seconds"
+            )
+        return attrs
 
     @property
     def device_info(self) -> dict[str, any]:
         """Return the device information."""
-        return {
-            "connections": {(CONNECTION_NETWORK_MAC, self._mac)},
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
-            "manufacturer": "AsusWRT Tracked device",
+        data = {
+            "connections": {(CONNECTION_NETWORK_MAC, self._device.mac)},
         }
+        if self._device.name:
+            data["default_name"] = self._device.name
+
+        return data
 
     @property
     def should_poll(self) -> bool:
@@ -125,12 +110,11 @@ class AsusWrtDevice(ScannerEntity):
     @callback
     def async_on_demand_update(self):
         """Update state."""
-        self.async_update_state()
+        self._device = self._router.devices[self._device.mac]
         self.async_write_ha_state()
 
     async def async_added_to_hass(self):
         """Register state update callback."""
-        self.async_update_state()
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clean up AsusWRT: 
- No longer override the name/manufacturer of all devices on the network. Instead supply default values if none are there.
~~- Clean up the unique ID of the router, as it needs to be unique per device. Include migration to new entry.~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
