### PR TITLE
Exclude homekit accessories created by the homekit integration from homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -18,8 +18,6 @@ from .const import DOMAIN, KNOWN_DEVICES
 
 HOMEKIT_DIR = ".homekit"
 HOMEKIT_BRIDGE_DOMAIN = "homekit"
-HOMEKIT_BRIDGE_SERIAL_NUMBER = "homekit.bridge"
-HOMEKIT_BRIDGE_MODEL = "Home Assistant HomeKit Bridge"
 
 HOMEKIT_IGNORE = [
     # eufy Indoor Cam 2K and 2K Pan & Tilt
@@ -181,8 +179,8 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         return self.async_abort(reason="no_devices")
 
-    async def _hkid_is_homekit_bridge(self, hkid):
-        """Determine if the device is a homekit bridge."""
+    async def _hkid_is_homekit(self, hkid):
+        """Determine if the device is a homekit bridge or accessory."""
         dev_reg = await async_get_device_registry(self.hass)
         device = dev_reg.async_get_device(
             identifiers=set(), connections={(CONNECTION_NETWORK_MAC, hkid)}
@@ -190,7 +188,13 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
 
         if device is None:
             return False
-        return device.model == HOMEKIT_BRIDGE_MODEL
+
+        for entry_id in device.config_entries:
+            entry = self.hass.config_entries.async_get_entry(entry_id)
+            if entry and entry.domain == HOMEKIT_BRIDGE_DOMAIN:
+                return True
+
+        return False
 
     async def async_step_zeroconf(self, discovery_info):
         """Handle a discovered HomeKit accessory.
@@ -266,8 +270,8 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow):
         if model in HOMEKIT_IGNORE:
             return self.async_abort(reason="ignored_model")
 
-        # If this is a HomeKit bridge exported by *this* HA instance ignore it.
-        if await self._hkid_is_homekit_bridge(hkid):
+        # If this is a HomeKit bridge/accessory exported by *this* HA instance ignore it.
+        if await self._hkid_is_homekit(hkid):
             return self.async_abort(reason="ignored_model")
 
         self.name = name

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -269,7 +269,7 @@ async def test_discovery_ignored_model(hass, controller):
 
 
 async def test_discovery_ignored_hk_bridge(hass, controller):
-    """Already paired."""
+    """Ensure we ignore homekit bridges and accessories created by the homekit integration."""
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
 
@@ -291,6 +291,30 @@ async def test_discovery_ignored_hk_bridge(hass, controller):
     )
     assert result["type"] == "abort"
     assert result["reason"] == "ignored_model"
+
+
+async def test_discovery_does_not_ignore_non_homekit(hass, controller):
+    """Do not ignore devices that are not from the homekit integration."""
+    device = setup_mock_accessory(controller)
+    discovery_info = get_device_discovery_info(device)
+
+    config_entry = MockConfigEntry(domain="not_homekit", data={})
+    config_entry.add_to_hass(hass)
+    formatted_mac = device_registry.format_mac("AA:BB:CC:DD:EE:FF")
+
+    dev_reg = mock_device_registry(hass)
+    dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
+    )
+
+    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
+
+    # Device is discovered
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller", context={"source": "zeroconf"}, data=discovery_info
+    )
+    assert result["type"] == "form"
 
 
 async def test_discovery_invalid_config_entry(hass, controller):

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -274,20 +274,13 @@ async def test_discovery_ignored_hk_bridge(hass, controller):
     discovery_info = get_device_discovery_info(device)
 
     config_entry = MockConfigEntry(domain=config_flow.HOMEKIT_BRIDGE_DOMAIN, data={})
+    config_entry.add_to_hass(hass)
     formatted_mac = device_registry.format_mac("AA:BB:CC:DD:EE:FF")
 
     dev_reg = mock_device_registry(hass)
     dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers={
-            (
-                config_flow.HOMEKIT_BRIDGE_DOMAIN,
-                config_entry.entry_id,
-                config_flow.HOMEKIT_BRIDGE_SERIAL_NUMBER,
-            )
-        },
         connections={(device_registry.CONNECTION_NETWORK_MAC, formatted_mac)},
-        model=config_flow.HOMEKIT_BRIDGE_MODEL,
     )
 
     discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Exclude homekit accessories created by the homekit integration from homekit_controller
 
We only prevented bridges from appearing. Since we now support accessory mode we should hide these as well.

Noticed looking these up was a linear search and optimized it here:
https://github.com/home-assistant/core/pull/48199

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
