### PR TITLE
Increase test coverage of deCONZ device triggers

### DIFF
--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -414,16 +414,12 @@ async def async_validate_trigger_config(hass, config):
 
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
 
-    if (
-        not device
-        or device.model not in REMOTES
-        or trigger not in REMOTES[device.model]
-    ):
-        if not device:
-            raise InvalidDeviceAutomationConfig(
-                f"deCONZ trigger {trigger} device with id "
-                f"{config[CONF_DEVICE_ID]} not found"
-            )
+    if not device:
+        raise InvalidDeviceAutomationConfig(
+            f"deCONZ trigger {trigger} device with ID "
+            f"{config[CONF_DEVICE_ID]} not found"
+        )
+    elif device.model not in REMOTES or trigger not in REMOTES[device.model]:
         raise InvalidDeviceAutomationConfig(
             f"deCONZ trigger {trigger} is not valid for device "
             f"{device} ({config[CONF_DEVICE_ID]})"

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -453,6 +453,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
         event_trigger.CONF_EVENT_TYPE: CONF_DECONZ_EVENT,
         event_trigger.CONF_EVENT_DATA: {CONF_UNIQUE_ID: event_id, **trigger},
     }
+
     event_config = event_trigger.TRIGGER_SCHEMA(event_config)
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, automation_info, platform_type="device"

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -453,7 +453,6 @@ async def async_attach_trigger(hass, config, action, automation_info):
         event_trigger.CONF_EVENT_TYPE: CONF_DECONZ_EVENT,
         event_trigger.CONF_EVENT_DATA: {CONF_UNIQUE_ID: event_id, **trigger},
     }
-
     event_config = event_trigger.TRIGGER_SCHEMA(event_config)
     return await event_trigger.async_attach_trigger(
         hass, event_config, action, automation_info, platform_type="device"

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 )
 
 from . import DOMAIN
-from .const import LOGGER
 from .deconz_event import CONF_DECONZ_EVENT, CONF_GESTURE
 
 CONF_SUBTYPE = "subtype"
@@ -440,8 +439,9 @@ async def async_attach_trigger(hass, config, action, automation_info):
 
     deconz_event = _get_deconz_event_from_device_id(hass, device.id)
     if deconz_event is None:
-        LOGGER.error("No deconz_event tied to device %s found", device.name)
-        raise InvalidDeviceAutomationConfig
+        raise InvalidDeviceAutomationConfig(
+            f'No deconz_event tied to device "{device.name}" found'
+        )
 
     event_id = deconz_event.serial
 

--- a/homeassistant/components/deconz/device_trigger.py
+++ b/homeassistant/components/deconz/device_trigger.py
@@ -419,7 +419,8 @@ async def async_validate_trigger_config(hass, config):
             f"deCONZ trigger {trigger} device with ID "
             f"{config[CONF_DEVICE_ID]} not found"
         )
-    elif device.model not in REMOTES or trigger not in REMOTES[device.model]:
+
+    if device.model not in REMOTES or trigger not in REMOTES[device.model]:
         raise InvalidDeviceAutomationConfig(
             f"deCONZ trigger {trigger} is not valid for device "
             f"{device} ({config[CONF_DEVICE_ID]})"

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -2,6 +2,9 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.deconz import device_trigger
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.device_trigger import CONF_SUBTYPE
@@ -14,33 +17,22 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_TYPE,
 )
+from homeassistant.setup import async_setup_component
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
-from tests.common import assert_lists_same, async_get_device_automations
+from tests.common import (
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+)
 from tests.components.blueprint.conftest import stub_blueprint_populate  # noqa: F401
 
-SENSORS = {
-    "1": {
-        "config": {
-            "alert": "none",
-            "battery": 60,
-            "group": "10",
-            "on": True,
-            "reachable": True,
-        },
-        "ep": 1,
-        "etag": "1b355c0b6d2af28febd7ca9165881952",
-        "manufacturername": "IKEA of Sweden",
-        "mode": 1,
-        "modelid": "TRADFRI on/off switch",
-        "name": "TRÅDFRI on/off switch ",
-        "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
-        "swversion": "1.4.018",
-        "type": "ZHASwitch",
-        "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
-    }
-}
+
+@pytest.fixture
+def automation_calls(hass):
+    """Track automation calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
 
 
 async def test_get_triggers(hass, aioclient_mock):
@@ -135,14 +127,275 @@ async def test_get_triggers(hass, aioclient_mock):
     assert_lists_same(triggers, expected_triggers)
 
 
+async def test_get_triggers_manage_unsupported_remotes(hass, aioclient_mock):
+    """Verify no triggers for an unsupported remote."""
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "alert": "none",
+                    "group": "10",
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "1b355c0b6d2af28febd7ca9165881952",
+                "manufacturername": "IKEA of Sweden",
+                "mode": 1,
+                "modelid": "Unsupported model",
+                "name": "TRÅDFRI on/off switch ",
+                "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
+                "swversion": "1.4.018",
+                "type": "ZHASwitch",
+                "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
+    )
+
+    assert device_trigger._get_deconz_event_from_device_id(hass, device.id)
+
+    triggers = await async_get_device_automations(hass, "trigger", device.id)
+
+    expected_triggers = []
+
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_functional_device_trigger(
+    hass, aioclient_mock, mock_deconz_websocket, automation_calls
+):
+    """Test proper matching and attachment of device trigger automation."""
+    await async_setup_component(hass, "persistent_notification", {})
+
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "alert": "none",
+                    "battery": 60,
+                    "group": "10",
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "1b355c0b6d2af28febd7ca9165881952",
+                "manufacturername": "IKEA of Sweden",
+                "mode": 1,
+                "modelid": "TRADFRI on/off switch",
+                "name": "TRÅDFRI on/off switch ",
+                "state": {"buttonevent": 2002, "lastupdated": "2019-09-07T07:39:39"},
+                "swversion": "1.4.018",
+                "type": "ZHASwitch",
+                "uniqueid": "d0:cf:5e:ff:fe:71:a4:3a-01-1000",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
+    )
+
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DECONZ_DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_button_press"},
+                    },
+                },
+            ]
+        },
+    )
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"buttonevent": 1002},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert len(automation_calls) == 1
+    assert automation_calls[0].data["some"] == "test_trigger_button_press"
+
+
+async def test_validate_trigger_unknown_device(
+    hass, aioclient_mock, mock_deconz_websocket, automation_calls
+):
+    """Test unknown device does not return a trigger config."""
+    await setup_deconz_integration(hass, aioclient_mock)
+
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DECONZ_DOMAIN,
+                        CONF_DEVICE_ID: "unknown device",
+                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_button_press"},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(automation_calls) == 0
+
+
+async def test_validate_trigger_unsupported_device(
+    hass, aioclient_mock, mock_deconz_websocket, automation_calls
+):
+    """Test unsupported device doesn't return a trigger config."""
+    config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")},
+        model="unsupported",
+    )
+
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DECONZ_DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_button_press"},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(automation_calls) == 0
+
+
+async def test_validate_trigger_unsupported_trigger(
+    hass, aioclient_mock, mock_deconz_websocket, automation_calls
+):
+    """Test unsupported trigger does not return a trigger config."""
+    config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")},
+        model="TRADFRI on/off switch",
+    )
+
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DECONZ_DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: "unsupported",
+                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_button_press"},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(automation_calls) == 0
+
+
+async def test_attach_trigger_no_matching_event(
+    hass, aioclient_mock, mock_deconz_websocket, automation_calls
+):
+    """Test no matching event for device doesn't return a trigger config."""
+    config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")},
+        model="TRADFRI on/off switch",
+    )
+
+    assert await async_setup_component(
+        hass,
+        AUTOMATION_DOMAIN,
+        {
+            AUTOMATION_DOMAIN: [
+                {
+                    "trigger": {
+                        CONF_PLATFORM: "device",
+                        CONF_DOMAIN: DECONZ_DOMAIN,
+                        CONF_DEVICE_ID: device.id,
+                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "test_trigger_button_press"},
+                    },
+                },
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert len(automation_calls) == 0
+
+
 async def test_helper_no_match(hass, aioclient_mock):
     """Verify trigger helper returns None when no event could be matched."""
     await setup_deconz_integration(hass, aioclient_mock)
-    deconz_event = device_trigger._get_deconz_event_from_device_id(hass, "mock-id")
-    assert not deconz_event
+    assert not device_trigger._get_deconz_event_from_device_id(hass, "mock-id")
 
 
 async def test_helper_no_gateway_exist(hass):
     """Verify trigger helper returns None when no gateway exist."""
-    deconz_event = device_trigger._get_deconz_event_from_device_id(hass, "mock-id")
-    assert not deconz_event
+    assert not device_trigger._get_deconz_event_from_device_id(hass, "mock-id")

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -8,6 +8,9 @@ from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.deconz import device_trigger
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.device_trigger import CONF_SUBTYPE
+from homeassistant.components.device_automation.exceptions import (
+    InvalidDeviceAutomationConfig,
+)
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -286,19 +289,25 @@ async def test_validate_trigger_unsupported_device(
         model="unsupported",
     )
 
+    trigger_config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DECONZ_DOMAIN,
+        CONF_DEVICE_ID: device.id,
+        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+    }
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_validate_trigger_config(hass, trigger_config)
+        await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
         {
             AUTOMATION_DOMAIN: [
                 {
-                    "trigger": {
-                        CONF_PLATFORM: "device",
-                        CONF_DOMAIN: DECONZ_DOMAIN,
-                        CONF_DEVICE_ID: device.id,
-                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
-                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
-                    },
+                    "trigger": trigger_config,
                     "action": {
                         "service": "test.automation",
                         "data_template": {"some": "test_trigger_button_press"},
@@ -325,19 +334,25 @@ async def test_validate_trigger_unsupported_trigger(
         model="TRADFRI on/off switch",
     )
 
+    trigger_config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DECONZ_DOMAIN,
+        CONF_DEVICE_ID: device.id,
+        CONF_TYPE: "unsupported",
+        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+    }
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_validate_trigger_config(hass, trigger_config)
+        await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
         {
             AUTOMATION_DOMAIN: [
                 {
-                    "trigger": {
-                        CONF_PLATFORM: "device",
-                        CONF_DOMAIN: DECONZ_DOMAIN,
-                        CONF_DEVICE_ID: device.id,
-                        CONF_TYPE: "unsupported",
-                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
-                    },
+                    "trigger": trigger_config,
                     "action": {
                         "service": "test.automation",
                         "data_template": {"some": "test_trigger_button_press"},
@@ -364,19 +379,25 @@ async def test_attach_trigger_no_matching_event(
         model="TRADFRI on/off switch",
     )
 
+    trigger_config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DECONZ_DOMAIN,
+        CONF_DEVICE_ID: device.id,
+        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+    }
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_attach_trigger(hass, trigger_config, None, None)
+        await hass.async_block_till_done()
+
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
         {
             AUTOMATION_DOMAIN: [
                 {
-                    "trigger": {
-                        CONF_PLATFORM: "device",
-                        CONF_DOMAIN: DECONZ_DOMAIN,
-                        CONF_DEVICE_ID: device.id,
-                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
-                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
-                    },
+                    "trigger": trigger_config,
                     "action": {
                         "service": "test.automation",
                         "data_template": {"some": "test_trigger_button_press"},

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -208,19 +208,23 @@ async def test_functional_device_trigger(
         identifiers={(DECONZ_DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
     )
 
+    trigger_config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DECONZ_DOMAIN,
+        CONF_DEVICE_ID: device.id,
+        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+    }
+
+    assert await device_trigger.async_validate_trigger_config(hass, trigger_config)
+
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
         {
             AUTOMATION_DOMAIN: [
                 {
-                    "trigger": {
-                        CONF_PLATFORM: "device",
-                        CONF_DOMAIN: DECONZ_DOMAIN,
-                        CONF_DEVICE_ID: device.id,
-                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
-                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
-                    },
+                    "trigger": trigger_config,
                     "action": {
                         "service": "test.automation",
                         "data_template": {"some": "test_trigger_button_press"},
@@ -250,19 +254,24 @@ async def test_validate_trigger_unknown_device(
     """Test unknown device does not return a trigger config."""
     await setup_deconz_integration(hass, aioclient_mock)
 
+    trigger_config = {
+        CONF_PLATFORM: "device",
+        CONF_DOMAIN: DECONZ_DOMAIN,
+        CONF_DEVICE_ID: "unknown device",
+        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
+        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
+    }
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_validate_trigger_config(hass, trigger_config)
+
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
         {
             AUTOMATION_DOMAIN: [
                 {
-                    "trigger": {
-                        CONF_PLATFORM: "device",
-                        CONF_DOMAIN: DECONZ_DOMAIN,
-                        CONF_DEVICE_ID: "unknown device",
-                        CONF_TYPE: device_trigger.CONF_SHORT_PRESS,
-                        CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
-                    },
+                    "trigger": trigger_config,
                     "action": {
                         "service": "test.automation",
                         "data_template": {"some": "test_trigger_button_press"},
@@ -299,7 +308,6 @@ async def test_validate_trigger_unsupported_device(
 
     with pytest.raises(InvalidDeviceAutomationConfig):
         await device_trigger.async_validate_trigger_config(hass, trigger_config)
-        await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,
@@ -344,7 +352,6 @@ async def test_validate_trigger_unsupported_trigger(
 
     with pytest.raises(InvalidDeviceAutomationConfig):
         await device_trigger.async_validate_trigger_config(hass, trigger_config)
-        await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,
@@ -389,7 +396,6 @@ async def test_attach_trigger_no_matching_event(
 
     with pytest.raises(InvalidDeviceAutomationConfig):
         await device_trigger.async_attach_trigger(hass, trigger_config, None, None)
-        await hass.async_block_till_done()
 
     assert await async_setup_component(
         hass,

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -8,9 +8,6 @@ from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
 from homeassistant.components.deconz import device_trigger
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.components.deconz.device_trigger import CONF_SUBTYPE
-from homeassistant.components.device_automation.exceptions import (
-    InvalidDeviceAutomationConfig,
-)
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
@@ -377,9 +374,6 @@ async def test_attach_trigger_no_matching_event(
         CONF_SUBTYPE: device_trigger.CONF_TURN_ON,
     }
 
-    with pytest.raises(InvalidDeviceAutomationConfig):
-        await device_trigger.async_attach_trigger(hass, trigger_config, None, None)
-
     assert await async_setup_component(
         hass,
         AUTOMATION_DOMAIN,
@@ -399,8 +393,7 @@ async def test_attach_trigger_no_matching_event(
 
     assert len(hass.states.async_entity_ids(AUTOMATION_DOMAIN)) == 1
 
-    # async_attach_trigger raise InvalidDeviceAutomationConfig
-
+    # Assert that deCONZ async_attach_trigger raises InvalidDeviceAutomationConfig
     assert not await async_initialize_triggers(
         hass,
         [trigger_config],
@@ -409,14 +402,3 @@ async def test_attach_trigger_no_matching_event(
         name="mock-name",
         log_cb=Mock(),
     )
-
-
-async def test_helper_no_match(hass, aioclient_mock):
-    """Verify trigger helper returns None when no event could be matched."""
-    await setup_deconz_integration(hass, aioclient_mock)
-    assert not device_trigger._get_deconz_event_from_device_id(hass, "mock-id")
-
-
-async def test_helper_no_gateway_exist(hass):
-    """Verify trigger helper returns None when no gateway exist."""
-    assert not device_trigger._get_deconz_event_from_device_id(hass, "mock-id")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve test coverage of deCONZ device triggers

When this PR is merged deCONZ test coverage will be 100% 🎉 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
