### PR TITLE
Only set fan state in ecobee set_fan_mode service

### DIFF
--- a/homeassistant/components/ecobee/climate.py
+++ b/homeassistant/components/ecobee/climate.py
@@ -644,14 +644,11 @@ class Thermostat(ClimateEntity):
             _LOGGER.error(error)
             return
 
-        cool_temp = self.thermostat["runtime"]["desiredCool"] / 10.0
-        heat_temp = self.thermostat["runtime"]["desiredHeat"] / 10.0
         self.data.ecobee.set_fan_mode(
             self.thermostat_index,
             fan_mode,
-            cool_temp,
-            heat_temp,
             self.hold_preference(),
+            holdHours=self.hold_hours(),
         )
 
         _LOGGER.info("Setting fan mode to: %s", fan_mode)

--- a/homeassistant/components/ecobee/manifest.json
+++ b/homeassistant/components/ecobee/manifest.json
@@ -3,7 +3,7 @@
   "name": "ecobee",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecobee",
-  "requirements": ["python-ecobee-api==0.2.10"],
+  "requirements": ["python-ecobee-api==0.2.11"],
   "codeowners": ["@marthoc"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1771,7 +1771,7 @@ python-clementine-remote==1.0.1
 python-digitalocean==1.13.2
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.2.10
+python-ecobee-api==0.2.11
 
 # homeassistant.components.eq3btsmart
 # python-eq3bt==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -962,7 +962,7 @@ pysqueezebox==0.5.5
 pysyncthru==0.7.0
 
 # homeassistant.components.ecobee
-python-ecobee-api==0.2.10
+python-ecobee-api==0.2.11
 
 # homeassistant.components.darksky
 python-forecastio==1.4.0

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -319,15 +319,11 @@ async def test_set_fan_mode_on(thermostat, data):
     """Test set fan mode to on."""
     data.reset_mock()
     thermostat.set_fan_mode("on")
-    data.ecobee.set_fan_mode.assert_has_calls(
-        [mock.call(1, "on", 20, 40, "nextTransition")]
-    )
+    data.ecobee.set_fan_mode.assert_has_calls([mock.call(1, "on", "nextTransition")])
 
 
 async def test_set_fan_mode_auto(thermostat, data):
     """Test set fan mode to auto."""
     data.reset_mock()
     thermostat.set_fan_mode("auto")
-    data.ecobee.set_fan_mode.assert_has_calls(
-        [mock.call(1, "auto", 20, 40, "nextTransition")]
-    )
+    data.ecobee.set_fan_mode.assert_has_calls([mock.call(1, "auto", "nextTransition")])

--- a/tests/components/ecobee/test_climate.py
+++ b/tests/components/ecobee/test_climate.py
@@ -319,11 +319,15 @@ async def test_set_fan_mode_on(thermostat, data):
     """Test set fan mode to on."""
     data.reset_mock()
     thermostat.set_fan_mode("on")
-    data.ecobee.set_fan_mode.assert_has_calls([mock.call(1, "on", "nextTransition")])
+    data.ecobee.set_fan_mode.assert_has_calls(
+        [mock.call(1, "on", "nextTransition", holdHours=None)]
+    )
 
 
 async def test_set_fan_mode_auto(thermostat, data):
     """Test set fan mode to auto."""
     data.reset_mock()
     thermostat.set_fan_mode("auto")
-    data.ecobee.set_fan_mode.assert_has_calls([mock.call(1, "auto", "nextTransition")])
+    data.ecobee.set_fan_mode.assert_has_calls(
+        [mock.call(1, "auto", "nextTransition", holdHours=None)]
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
-->
With this change setting a fan hold in the ecobee integration will no longer also set a temperature hold. If any automations assumed that the temperature would be set when calling the set_fan_mode service on an ecobee device, those automations will need to add the appropriate set_temperature service call.

## Proposed change
<!--
-->
This change modifies the set_fan_mode behavior in the ecobee integration to not force setting the hold temperature when setting a fan hold. With this change set_fan_mode will only change the fan mode. This change depends on python-ecobee-api version 0.2.11.

Update ecobee integration set_fan_mode
  - Remove setting desiredHeat/desiredCool through set_fan_mode.
    Setting temp is supported through the temp calls, and setting them in the
    set_fan_mode will set temperature holds when not expected.
  - Pass the hold_hours value into the set_fan_mode call. This will allow
    a fan hold to be set with the holdHours mode.

Update python-ecobee-api to 0.2.11
 - This update is required to support the set_fan_mode changes in HA
 - https://github.com/nkgilley/python-ecobee-api/compare/0.2.10...0.2.11

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #40087
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
