### PR TITLE
Update pyupgrade to v2.10.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.7.2
+    rev: v2.10.1
     hooks:
       - id: pyupgrade
         args: [--py38-plus]

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -8,5 +8,5 @@ flake8==3.8.4
 isort==5.7.0
 pydocstyle==5.1.1
 python-typing-update==0.3.0
-pyupgrade==2.7.2
+pyupgrade==2.10.1
 yamllint==1.24.2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrade the [pyupgrade](https://github.com/asottile/pyupgrade) pre-commit hook to the newest version.
<https://github.com/asottile/pyupgrade/compare/v2.7.2...v2.10.1>

The update mainly includes automatic updates of type annotations where possible.
Requires `from __future__ import annotations` to be present in file.

Related: https://github.com/home-assistant/architecture/issues/493
Depends on: #48087


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
