### PR TITLE
Raise an exception when event_type exceeds the max length

### DIFF
--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 from sqlalchemy.orm.session import Session
 
+from homeassistant.const import MAX_LENGTH_EVENT_TYPE
 from homeassistant.core import Context, Event, EventOrigin, State, split_entity_id
 from homeassistant.helpers.json import JSONEncoder
 import homeassistant.util.dt as dt_util
@@ -53,7 +54,7 @@ class Events(Base):  # type: ignore
     }
     __tablename__ = TABLE_EVENTS
     event_id = Column(Integer, primary_key=True)
-    event_type = Column(String(64))
+    event_type = Column(String(MAX_LENGTH_EVENT_TYPE))
     event_data = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
     origin = Column(String(32))
     time_fired = Column(DATETIME_TYPE, index=True)

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -23,7 +23,7 @@ ENTITY_MATCH_ALL = "all"
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
 # Max characters for an event_type
-MAX_CHARACTERS_EVENT_TYPE = 32
+MAX_LENGTH_EVENT_TYPE = 32
 
 # Sun events
 SUN_EVENT_SUNSET = "sunset"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -22,6 +22,9 @@ ENTITY_MATCH_ALL = "all"
 # If no name is specified
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
+# Max characters for an event_type
+MAX_CHARACTERS_EVENT_TYPE = 32
+
 # Sun events
 SUN_EVENT_SUNSET = "sunset"
 SUN_EVENT_SUNRISE = "sunrise"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -22,7 +22,8 @@ ENTITY_MATCH_ALL = "all"
 # If no name is specified
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
-# Max characters for an event_type
+# Max characters for an event_type (changing this requires a recorder
+# database migration)
 MAX_LENGTH_EVENT_TYPE = 64
 
 # Sun events

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -23,7 +23,7 @@ ENTITY_MATCH_ALL = "all"
 DEVICE_DEFAULT_NAME = "Unnamed Device"
 
 # Max characters for an event_type
-MAX_LENGTH_EVENT_TYPE = 32
+MAX_LENGTH_EVENT_TYPE = 64
 
 # Sun events
 SUN_EVENT_SUNSET = "sunset"

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -58,7 +58,7 @@ from homeassistant.const import (
     EVENT_TIMER_OUT_OF_SYNC,
     LENGTH_METERS,
     MATCH_ALL,
-    MAX_CHARACTERS_EVENT_TYPE,
+    MAX_LENGTH_EVENT_TYPE,
     __version__,
 )
 from homeassistant.exceptions import (
@@ -699,8 +699,8 @@ class EventBus:
 
         This method must be run in the event loop.
         """
-        if len(event_type) > MAX_CHARACTERS_EVENT_TYPE:
-            raise MaxLengthExceeded(event_type, "event_type", MAX_CHARACTERS_EVENT_TYPE)
+        if len(event_type) > MAX_LENGTH_EVENT_TYPE:
+            raise MaxLengthExceeded(event_type, "event_type", MAX_LENGTH_EVENT_TYPE)
 
         listeners = self._listeners.get(event_type, [])
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -58,12 +58,14 @@ from homeassistant.const import (
     EVENT_TIMER_OUT_OF_SYNC,
     LENGTH_METERS,
     MATCH_ALL,
+    MAX_CHARACTERS_EVENT_TYPE,
     __version__,
 )
 from homeassistant.exceptions import (
     HomeAssistantError,
     InvalidEntityFormatError,
     InvalidStateError,
+    MaxLengthExceeded,
     ServiceNotFound,
     Unauthorized,
 )
@@ -697,6 +699,9 @@ class EventBus:
 
         This method must be run in the event loop.
         """
+        if len(event_type) > MAX_CHARACTERS_EVENT_TYPE:
+            raise MaxLengthExceeded(event_type, "event_type", MAX_CHARACTERS_EVENT_TYPE)
+
         listeners = self._listeners.get(event_type, [])
 
         # EVENT_HOMEASSISTANT_CLOSE should go only to his listeners

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -154,3 +154,27 @@ class ServiceNotFound(HomeAssistantError):
     def __str__(self) -> str:
         """Return string representation."""
         return f"Unable to find service {self.domain}.{self.service}"
+
+
+class MaxLengthExceeded(HomeAssistantError):
+    """Raised when a property value has exceeded the max character length."""
+
+    def __init__(self, value: str, property_name: str, max_length: int) -> None:
+        """Initialize error."""
+        super().__init__(
+            self,
+            (
+                f"Value {value} for property {property_name} has a max length of "
+                f"{max_length} characters"
+            ),
+        )
+        self.value = value
+        self.property_name = property_name
+        self.max_length = max_length
+
+    def __str__(self) -> str:
+        """Return string representation."""
+        return (
+            f"Value {self.value} for property {self.property_name} has a max length "
+            f"of {self.max_length} characters"
+        )

--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -171,10 +171,3 @@ class MaxLengthExceeded(HomeAssistantError):
         self.value = value
         self.property_name = property_name
         self.max_length = max_length
-
-    def __str__(self) -> str:
-        """Return string representation."""
-        return (
-            f"Value {self.value} for property {self.property_name} has a max length "
-            f"of {self.max_length} characters"
-        )

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -164,7 +164,7 @@ async def async_setup_reload_service(
     async def _reload_config(call: Event) -> None:
         """Reload the platforms."""
         await async_reload_integration_platforms(hass, domain, platforms)
-        hass.bus.async_fire(f"event_{domain}_reloaded", context=call.context)
+        hass.bus.async_fire(f"{domain}_reloaded", context=call.context)
 
     hass.helpers.service.async_register_admin_service(
         domain, SERVICE_RELOAD, _reload_config

--- a/homeassistant/helpers/reload.py
+++ b/homeassistant/helpers/reload.py
@@ -164,7 +164,7 @@ async def async_setup_reload_service(
     async def _reload_config(call: Event) -> None:
         """Reload the platforms."""
         await async_reload_integration_platforms(hass, domain, platforms)
-        hass.bus.async_fire(f"{domain}_reloaded", context=call.context)
+        hass.bus.async_fire(f"event_{domain}_reloaded", context=call.context)
 
     hass.helpers.service.async_register_admin_service(
         domain, SERVICE_RELOAD, _reload_config

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -536,7 +536,7 @@ async def test_eventbus_max_length_exceeded(hass):
         hass.bus.async_fire(long_evt_name)
 
     assert exc_info.value.property_name == "event_type"
-    assert exc_info.value.max_length == 32
+    assert exc_info.value.max_length == 64
     assert exc_info.value.value == long_evt_name
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -528,10 +528,16 @@ async def test_eventbus_coroutine_event_listener(hass):
 async def test_eventbus_max_length_exceeded(hass):
     """Test that an exception is raised when the max character length is exceeded."""
 
-    with pytest.raises(MaxLengthExceeded):
-        hass.bus.async_fire(
-            "this_event_exceeds_the_max_character_length_even_after_extending_the_limit"
-        )
+    long_evt_name = (
+        "this_event_exceeds_the_max_character_length_even_with_the_new_limit"
+    )
+
+    with pytest.raises(MaxLengthExceeded) as exc_info:
+        hass.bus.async_fire(long_evt_name)
+
+    assert exc_info.value.property_name == "event_type"
+    assert exc_info.value.max_length == 32
+    assert exc_info.value.value == long_evt_name
 
 
 def test_state_init():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -529,7 +529,9 @@ async def test_eventbus_max_length_exceeded(hass):
     """Test that an exception is raised when the max character length is exceeded."""
 
     with pytest.raises(MaxLengthExceeded):
-        hass.bus.async_fire("this_event_exceeds_the_max_character_length")
+        hass.bus.async_fire(
+            "this_event_exceeds_the_max_character_length_even_after_extending_the_limit"
+        )
 
 
 def test_state_init():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,6 +36,7 @@ import homeassistant.core as ha
 from homeassistant.exceptions import (
     InvalidEntityFormatError,
     InvalidStateError,
+    MaxLengthExceeded,
     ServiceNotFound,
 )
 import homeassistant.util.dt as dt_util
@@ -522,6 +523,13 @@ async def test_eventbus_coroutine_event_listener(hass):
     hass.bus.async_fire("test_coroutine")
     await hass.async_block_till_done()
     assert len(coroutine_calls) == 1
+
+
+async def test_eventbus_max_length_exceeded(hass):
+    """Test that an exception is raised when the max character length is exceeded."""
+
+    with pytest.raises(MaxLengthExceeded):
+        hass.bus.async_fire("this_event_exceeds_the_max_character_length")
 
 
 def test_state_init():


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
- An event fired with an `event_type` of more than 64 characters would previously result in recorder errors but the event would otherwise work. Now, firing an event with more than 64 characters in the event type will raise immediately. Custom integration authors should review their event types.


## Proposed change
There is an implicit max length of 64 characters for the `event_type` property of an event. Tests will pass fine when you use the wrong length, but in production you will get recorder errors because the column size is 64 for the recorder. Here we explicitly raise an exception when the max length is exceeded so that we prevent developers from exceeding this.

Requires https://github.com/home-assistant/core/pull/47748 to be merged first


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
