### PR TITLE
Index config entries by id

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -18,7 +18,6 @@ from time import monotonic
 import types
 from typing import Any, Awaitable, Collection
 from unittest.mock import AsyncMock, Mock, patch
-import uuid
 
 from aiohttp.test_utils import unused_port as get_test_instance_port  # noqa: F401
 
@@ -61,6 +60,7 @@ from homeassistant.setup import async_setup_component, setup_component
 from homeassistant.util.async_ import run_callback_threadsafe
 import homeassistant.util.dt as date_util
 from homeassistant.util.unit_system import METRIC_SYSTEM
+import homeassistant.util.uuid as uuid_util
 import homeassistant.util.yaml.loader as yaml_loader
 
 _LOGGER = logging.getLogger(__name__)
@@ -276,7 +276,7 @@ async def async_test_home_assistant(loop, load_registries=True):
     hass.config.skip_pip = True
 
     hass.config_entries = config_entries.ConfigEntries(hass, {})
-    hass.config_entries._entries = []
+    hass.config_entries._entries = {}
     hass.config_entries._store._async_ensure_stop_listener = lambda: None
 
     # Load the registries
@@ -737,7 +737,7 @@ class MockConfigEntry(config_entries.ConfigEntry):
     ):
         """Initialize a mock config entry."""
         kwargs = {
-            "entry_id": entry_id or uuid.uuid4().hex,
+            "entry_id": entry_id or uuid_util.random_uuid_hex(),
             "domain": domain,
             "data": data or {},
             "system_options": system_options,
@@ -756,11 +756,11 @@ class MockConfigEntry(config_entries.ConfigEntry):
 
     def add_to_hass(self, hass):
         """Test helper to add entry to hass."""
-        hass.config_entries._entries.append(self)
+        hass.config_entries._entries[self.entry_id] = self
 
     def add_to_manager(self, manager):
         """Test helper to add entry to entry manager."""
-        manager._entries.append(self)
+        manager._entries[self.entry_id] = self
 
 
 def patch_yaml_files(files_dict, endswith=True):

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -569,7 +569,7 @@ async def test_options_flow(hass, client):
         source="bla",
         connection_class=core_ce.CONN_CLASS_LOCAL_POLL,
     ).add_to_hass(hass)
-    entry = hass.config_entries._entries[0]
+    entry = hass.config_entries.async_entries()[0]
 
     with patch.dict(HANDLERS, {"test": TestFlow}):
         url = "/api/config/config_entries/options/flow"
@@ -618,7 +618,7 @@ async def test_two_step_options_flow(hass, client):
         source="bla",
         connection_class=core_ce.CONN_CLASS_LOCAL_POLL,
     ).add_to_hass(hass)
-    entry = hass.config_entries._entries[0]
+    entry = hass.config_entries.async_entries()[0]
 
     with patch.dict(HANDLERS, {"test": TestFlow}):
         url = "/api/config/config_entries/options/flow"

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -12,6 +12,7 @@ from homeassistant import config_entries
 from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base as hue_sensor_base
 
+from tests.common import MockConfigEntry
 from tests.components.light.conftest import mock_light_profiles  # noqa: F401
 
 
@@ -111,13 +112,11 @@ async def setup_bridge_for_sensors(hass, mock_bridge, hostname=None):
     if hostname is None:
         hostname = "mock-host"
     hass.config.components.add(hue.DOMAIN)
-    config_entry = config_entries.ConfigEntry(
-        1,
-        hue.DOMAIN,
-        "Mock Title",
-        {"host": hostname},
-        "test",
-        config_entries.CONN_CLASS_LOCAL_POLL,
+    config_entry = MockConfigEntry(
+        domain=hue.DOMAIN,
+        title="Mock Title",
+        data={"host": hostname},
+        connection_class=config_entries.CONN_CLASS_LOCAL_POLL,
         system_options={},
     )
     mock_bridge.config_entry = config_entry
@@ -125,7 +124,7 @@ async def setup_bridge_for_sensors(hass, mock_bridge, hostname=None):
     await hass.config_entries.async_forward_entry_setup(config_entry, "binary_sensor")
     await hass.config_entries.async_forward_entry_setup(config_entry, "sensor")
     # simulate a full setup by manually adding the bridge config entry
-    hass.config_entries._entries.append(config_entry)
+    config_entry.add_to_hass(hass)
 
     # and make sure it completes before going further
     await hass.async_block_till_done()

--- a/tests/components/huisbaasje/test_init.py
+++ b/tests/components/huisbaasje/test_init.py
@@ -9,12 +9,12 @@ from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_ERROR,
-    ConfigEntry,
 )
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
+from tests.common import MockConfigEntry
 from tests.components.huisbaasje.test_data import MOCK_CURRENT_MEASUREMENTS
 
 
@@ -36,20 +36,20 @@ async def test_setup_entry(hass: HomeAssistant):
         return_value=MOCK_CURRENT_MEASUREMENTS,
     ) as mock_current_measurements:
         hass.config.components.add(huisbaasje.DOMAIN)
-        config_entry = ConfigEntry(
-            1,
-            huisbaasje.DOMAIN,
-            "userId",
-            {
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=huisbaasje.DOMAIN,
+            title="userId",
+            data={
                 CONF_ID: "userId",
                 CONF_USERNAME: "username",
                 CONF_PASSWORD: "password",
             },
-            "test",
-            CONN_CLASS_CLOUD_POLL,
+            source="test",
+            connection_class=CONN_CLASS_CLOUD_POLL,
             system_options={},
         )
-        hass.config_entries._entries.append(config_entry)
+        config_entry.add_to_hass(hass)
 
         assert config_entry.state == ENTRY_STATE_NOT_LOADED
         assert await hass.config_entries.async_setup(config_entry.entry_id)
@@ -77,20 +77,20 @@ async def test_setup_entry_error(hass: HomeAssistant):
         "huisbaasje.Huisbaasje.authenticate", side_effect=HuisbaasjeException
     ) as mock_authenticate:
         hass.config.components.add(huisbaasje.DOMAIN)
-        config_entry = ConfigEntry(
-            1,
-            huisbaasje.DOMAIN,
-            "userId",
-            {
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=huisbaasje.DOMAIN,
+            title="userId",
+            data={
                 CONF_ID: "userId",
                 CONF_USERNAME: "username",
                 CONF_PASSWORD: "password",
             },
-            "test",
-            CONN_CLASS_CLOUD_POLL,
+            source="test",
+            connection_class=CONN_CLASS_CLOUD_POLL,
             system_options={},
         )
-        hass.config_entries._entries.append(config_entry)
+        config_entry.add_to_hass(hass)
 
         assert config_entry.state == ENTRY_STATE_NOT_LOADED
         await hass.config_entries.async_setup(config_entry.entry_id)
@@ -119,20 +119,20 @@ async def test_unload_entry(hass: HomeAssistant):
         return_value=MOCK_CURRENT_MEASUREMENTS,
     ) as mock_current_measurements:
         hass.config.components.add(huisbaasje.DOMAIN)
-        config_entry = ConfigEntry(
-            1,
-            huisbaasje.DOMAIN,
-            "userId",
-            {
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=huisbaasje.DOMAIN,
+            title="userId",
+            data={
                 CONF_ID: "userId",
                 CONF_USERNAME: "username",
                 CONF_PASSWORD: "password",
             },
-            "test",
-            CONN_CLASS_CLOUD_POLL,
+            source="test",
+            connection_class=CONN_CLASS_CLOUD_POLL,
             system_options={},
         )
-        hass.config_entries._entries.append(config_entry)
+        config_entry.add_to_hass(hass)
 
         # Load config entry
         assert await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/huisbaasje/test_sensor.py
+++ b/tests/components/huisbaasje/test_sensor.py
@@ -2,10 +2,11 @@
 from unittest.mock import patch
 
 from homeassistant.components import huisbaasje
-from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, ConfigEntry
+from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
+from tests.common import MockConfigEntry
 from tests.components.huisbaasje.test_data import (
     MOCK_CURRENT_MEASUREMENTS,
     MOCK_LIMITED_CURRENT_MEASUREMENTS,
@@ -24,20 +25,20 @@ async def test_setup_entry(hass: HomeAssistant):
     ) as mock_current_measurements:
 
         hass.config.components.add(huisbaasje.DOMAIN)
-        config_entry = ConfigEntry(
-            1,
-            huisbaasje.DOMAIN,
-            "userId",
-            {
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=huisbaasje.DOMAIN,
+            title="userId",
+            data={
                 CONF_ID: "userId",
                 CONF_USERNAME: "username",
                 CONF_PASSWORD: "password",
             },
-            "test",
-            CONN_CLASS_CLOUD_POLL,
+            source="test",
+            connection_class=CONN_CLASS_CLOUD_POLL,
             system_options={},
         )
-        hass.config_entries._entries.append(config_entry)
+        config_entry.add_to_hass(hass)
 
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -81,20 +82,20 @@ async def test_setup_entry_absent_measurement(hass: HomeAssistant):
     ) as mock_current_measurements:
 
         hass.config.components.add(huisbaasje.DOMAIN)
-        config_entry = ConfigEntry(
-            1,
-            huisbaasje.DOMAIN,
-            "userId",
-            {
+        config_entry = MockConfigEntry(
+            version=1,
+            domain=huisbaasje.DOMAIN,
+            title="userId",
+            data={
                 CONF_ID: "userId",
                 CONF_USERNAME: "username",
                 CONF_PASSWORD: "password",
             },
-            "test",
-            CONN_CLASS_CLOUD_POLL,
+            source="test",
+            connection_class=CONN_CLASS_CLOUD_POLL,
             system_options={},
         )
-        hass.config_entries._entries.append(config_entry)
+        config_entry.add_to_hass(hass)
 
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As we move more integrations to config entries the linear searchs
to find the config entry by id were starting to show up on a profile.

```
# grep entry_id .storage/core.config_entries |wc
    135     270    8640
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
