### PR TITLE
Fix Raspi GPIO binary_sensor produces unreliable responses

### DIFF
--- a/homeassistant/components/rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/rpi_gpio/binary_sensor.py
@@ -1,7 +1,6 @@
 """Support for binary sensor using RPi GPIO."""
 
 import asyncio
-import logging
 
 import voluptuous as vol
 
@@ -13,7 +12,6 @@ from homeassistant.helpers.reload import setup_reload_service
 
 from . import DOMAIN, PLATFORMS
 
-_LOGGER = logging.getLogger(__name__)
 CONF_BOUNCETIME = "bouncetime"
 CONF_INVERT_LOGIC = "invert_logic"
 CONF_PORTS = "ports"
@@ -83,7 +81,6 @@ class RPiGPIOBinarySensor(BinarySensorEntity):
 
         def edge_detected(port):
             """Edge detection handler."""
-            _LOGGER.debug("Edge detected")
             self.hass.add_job(self.async_read_gpio)
 
         rpi_gpio.edge_detect(self._port, edge_detected, self._bouncetime)

--- a/homeassistant/components/rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/rpi_gpio/binary_sensor.py
@@ -1,4 +1,8 @@
 """Support for binary sensor using RPi GPIO."""
+
+import asyncio
+import logging
+
 import voluptuous as vol
 
 from homeassistant.components import rpi_gpio
@@ -9,6 +13,7 @@ from homeassistant.helpers.reload import setup_reload_service
 
 from . import DOMAIN, PLATFORMS
 
+_LOGGER = logging.getLogger(__name__)
 CONF_BOUNCETIME = "bouncetime"
 CONF_INVERT_LOGIC = "invert_logic"
 CONF_PORTS = "ports"
@@ -52,6 +57,14 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 class RPiGPIOBinarySensor(BinarySensorEntity):
     """Represent a binary sensor that uses Raspberry Pi GPIO."""
 
+    async def async_read_gpio(self):
+        """Read state from GPIO."""
+        await asyncio.sleep(float(self._bouncetime) / 1000)
+        self._state = await self.hass.async_add_executor_job(
+            rpi_gpio.read_input, self._port
+        )
+        self.async_write_ha_state()
+
     def __init__(self, name, port, pull_mode, bouncetime, invert_logic):
         """Initialize the RPi binary sensor."""
         self._name = name or DEVICE_DEFAULT_NAME
@@ -68,7 +81,12 @@ class RPiGPIOBinarySensor(BinarySensorEntity):
             self._state = rpi_gpio.read_input(self._port)
             self.schedule_update_ha_state()
 
-        rpi_gpio.edge_detect(self._port, read_gpio, self._bouncetime)
+        def edge_detected(port):
+            """Edge detection handler."""
+            _LOGGER.debug("Edge detected")
+            self.hass.add_job(self.async_read_gpio)
+
+        rpi_gpio.edge_detect(self._port, edge_detected, self._bouncetime)
 
     @property
     def should_poll(self):

--- a/homeassistant/components/rpi_gpio/binary_sensor.py
+++ b/homeassistant/components/rpi_gpio/binary_sensor.py
@@ -74,11 +74,6 @@ class RPiGPIOBinarySensor(BinarySensorEntity):
 
         rpi_gpio.setup_input(self._port, self._pull_mode)
 
-        def read_gpio(port):
-            """Read state from GPIO."""
-            self._state = rpi_gpio.read_input(self._port)
-            self.schedule_update_ha_state()
-
         def edge_detected(port):
             """Edge detection handler."""
             self.hass.add_job(self.async_read_gpio)


### PR DESCRIPTION
Home Assistant's rpi_gpio binary sensor captures the pin state directly in the first egde interrupt.
At first glance, it looks logical and, on a real-time platform like Arduino, it would work properly.
On RPi/Linux, however, the timing is unpredictable, so that it might (actually, it often does) happen
that the signal bounces back before the edge handler has been called, and the handler captures a wrong pin
state. To fix it, we just wait until the signal stabilizes itself ("bouncetime" parameter) and capture
the pin state after that.

The changes are taken over from previous PR#31788 + proposal from balloob in discussion which was somehow never finished


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x]  Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
no changes in configuration.yaml


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #10498
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
