### PR TITLE
Add python-typing-update to pre-commit-config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,18 @@ repos:
     hooks:
       - id: prettier
         stages: [manual]
+  - repo: https://github.com/cdce8p/python-typing-update
+    rev: v0.2.0
+    hooks:
+      # Run `python-typing-update` hook manually from time to time
+      # to update python typing syntax.
+      # Will require manual work, before submitting changes!
+      - id: python-typing-update
+        stages: [manual]
+        args:
+          - --py38-plus
+          - --force
+        files: ^(homeassistant|tests|script)/.+\.py$
   - repo: local
     hooks:
       # Run mypy through our wrapper script in order to get the possible

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
       - id: prettier
         stages: [manual]
   - repo: https://github.com/cdce8p/python-typing-update
-    rev: v0.2.0
+    rev: v0.3.0
     hooks:
       # Run `python-typing-update` hook manually from time to time
       # to update python typing syntax.
@@ -78,6 +78,7 @@ repos:
         args:
           - --py38-plus
           - --force
+          - --keep-updates
         files: ^(homeassistant|tests|script)/.+\.py$
   - repo: local
     hooks:

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -7,6 +7,6 @@ flake8-docstrings==1.5.0
 flake8==3.8.4
 isort==5.7.0
 pydocstyle==5.1.1
-python-typing-update==0.2.0
+python-typing-update==0.3.0
 pyupgrade==2.7.2
 yamllint==1.24.2

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -7,5 +7,6 @@ flake8-docstrings==1.5.0
 flake8==3.8.4
 isort==5.7.0
 pydocstyle==5.1.1
+python-typing-update==0.2.0
 pyupgrade==2.7.2
 yamllint==1.24.2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As follow up to the python typing updates, https://github.com/home-assistant/architecture/issues/493. This PR adds [python-typing-update](https://github.com/cdce8p/python-typing-update) to the `.pre-commit-config.yaml` in stage `manual`. That way it can be executed more easily from time to time.

Since the tool can't handle all situation, I would suggest not to add it as CI check.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests