### PR TITLE
Add it500 Salus integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -442,12 +442,8 @@ homeassistant/components/rpi_power/* @shenxn @swetoast
 homeassistant/components/ruckus_unleashed/* @gabe565
 homeassistant/components/safe_mode/* @home-assistant/core
 homeassistant/components/saj/* @fredericvl
-<<<<<<< HEAD
-homeassistant/components/samsungtv/* @escoand @chemelli74
-=======
 homeassistant/components/salus/* @cipacda
-homeassistant/components/samsungtv/* @escoand
->>>>>>> ac7be2d7fc (Add it500 Salus integration)
+homeassistant/components/samsungtv/* @escoand @chemelli74
 homeassistant/components/scene/* @home-assistant/core
 homeassistant/components/schluter/* @prairieapps
 homeassistant/components/scrape/* @fabaff

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -442,7 +442,12 @@ homeassistant/components/rpi_power/* @shenxn @swetoast
 homeassistant/components/ruckus_unleashed/* @gabe565
 homeassistant/components/safe_mode/* @home-assistant/core
 homeassistant/components/saj/* @fredericvl
+<<<<<<< HEAD
 homeassistant/components/samsungtv/* @escoand @chemelli74
+=======
+homeassistant/components/salus/* @cipacda
+homeassistant/components/samsungtv/* @escoand
+>>>>>>> ac7be2d7fc (Add it500 Salus integration)
 homeassistant/components/scene/* @home-assistant/core
 homeassistant/components/schluter/* @prairieapps
 homeassistant/components/scrape/* @fabaff

--- a/homeassistant/components/salus/__init__.py
+++ b/homeassistant/components/salus/__init__.py
@@ -1,0 +1,68 @@
+"""Initialize Salus integration."""
+import logging
+
+from salus.api import Api
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN, PLATFORMS
+from .coordinator import SalusDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: vol.Schema(
+            {
+                vol.Required(CONF_USERNAME): cv.string,
+                vol.Required(CONF_PASSWORD): cv.string,
+            }
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+async def async_setup(hass: HomeAssistantType, config: dict) -> bool:
+    """Set up the Salus integration."""
+    hass.data.setdefault(DOMAIN, {})
+
+    # Return boolean to indicate that initialization was successful.
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+    """Set up Salus from a config entry."""
+    salus_api = await hass.async_add_executor_job(_get_salus_api_instance, entry)
+    devices = await hass.async_add_executor_job(salus_api.get_devices)
+    device = next(d for d in devices if d.device_id == entry.data[CONF_DEVICE])
+
+    coordinator = SalusDataUpdateCoordinator(
+        hass,
+        api=salus_api,
+        device_id=entry.data[CONF_DEVICE],
+    )
+    await coordinator.async_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = (coordinator, device)
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    return True
+
+
+def _get_salus_api_instance(entry: ConfigEntry) -> Api:
+    """Initialize a new instance of SalusApi."""
+    salus = Api(
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+    )
+
+    return salus

--- a/homeassistant/components/salus/__init__.py
+++ b/homeassistant/components/salus/__init__.py
@@ -5,7 +5,7 @@ from salus.api import Api
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, PLATFORMS
 from .coordinator import SalusDataUpdateCoordinator
@@ -13,15 +13,7 @@ from .coordinator import SalusDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistantType, config: dict) -> bool:
-    """Set up the Salus integration."""
-    hass.data.setdefault(DOMAIN, {})
-
-    # Return boolean to indicate that initialization was successful.
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Salus from a config entry."""
     salus_api = await hass.async_add_executor_job(_get_salus_api_instance, entry)
     devices = await hass.async_add_executor_job(salus_api.get_devices)
@@ -34,6 +26,7 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
     )
     await coordinator.async_refresh()
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = (coordinator, device)
 
     for platform in PLATFORMS:

--- a/homeassistant/components/salus/__init__.py
+++ b/homeassistant/components/salus/__init__.py
@@ -2,29 +2,15 @@
 import logging
 
 from salus.api import Api
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import DOMAIN, PLATFORMS
 from .coordinator import SalusDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-            }
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
 
 
 async def async_setup(hass: HomeAssistantType, config: dict) -> bool:

--- a/homeassistant/components/salus/climate.py
+++ b/homeassistant/components/salus/climate.py
@@ -8,7 +8,9 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     SUPPORT_TARGET_TEMPERATURE,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, MANUFACTURER
@@ -16,7 +18,9 @@ from .const import DOMAIN, MANUFACTURER
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities
+):
     """Set up the it500 Salus thermostat."""
     coordinator, device = hass.data[DOMAIN][config_entry.entry_id]
 
@@ -94,6 +98,9 @@ class IT500Salus(CoordinatorEntity, ClimateEntity):
             "model": "IT500 Salus",
             "manufacturer": MANUFACTURER,
         }
+
+    def set_hvac_mode(self, mode: str):
+        """We do nothing here as we only support heating."""
 
     async def async_set_temperature(self, **kwargs):
         """Set a new target temperature."""

--- a/homeassistant/components/salus/climate.py
+++ b/homeassistant/components/salus/climate.py
@@ -1,0 +1,103 @@
+"""Climate entity for the Salus integration."""
+
+from homeassistant.components.climate import ClimateEntity
+from homeassistant.components.climate.const import (
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_IDLE,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_OFF,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+from homeassistant.const import ATTR_TEMPERATURE
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+
+SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the it500 Salus thermostat."""
+    coordinator, device = hass.data[DOMAIN][config_entry.entry_id]
+
+    temperature_unit = hass.config.units.temperature_unit
+    entity = IT500Salus(coordinator, temperature_unit, device)
+
+    async_add_entities([entity], True)
+
+
+class IT500Salus(CoordinatorEntity, ClimateEntity):
+    """Representation of a Salus IT500 Thermostat."""
+
+    def __init__(self, coordinator, temperature_unit, device):
+        """Initialize the thermostat."""
+        super().__init__(coordinator)
+        self._coordinator = coordinator
+        self._temperature_unit = temperature_unit
+        self._device = device
+
+    @property
+    def name(self):
+        """Return default name for entity."""
+        return f"{self._device.name} Temperature"
+
+    @property
+    def temperature_unit(self):
+        """Return temperature unit user."""
+        return self._temperature_unit
+
+    @property
+    def current_temperature(self):
+        """Return current room temperature."""
+        return self._coordinator.data.current_temperature
+
+    @property
+    def target_temperature(self):
+        """Return currently set target temperature."""
+        return self._coordinator.data.current_target_temperature
+
+    @property
+    def hvac_mode(self):
+        """Return current HVAC mode. IT500 Salus only supports heat/off modes."""
+        if self.hvac_action == CURRENT_HVAC_IDLE:
+            return HVAC_MODE_OFF
+        return HVAC_MODE_HEAT
+
+    @property
+    def hvac_action(self):
+        """Return current HVAC action."""
+        if self._coordinator.data.heat_on:
+            return CURRENT_HVAC_HEAT
+        return CURRENT_HVAC_IDLE
+
+    @property
+    def hvac_modes(self):
+        """Return manageable HVAC modes. IT500 Salus only supports heat/off modes."""
+        return [HVAC_MODE_HEAT]
+
+    @property
+    def supported_features(self):
+        """Return the list of supported features."""
+        return SUPPORT_FLAGS
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._device.device_id
+
+    @property
+    def device_info(self):
+        """Return the device_info of the device."""
+        return {
+            "identifiers": {(DOMAIN, self._device.name)},
+            "name": self._device.name,
+            "model": "IT500 Salus",
+            "manufacturer": MANUFACTURER,
+        }
+
+    async def async_set_temperature(self, **kwargs):
+        """Set a new target temperature."""
+        await self._coordinator.set_manual_temperature_override(
+            kwargs.get(ATTR_TEMPERATURE)
+        )
+        self.schedule_update_ha_state(False)

--- a/homeassistant/components/salus/config_flow.py
+++ b/homeassistant/components/salus/config_flow.py
@@ -1,0 +1,115 @@
+"""Config flow for user setup."""
+
+import logging
+from typing import Any, Dict
+
+from requests import ConnectTimeout, HTTPError
+from salus.api import Api
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers.typing import HomeAssistantType
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def validate_input(hass: HomeAssistantType, data: dict) -> Dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from DATA_SCHEMA with values provided by the user.
+    """
+    # constructor does login call
+    Api(
+        data[CONF_USERNAME],
+        data[CONF_PASSWORD],
+    )
+
+    return True
+
+
+def get_salus_devices(hass: HomeAssistantType, data: dict) -> Dict[str, Any]:
+    """Get a list of available Salus devices in user account."""
+    api = Api(
+        data[CONF_USERNAME],
+        data[CONF_PASSWORD],
+    )
+    return api.get_devices()
+
+
+class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Config flow for Salus integration."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input):
+        """Handle a flow initiated by the user."""
+
+        errors = {}
+        default_username = ""
+
+        if user_input is not None:
+            default_username = user_input[CONF_USERNAME]
+            try:
+                await self.hass.async_add_executor_job(
+                    validate_input, self.hass, user_input
+                )
+            except (ConnectTimeout, HTTPError):
+                errors["base"] = "cannot_connect"
+            except Exception as e:  # pylint: disable=broad-except
+                if e.__str__() == "Invalid credentials":
+                    errors["base"] = "invalid_auth"
+                else:
+                    _LOGGER.exception("Unexpected exception")
+                    return self.async_abort(reason="unknown")
+            else:
+                self.user_data = user_input
+                self.devices = await self.hass.async_add_executor_job(
+                    get_salus_devices, self.hass, user_input
+                )
+
+                return await self.async_step_device()
+
+        form_schema = {
+            vol.Required(CONF_USERNAME, default=default_username): str,
+            vol.Required(CONF_PASSWORD): str,
+        }
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(form_schema),
+            errors=errors,
+        )
+
+    async def async_step_device(self, user_input=None):
+        """Second step to choose device to configure in this process."""
+        errors = {}
+
+        if user_input is not None:
+            data = {}
+            device_name = user_input[CONF_DEVICE]
+            device_id = next(d.device_id for d in self.devices if d.name == device_name)
+
+            await self.async_set_unique_id(f"salus-{device_id}")
+            self._abort_if_unique_id_configured()
+
+            data[CONF_USERNAME] = self.user_data[CONF_USERNAME]
+            data[CONF_PASSWORD] = self.user_data[CONF_PASSWORD]
+            data[CONF_DEVICE] = device_id
+
+            return self.async_create_entry(title=device_name, data=data)
+
+        device_names = [d.name for d in self.devices]
+
+        form_schema = {
+            vol.Required(CONF_DEVICE): vol.In(device_names),
+        }
+
+        return self.async_show_form(
+            step_id="device",
+            data_schema=vol.Schema(form_schema),
+            errors=errors,
+        )

--- a/homeassistant/components/salus/config_flow.py
+++ b/homeassistant/components/salus/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.typing import HomeAssistantType
 
+# pylint: disable=unused-import
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,7 +46,14 @@ class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_step_user(self, user_input):
+    def __init__(self):
+        """Initialize SalusConfigFlow data updater."""
+        self.user_data = None
+        self.devices = []
+
+        super().__init__()
+
+    async def async_step_user(self, user_input=None):
         """Handle a flow initiated by the user."""
 
         errors = {}
@@ -59,8 +67,8 @@ class SalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             except (ConnectTimeout, HTTPError):
                 errors["base"] = "cannot_connect"
-            except Exception as e:  # pylint: disable=broad-except
-                if e.__str__() == "Invalid credentials":
+            except Exception as error:  # pylint: disable=broad-except
+                if error.__str__() == "Invalid credentials":
                     errors["base"] = "invalid_auth"
                 else:
                     _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/salus/config_flow.py
+++ b/homeassistant/components/salus/config_flow.py
@@ -3,21 +3,20 @@
 import logging
 from typing import Any, Dict
 
-from requests import ConnectTimeout, HTTPError
+from requests.exceptions import ConnectTimeout, HTTPError
 from salus.api import Api
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
-# pylint: disable=unused-import
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 
-def validate_input(hass: HomeAssistantType, data: dict) -> Dict[str, Any]:
+def validate_input(hass: HomeAssistant, data: dict) -> bool:
     """Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
@@ -31,7 +30,7 @@ def validate_input(hass: HomeAssistantType, data: dict) -> Dict[str, Any]:
     return True
 
 
-def get_salus_devices(hass: HomeAssistantType, data: dict) -> Dict[str, Any]:
+def get_salus_devices(hass: HomeAssistant, data: dict) -> Dict[str, Any]:
     """Get a list of available Salus devices in user account."""
     api = Api(
         data[CONF_USERNAME],

--- a/homeassistant/components/salus/const.py
+++ b/homeassistant/components/salus/const.py
@@ -1,0 +1,7 @@
+"""Constants for the Salus integration."""
+
+DOMAIN = "salus"
+
+MANUFACTURER = "Salus"
+
+PLATFORMS = ["climate"]

--- a/homeassistant/components/salus/coordinator.py
+++ b/homeassistant/components/salus/coordinator.py
@@ -1,0 +1,58 @@
+"""Provides the Salus integration DataUpdateCoordinator."""
+from datetime import timedelta
+import logging
+
+from async_timeout import timeout
+from requests import ConnectTimeout, HTTPError
+from salus.api import Api
+
+from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SalusDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Salus data."""
+
+    def __init__(self, hass: HomeAssistantType, *, api: Api, device_id: str):
+        """Initialize global Salus data updater."""
+        self.salus = api
+        self._device_id = device_id
+        update_interval = timedelta(seconds=15)
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=update_interval,
+        )
+
+    def _update_data(self) -> dict:
+        """Fetch data from Salus device."""
+        return self.salus.get_device_reading(self._device_id)
+
+    async def _async_update_data(self) -> dict:
+        """Fetch data from Salus."""
+
+        try:
+            async with timeout(15):
+                return await self.hass.async_add_executor_job(self._update_data)
+        except (ConnectTimeout, HTTPError) as error:
+            raise UpdateFailed(f"Invalid response from API: {error}") from error
+
+    def _update_temperature(self, temperature: float):
+        """Update the target temperature - doing a manual override."""
+        self.salus.set_manual_override(self._device_id, temperature)
+
+    async def set_manual_temperature_override(self, temperature: float):
+        """Async update the target temperature - doing a manual override."""
+        try:
+            async with timeout(15):
+                return await self.hass.async_add_executor_job(
+                    lambda: self._update_temperature(temperature)
+                )
+        except (ConnectTimeout, HTTPError) as error:
+            raise UpdateFailed(f"Invalid response from API: {error}") from error

--- a/homeassistant/components/salus/manifest.json
+++ b/homeassistant/components/salus/manifest.json
@@ -1,0 +1,9 @@
+{
+  "config_flow": true,
+  "domain": "salus",
+  "name": "Salus",
+  "documentation": "https://www.home-assistant.io/integrations/salus",
+  "requirements": ["py-salus==0.1.3"],
+  "codeowners": ["@cipacda"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/salus/manifest.json
+++ b/homeassistant/components/salus/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://www.home-assistant.io/integrations/salus",
   "requirements": ["py-salus==0.1.3"],
   "codeowners": ["@cipacda"],
-  "quality_scale": "internal"
+  "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/salus/strings.json
+++ b/homeassistant/components/salus/strings.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "flow_title": "Salus: {name}",
+    "step": {
+      "device": {
+        "title": "Select device",
+        "data": {
+          "device": "[%key:common::config_flow::data::device%]"
+        }
+      },
+      "user": {
+        "title": "Connect to it500 Salus",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "abort": {
+      "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    }
+  }
+}

--- a/homeassistant/components/salus/translations/en.json
+++ b/homeassistant/components/salus/translations/en.json
@@ -1,0 +1,28 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Already configured. Only a single configuration possible.",
+            "unknown": "Unexpected error"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication"
+        },
+        "flow_title": "Salus: {name}",
+        "step": {
+            "device": {
+                "data": {
+                    "device": "Device"
+                },
+                "title": "Select device"
+            },
+            "user": {
+                "data": {
+                    "password": "Password",
+                    "username": "Username"
+                },
+                "title": "Connect to it500 Salus"
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -244,6 +244,7 @@ FLOWS = [
     "roon",
     "rpi_power",
     "ruckus_unleashed",
+    "salus",
     "samsungtv",
     "screenlogic",
     "sense",

--- a/homeassistant/strings.json
+++ b/homeassistant/strings.json
@@ -45,7 +45,8 @@
         "latitude": "Latitude",
         "location": "Location",
         "pin": "PIN Code",
-        "mode": "Mode"
+        "mode": "Mode",
+        "device": "Device"
       },
       "create_entry": {
         "authenticated": "Successfully authenticated"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1289,6 +1289,9 @@ py-melissa-climate==2.1.4
 # homeassistant.components.nightscout
 py-nightscout==1.2.2
 
+# homeassistant.components.salus
+py-salus==0.1.3
+
 # homeassistant.components.schluter
 py-schluter==0.1.7
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -767,13 +767,11 @@ py-melissa-climate==2.1.4
 # homeassistant.components.nightscout
 py-nightscout==1.2.2
 
-<<<<<<< HEAD
-# homeassistant.components.synology_dsm
-py-synologydsm-api==1.0.4
-=======
 # homeassistant.components.salus
 py-salus==0.1.3
->>>>>>> ac7be2d7fc (Add it500 Salus integration)
+
+# homeassistant.components.synology_dsm
+py-synologydsm-api==1.0.4
 
 # homeassistant.components.seventeentrack
 py17track==3.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -767,8 +767,13 @@ py-melissa-climate==2.1.4
 # homeassistant.components.nightscout
 py-nightscout==1.2.2
 
+<<<<<<< HEAD
 # homeassistant.components.synology_dsm
 py-synologydsm-api==1.0.4
+=======
+# homeassistant.components.salus
+py-salus==0.1.3
+>>>>>>> ac7be2d7fc (Add it500 Salus integration)
 
 # homeassistant.components.seventeentrack
 py17track==3.2.1

--- a/tests/components/salus/__init__.py
+++ b/tests/components/salus/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the salus component."""

--- a/tests/components/salus/mocks.py
+++ b/tests/components/salus/mocks.py
@@ -1,0 +1,48 @@
+"""The test for the NuHeat thermostat module."""
+from unittest.mock import MagicMock, Mock
+
+from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
+
+MOCK_DEVICE_ID = "12345"
+MOCK_DEVICE_NAME = "IT500 Salus"
+
+MOCK_CONFIG_ENTRY = {
+    CONF_USERNAME: "test@salus.com",
+    CONF_PASSWORD: "salusPassword",
+    CONF_DEVICE: MOCK_DEVICE_ID,
+}
+
+
+def _get_mock_device():
+    mock_device = Mock(
+        device_id=MOCK_DEVICE_ID,
+    )
+    mock_device.name = MOCK_DEVICE_NAME
+    return mock_device
+
+
+def _get_mock_device_reading():
+    return Mock(
+        current_temperature=21.5,
+        current_target_temperature=23.5,
+        heat_on=True,
+    )
+
+
+def _get_mock_device_reading_not_heating():
+    return Mock(
+        current_temperature=23,
+        current_target_temperature=22.5,
+        heat_on=False,
+    )
+
+
+def _get_mock_salus(get_mock_device_reading=_get_mock_device_reading):
+    salus_mock = MagicMock()
+    type(salus_mock).login = MagicMock()
+    type(salus_mock).get_devices = MagicMock(return_value=[_get_mock_device()])
+    type(salus_mock).get_device_reading = MagicMock(
+        return_value=get_mock_device_reading()
+    )
+
+    return salus_mock

--- a/tests/components/salus/test_climate.py
+++ b/tests/components/salus/test_climate.py
@@ -1,0 +1,75 @@
+"""The test for the NuHeat thermostat module."""
+from unittest.mock import patch
+
+from homeassistant.components.salus.const import DOMAIN
+
+from .mocks import (
+    MOCK_CONFIG_ENTRY,
+    _get_mock_device_reading_not_heating,
+    _get_mock_salus,
+)
+
+from tests.common import MockConfigEntry
+
+
+async def test_climate_thermostat_run(hass):
+    """Test a thermostat with the schedule running."""
+    mock_salus = _get_mock_salus()
+
+    with patch(
+        "homeassistant.components.salus.Api",
+        return_value=mock_salus,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.it500_salus_temperature")
+    assert state.state == "heat"
+    expected_attributes = {
+        "hvac_modes": ["heat"],
+        "min_temp": 7,
+        "max_temp": 35,
+        "hvac_action": "heating",
+        "current_temperature": 21.5,
+        "temperature": 23.5,
+        "friendly_name": "IT500 Salus Temperature",
+        "supported_features": 1,
+    }
+
+    # Only test for a subset of attributes in case
+    # HA changes the implementation and a new one appears
+    assert all(item in state.attributes.items() for item in expected_attributes.items())
+
+
+async def test_climate_thermostat_not_heating(hass):
+    """Test a thermostat with the schedule not running."""
+    mock_salus = _get_mock_salus(_get_mock_device_reading_not_heating)
+
+    with patch(
+        "homeassistant.components.salus.Api",
+        return_value=mock_salus,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.it500_salus_temperature")
+    print(state.attributes.items())
+    assert state.state == "off"
+    expected_attributes = {
+        "hvac_modes": ["heat"],
+        "min_temp": 7,
+        "max_temp": 35,
+        "hvac_action": "idle",
+        "current_temperature": 23,
+        "temperature": 22.5,
+        "friendly_name": "IT500 Salus Temperature",
+        "supported_features": 1,
+    }
+
+    # Only test for a subset of attributes in case
+    # HA changes the implementation and a new one appears
+    assert all(item in state.attributes.items() for item in expected_attributes.items())

--- a/tests/components/salus/test_climate.py
+++ b/tests/components/salus/test_climate.py
@@ -1,10 +1,16 @@
-"""The test for the NuHeat thermostat module."""
-from unittest.mock import patch
+"""The test for the Salus thermostat module."""
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+from requests import HTTPError
 
 from homeassistant.components.salus.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .mocks import (
     MOCK_CONFIG_ENTRY,
+    MOCK_DEVICE_ID,
     _get_mock_device_reading_not_heating,
     _get_mock_salus,
 )
@@ -73,3 +79,62 @@ async def test_climate_thermostat_not_heating(hass):
     # Only test for a subset of attributes in case
     # HA changes the implementation and a new one appears
     assert all(item in state.attributes.items() for item in expected_attributes.items())
+
+
+async def test_climate_set_temperature(hass):
+    """Test setting a temperature."""
+    mock_salus = _get_mock_salus(_get_mock_device_reading_not_heating)
+    mock_set_temperature = MagicMock()
+    type(mock_salus).set_manual_override = mock_set_temperature
+
+    with patch(
+        "homeassistant.components.salus.Api",
+        return_value=mock_salus,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "climate",
+        "set_temperature",
+        service_data={
+            ATTR_ENTITY_ID: "climate.it500_salus_temperature",
+            "temperature": 22,
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_set_temperature.assert_called_once_with(MOCK_DEVICE_ID, 22)
+
+
+async def test_climate_set_temperature_on_error(hass):
+    """Test setting a temperature."""
+    mock_salus = _get_mock_salus()
+    mock_set_temperature = MagicMock()
+    mock_set_temperature.side_effect = HTTPError(Mock(status=500), "unknown")
+    type(mock_salus).set_manual_override = mock_set_temperature
+
+    with patch(
+        "homeassistant.components.salus.Api",
+        return_value=mock_salus,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    with pytest.raises(UpdateFailed):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            service_data={
+                ATTR_ENTITY_ID: "climate.it500_salus_temperature",
+                "temperature": 22,
+            },
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    mock_set_temperature.assert_called_once_with(MOCK_DEVICE_ID, 22)

--- a/tests/components/salus/test_config_flow.py
+++ b/tests/components/salus/test_config_flow.py
@@ -1,0 +1,124 @@
+"""Test the NuHeat config flow."""
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from homeassistant import config_entries
+from homeassistant.components.salus.const import DOMAIN
+from homeassistant.const import CONF_DEVICE, CONF_PASSWORD, CONF_USERNAME
+
+from .mocks import MOCK_DEVICE_ID, MOCK_DEVICE_NAME, _get_mock_salus
+
+
+async def test_form_user(hass):
+    """Test we get the form with user source."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.salus.config_flow.Api",
+        return_value=_get_mock_salus(),
+    ), patch(
+        "homeassistant.components.salus.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.salus.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+        assert result2["type"] == "form"
+        assert result2["errors"] == {}
+        assert result2["step_id"] == "device"
+
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {
+                CONF_DEVICE: MOCK_DEVICE_NAME,
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == "create_entry"
+    assert result3["data"] == {
+        CONF_USERNAME: "test-username",
+        CONF_PASSWORD: "test-password",
+        CONF_DEVICE: MOCK_DEVICE_ID,
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.salus.config_flow.Api.login",
+        side_effect=requests.ConnectTimeout(MagicMock(), MagicMock()),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.salus.config_flow.Api.login",
+        side_effect=Exception("Invalid credentials"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_unknown_error_abort(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.salus.config_flow.Api.login",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_USERNAME: "test-username",
+                CONF_PASSWORD: "test-password",
+            },
+        )
+
+    assert result2["type"] == "abort"
+    assert result2["reason"] == "unknown"

--- a/tests/components/salus/test_coordinator.py
+++ b/tests/components/salus/test_coordinator.py
@@ -1,0 +1,29 @@
+"""The test for the Salus data update coordinator."""
+from unittest.mock import MagicMock, Mock
+
+import pytest
+from requests import HTTPError
+
+from homeassistant.components.salus.coordinator import SalusDataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from .mocks import MOCK_DEVICE_ID, _get_mock_salus
+
+
+async def test_coordinator_update_error(hass):
+    """Test getting an error on data update."""
+    mock_salus = _get_mock_salus()
+    mock_get_device_readings = MagicMock()
+    mock_get_device_readings.side_effect = HTTPError(Mock(status=500), "unknown")
+    type(mock_salus).get_device_reading = mock_get_device_readings
+
+    coordinator = SalusDataUpdateCoordinator(
+        hass,
+        api=mock_salus,
+        device_id=MOCK_DEVICE_ID,
+    )
+
+    with pytest.raises(UpdateFailed):
+        await coordinator._async_update_data()
+
+    mock_get_device_readings.assert_called_once_with(MOCK_DEVICE_ID)

--- a/tests/components/salus/test_init.py
+++ b/tests/components/salus/test_init.py
@@ -1,0 +1,22 @@
+"""Salus component tests."""
+from unittest.mock import patch
+
+from homeassistant.components.salus.const import DOMAIN
+
+from .mocks import MOCK_CONFIG_ENTRY, _get_mock_salus
+
+from tests.common import MockConfigEntry
+
+
+async def test_init_success(hass):
+    """Test that we can setup with valid config."""
+    mock_salus = _get_mock_salus()
+
+    with patch(
+        "homeassistant.components.salus.Api",
+        return_value=mock_salus,
+    ):
+        config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG_ENTRY)
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR includes adding an integration of IT500 Salus thermostat device. This is done using a library (py-salus) I developed as well. Currently the integration is basic and only allows for overriding the current target temperature and does not handle any of the automated schedules. 
During configuration a user will need to select a device to configure, as Salus only offers one account and some devices under the account may be part of a different home.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

I used the cofig flow to setup the integration and not a configuration.yaml file. Should I?
```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x ] The code change is tested and works locally.
- [x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [x ] I have followed the [development checklist][dev-checklist]
- [x ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x ] Documentation added/updated for [www.home-assistant.io][docs-repository]
(PR to be submitted today as well)

If the code communicates with devices, web services, or third-party tools:

- [x ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.
Being my first PR, I'd first like to go through with it, make sure I am aligned with your practices and in the following PRs I will make sure I review some other PRs as well. I expect to do more PRs to add more features to this integration at least, but likely others as well.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
