### PR TITLE
Bump zwave-js-server-python to 0.22.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.21.1"],
+  "requirements": ["zwave-js-server-python==0.22.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["http", "websocket_api"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2393,4 +2393,4 @@ zigpy==0.33.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.21.1
+zwave-js-server-python==0.22.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1236,4 +1236,4 @@ zigpy-znp==0.4.0
 zigpy==0.33.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.21.1
+zwave-js-server-python==0.22.0

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -229,7 +229,7 @@ async def test_set_config_parameter(
     entry = integration
     ws_client = await hass_ws_client(hass)
 
-    client.async_send_command.return_value = {"success": True}
+    client.async_send_command_no_wait.return_value = None
 
     await ws_client.send_json(
         {
@@ -244,10 +244,10 @@ async def test_set_config_parameter(
     )
 
     msg = await ws_client.receive_json()
-    assert msg["result"]
+    assert msg["success"]
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
@@ -275,7 +275,7 @@ async def test_set_config_parameter(
     }
     assert args["value"] == 1
 
-    client.async_send_command.reset_mock()
+    client.async_send_command_no_wait.reset_mock()
 
     with patch(
         "homeassistant.components.zwave_js.api.async_set_config_parameter",
@@ -295,7 +295,7 @@ async def test_set_config_parameter(
 
         msg = await ws_client.receive_json()
 
-        assert len(client.async_send_command.call_args_list) == 0
+        assert len(client.async_send_command_no_wait.call_args_list) == 0
         assert not msg["success"]
         assert msg["error"]["code"] == "not_supported"
         assert msg["error"]["message"] == "test"
@@ -315,7 +315,7 @@ async def test_set_config_parameter(
 
         msg = await ws_client.receive_json()
 
-        assert len(client.async_send_command.call_args_list) == 0
+        assert len(client.async_send_command_no_wait.call_args_list) == 0
         assert not msg["success"]
         assert msg["error"]["code"] == "not_found"
         assert msg["error"]["message"] == "test"
@@ -335,7 +335,7 @@ async def test_set_config_parameter(
 
         msg = await ws_client.receive_json()
 
-        assert len(client.async_send_command.call_args_list) == 0
+        assert len(client.async_send_command_no_wait.call_args_list) == 0
         assert not msg["success"]
         assert msg["error"]["code"] == "unknown_error"
         assert msg["error"]["message"] == "test"

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -72,7 +72,7 @@ async def test_thermostat_v2(
         | SUPPORT_FAN_MODE
     )
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting hvac mode
     await hass.services.async_call(
@@ -85,8 +85,8 @@ async def test_thermostat_v2(
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
@@ -108,7 +108,7 @@ async def test_thermostat_v2(
     }
     assert args["value"] == 2
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting temperature
     await hass.services.async_call(
@@ -122,8 +122,8 @@ async def test_thermostat_v2(
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 2
-    args = client.async_send_command_no_wait.call_args_list[0][0][0]
+    assert len(client.async_send_command.call_args_list) == 2
+    args = client.async_send_command.call_args_list[0][0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
@@ -144,7 +144,7 @@ async def test_thermostat_v2(
         "value": 1,
     }
     assert args["value"] == 2
-    args = client.async_send_command_no_wait.call_args_list[1][0][0]
+    args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
@@ -166,7 +166,7 @@ async def test_thermostat_v2(
     }
     assert args["value"] == 77
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test cool mode update from value updated event
     event = Event(
@@ -217,7 +217,7 @@ async def test_thermostat_v2(
     assert state.attributes[ATTR_TARGET_TEMP_HIGH] == 22.8
     assert state.attributes[ATTR_TARGET_TEMP_LOW] == 22.2
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting temperature with heat_cool
     await hass.services.async_call(
@@ -231,8 +231,8 @@ async def test_thermostat_v2(
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 2
-    args = client.async_send_command_no_wait.call_args_list[0][0][0]
+    assert len(client.async_send_command.call_args_list) == 2
+    args = client.async_send_command.call_args_list[0][0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
@@ -254,7 +254,7 @@ async def test_thermostat_v2(
     }
     assert args["value"] == 77
 
-    args = client.async_send_command_no_wait.call_args_list[1][0][0]
+    args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
@@ -276,7 +276,7 @@ async def test_thermostat_v2(
     }
     assert args["value"] == 86
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting invalid hvac mode
     with pytest.raises(ValueError):
@@ -290,7 +290,7 @@ async def test_thermostat_v2(
             blocking=True,
         )
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting fan mode
     await hass.services.async_call(
@@ -303,8 +303,8 @@ async def test_thermostat_v2(
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 13
     assert args["valueId"] == {
@@ -327,7 +327,7 @@ async def test_thermostat_v2(
     }
     assert args["value"] == 1
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting invalid fan mode
     with pytest.raises(ValueError):
@@ -485,8 +485,8 @@ async def test_preset_and_no_setpoint(
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 8
     assert args["valueId"] == {
@@ -514,7 +514,7 @@ async def test_preset_and_no_setpoint(
     }
     assert args["value"] == 15
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test Full power preset update from value updated event
     event = Event(
@@ -553,9 +553,9 @@ async def test_preset_and_no_setpoint(
             blocking=True,
         )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 0
+    assert len(client.async_send_command.call_args_list) == 0
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Restore hvac mode by setting preset None
     await hass.services.async_call(
@@ -568,8 +568,8 @@ async def test_preset_and_no_setpoint(
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 8
     assert args["valueId"]["commandClass"] == 64
@@ -577,4 +577,4 @@ async def test_preset_and_no_setpoint(
     assert args["valueId"]["property"] == "mode"
     assert args["value"] == 1
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -38,8 +38,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
@@ -60,7 +60,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert args["value"] == 50
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting position
     await hass.services.async_call(
@@ -70,8 +70,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
@@ -92,7 +92,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert args["value"] == 0
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test opening
     await hass.services.async_call(
@@ -102,8 +102,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
@@ -124,7 +124,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert args["value"]
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
     # Test stop after opening
     await hass.services.async_call(
         "cover",
@@ -133,8 +133,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 2
-    open_args = client.async_send_command_no_wait.call_args_list[0][0][0]
+    assert len(client.async_send_command.call_args_list) == 2
+    open_args = client.async_send_command.call_args_list[0][0][0]
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 6
     assert open_args["valueId"] == {
@@ -153,7 +153,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert not open_args["value"]
 
-    close_args = client.async_send_command_no_wait.call_args_list[1][0][0]
+    close_args = client.async_send_command.call_args_list[1][0][0]
     assert close_args["command"] == "node.set_value"
     assert close_args["nodeId"] == 6
     assert close_args["valueId"] == {
@@ -191,7 +191,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         },
     )
     node.receive_event(event)
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     state = hass.states.get(WINDOW_COVER_ENTITY)
     assert state.state == "open"
@@ -203,8 +203,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         {"entity_id": WINDOW_COVER_ENTITY},
         blocking=True,
     )
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 6
     assert args["valueId"] == {
@@ -225,7 +225,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert args["value"] == 0
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test stop after closing
     await hass.services.async_call(
@@ -235,8 +235,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 2
-    open_args = client.async_send_command_no_wait.call_args_list[0][0][0]
+    assert len(client.async_send_command.call_args_list) == 2
+    open_args = client.async_send_command.call_args_list[0][0][0]
     assert open_args["command"] == "node.set_value"
     assert open_args["nodeId"] == 6
     assert open_args["valueId"] == {
@@ -255,7 +255,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert not open_args["value"]
 
-    close_args = client.async_send_command_no_wait.call_args_list[1][0][0]
+    close_args = client.async_send_command.call_args_list[1][0][0]
     assert close_args["command"] == "node.set_value"
     assert close_args["nodeId"] == 6
     assert close_args["valueId"] == {
@@ -274,7 +274,7 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     }
     assert not close_args["value"]
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     event = Event(
         type="value updated",
@@ -314,8 +314,8 @@ async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
         DOMAIN, SERVICE_OPEN_COVER, {"entity_id": GDC_COVER_ENTITY}, blocking=True
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 12
     assert args["value"] == 255
@@ -341,15 +341,15 @@ async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
     state = hass.states.get(GDC_COVER_ENTITY)
     assert state.state == STATE_CLOSED
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test close
     await hass.services.async_call(
         DOMAIN, SERVICE_CLOSE_COVER, {"entity_id": GDC_COVER_ENTITY}, blocking=True
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 12
     assert args["value"] == 0
@@ -375,7 +375,7 @@ async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):
     state = hass.states.get(GDC_COVER_ENTITY)
     assert state.state == STATE_CLOSED
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Barrier sends an opening state
     event = Event(

--- a/tests/components/zwave_js/test_fan.py
+++ b/tests/components/zwave_js/test_fan.py
@@ -23,8 +23,8 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 17
     assert args["valueId"] == {
@@ -45,7 +45,7 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
     }
     assert args["value"] == 66
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test setting unknown speed
     with pytest.raises(ValueError):
@@ -56,7 +56,7 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
             blocking=True,
         )
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turn on no speed
     await hass.services.async_call(
@@ -66,8 +66,8 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 17
     assert args["valueId"] == {
@@ -88,7 +88,7 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
     }
     assert args["value"] == 255
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning off
     await hass.services.async_call(
@@ -98,8 +98,8 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 17
     assert args["valueId"] == {
@@ -120,7 +120,7 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
     }
     assert args["value"] == 0
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test speed update from value updated event
     event = Event(
@@ -146,7 +146,7 @@ async def test_fan(hass, client, in_wall_smart_fan_control, integration):
     assert state.state == "on"
     assert state.attributes[ATTR_SPEED] == "high"
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     event = Event(
         type="value updated",

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -38,8 +38,8 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
@@ -60,7 +60,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     }
     assert args["value"] == 255
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test brightness update from value updated event
     event = Event(
@@ -95,9 +95,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    assert len(client.async_send_command.call_args_list) == 1
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning on with brightness
     await hass.services.async_call(
@@ -107,8 +107,8 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {
@@ -129,7 +129,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     }
     assert args["value"] == 50
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning on with rgb color
     await hass.services.async_call(
@@ -139,8 +139,8 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 6
-    warm_args = client.async_send_command_no_wait.call_args_list[0][0][0]  # red 255
+    assert len(client.async_send_command.call_args_list) == 6
+    warm_args = client.async_send_command.call_args_list[0][0][0]  # red 255
     assert warm_args["command"] == "node.set_value"
     assert warm_args["nodeId"] == 39
     assert warm_args["valueId"]["commandClassName"] == "Color Switch"
@@ -151,7 +151,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert warm_args["valueId"]["propertyName"] == "targetColor"
     assert warm_args["value"] == 255
 
-    cold_args = client.async_send_command_no_wait.call_args_list[1][0][0]  # green 76
+    cold_args = client.async_send_command.call_args_list[1][0][0]  # green 76
     assert cold_args["command"] == "node.set_value"
     assert cold_args["nodeId"] == 39
     assert cold_args["valueId"]["commandClassName"] == "Color Switch"
@@ -161,7 +161,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert cold_args["valueId"]["property"] == "targetColor"
     assert cold_args["valueId"]["propertyName"] == "targetColor"
     assert cold_args["value"] == 76
-    red_args = client.async_send_command_no_wait.call_args_list[2][0][0]  # blue 255
+    red_args = client.async_send_command.call_args_list[2][0][0]  # blue 255
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
@@ -171,9 +171,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["property"] == "targetColor"
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 255
-    green_args = client.async_send_command_no_wait.call_args_list[3][0][
-        0
-    ]  # warm white 0
+    green_args = client.async_send_command.call_args_list[3][0][0]  # warm white 0
     assert green_args["command"] == "node.set_value"
     assert green_args["nodeId"] == 39
     assert green_args["valueId"]["commandClassName"] == "Color Switch"
@@ -183,9 +181,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert green_args["valueId"]["property"] == "targetColor"
     assert green_args["valueId"]["propertyName"] == "targetColor"
     assert green_args["value"] == 0
-    blue_args = client.async_send_command_no_wait.call_args_list[4][0][
-        0
-    ]  # cold white 0
+    blue_args = client.async_send_command.call_args_list[4][0][0]  # cold white 0
     assert blue_args["command"] == "node.set_value"
     assert blue_args["nodeId"] == 39
     assert blue_args["valueId"]["commandClassName"] == "Color Switch"
@@ -236,7 +232,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert state.attributes[ATTR_BRIGHTNESS] == 255
     assert state.attributes[ATTR_RGB_COLOR] == (255, 76, 255)
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning on with same rgb color
     await hass.services.async_call(
@@ -246,9 +242,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 6
+    assert len(client.async_send_command.call_args_list) == 6
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning on with color temp
     await hass.services.async_call(
@@ -258,8 +254,8 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 6
-    red_args = client.async_send_command_no_wait.call_args_list[0][0][0]  # red 0
+    assert len(client.async_send_command.call_args_list) == 6
+    red_args = client.async_send_command.call_args_list[0][0][0]  # red 0
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
@@ -269,7 +265,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["property"] == "targetColor"
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 0
-    red_args = client.async_send_command_no_wait.call_args_list[1][0][0]  # green 0
+    red_args = client.async_send_command.call_args_list[1][0][0]  # green 0
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
@@ -279,7 +275,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["property"] == "targetColor"
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 0
-    red_args = client.async_send_command_no_wait.call_args_list[2][0][0]  # blue 0
+    red_args = client.async_send_command.call_args_list[2][0][0]  # blue 0
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
@@ -289,9 +285,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["property"] == "targetColor"
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 0
-    warm_args = client.async_send_command_no_wait.call_args_list[3][0][
-        0
-    ]  # warm white 0
+    warm_args = client.async_send_command.call_args_list[3][0][0]  # warm white 0
     assert warm_args["command"] == "node.set_value"
     assert warm_args["nodeId"] == 39
     assert warm_args["valueId"]["commandClassName"] == "Color Switch"
@@ -301,7 +295,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert warm_args["valueId"]["property"] == "targetColor"
     assert warm_args["valueId"]["propertyName"] == "targetColor"
     assert warm_args["value"] == 20
-    red_args = client.async_send_command_no_wait.call_args_list[4][0][0]  # cold white
+    red_args = client.async_send_command.call_args_list[4][0][0]  # cold white
     assert red_args["command"] == "node.set_value"
     assert red_args["nodeId"] == 39
     assert red_args["valueId"]["commandClassName"] == "Color Switch"
@@ -312,7 +306,7 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
     assert red_args["valueId"]["propertyName"] == "targetColor"
     assert red_args["value"] == 235
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test color temp update from value updated event
     red_event = Event(
@@ -368,9 +362,9 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 6
+    assert len(client.async_send_command.call_args_list) == 6
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning off
     await hass.services.async_call(
@@ -380,8 +374,8 @@ async def test_light(hass, client, bulb_6_multi_color, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 39
     assert args["valueId"] == {

--- a/tests/components/zwave_js/test_lock.py
+++ b/tests/components/zwave_js/test_lock.py
@@ -33,8 +33,8 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
@@ -64,7 +64,7 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     }
     assert args["value"] == 255
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test locked update from value updated event
     event = Event(
@@ -88,7 +88,7 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
 
     assert hass.states.get(SCHLAGE_BE469_LOCK_ENTITY).state == STATE_LOCKED
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test unlocking
     await hass.services.async_call(
@@ -98,8 +98,8 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
@@ -129,7 +129,7 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     }
     assert args["value"] == 0
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test set usercode service
     await hass.services.async_call(
@@ -143,8 +143,8 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {
@@ -167,7 +167,7 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
     }
     assert args["value"] == "1234"
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test clear usercode
     await hass.services.async_call(
@@ -177,8 +177,8 @@ async def test_door_lock(hass, client, lock_schlage_be469, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 20
     assert args["valueId"] == {

--- a/tests/components/zwave_js/test_number.py
+++ b/tests/components/zwave_js/test_number.py
@@ -20,8 +20,8 @@ async def test_number(hass, client, aeotec_radiator_thermostat, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 4
     assert args["valueId"] == {
@@ -43,7 +43,7 @@ async def test_number(hass, client, aeotec_radiator_thermostat, integration):
     }
     assert args["value"] == 30.0
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test value update from value updated event
     event = Event(

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -39,8 +39,8 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
@@ -68,7 +68,7 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     }
     assert args["value"] == 1
 
-    client.async_send_command.reset_mock()
+    client.async_send_command_no_wait.reset_mock()
 
     # Test setting parameter by property name
     await hass.services.async_call(
@@ -82,8 +82,8 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
@@ -111,7 +111,7 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     }
     assert args["value"] == 1
 
-    client.async_send_command.reset_mock()
+    client.async_send_command_no_wait.reset_mock()
 
     # Test setting parameter by property name and state label
     await hass.services.async_call(
@@ -125,8 +125,8 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
@@ -154,7 +154,7 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     }
     assert args["value"] == 2
 
-    client.async_send_command.reset_mock()
+    client.async_send_command_no_wait.reset_mock()
 
     # Test setting parameter by property and bitmask
     await hass.services.async_call(
@@ -169,8 +169,8 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
         blocking=True,
     )
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 52
     assert args["valueId"] == {
@@ -302,15 +302,15 @@ async def test_poll_value(
 ):
     """Test the poll_value service."""
     # Test polling the primary value
-    client.async_send_command_no_wait.return_value = {"result": 2}
+    client.async_send_command.return_value = {"result": 2}
     await hass.services.async_call(
         DOMAIN,
         SERVICE_REFRESH_VALUE,
         {ATTR_ENTITY_ID: CLIMATE_RADIO_THERMOSTAT_ENTITY},
         blocking=True,
     )
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.poll_value"
     assert args["nodeId"] == 26
     assert args["valueId"] == {
@@ -339,10 +339,10 @@ async def test_poll_value(
         "ccVersion": 2,
     }
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test polling all watched values
-    client.async_send_command_no_wait.return_value = {"result": 2}
+    client.async_send_command.return_value = {"result": 2}
     await hass.services.async_call(
         DOMAIN,
         SERVICE_REFRESH_VALUE,
@@ -352,7 +352,7 @@ async def test_poll_value(
         },
         blocking=True,
     )
-    assert len(client.async_send_command_no_wait.call_args_list) == 8
+    assert len(client.async_send_command.call_args_list) == 8
 
     # Test polling against an invalid entity raises ValueError
     with pytest.raises(ValueError):

--- a/tests/components/zwave_js/test_switch.py
+++ b/tests/components/zwave_js/test_switch.py
@@ -21,7 +21,7 @@ async def test_switch(hass, hank_binary_switch, integration, client):
         "switch", "turn_on", {"entity_id": SWITCH_ENTITY}, blocking=True
     )
 
-    args = client.async_send_command_no_wait.call_args[0][0]
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 32
     assert args["valueId"] == {
@@ -68,7 +68,7 @@ async def test_switch(hass, hank_binary_switch, integration, client):
         "switch", "turn_off", {"entity_id": SWITCH_ENTITY}, blocking=True
     )
 
-    args = client.async_send_command_no_wait.call_args[0][0]
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 32
     assert args["valueId"] == {
@@ -102,8 +102,8 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
         DOMAIN, SERVICE_TURN_OFF, {"entity_id": entity}, blocking=True
     )
 
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 12
     assert args["value"] == 0
@@ -134,7 +134,7 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
     state = hass.states.get(entity)
     assert state.state == STATE_OFF
 
-    client.async_send_command_no_wait.reset_mock()
+    client.async_send_command.reset_mock()
 
     # Test turning on
     await hass.services.async_call(
@@ -143,8 +143,8 @@ async def test_barrier_signaling_switch(hass, gdc_zw062, integration, client):
 
     # Note: the valueId's value is still 255 because we never
     # received an updated value
-    assert len(client.async_send_command_no_wait.call_args_list) == 1
-    args = client.async_send_command_no_wait.call_args[0][0]
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
     assert args["command"] == "node.set_value"
     assert args["nodeId"] == 12
     assert args["value"] == 255


### PR DESCRIPTION
## Proposed change
Changelog: https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.22.0

Major Changes:
- We now automatically choose to wait for a command result or not wait for a command result based on whether the node status is `ASLEEP`
- Config parameters with `allowManualEntry == True` are now properly supported

We don't need a patch release for this change but it might be worth including if we do another patch release as it fixes an issue with setting a config parameter when using `zwave-js 6.6`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
