### PR TITLE
Improve deCONZ sensor coverage by verifying daylight sensor attributes

### DIFF
--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -1,10 +1,12 @@
 """deCONZ sensor platform tests."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
 from homeassistant.components.deconz.const import CONF_ALLOW_CLIP_SENSOR
 from homeassistant.components.deconz.sensor import ATTR_DAYLIGHT
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.config_entries import RELOAD_AFTER_UPDATE_DELAY
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     DEVICE_CLASS_BATTERY,
@@ -13,8 +15,12 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+
+from tests.common import async_fire_time_changed
 
 
 async def test_no_sensors(hass, aioclient_mock):
@@ -56,27 +62,20 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
                 "uniqueid": "00:00:00:00:00:00:00:03-00",
             },
             "5": {
-                "name": "Daylight sensor",
-                "type": "Daylight",
-                "state": {"daylight": True, "status": 130},
-                "config": {},
-                "uniqueid": "00:00:00:00:00:00:00:04-00",
-            },
-            "6": {
                 "name": "Power sensor",
                 "type": "ZHAPower",
                 "state": {"current": 2, "power": 6, "voltage": 3},
                 "config": {"reachable": True},
                 "uniqueid": "00:00:00:00:00:00:00:05-00",
             },
-            "7": {
+            "6": {
                 "name": "Consumption sensor",
                 "type": "ZHAConsumption",
                 "state": {"consumption": 2, "power": 6},
                 "config": {"reachable": True},
                 "uniqueid": "00:00:00:00:00:00:00:06-00",
             },
-            "8": {
+            "7": {
                 "id": "CLIP light sensor id",
                 "name": "CLIP light level sensor",
                 "type": "CLIPLightLevel",
@@ -440,6 +439,57 @@ async def test_air_quality_sensor(hass, aioclient_mock):
 
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("sensor.air_quality").state == "poor"
+
+
+async def test_daylight_sensor(hass, aioclient_mock):
+    """Test daylight sensor is disabled by default and when created has expected attributes."""
+    data = {
+        "sensors": {
+            "0": {
+                "config": {
+                    "configured": True,
+                    "on": True,
+                    "sunriseoffset": 30,
+                    "sunsetoffset": -30,
+                },
+                "etag": "55047cf652a7e594d0ee7e6fae01dd38",
+                "manufacturername": "Philips",
+                "modelid": "PHDL00",
+                "name": "Daylight sensor",
+                "state": {
+                    "daylight": True,
+                    "lastupdated": "2018-03-24T17:26:12",
+                    "status": 170,
+                },
+                "swversion": "1.0",
+                "type": "Daylight",
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 0
+    assert not hass.states.get("sensor.daylight_sensor")
+
+    # Enable in entity registry
+
+    entity_registry = er.async_get(hass)
+    entity_registry.async_update_entity(
+        entity_id="sensor.daylight_sensor", disabled_by=None
+    )
+    await hass.async_block_till_done()
+
+    async_fire_time_changed(
+        hass,
+        dt.utcnow() + timedelta(seconds=RELOAD_AFTER_UPDATE_DELAY + 1),
+    )
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("sensor.daylight_sensor")
+    assert hass.states.get("sensor.daylight_sensor").attributes[ATTR_DAYLIGHT]
 
 
 async def test_time_sensor(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Enable daylight sensor to verify attribute which was the last piece to 100% coverage of deCONZ sensor platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
