### PR TITLE
Warn on undefined variables in templates

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1318,7 +1318,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
 
     def __init__(self, hass, limited=False):
         """Initialise template environment."""
-        super().__init__()
+        super().__init__(undefined=jinja2.make_logging_undefined(logger=_LOGGER))
         self.hass = hass
         self.template_cache = weakref.WeakValueDictionary()
         self.filters["round"] = forgiving_round

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -442,7 +442,7 @@ async def test_error_querying_influx(
 
 
 @pytest.mark.parametrize(
-    "mock_client, config_ext, queries, set_query_mock, make_resultset",
+    "mock_client, config_ext, queries, set_query_mock, make_resultset, key",
     [
         (
             DEFAULT_API_VERSION,
@@ -459,6 +459,7 @@ async def test_error_querying_influx(
             },
             _set_query_mock_v1,
             _make_v1_resultset,
+            "where",
         ),
         (
             API_VERSION_2,
@@ -466,12 +467,13 @@ async def test_error_querying_influx(
             {"queries_flux": [{"name": "test", "query": "{{ illegal.template }}"}]},
             _set_query_mock_v2,
             _make_v2_resultset,
+            "query",
         ),
     ],
     indirect=["mock_client"],
 )
 async def test_error_rendering_template(
-    hass, caplog, mock_client, config_ext, queries, set_query_mock, make_resultset
+    hass, caplog, mock_client, config_ext, queries, set_query_mock, make_resultset, key
 ):
     """Test behavior of sensor with error rendering template."""
     set_query_mock(mock_client, return_value=make_resultset(42))
@@ -484,7 +486,7 @@ async def test_error_rendering_template(
                 record
                 for record in caplog.records
                 if record.levelname == "ERROR"
-                and "Could not render where template" in record.msg
+                and f"Could not render {key} template" in record.msg
             ]
         )
         == 1

--- a/tests/components/influxdb/test_sensor.py
+++ b/tests/components/influxdb/test_sensor.py
@@ -479,7 +479,15 @@ async def test_error_rendering_template(
     sensors = await _setup(hass, config_ext, queries, ["sensor.test"])
     assert sensors[0].state == STATE_UNKNOWN
     assert (
-        len([record for record in caplog.records if record.levelname == "ERROR"]) == 1
+        len(
+            [
+                record
+                for record in caplog.records
+                if record.levelname == "ERROR"
+                and "Could not render where template" in record.msg
+            ]
+        )
+        == 1
     )
 
 

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -1277,8 +1277,7 @@ async def test_repeat_condition_warning(hass, caplog, condition):
     hass.async_create_task(script_obj.async_run(context=Context()))
     await asyncio.wait_for(hass.async_block_till_done(), 1)
 
-    assert len(caplog.record_tuples) == 1
-    assert caplog.record_tuples[0][1] == logging.WARNING
+    assert f"Error in '{condition}[0]' evaluation" in caplog.text
 
     assert len(events) == count
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2509,3 +2509,10 @@ async def test_parse_result(hass):
         ("0011101.00100001010001", "0011101.00100001010001"),
     ):
         assert template.Template(tpl, hass).async_render() == result
+
+
+async def test_undefined_variable(hass, caplog):
+    """Test a warning is logged on undefined variables."""
+    tpl = template.Template("{{ no_such_variable }}", hass)
+    assert tpl.async_render() == ""
+    assert "Template variable warning: no_such_variable is undefined" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
During template rendering, undefined variables are replaced with the empty string. As an example the template `{{undefined_variable}}` will render as the empty string.
This is error prone as it means misspelled or non existent variables are silently accepted by the template engine.
Starting with Home Assistant 2021.4, there will be a warning message in the log when a variable is undefined, but it is still rendered as the empty string.
Starting with Home Assistant 2021.10, undefined variables will be treated as an error and template rendering will fail.
To allow rendering of templates where it is expected that a variably may not be defined without logging a warning or failing to render, use the `default` filter: `{{undefined_variable | default}}`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Warn on undefined variables in templates.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
