### PR TITLE
ESPHome trigger reconnect immediately when mDNS record received

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -18,6 +18,7 @@ from aioesphomeapi import (
     UserServiceArgType,
 )
 import voluptuous as vol
+from zeroconf import DNSPointer, DNSRecord, RecordUpdateListener, Zeroconf
 
 from homeassistant import const
 from homeassistant.components import zeroconf
@@ -199,7 +200,9 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
             # Re-connection logic will trigger after this
             await cli.disconnect()
 
-    try_connect = await _setup_auto_reconnect_logic(hass, cli, entry, host, on_login)
+    reconnect_logic = ReconnectLogic(
+        hass, cli, entry, host, on_login, zeroconf_instance
+    )
 
     async def complete_setup() -> None:
         """Complete the config entry setup."""
@@ -207,85 +210,195 @@ async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool
         await entry_data.async_update_static_infos(hass, entry, infos)
         await _setup_services(hass, entry_data, services)
 
-        # Create connection attempt outside of HA's tracked task in order
-        # not to delay startup.
-        hass.loop.create_task(try_connect(is_disconnect=False))
+        await reconnect_logic.start()
+        entry_data.cleanup_callbacks.append(reconnect_logic.stop_callback)
 
     hass.async_create_task(complete_setup())
     return True
 
 
-async def _setup_auto_reconnect_logic(
-    hass: HomeAssistantType, cli: APIClient, entry: ConfigEntry, host: str, on_login
-):
-    """Set up the re-connect logic for the API client."""
+class ReconnectLogic(RecordUpdateListener):
+    """Reconnectiong logic handler for ESPHome config entries.
 
-    async def try_connect(tries: int = 0, is_disconnect: bool = True) -> None:
-        """Try connecting to the API client. Will retry if not successful."""
-        if entry.entry_id not in hass.data[DOMAIN]:
-            # When removing/disconnecting manually
+    Contains two reconnect strategies:
+     - Connect with increasing time between connection attempts.
+     - Listen to zeroconf mDNS records, if any records are found for this device, try reconnecting immediately.
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistantType,
+        cli: APIClient,
+        entry: ConfigEntry,
+        host: str,
+        on_login,
+        zc: Zeroconf,
+    ):
+        """Initialize ReconnectingLogic."""
+        self._hass = hass
+        self._cli = cli
+        self._entry = entry
+        self._host = host
+        self._on_login = on_login
+        self._zc = zc
+        self._connected = True
+        self._connected_lock = asyncio.Lock()
+        self._reconnect_event = asyncio.Event()
+        self._loop_task: asyncio.Task | None = None
+        self._tries = 0
+        self._tries_lock = asyncio.Lock()
+
+    @property
+    def _entry_data(self) -> RuntimeEntryData | None:
+        return self._hass.data[DOMAIN].get(self._entry.entry_id)
+
+    async def _on_disconnect(self):
+        if self._entry_data is None:
             return
+        # This can happen often depending on WiFi signal strength.
+        # So therefore all these connection warnings are logged
+        # as infos. The "unavailable" logic will still trigger so the
+        # user knows if the device is not connected.
+        _LOGGER.info("Disconnected from ESPHome API for %s", self._host)
 
-        device_registry = await hass.helpers.device_registry.async_get_registry()
-        devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-        for device in devices:
-            # There is only one device in ESPHome
-            if device.disabled:
-                # Don't attempt to connect if it's disabled
-                return
-
-        data: RuntimeEntryData = hass.data[DOMAIN][entry.entry_id]
-        for disconnect_cb in data.disconnect_callbacks:
+        # Run disconnect hooks
+        for disconnect_cb in self._entry_data.disconnect_callbacks:
             disconnect_cb()
-        data.disconnect_callbacks = []
-        data.available = False
-        data.async_update_device_state(hass)
+        self._entry_data.disconnect_callbacks = []
+        self._entry_data.available = False
+        self._entry_data.async_update_device_state(self._hass)
 
-        if is_disconnect:
-            # This can happen often depending on WiFi signal strength.
-            # So therefore all these connection warnings are logged
-            # as infos. The "unavailable" logic will still trigger so the
-            # user knows if the device is not connected.
-            _LOGGER.info("Disconnected from ESPHome API for %s", host)
+        # Reset tries
+        async with self._tries_lock:
+            self._tries = 0
+        # Connected needs to be reset before the reconnect event (opposite order of check)
+        async with self._connected_lock:
+            self._connected = False
+        self._reconnect_event.set()
 
-        if tries != 0:
-            # If not first re-try, wait and print message
-            # Cap wait time at 1 minute. This is because while working on the
-            # device (e.g. soldering stuff), users don't want to have to wait
-            # a long time for their device to show up in HA again (this was
-            # mentioned a lot in early feedback)
-            #
-            # In the future another API will be set up so that the ESP can
-            # notify HA of connectivity directly, but for new we'll use a
-            # really short reconnect interval.
-            tries = min(tries, 10)  # prevent OverflowError
-            wait_time = int(round(min(1.8 ** tries, 60.0)))
-            if tries == 1:
-                _LOGGER.info("Trying to reconnect to %s in the background", host)
-            _LOGGER.debug("Retrying %s in %d seconds", host, wait_time)
-            await asyncio.sleep(wait_time)
+    async def _wait_and_start_reconnect(self):
+        async with self._tries_lock:
+            tries = self._tries
+        # If not first re-try, wait and print message
+        # Cap wait time at 1 minute. This is because while working on the
+        # device (e.g. soldering stuff), users don't want to have to wait
+        # a long time for their device to show up in HA again (this was
+        # mentioned a lot in early feedback)
+        tries = min(tries, 10)  # prevent OverflowError
+        wait_time = int(round(min(1.8 ** tries, 60.0)))
+        if tries == 1:
+            _LOGGER.info("Trying to reconnect to %s in the background", self._host)
+        _LOGGER.debug("Retrying %s in %d seconds", self._host, wait_time)
+        await asyncio.sleep(wait_time)
+        self._reconnect_event.set()
+
+    async def _try_connect(self):
+        """Try connecting to the API client."""
+        async with self._tries_lock:
+            tries = self._tries
+            self._tries += 1
 
         try:
-            await cli.connect(on_stop=try_connect, login=True)
+            await self._cli.connect(on_stop=self._on_disconnect, login=True)
         except APIConnectionError as error:
             level = logging.WARNING if tries == 0 else logging.DEBUG
             _LOGGER.log(
                 level,
                 "Can't connect to ESPHome API for %s (%s): %s",
-                entry.unique_id,
-                host,
+                self._entry.unique_id,
+                self._host,
                 error,
             )
             # Schedule re-connect in event loop in order not to delay HA
             # startup. First connect is scheduled in tracked tasks.
-            data.reconnect_task = hass.loop.create_task(
-                try_connect(tries + 1, is_disconnect=False)
-            )
+            self._hass.loop.create_task(self._wait_and_start_reconnect())
         else:
-            _LOGGER.info("Successfully connected to %s", host)
-            hass.async_create_task(on_login())
+            _LOGGER.info("Successfully connected to %s", self._host)
+            async with self._tries_lock:
+                self._tries = 0
+            async with self._connected_lock:
+                self._connected = True
+            self._hass.async_create_task(self._on_login())
 
-    return try_connect
+    async def _reconnect_loop(self):
+        while True:
+            await self._reconnect_event.wait()
+            self._reconnect_event.clear()
+
+            async with self._connected_lock:
+                if self._connected:
+                    continue
+
+            # Check if the entry got removed or disabled, in which case we shouldn't reconnect
+            if self._entry.entry_id not in self._hass.data[DOMAIN]:
+                # When removing/disconnecting manually
+                return
+            device_registry = (
+                await self._hass.helpers.device_registry.async_get_registry()
+            )
+            devices = dr.async_entries_for_config_entry(
+                device_registry, self._entry.entry_id
+            )
+            for device in devices:
+                # There is only one device in ESPHome
+                if device.disabled:
+                    # Don't attempt to connect if it's disabled
+                    return
+
+            await self._try_connect()
+
+    async def start(self):
+        """Start the reconnecting logic background task."""
+        # Create reconnection loop outside of HA's tracked tasks in order
+        # not to delay startup.
+        self._loop_task = self._hass.loop.create_task(self._reconnect_loop())
+        # Listen for mDNS records so we can reconnect directly if a received mDNS record
+        # indicates the node is up again
+        await self._hass.async_add_executor_job(self._zc.add_listener, self, None)
+
+        async with self._connected_lock:
+            self._connected = False
+        self._reconnect_event.set()
+
+    async def stop(self):
+        """Stop the reconnecting logic background task. Does not disconnect the client."""
+        if self._loop_task is not None:
+            self._loop_task.cancel()
+            self._loop_task = None
+        await self._hass.async_add_executor_job(self._zc.remove_listener, self)
+
+    @callback
+    def stop_callback(self):
+        """Stop as an async callback function."""
+        self._hass.async_create_task(self.stop())
+
+    def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
+        """Listen to zeroconf updated mDNS records."""
+        if not isinstance(record, DNSPointer):
+            # We only consider PTR records and match using the alias name
+            return
+        if self._entry_data is None or self._entry_data.device_info is None:
+            # Either the entry was already teared down or we haven't received device info yet
+            return
+        filter_alias = f"{self._entry_data.device_info.name}._esphomelib._tcp.local."
+        if record.alias != filter_alias:
+            return
+
+        # This is a mDNS record from the device and could mean it just woke up
+        # Check if already connected, no lock needed for this access
+        if self._connected:
+            return
+
+        # Tell reconnection logic to retry connection attempt now (even before reconnect timer finishes)
+        async def set_reconnect():
+            self._reconnect_event.set()
+
+        _LOGGER.debug(
+            "%s: Triggering reconnect because of received mDNS record %s",
+            self._host,
+            record,
+        )
+        self._hass.add_job(set_reconnect)
 
 
 async def _async_setup_device_registry(
@@ -421,8 +534,6 @@ async def _cleanup_instance(
 ) -> RuntimeEntryData:
     """Cleanup the esphome client if it exists."""
     data: RuntimeEntryData = hass.data[DOMAIN].pop(entry.entry_id)
-    if data.reconnect_task is not None:
-        data.reconnect_task.cancel()
     for disconnect_cb in data.disconnect_callbacks:
         disconnect_cb()
     for cleanup_callback in data.cleanup_callbacks:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -341,9 +341,7 @@ class ReconnectLogic(RecordUpdateListener):
             if self._entry.entry_id not in self._hass.data[DOMAIN]:
                 # When removing/disconnecting manually
                 return
-            device_registry = (
-                await self._hass.helpers.device_registry.async_get_registry()
-            )
+            device_registry = self._hass.helpers.device_registry.async_get()
             devices = dr.async_entries_for_config_entry(
                 device_registry, self._entry.entry_id
             )

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -380,6 +380,9 @@ class ReconnectLogic(RecordUpdateListener):
         """Stop as an async callback function."""
         self._hass.async_create_task(self.stop())
 
+    async def _set_reconnect(self):
+        self._reconnect_event.set()
+
     def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
         """Listen to zeroconf updated mDNS records."""
         if not isinstance(record, DNSPointer):
@@ -398,15 +401,12 @@ class ReconnectLogic(RecordUpdateListener):
             return
 
         # Tell reconnection logic to retry connection attempt now (even before reconnect timer finishes)
-        async def set_reconnect():
-            self._reconnect_event.set()
-
         _LOGGER.debug(
             "%s: Triggering reconnect because of received mDNS record %s",
             self._host,
             record,
         )
-        self._hass.add_job(set_reconnect)
+        self._hass.add_job(self._set_reconnect)
 
 
 async def _async_setup_device_registry(

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -404,7 +404,8 @@ class ReconnectLogic(RecordUpdateListener):
         """Stop as an async callback function."""
         self._hass.async_create_task(self.stop())
 
-    async def _set_reconnect(self):
+    @callback
+    def _set_reconnect(self):
         self._reconnect_event.set()
 
     def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -54,7 +54,6 @@ class RuntimeEntryData:
     entry_id: str = attr.ib()
     client: APIClient = attr.ib()
     store: Store = attr.ib()
-    reconnect_task: asyncio.Task | None = attr.ib(default=None)
     state: dict[str, dict[str, Any]] = attr.ib(factory=dict)
     info: dict[str, dict[str, Any]] = attr.ib(factory=dict)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
**Problem**: ESPHome's native API has been difficult to use with the deep sleep feature, because home assistant only checks every 60s if the device is online again after sleep, so the device has to stay awake longer until HA connects and wasting power.

**Idea**: I had an idea yesterday: actually HA already knows when a device comes up again, because on startup the device broadcasts mDNS records on the network.

**This PR**: So this change implements an mDNS/zeroconf listener that triggers the reconnection logic immediately when such a DNS record is received.

In the process, I also refactored the logic into a new class `ReconnectLogic` because the code would have gotten messy otherwise. Note: not happy with the tries/connected/reconnect_event variables, but could not find more suitable synchronization primitives

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: none
- This PR is related to issue: none
- Link to documentation pull request: n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver (I think?)
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
