### PR TITLE
Bump zwave-js-server-python to 0.23.0 to support zwave-js 7

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -111,7 +111,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await async_ensure_addon_running(hass, entry)
 
     client = ZwaveClient(entry.data[CONF_URL], async_get_clientsession(hass))
-    dev_reg = await device_registry.async_get_registry(hass)
+    dev_reg = device_registry.async_get(hass)
     ent_reg = entity_registry.async_get(hass)
 
     @callback

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -47,7 +47,6 @@ from .const import (
     ATTR_PROPERTY_KEY_NAME,
     ATTR_PROPERTY_NAME,
     ATTR_TYPE,
-    ATTR_TYPE_,
     ATTR_VALUE,
     ATTR_VALUE_RAW,
     CONF_INTEGRATION_CREATED_ADDON,
@@ -60,7 +59,8 @@ from .const import (
     EVENT_DEVICE_ADDED_TO_REGISTRY,
     LOGGER,
     PLATFORMS,
-    ZWAVE_JS_EVENT,
+    ZWAVE_JS_NOTIFICATION_EVENT,
+    ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
 )
 from .discovery import async_discover_values
 from .helpers import get_device_id
@@ -178,9 +178,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if notification.metadata.states:
             value = notification.metadata.states.get(str(value), value)
         hass.bus.async_fire(
-            ZWAVE_JS_EVENT,
+            ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
             {
-                ATTR_TYPE: "value_notification",
                 ATTR_DOMAIN: DOMAIN,
                 ATTR_NODE_ID: notification.node.node_id,
                 ATTR_HOME_ID: client.driver.controller.home_id,
@@ -205,7 +204,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         """Relay stateless notification events from Z-Wave nodes to hass."""
         device = dev_reg.async_get_device({get_device_id(client, notification.node)})
         event_data = {
-            ATTR_TYPE: "notification",
             ATTR_DOMAIN: DOMAIN,
             ATTR_NODE_ID: notification.node.node_id,
             ATTR_HOME_ID: client.driver.controller.home_id,
@@ -227,14 +225,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 {
                     ATTR_COMMAND_CLASS_NAME: "Notification",
                     ATTR_LABEL: notification.label,
-                    ATTR_TYPE_: notification.type_,
+                    ATTR_TYPE: notification.type_,
                     ATTR_EVENT: notification.event,
                     ATTR_EVENT_LABEL: notification.event_label,
                     ATTR_PARAMETERS: notification.parameters,
                 }
             )
 
-        hass.bus.async_fire(ZWAVE_JS_EVENT, event_data)
+        hass.bus.async_fire(ZWAVE_JS_NOTIFICATION_EVENT, event_data)
 
     entry_hass_data: dict = hass.data[DOMAIN].setdefault(entry.entry_id, {})
     # connect and throw error if connection failed

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -6,7 +6,6 @@ from typing import Callable
 
 from async_timeout import timeout
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.const import CommandClass
 from zwave_js_server.exceptions import BaseZwaveJSServerError, InvalidServerVersion
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.notification import (
@@ -212,14 +211,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             ATTR_HOME_ID: client.driver.controller.home_id,
             ATTR_DEVICE_ID: device.id,  # type: ignore
             ATTR_COMMAND_CLASS: notification.command_class,
-            ATTR_COMMAND_CLASS_NAME: CommandClass(
-                notification.command_class
-            ).name.title(),
         }
 
         if isinstance(notification, EntryControlNotification):
             event_data.update(
                 {
+                    ATTR_COMMAND_CLASS_NAME: "Entry Control",
                     ATTR_EVENT_TYPE: notification.event_type,
                     ATTR_DATA_TYPE: notification.data_type,
                     ATTR_EVENT_DATA: notification.event_data,
@@ -228,6 +225,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         else:
             event_data.update(
                 {
+                    ATTR_COMMAND_CLASS_NAME: "Notification",
                     ATTR_LABEL: notification.label,
                     ATTR_TYPE_: notification.type_,
                     ATTR_EVENT: notification.event,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -395,11 +395,6 @@ def websocket_get_config_parameters(
     )
 
 
-def convert_log_level_to_enum(value: str) -> LogLevel:
-    """Convert log level string to LogLevel enum."""
-    return LogLevel[value.upper()]
-
-
 def filename_is_present_if_logging_to_file(obj: dict) -> dict:
     """Validate that filename is provided if log_to_file is True."""
     if obj.get(LOG_TO_FILE, False) and FILENAME not in obj:
@@ -420,8 +415,7 @@ def filename_is_present_if_logging_to_file(obj: dict) -> dict:
                     vol.Optional(LEVEL): vol.All(
                         cv.string,
                         vol.Lower,
-                        vol.In([log_level.name.lower() for log_level in LogLevel]),
-                        lambda val: LogLevel[val.upper()],
+                        vol.In([log_level.value for log_level in LogLevel]),
                     ),
                     vol.Optional(LOG_TO_FILE): cv.boolean,
                     vol.Optional(FILENAME): cv.string,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -423,7 +423,7 @@ def filename_is_present_if_logging_to_file(obj: dict) -> dict:
                         cv.string,
                         vol.Lower,
                         vol.In([log_level.value for log_level in LogLevel]),
-                        lambda val: LogLevel(val),
+                        lambda val: LogLevel(val),  # pylint: disable=unnecessary-lambda
                     ),
                     vol.Optional(LOG_TO_FILE): cv.boolean,
                     vol.Optional(FILENAME): cv.string,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -46,6 +46,10 @@ FILENAME = "filename"
 ENABLED = "enabled"
 FORCE_CONSOLE = "force_console"
 
+# constants for setting config parameters
+VALUE_ID = "value_id"
+STATUS = "status"
+
 
 @callback
 def async_register_api(hass: HomeAssistant) -> None:
@@ -321,7 +325,7 @@ async def websocket_set_config_parameter(
     client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
     node = client.driver.controller.nodes[node_id]
     try:
-        result = await async_set_config_parameter(
+        zwave_value, cmd_status = await async_set_config_parameter(
             node, value, property_, property_key=property_key
         )
     except (InvalidNewValue, NotFoundError, NotImplementedError, SetValueFailed) as err:
@@ -340,7 +344,10 @@ async def websocket_set_config_parameter(
 
     connection.send_result(
         msg[ID],
-        str(result),
+        {
+            VALUE_ID: zwave_value.value_id,
+            STATUS: cmd_status,
+        },
     )
 
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -416,6 +416,7 @@ def filename_is_present_if_logging_to_file(obj: dict) -> dict:
                         cv.string,
                         vol.Lower,
                         vol.In([log_level.value for log_level in LogLevel]),
+                        lambda val: LogLevel(val),
                     ),
                     vol.Optional(LOG_TO_FILE): cv.boolean,
                     vol.Optional(FILENAME): cv.string,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -135,7 +135,7 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             self._setpoint_values[enum] = self.get_zwave_value(
                 THERMOSTAT_SETPOINT_PROPERTY,
                 command_class=CommandClass.THERMOSTAT_SETPOINT,
-                value_property_key=enum.value.key,
+                value_property_key=enum.value,
                 add_to_watched_value_ids=True,
             )
             # Use the first found setpoint value to always determine the temperature unit

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -28,7 +28,8 @@ EVENT_DEVICE_ADDED_TO_REGISTRY = f"{DOMAIN}_device_added_to_registry"
 LOGGER = logging.getLogger(__package__)
 
 # constants for events
-ZWAVE_JS_EVENT = f"{DOMAIN}_event"
+ZWAVE_JS_VALUE_NOTIFICATION_EVENT = f"{DOMAIN}_value_notification"
+ZWAVE_JS_NOTIFICATION_EVENT = f"{DOMAIN}_notification"
 ATTR_NODE_ID = "node_id"
 ATTR_HOME_ID = "home_id"
 ATTR_ENDPOINT = "endpoint"
@@ -45,7 +46,6 @@ ATTR_PROPERTY_KEY = "property_key"
 ATTR_PARAMETERS = "parameters"
 ATTR_EVENT = "event"
 ATTR_EVENT_LABEL = "event_label"
-ATTR_TYPE_ = "type_"
 ATTR_EVENT_TYPE = "event_type"
 ATTR_EVENT_DATA = "event_data"
 ATTR_DATA_TYPE = "data_type"

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -43,6 +43,12 @@ ATTR_PROPERTY_KEY_NAME = "property_key_name"
 ATTR_PROPERTY = "property"
 ATTR_PROPERTY_KEY = "property_key"
 ATTR_PARAMETERS = "parameters"
+ATTR_EVENT = "event"
+ATTR_EVENT_LABEL = "event_label"
+ATTR_TYPE_ = "type_"
+ATTR_EVENT_TYPE = "event_type"
+ATTR_EVENT_DATA = "event_data"
+ATTR_DATA_TYPE = "data_type"
 
 # service constants
 SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -247,12 +247,11 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
 
     async def _async_set_color(self, color: ColorComponent, new_value: int) -> None:
         """Set defined color to given value."""
-        property_key = color.value
         # actually set the new color value
         target_zwave_value = self.get_zwave_value(
             "targetColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=property_key.key,
+            value_property_key=color.value,
         )
         if target_zwave_value is None:
             # guard for unsupported color
@@ -315,27 +314,27 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         red_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.RED.value.key,
+            value_property_key=ColorComponent.RED.value,
         )
         green_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.GREEN.value.key,
+            value_property_key=ColorComponent.GREEN.value,
         )
         blue_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.BLUE.value.key,
+            value_property_key=ColorComponent.BLUE.value,
         )
         ww_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.WARM_WHITE.value.key,
+            value_property_key=ColorComponent.WARM_WHITE.value,
         )
         cw_val = self.get_zwave_value(
             "currentColor",
             CommandClass.SWITCH_COLOR,
-            value_property_key=ColorComponent.COLD_WHITE.value.key,
+            value_property_key=ColorComponent.COLD_WHITE.value,
         )
         # prefer the (new) combined color property
         # https://github.com/zwave-js/node-zwave-js/pull/1782

--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.22.0"],
+  "requirements": ["zwave-js-server-python==0.23.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["http", "websocket_api"]
 }

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -117,7 +117,7 @@ class ZWaveServices:
             else:
                 msg = (
                     "Added command to queue to set configuration parameter %s on Node "
-                    "%s with value %s. Parameter will be set when the device wakes up."
+                    "%s with value %s. Parameter will be set when the device wakes up"
                 )
 
             _LOGGER.info(msg, zwave_value, node, new_value)

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 
 import voluptuous as vol
+from zwave_js_server.const import CommandStatus
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.util.node import async_set_config_parameter
 
@@ -104,25 +105,22 @@ class ZWaveServices:
         new_value = service.data[const.ATTR_CONFIG_VALUE]
 
         for node in nodes:
-            zwave_value = await async_set_config_parameter(
+            zwave_value, cmd_status = await async_set_config_parameter(
                 node,
                 new_value,
                 property_or_property_name,
                 property_key=property_key,
             )
 
-            if zwave_value:
-                _LOGGER.info(
-                    "Set configuration parameter %s on Node %s with value %s",
-                    zwave_value,
-                    node,
-                    new_value,
-                )
+            if cmd_status == CommandStatus.ACCEPTED:
+                msg = "Set configuration parameter %s on Node %s with value %s"
             else:
-                raise ValueError(
-                    f"Unable to set configuration parameter on Node {node} with "
-                    f"value {new_value}"
+                msg = (
+                    "Added command to set configuration parameter %s on Node %s with "
+                    "value %s to queue. Parameter will be set when the device wakes up."
                 )
+
+            _LOGGER.info(msg, zwave_value, node, new_value)
 
     async def async_poll_value(self, service: ServiceCall) -> None:
         """Poll value on a node."""

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -116,8 +116,8 @@ class ZWaveServices:
                 msg = "Set configuration parameter %s on Node %s with value %s"
             else:
                 msg = (
-                    "Added command to set configuration parameter %s on Node %s with "
-                    "value %s to queue. Parameter will be set when the device wakes up."
+                    "Added command to queue to set configuration parameter %s on Node "
+                    "%s with value %s. Parameter will be set when the device wakes up."
                 )
 
             _LOGGER.info(msg, zwave_value, node, new_value)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2399,4 +2399,4 @@ zigpy==0.33.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.22.0
+zwave-js-server-python==0.23.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1242,4 +1242,4 @@ zigpy-znp==0.4.0
 zigpy==0.33.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.22.0
+zwave-js-server-python==0.23.0

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -381,7 +381,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "update_log_config"
-    assert args["config"] == {"level": 0}
+    assert args["config"] == {"level": "error"}
 
     client.async_send_command.reset_mock()
 
@@ -428,7 +428,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
     args = client.async_send_command.call_args[0][0]
     assert args["command"] == "update_log_config"
     assert args["config"] == {
-        "level": 0,
+        "level": "error",
         "logToFile": True,
         "filename": "/test",
         "forceConsole": True,
@@ -490,7 +490,7 @@ async def test_get_log_config(hass, client, integration, hass_ws_client):
         "success": True,
         "config": {
             "enabled": True,
-            "level": 0,
+            "level": "error",
             "logToFile": False,
             "filename": "/test.txt",
             "forceConsole": False,

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -9,7 +9,7 @@ async def test_scenes(hass, hank_binary_switch, integration, client):
     """Test scene events."""
     # just pick a random node to fake the value notification events
     node = hank_binary_switch
-    events = async_capture_events(hass, "zwave_js_event")
+    events = async_capture_events(hass, "zwave_js_value_notification")
 
     # Publish fake Basic Set value notification
     event = Event(
@@ -138,7 +138,7 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     """Test notification events."""
     # just pick a random node to fake the value notification events
     node = hank_binary_switch
-    events = async_capture_events(hass, "zwave_js_event")
+    events = async_capture_events(hass, "zwave_js_notification")
 
     # Publish fake Notification CC notification
     event = Event(
@@ -161,10 +161,9 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     # wait for the event
     await hass.async_block_till_done()
     assert len(events) == 1
-    assert events[0].data["type"] == "notification"
     assert events[0].data["home_id"] == client.driver.controller.home_id
     assert events[0].data["node_id"] == 32
-    assert events[0].data["type_"] == 6
+    assert events[0].data["type"] == 6
     assert events[0].data["event"] == 5
     assert events[0].data["label"] == "Access Control"
     assert events[0].data["event_label"] == "Keypad lock operation"
@@ -188,7 +187,6 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     # wait for the event
     await hass.async_block_till_done()
     assert len(events) == 2
-    assert events[1].data["type"] == "notification"
     assert events[1].data["home_id"] == client.driver.controller.home_id
     assert events[1].data["node_id"] == 32
     assert events[1].data["event_type"] == 5

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -139,15 +139,21 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     node = hank_binary_switch
     events = async_capture_events(hass, "zwave_js_event")
 
-    # Publish fake Basic Set value notification
+    # Publish fake Notification CC notification
     event = Event(
         type="notification",
         data={
             "source": "node",
             "event": "notification",
-            "nodeId": 23,
-            "notificationLabel": "Keypad lock operation",
-            "parameters": {"userId": 1},
+            "nodeId": 32,
+            "ccId": 113,
+            "args": {
+                "type": 6,
+                "event": 5,
+                "label": "Access Control",
+                "eventLabel": "Keypad lock operation",
+                "parameters": {"userId": 1},
+            },
         },
     )
     node.receive_event(event)
@@ -157,5 +163,31 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     assert events[0].data["type"] == "notification"
     assert events[0].data["home_id"] == client.driver.controller.home_id
     assert events[0].data["node_id"] == 32
-    assert events[0].data["label"] == "Keypad lock operation"
+    assert events[0].data["type_"] == 6
+    assert events[0].data["event"] == 5
+    assert events[0].data["label"] == "Access Control"
+    assert events[0].data["event_label"] == "Keypad lock operation"
     assert events[0].data["parameters"]["userId"] == 1
+
+    # Publish fake Entry Control CC notification
+    event = Event(
+        type="notification",
+        data={
+            "source": "node",
+            "event": "notification",
+            "nodeId": 32,
+            "ccId": 111,
+            "args": {"eventType": 5, "dataType": 2, "eventData": "555"},
+        },
+    )
+
+    node.receive_event(event)
+    # wait for the event
+    await hass.async_block_till_done()
+    assert len(events) == 2
+    assert events[1].data["type"] == "notification"
+    assert events[1].data["home_id"] == client.driver.controller.home_id
+    assert events[1].data["node_id"] == 32
+    assert events[1].data["event_type"] == 5
+    assert events[1].data["data_type"] == 2
+    assert events[1].data["event_data"] == "555"

--- a/tests/components/zwave_js/test_events.py
+++ b/tests/components/zwave_js/test_events.py
@@ -1,4 +1,5 @@
 """Test Z-Wave JS (value notification) events."""
+from zwave_js_server.const import CommandClass
 from zwave_js_server.event import Event
 
 from tests.common import async_capture_events
@@ -168,6 +169,8 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     assert events[0].data["label"] == "Access Control"
     assert events[0].data["event_label"] == "Keypad lock operation"
     assert events[0].data["parameters"]["userId"] == 1
+    assert events[0].data["command_class"] == CommandClass.NOTIFICATION
+    assert events[0].data["command_class_name"] == "Notification"
 
     # Publish fake Entry Control CC notification
     event = Event(
@@ -191,3 +194,5 @@ async def test_notifications(hass, hank_binary_switch, integration, client):
     assert events[1].data["event_type"] == 5
     assert events[1].data["data_type"] == 2
     assert events[1].data["event_data"] == "555"
+    assert events[1].data["command_class"] == CommandClass.ENTRY_CONTROL
+    assert events[1].data["command_class_name"] == "Entry Control"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The event names for Z-Wave JS value notification (central scene) events will now be called `zwave_js_value_notification` and notification (e.g. locking or unlocking a lock) events will now be called `zwave_js_notification`. For notification events, the properties that Z-Wave JS provides have changed, and we have changed the HA event property names to reflect that. The parameter that used to be called `label` (The human-readable label for the notification **event**) is now called `event_label` as there is now a new `label` property which is the human-readable label for the notification **type**. In addition, we now support notification events for two command classes, Entry Control and Notification, so the command class is reflected in the event data. You can learn more about the different command class notifications and what each parameter means for the different notifications here: https://zwave-js.github.io/node-zwave-js/#/api/node?id=quotnotificationquot


## Proposed change
Bump `zwave-js-server-python` to 0.23.0 to support `zwave-js 7.0.0`. Major changes that affect HA include:
- Addition of a new notification event for the Entry Control CC
- Changes to the schema of the notification event for the Notification CC
- `get_log_config` returns a string for log level (`LogLevel` switched from `IntEnum` to `Enum`)
- Under the hood, `update_log_config` also expects a `string` instead of an `int` for log level but that translation is transparent to the user/consuming application (e.g. frontend) because we always expected a `string` as input and transformed it into an `int` as part of thee voluptuous schema.
- Switched `ThermostatMode` and `ColorComponent` back to `IntEnum` since current value ID format only uses property key and not property key name (https://github.com/home-assistant-libs/zwave-js-server-python/pull/171)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17053

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
