### PR TITLE
Type check KNX integration cover

### DIFF
--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Callable
+from typing import Any, Callable, Iterable
 
 from xknx.devices import Cover as XknxCover, Device as XknxDevice
 
@@ -22,6 +22,7 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.helpers.typing import (
     ConfigType,
@@ -36,7 +37,7 @@ from .knx_entity import KnxEntity
 async def async_setup_platform(
     hass: HomeAssistantType,
     config: ConfigType,
-    async_add_entities: Callable,
+    async_add_entities: Callable[[Iterable[Entity]], None],
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up cover(s) for KNX platform."""
@@ -55,7 +56,7 @@ class KNXCover(KnxEntity, CoverEntity):
         self._device: XknxCover
         super().__init__(device)
 
-        self._unsubscribe_auto_updater: Callable | None = None
+        self._unsubscribe_auto_updater: Callable[[], None] | None = None
 
     @callback
     async def after_update_callback(self, device: XknxDevice) -> None:

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -163,7 +163,7 @@ class KNXCover(KnxEntity, CoverEntity):
 
     def start_auto_updater(self) -> None:
         """Start the autoupdater to update Home Assistant while cover is moving."""
-        if self._unsubscribe_auto_updater is None and self.hass is not None:
+        if self._unsubscribe_auto_updater is None:
             self._unsubscribe_auto_updater = async_track_utc_time_change(
                 self.hass, self.auto_updater_hook
             )
@@ -179,6 +179,5 @@ class KNXCover(KnxEntity, CoverEntity):
         """Call for the autoupdater."""
         self.async_write_ha_state()
         if self._device.position_reached():
-            assert self.hass is not None
             self.hass.async_create_task(self._device.auto_stop_if_necessary())
             self.stop_auto_updater()

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -166,6 +166,5 @@ class KNXCover(KnxEntity, CoverEntity):
         """Call for the autoupdater."""
         self.async_write_ha_state()
         if self._device.position_reached():
+            self.hass.async_create_task(self._device.auto_stop_if_necessary())
             self.stop_auto_updater()
-
-        self.hass.add_job(self._device.auto_stop_if_necessary())

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -1,5 +1,10 @@
 """Support for KNX/IP covers."""
-from xknx.devices import Cover as XknxCover
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Callable
+
+from xknx.devices import Cover as XknxCover, Device as XknxDevice
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -18,12 +23,22 @@ from homeassistant.components.cover import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_utc_time_change
+from homeassistant.helpers.typing import (
+    ConfigType,
+    DiscoveryInfoType,
+    HomeAssistantType,
+)
 
 from .const import DOMAIN
 from .knx_entity import KnxEntity
 
 
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass: HomeAssistantType,
+    config: ConfigType,
+    async_add_entities: Callable,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Set up cover(s) for KNX platform."""
     entities = []
     for device in hass.data[DOMAIN].xknx.devices:
@@ -37,19 +52,20 @@ class KNXCover(KnxEntity, CoverEntity):
 
     def __init__(self, device: XknxCover):
         """Initialize the cover."""
+        self._device: XknxCover
         super().__init__(device)
 
-        self._unsubscribe_auto_updater = None
+        self._unsubscribe_auto_updater: Callable | None = None
 
     @callback
-    async def after_update_callback(self, device):
+    async def after_update_callback(self, device: XknxDevice) -> None:
         """Call after device was updated."""
         self.async_write_ha_state()
         if self._device.is_traveling():
             self.start_auto_updater()
 
     @property
-    def device_class(self):
+    def device_class(self) -> str | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
         if self._device.device_class in DEVICE_CLASSES:
             return self._device.device_class
@@ -58,7 +74,7 @@ class KNXCover(KnxEntity, CoverEntity):
         return None
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> int:
         """Flag supported features."""
         supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
         if self._device.supports_stop:
@@ -73,19 +89,17 @@ class KNXCover(KnxEntity, CoverEntity):
         return supported_features
 
     @property
-    def current_cover_position(self):
+    def current_cover_position(self) -> int | None:
         """Return the current position of the cover.
 
         None is unknown, 0 is closed, 100 is fully open.
         """
         # In KNX 0 is open, 100 is closed.
-        try:
-            return 100 - self._device.current_position()
-        except TypeError:
-            return None
+        pos = self._device.current_position()
+        return 100 - pos if pos is not None else None
 
     @property
-    def is_closed(self):
+    def is_closed(self) -> bool | None:
         """Return if the cover is closed."""
         # state shall be "unknown" when xknx travelcalculator is not initialized
         if self._device.current_position() is None:
@@ -93,78 +107,77 @@ class KNXCover(KnxEntity, CoverEntity):
         return self._device.is_closed()
 
     @property
-    def is_opening(self):
+    def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         return self._device.is_opening()
 
     @property
-    def is_closing(self):
+    def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         return self._device.is_closing()
 
-    async def async_close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""
         await self._device.set_down()
 
-    async def async_open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
         await self._device.set_up()
 
-    async def async_set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         knx_position = 100 - kwargs[ATTR_POSITION]
         await self._device.set_position(knx_position)
 
-    async def async_stop_cover(self, **kwargs):
+    async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
         await self._device.stop()
         self.stop_auto_updater()
 
     @property
-    def current_cover_tilt_position(self):
+    def current_cover_tilt_position(self) -> int | None:
         """Return current tilt position of cover."""
         if not self._device.supports_angle:
             return None
-        try:
-            return 100 - self._device.current_angle()
-        except TypeError:
-            return None
+        ang = self._device.current_angle()
+        return 100 - ang if ang is not None else None
 
-    async def async_set_cover_tilt_position(self, **kwargs):
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
         """Move the cover tilt to a specific position."""
         knx_tilt_position = 100 - kwargs[ATTR_TILT_POSITION]
         await self._device.set_angle(knx_tilt_position)
 
-    async def async_open_cover_tilt(self, **kwargs):
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
         """Open the cover tilt."""
         await self._device.set_short_up()
 
-    async def async_close_cover_tilt(self, **kwargs):
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
         """Close the cover tilt."""
         await self._device.set_short_down()
 
-    async def async_stop_cover_tilt(self, **kwargs):
+    async def async_stop_cover_tilt(self, **kwargs: Any) -> None:
         """Stop the cover tilt."""
         await self._device.stop()
         self.stop_auto_updater()
 
-    def start_auto_updater(self):
+    def start_auto_updater(self) -> None:
         """Start the autoupdater to update Home Assistant while cover is moving."""
-        if self._unsubscribe_auto_updater is None:
+        if self._unsubscribe_auto_updater is None and self.hass is not None:
             self._unsubscribe_auto_updater = async_track_utc_time_change(
                 self.hass, self.auto_updater_hook
             )
 
-    def stop_auto_updater(self):
+    def stop_auto_updater(self) -> None:
         """Stop the autoupdater."""
         if self._unsubscribe_auto_updater is not None:
             self._unsubscribe_auto_updater()
             self._unsubscribe_auto_updater = None
 
     @callback
-    def auto_updater_hook(self, now):
+    def auto_updater_hook(self, now: datetime) -> None:
         """Call for the autoupdater."""
         self.async_write_ha_state()
         if self._device.position_reached():
+            assert self.hass is not None
             self.hass.async_create_task(self._device.auto_stop_if_necessary())
             self.stop_auto_updater()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Typecheck KNX integration. Step by step...
- auto_stop_if_necessary is a coroutine in xknx - so we `hass.async_create_task` instead of `hass.add_job` and do it only once instead of once a second
- typecheck the module - nothing notable here, just a bunch of return types and None checks

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #48006
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
