### PR TITLE
Avoid divide by zero errors in tplink light integration

### DIFF
--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 import logging
+import re
 import time
 from typing import Any, NamedTuple, cast
 
@@ -59,6 +60,21 @@ LIGHT_SYSINFO_IS_COLOR = "is_color"
 
 MAX_ATTEMPTS = 300
 SLEEP_TIME = 2
+
+TPLINK_KELVIN = {
+    "LB130": (2500, 9000),
+    "LB120": (2700, 6500),
+    "LB230": (2500, 9000),
+    "KB130": (2500, 9000),
+    "KL130": (2500, 9000),
+    "KL125": (2500, 6500),
+    r"KL120\(EU\)": (2700, 6500),
+    r"KL120\(US\)": (2700, 5000),
+    r"KL430\(US\)": (2500, 9000),
+}
+
+FALLBACK_MIN_COLOR = 2700
+FALLBACK_MAX_COLOR = 5000
 
 
 async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
@@ -269,6 +285,19 @@ class TPLinkSmartBulb(LightEntity):
         """Flag supported features."""
         return self._light_features.supported_features
 
+    def _get_valid_temperature_range(self):
+        """Return the device-specific white temperature range (in Kelvin).
+
+        :return: White temperature range in Kelvin (minimum, maximum)
+        """
+        model = self.smartbulb.sys_info[LIGHT_SYSINFO_MODEL]
+        for obj, temp_range in TPLINK_KELVIN.items():
+            if re.match(obj, model):
+                return temp_range
+        # pyHS100 is abandoned, but some bulb definitions aren't present
+        # use "safe" values for something that advertises color temperature
+        return FALLBACK_MIN_COLOR, FALLBACK_MAX_COLOR
+
     def _get_light_features(self):
         """Determine all supported features in one go."""
         sysinfo = self.smartbulb.sys_info
@@ -285,9 +314,7 @@ class TPLinkSmartBulb(LightEntity):
             supported_features += SUPPORT_BRIGHTNESS
         if sysinfo.get(LIGHT_SYSINFO_IS_VARIABLE_COLOR_TEMP):
             supported_features += SUPPORT_COLOR_TEMP
-            # Have to make another api request here in
-            # order to not re-implement pyHS100 here
-            max_range, min_range = self.smartbulb.valid_temperature_range
+            max_range, min_range = self._get_valid_temperature_range()
             min_mireds = kelvin_to_mired(min_range)
             max_mireds = kelvin_to_mired(max_range)
         if sysinfo.get(LIGHT_SYSINFO_IS_COLOR):

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -60,6 +60,116 @@ class SmartSwitchMockData(NamedTuple):
     get_sysinfo_mock: Mock
 
 
+@pytest.fixture(name="unknown_light_mock_data")
+def unknown_light_mock_data_fixture() -> None:
+    """Create light mock data."""
+    sys_info = {
+        "sw_ver": "1.2.3",
+        "hw_ver": "2.3.4",
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "mic_mac": "00:11:22:33:44",
+        "type": "light",
+        "hwId": "1234",
+        "fwId": "4567",
+        "oemId": "891011",
+        "dev_name": "light1",
+        "rssi": 11,
+        "latitude": "0",
+        "longitude": "0",
+        "is_color": True,
+        "is_dimmable": True,
+        "is_variable_color_temp": True,
+        "model": "Foo",
+        "alias": "light1",
+    }
+    light_state = {
+        "on_off": True,
+        "dft_on_state": {
+            "brightness": 12,
+            "color_temp": 3200,
+            "hue": 110,
+            "saturation": 90,
+        },
+        "brightness": 13,
+        "color_temp": 3300,
+        "hue": 110,
+        "saturation": 90,
+    }
+
+    def set_light_state(state) -> None:
+        nonlocal light_state
+        drt_on_state = light_state["dft_on_state"]
+        drt_on_state.update(state.get("dft_on_state", {}))
+
+        light_state.update(state)
+        light_state["dft_on_state"] = drt_on_state
+        return light_state
+
+    set_light_state_patch = patch(
+        "homeassistant.components.tplink.common.SmartBulb.set_light_state",
+        side_effect=set_light_state,
+    )
+    get_light_state_patch = patch(
+        "homeassistant.components.tplink.common.SmartBulb.get_light_state",
+        return_value=light_state,
+    )
+    current_consumption_patch = patch(
+        "homeassistant.components.tplink.common.SmartDevice.current_consumption",
+        return_value=3.23,
+    )
+    get_sysinfo_patch = patch(
+        "homeassistant.components.tplink.common.SmartDevice.get_sysinfo",
+        return_value=sys_info,
+    )
+    get_emeter_daily_patch = patch(
+        "homeassistant.components.tplink.common.SmartDevice.get_emeter_daily",
+        return_value={
+            1: 1.01,
+            2: 1.02,
+            3: 1.03,
+            4: 1.04,
+            5: 1.05,
+            6: 1.06,
+            7: 1.07,
+            8: 1.08,
+            9: 1.09,
+            10: 1.10,
+            11: 1.11,
+            12: 1.12,
+        },
+    )
+    get_emeter_monthly_patch = patch(
+        "homeassistant.components.tplink.common.SmartDevice.get_emeter_monthly",
+        return_value={
+            1: 2.01,
+            2: 2.02,
+            3: 2.03,
+            4: 2.04,
+            5: 2.05,
+            6: 2.06,
+            7: 2.07,
+            8: 2.08,
+            9: 2.09,
+            10: 2.10,
+            11: 2.11,
+            12: 2.12,
+        },
+    )
+
+    with set_light_state_patch as set_light_state_mock, get_light_state_patch as get_light_state_mock, current_consumption_patch as current_consumption_mock, get_sysinfo_patch as get_sysinfo_mock, get_emeter_daily_patch as get_emeter_daily_mock, get_emeter_monthly_patch as get_emeter_monthly_mock:
+        yield LightMockData(
+            sys_info=sys_info,
+            light_state=light_state,
+            set_light_state=set_light_state,
+            set_light_state_mock=set_light_state_mock,
+            get_light_state_mock=get_light_state_mock,
+            current_consumption_mock=current_consumption_mock,
+            get_sysinfo_mock=get_sysinfo_mock,
+            get_emeter_daily_mock=get_emeter_daily_mock,
+            get_emeter_monthly_mock=get_emeter_monthly_mock,
+        )
+
+
 @pytest.fixture(name="light_mock_data")
 def light_mock_data_fixture() -> None:
     """Create light mock data."""
@@ -341,6 +451,31 @@ async def test_smartswitch(
     assert state.state == "on"
     assert state.attributes["brightness"] == 168
     assert sys_info["brightness"] == 66
+
+
+async def test_unknown_light(
+    hass: HomeAssistant, unknown_light_mock_data: LightMockData
+) -> None:
+    """Test function."""
+    await async_setup_component(hass, HA_DOMAIN, {})
+    await hass.async_block_till_done()
+
+    await async_setup_component(
+        hass,
+        tplink.DOMAIN,
+        {
+            tplink.DOMAIN: {
+                CONF_DISCOVERY: False,
+                CONF_LIGHT: [{CONF_HOST: "123.123.123.123"}],
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.light1")
+    assert state.state == "on"
+    assert state.attributes["min_mireds"] == 200
+    assert state.attributes["max_mireds"] == 370
 
 
 async def test_light(hass: HomeAssistant, light_mock_data: LightMockData) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some bulbs such as kl125 don't have a definition submitted into
pyHS100.  Trying to interact with them will cause a divide by
zero error:
```
  File "/usr/src/homeassistant/homeassistant/components/tplink/light.py", line 248, in attempt_update
    self._light_features = self._get_light_features()
  File "/usr/src/homeassistant/homeassistant/components/tplink/light.py", line 289, in _get_light_features
    min_mireds = kelvin_to_mired(min_range)
  File "/usr/src/homeassistant/homeassistant/util/color.py", line 515, in color_temperature_kelvin_to_mired
    return math.floor(1000000 / kelvin_temperature)
ZeroDivisionError: division by zero
```

As the `pyHS100` project has been abandoned in favor of `python-kasa` but there isn't yet
a component in home assistant for using `python-kasa` add some fallback code into the component.

If the light specifies it supports color temperature but the range isn't available choose a "safe"
range that is the minimum of what is available in bulbs today.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
tplink:
  discovery: false
  light:
    - host: !secret kasa_bulb_1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45675
- This PR is related to issue: https://github.com/GadgetReactor/pyHS100/pull/201
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17125

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
