### PR TITLE
Add purge_entities service call to recorder

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -268,7 +268,7 @@ def _async_register_services(hass, instance):
         DOMAIN, SERVICE_PURGE, async_handle_purge_service, schema=SERVICE_PURGE_SCHEMA
     )
 
-    async def async_handle_purge_entities_sevice(service):
+    async def async_handle_purge_entities_service(service):
         """Handle calls to the purge entities service."""
         entity_ids = await async_extract_entity_ids(hass, service)
         domains = service.data.get(ATTR_DOMAINS, [])
@@ -279,15 +279,18 @@ def _async_register_services(hass, instance):
     hass.services.async_register(
         DOMAIN,
         SERVICE_PURGE_ENTITIES,
-        async_handle_purge_entities_sevice,
+        async_handle_purge_entities_service,
         schema=SERVICE_PURGE_ENTITIES_SCHEMA,
     )
 
-    async def async_handle_enable_sevice(service):
+    async def async_handle_enable_service(service):
         instance.set_enable(True)
 
     hass.services.async_register(
-        DOMAIN, SERVICE_ENABLE, async_handle_enable_sevice, schema=SERVICE_ENABLE_SCHEMA
+        DOMAIN,
+        SERVICE_ENABLE,
+        async_handle_enable_service,
+        schema=SERVICE_ENABLE_SCHEMA,
     )
 
     async def async_handle_disable_service(service):

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -301,10 +301,6 @@ def _async_register_services(hass, instance):
     )
 
 
-class PerodicCleanupTask:
-    """An object to insert into the recorder to trigger cleanup tasks when auto purge is disabled."""
-
-
 class PurgeTask(NamedTuple):
     """Object to store information about purge task."""
 
@@ -317,6 +313,10 @@ class PurgeEntitiesTask(NamedTuple):
     """Object to store entity information about purge task."""
 
     entity_filter: Callable[[str], bool]
+
+
+class PerodicCleanupTask:
+    """An object to insert into the recorder to trigger cleanup tasks when auto purge is disabled."""
 
 
 class StatisticsTask(NamedTuple):
@@ -721,13 +721,14 @@ class Recorder(threading.Thread):
 
     def _process_one_event(self, event):
         """Process one event."""
-        if isinstance(event, PerodicCleanupTask):
-            perodic_db_cleanups(self)
         if isinstance(event, PurgeTask):
             self._run_purge(event.keep_days, event.repack, event.apply_filter)
             return
         if isinstance(event, PurgeEntitiesTask):
             self._run_purge_entities(event.entity_filter)
+            return
+        if isinstance(event, PerodicCleanupTask):
+            perodic_db_cleanups(self)
             return
         if isinstance(event, StatisticsTask):
             self._run_statistics(event.start)

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -66,7 +66,6 @@ _LOGGER = logging.getLogger(__name__)
 
 SERVICE_PURGE = "purge"
 SERVICE_PURGE_ENTITIES = "purge_entities"
-SERVICE_STATISTICS = "statistics"
 SERVICE_ENABLE = "enable"
 SERVICE_DISABLE = "disable"
 

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -1,8 +1,6 @@
 """Purge old data helper."""
 from __future__ import annotations
 
-from collections.abc import Generator
-from contextlib import contextmanager
 from datetime import datetime, timedelta
 import logging
 from typing import TYPE_CHECKING, Callable

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -1,9 +1,11 @@
 """Purge old data helper."""
 from __future__ import annotations
 
+from collections.abc import Generator
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable
 
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import distinct
@@ -195,3 +197,22 @@ def _purge_filtered_events(session: Session, excluded_event_types: list[str]) ->
     state_ids: list[int] = [state.state_id for state in states]
     _purge_state_ids(session, state_ids)
     _purge_event_ids(session, event_ids)
+
+
+@retryable_database_job("purge")
+def purge_entity_data(instance: Recorder, entity_filter: Callable[[str], bool]) -> bool:
+    """Purge states and events of specified entities."""
+    with session_scope(session=instance.get_session()) as session:  # type: ignore
+        # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
+        selected_entity_ids: list[str] = [
+            entity_id
+            for (entity_id,) in session.query(distinct(States.entity_id)).all()
+            if entity_filter(entity_id)
+        ]
+        _LOGGER.debug("Remove entity data for %s", selected_entity_ids)
+        if len(selected_entity_ids) > 0:
+            _purge_filtered_states(session, selected_entity_ids)
+            _LOGGER.debug("Remove entity data hasn't fully completed yet")
+            return False
+
+    return True

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -201,16 +201,16 @@ def _purge_filtered_events(session: Session, excluded_event_types: list[str]) ->
 def purge_entity_data(instance: Recorder, entity_filter: Callable[[str], bool]) -> bool:
     """Purge states and events of specified entities."""
     with session_scope(session=instance.get_session()) as session:  # type: ignore
-        # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
         selected_entity_ids: list[str] = [
             entity_id
             for (entity_id,) in session.query(distinct(States.entity_id)).all()
             if entity_filter(entity_id)
         ]
-        _LOGGER.debug("Remove entity data for %s", selected_entity_ids)
+        _LOGGER.debug("Purging entity data for %s", selected_entity_ids)
         if len(selected_entity_ids) > 0:
+            # Purge a max of MAX_ROWS_TO_PURGE, based on the oldest states or events record
             _purge_filtered_states(session, selected_entity_ids)
-            _LOGGER.debug("Remove entity data hasn't fully completed yet")
+            _LOGGER.debug("Purging entity data hasn't fully completed yet")
             return False
 
     return True

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -41,7 +41,7 @@ purge_entities:
     domains:
       name: Domains to remove
       description: List the domains that need to be removed from the recorder database.
-      example: "sensor"
+      example: "sun"
       required: false
       default: []
       selector:
@@ -50,7 +50,7 @@ purge_entities:
     entity_globs:
       name: Entity Globs to remove
       description: List the regular expressions to select entities for removal from the recorder database.
-      example: "*.purge*"
+      example: "domain*.object_id*"
       required: false
       default: []
       selector:

--- a/homeassistant/components/recorder/services.yaml
+++ b/homeassistant/components/recorder/services.yaml
@@ -18,8 +18,7 @@ purge:
 
     repack:
       name: Repack
-      description:
-        Attempt to save disk space by rewriting the entire database file.
+      description: Attempt to save disk space by rewriting the entire database file.
       example: true
       default: false
       selector:
@@ -32,6 +31,30 @@ purge:
       default: false
       selector:
         boolean:
+
+purge_entities:
+  name: Purge Entities
+  description: Start purge task to remove specific entities from your database.
+  target:
+    entity: {}
+  fields:
+    domains:
+      name: Domains to remove
+      description: List the domains that need to be removed from the recorder database.
+      example: "sensor"
+      required: false
+      default: []
+      selector:
+        object:
+
+    entity_globs:
+      name: Entity Globs to remove
+      description: List the regular expressions to select entities for removal from the recorder database.
+      example: "*.purge*"
+      required: false
+      default: []
+      selector:
+        object:
 
 disable:
   name: Disable

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -17,6 +17,7 @@ from homeassistant.components.recorder import (
     SERVICE_DISABLE,
     SERVICE_ENABLE,
     SERVICE_PURGE,
+    SERVICE_PURGE_ENTITIES,
     SQLITE_URL_PREFIX,
     Recorder,
     run_information,
@@ -822,6 +823,7 @@ def test_has_services(hass_recorder):
     assert hass.services.has_service(DOMAIN, SERVICE_DISABLE)
     assert hass.services.has_service(DOMAIN, SERVICE_ENABLE)
     assert hass.services.has_service(DOMAIN, SERVICE_PURGE)
+    assert hass.services.has_service(DOMAIN, SERVICE_PURGE_ENTITIES)
 
 
 def test_service_disable_events_not_recording(hass, hass_recorder):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds service call to selectively delete entity records from recorder as discussed in PR #45826. Accepts arguments of Target (i.e. combination of Areas, Devices, Entities), as well as, optional Domains and Entity Globs. Similar in style to Recorder Purge with Include/Excludes. Intended for rare occasions when unwanted data has inadvertently landed in database (e.g. unwanted integration, verbose sensor, sensitive data etc)

@bdraco , @cdce8p , would appreciate any feedback and happy to make any alterations. (Also, thanks for PR #45826 that did all the leg-work 8).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Service call
service: recorder.purge_entities
data:
  domains:
    - domain_1
    - domain_2
  entity_globs:
    - sensor.base_*
    - sensor.*_tail
target:
  entity_id: device_tracker.untracked_person
  device_id: a8d681f1caf4927e3720632fa7f0e22c
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17867

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
