### PR TITLE
Add Lock for Yale Smart Living

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1145,7 +1145,7 @@ omit =
     homeassistant/components/xiaomi_tv/media_player.py
     homeassistant/components/xmpp/notify.py
     homeassistant/components/xs1/*
-    homeassistant/components/yale_smart_alarm/alarm_control_panel.py
+    homeassistant/components/yale_smart_alarm/*
     homeassistant/components/yamaha_musiccast/media_player.py
     homeassistant/components/yandex_transport/*
     homeassistant/components/yeelightsunflower/light.py

--- a/homeassistant/components/yale_smart_alarm/lock.py
+++ b/homeassistant/components/yale_smart_alarm/lock.py
@@ -1,0 +1,127 @@
+"""Component for interacting with the Yale Smart Alarm System API."""
+import logging
+
+import voluptuous as vol
+from yalesmartalarmclient.client import (
+    AuthenticationError,
+    YaleSmartAlarmClient,
+)
+
+from homeassistant.components.lock import (
+    PLATFORM_SCHEMA,
+    LockEntity,
+)
+from homeassistant.const import (
+    ATTR_CODE,
+    STATE_LOCKED,
+    STATE_UNLOCKED,
+    STATE_UNAVAILABLE,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_CODE,
+)
+
+import homeassistant.helpers.config_validation as cv
+
+CONF_AREA_ID = "area_id"
+
+DEFAULT_NAME = "Yale Smart Alarm"
+
+DEFAULT_AREA_ID = "1"
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+        vol.Optional(CONF_AREA_ID, default=DEFAULT_AREA_ID): cv.string,
+        vol.Optional(CONF_CODE): cv.string,
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    """Set up the alarm platform."""
+    name = config[CONF_NAME]
+    username = config[CONF_USERNAME]
+    password = config[CONF_PASSWORD]
+    area_id = config[CONF_AREA_ID]
+    code = config[CONF_CODE]
+
+    try:
+        client = YaleSmartAlarmClient(username, password, area_id)
+    except AuthenticationError:
+        _LOGGER.error("Authentication failed. Check credentials")
+        return
+
+    lockdevices = []
+    locks = client.lock_api.locks()
+    for lock in locks:
+        lockdevices.append(YaleDoorlock(lock, client, code))
+
+    if lockdevices is not None and lockdevices != []:
+        add_entities(lockdevices)
+    else:
+        return False
+
+    return True
+
+
+class YaleDoorlock(LockEntity):
+    """Representation of a Yale doorlock."""
+
+    def __init__(self, lock, client, code):
+        """Initialize the Yale Alarm Device."""
+        self._name = lock.name
+        self._lock = lock
+        self._client = client
+        self._state = None
+        self._code = code
+
+        self._state_map = {
+            1: STATE_LOCKED,
+            2: STATE_UNLOCKED,
+            3: STATE_UNLOCKED,
+            4: STATE_UNAVAILABLE,
+        }
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._name
+
+    @property
+    def state(self):
+        """Return the state of the device."""
+        return self._state
+
+    @property
+    def is_locked(self):
+        return self._state == STATE_LOCKED
+
+    def update(self):
+        """Return the state of the device."""
+        lock_status = self._client.lock_api.get(self._name)._state._value_
+
+        self._state = self._state_map.get(lock_status)
+
+    def unlock(self, **kwargs) -> None:
+        """Send unlock command."""
+        code = kwargs.get(ATTR_CODE, self._code)
+        if code is None:
+            LOGGER.error("Code required but none provided")
+            return
+
+        self._client.lock_api.open_lock(self._lock, pin_code=code)
+
+    def lock(self, **kwargs) -> None:
+        """Send lock command."""
+        code = kwargs.get(ATTR_CODE, self._code)
+        if code is None:
+            LOGGER.error("Code required but none provided")
+            return
+
+        self._client.lock_api.close_lock(self._lock, pin_code=code)

--- a/homeassistant/components/yale_smart_alarm/manifest.json
+++ b/homeassistant/components/yale_smart_alarm/manifest.json
@@ -2,6 +2,6 @@
   "domain": "yale_smart_alarm",
   "name": "Yale Smart Living",
   "documentation": "https://www.home-assistant.io/integrations/yale_smart_alarm",
-  "requirements": ["yalesmartalarmclient==0.1.6"],
+  "requirements": ["yalesmartalarmclient==0.3.1],
   "codeowners": []
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Add lock to integration Yale Smart Living


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
lock:
  - platform: yale_smart_alarm
    username: YOUR_USERNAME
    password: YOUR_PASSWORD
    code: 123456
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: to be completed

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
