### PR TITLE
Only raise integrationnotfound for dependencies

### DIFF
--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -104,16 +104,21 @@ async def async_get_integration_with_requirements(
             ],
             return_exceptions=True,
         )
-        for result in results:
-            if (
-                isinstance(result, IntegrationNotFound)
-                and result.domain not in integration.after_dependencies
-                or (
-                    isinstance(result, BaseException)
-                    and not isinstance(result, IntegrationNotFound)
-                )
-            ):
-                raise result
+        filtered_results = list(
+            filter(
+                lambda result: (
+                    isinstance(result, IntegrationNotFound)
+                    and result.domain not in integration.after_dependencies
+                    or (
+                        isinstance(result, BaseException)
+                        and not isinstance(result, IntegrationNotFound)
+                    )
+                ),
+                results,
+            )
+        )
+        if filtered_results:
+            raise filtered_results[0]
 
     cache[domain] = integration
     event.set()

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -106,9 +106,12 @@ async def async_get_integration_with_requirements(
         )
         for result in results:
             if not isinstance(result, BaseException):
-               continue
-            if not isinstance(result, IntegrationNotFound) or result.domain not in integration.after_dependencies:
-               raise result
+                continue
+            if (
+                not isinstance(result, IntegrationNotFound)
+                or result.domain not in integration.after_dependencies
+            ):
+                raise result
 
     cache[domain] = integration
     event.set()

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -113,7 +113,7 @@ async def async_get_integration_with_requirements(
             if not isinstance(result, BaseException):
                 continue
             if not isinstance(result, IntegrationNotFound) or not (
-                integration.pkg_path.startswith(PACKAGE_CUSTOM_COMPONENTS)
+                not integration.is_built_in
                 and result.domain in integration.after_dependencies
             ):
                 raise result

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -104,21 +104,11 @@ async def async_get_integration_with_requirements(
             ],
             return_exceptions=True,
         )
-        filtered_results = list(
-            filter(
-                lambda result: (
-                    isinstance(result, IntegrationNotFound)
-                    and result.domain not in integration.after_dependencies
-                    or (
-                        isinstance(result, BaseException)
-                        and not isinstance(result, IntegrationNotFound)
-                    )
-                ),
-                results,
-            )
-        )
-        if filtered_results:
-            raise filtered_results[0]
+        for result in results:
+            if not isinstance(result, BaseException):
+               continue
+            if not isinstance(result, IntegrationNotFound) or result.domain not in integration.after_dependencies:
+               raise result
 
     cache[domain] = integration
     event.set()

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -97,12 +97,18 @@ async def async_get_integration_with_requirements(
             deps_to_check.append(check_domain)
 
     if deps_to_check:
-        await asyncio.gather(
-            *[
-                async_get_integration_with_requirements(hass, dep, done)
-                for dep in deps_to_check
-            ]
-        )
+        try:
+            await asyncio.gather(
+                *[
+                    async_get_integration_with_requirements(hass, dep, done)
+                    for dep in deps_to_check
+                ]
+            )
+        except IntegrationNotFound as exception:
+            if exception.domain in integration.after_dependencies:
+                pass
+            else:
+                raise exception
 
     cache[domain] = integration
     event.set()

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -8,7 +8,12 @@ from typing import Any, Iterable, cast
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
-from homeassistant.loader import Integration, IntegrationNotFound, async_get_integration
+from homeassistant.loader import (
+    PACKAGE_CUSTOM_COMPONENTS,
+    Integration,
+    IntegrationNotFound,
+    async_get_integration,
+)
 import homeassistant.util.package as pkg_util
 
 # mypy: disallow-any-generics
@@ -107,9 +112,9 @@ async def async_get_integration_with_requirements(
         for result in results:
             if not isinstance(result, BaseException):
                 continue
-            if (
-                not isinstance(result, IntegrationNotFound)
-                or result.domain not in integration.after_dependencies
+            if not isinstance(result, IntegrationNotFound) or not (
+                integration.pkg_path.startswith(PACKAGE_CUSTOM_COMPONENTS)
+                and result.domain in integration.after_dependencies
             ):
                 raise result
 

--- a/homeassistant/requirements.py
+++ b/homeassistant/requirements.py
@@ -8,12 +8,7 @@ from typing import Any, Iterable, cast
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import UNDEFINED, UndefinedType
-from homeassistant.loader import (
-    PACKAGE_CUSTOM_COMPONENTS,
-    Integration,
-    IntegrationNotFound,
-    async_get_integration,
-)
+from homeassistant.loader import Integration, IntegrationNotFound, async_get_integration
 import homeassistant.util.package as pkg_util
 
 # mypy: disallow-any-generics

--- a/tests/common.py
+++ b/tests/common.py
@@ -1046,10 +1046,15 @@ async def get_system_health_info(hass, domain):
     return await hass.data["system_health"][domain].info_callback(hass)
 
 
-def mock_integration(hass, module):
+def mock_integration(hass, module, built_in=True):
     """Mock an integration."""
     integration = loader.Integration(
-        hass, f"homeassistant.components.{module.DOMAIN}", None, module.mock_manifest()
+        hass,
+        f"{loader.PACKAGE_BUILTIN}.{module.DOMAIN}"
+        if built_in
+        else f"{loader.PACKAGE_CUSTOM_COMPONENTS}.{module.DOMAIN}",
+        None,
+        module.mock_manifest(),
     )
 
     def mock_import_platform(platform_name):

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -139,6 +139,40 @@ async def test_get_integration_with_requirements(hass):
     ]
 
 
+async def test_get_integration_with_missing_dependencies(hass):
+    """Check getting an integration with missing dependencies."""
+    hass.config.skip_pip = False
+    mock_integration(
+        hass,
+        MockModule("test_component_after_dep"),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component",
+            dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+    with pytest.raises(loader.IntegrationNotFound):
+        await async_get_integration_with_requirements(hass, "test_component")
+
+
+async def test_get_integration_with_missing_after_dependencies(hass):
+    """Check getting an integration with loaded requirements with missing after_dependencies."""
+    hass.config.skip_pip = False
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component",
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+    integration = await async_get_integration_with_requirements(hass, "test_component")
+    assert integration
+    assert integration.domain == "test_component"
+
+
 async def test_install_with_wheels_index(hass):
     """Test an install attempt with wheels index URL."""
     hass.config.skip_pip = False

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,5 +1,4 @@
 """Test requirements module."""
-from asyncio import Future
 import os
 from unittest.mock import call, patch
 
@@ -172,94 +171,6 @@ async def test_get_integration_with_missing_after_dependencies(hass):
     integration = await async_get_integration_with_requirements(hass, "test_component")
     assert integration
     assert integration.domain == "test_component"
-
-
-async def test_get_integration_with_missing_dependencies_first(hass):
-    """Check getting an integration with missing dependencies raising an exception first."""
-    hass.config.skip_pip = False
-    mock_integration(
-        hass,
-        MockModule(
-            "test_component",
-            dependencies=["test_component_dep"],
-            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
-        ),
-    )
-    mock_gather = Future()
-    mock_gather.set_result(
-        [
-            loader.IntegrationNotFound("test_component_dep"),
-            mock_integration(
-                hass,
-                MockModule("test_component_after_dep"),
-            ),
-        ]
-    )
-    with patch(
-        "homeassistant.requirements.asyncio.gather",
-        return_value=mock_gather,
-    ), pytest.raises(loader.IntegrationNotFound):
-        await async_get_integration_with_requirements(hass, "test_component")
-
-
-async def test_get_integration_with_missing_after_dependencies_first(hass):
-    """Check getting an integration with missing after_dependencies raising an exception first."""
-    hass.config.skip_pip = False
-    mock_integration(
-        hass,
-        MockModule(
-            "test_component",
-            dependencies=["test_component_dep"],
-            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
-        ),
-    )
-    mock_gather = Future()
-    mock_gather.set_result(
-        [
-            loader.IntegrationNotFound("test_component_after_dep"),
-            mock_integration(
-                hass,
-                MockModule("test_component_after_dep"),
-            ),
-        ]
-    )
-    with patch(
-        "homeassistant.requirements.asyncio.gather",
-        return_value=mock_gather,
-    ):
-        integration = await async_get_integration_with_requirements(
-            hass, "test_component"
-        )
-        assert integration
-        assert integration.domain == "test_component"
-
-
-async def test_get_integration_with_exception(hass):
-    """Check getting an integration with general exception is raised."""
-    hass.config.skip_pip = False
-    mock_integration(
-        hass,
-        MockModule("test_component_after_dep"),
-    )
-    mock_integration(
-        hass,
-        MockModule(
-            "test_component",
-            dependencies=["test_component_dep"],
-            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
-        ),
-    )
-    mock_gather = Future()
-    mock_gather.set_result(
-        [
-            BaseException("Exception found"),
-        ]
-    )
-    with patch(
-        "homeassistant.requirements.asyncio.gather",
-        return_value=mock_gather,
-    ), pytest.raises(BaseException):
-        await async_get_integration_with_requirements(hass, "test_component")
 
 
 async def test_install_with_wheels_index(hass):

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -1,4 +1,5 @@
 """Test requirements module."""
+from asyncio import Future
 import os
 from unittest.mock import call, patch
 
@@ -159,7 +160,7 @@ async def test_get_integration_with_missing_dependencies(hass):
 
 
 async def test_get_integration_with_missing_after_dependencies(hass):
-    """Check getting an integration with loaded requirements with missing after_dependencies."""
+    """Check getting an integration with missing after_dependencies."""
     hass.config.skip_pip = False
     mock_integration(
         hass,
@@ -171,6 +172,94 @@ async def test_get_integration_with_missing_after_dependencies(hass):
     integration = await async_get_integration_with_requirements(hass, "test_component")
     assert integration
     assert integration.domain == "test_component"
+
+
+async def test_get_integration_with_missing_dependencies_first(hass):
+    """Check getting an integration with missing dependencies raising an exception first."""
+    hass.config.skip_pip = False
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component",
+            dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+    mock_gather = Future()
+    mock_gather.set_result(
+        [
+            loader.IntegrationNotFound("test_component_dep"),
+            mock_integration(
+                hass,
+                MockModule("test_component_after_dep"),
+            ),
+        ]
+    )
+    with patch(
+        "homeassistant.requirements.asyncio.gather",
+        return_value=mock_gather,
+    ), pytest.raises(loader.IntegrationNotFound):
+        await async_get_integration_with_requirements(hass, "test_component")
+
+
+async def test_get_integration_with_missing_after_dependencies_first(hass):
+    """Check getting an integration with missing after_dependencies raising an exception first."""
+    hass.config.skip_pip = False
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component",
+            dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+    mock_gather = Future()
+    mock_gather.set_result(
+        [
+            loader.IntegrationNotFound("test_component_after_dep"),
+            mock_integration(
+                hass,
+                MockModule("test_component_after_dep"),
+            ),
+        ]
+    )
+    with patch(
+        "homeassistant.requirements.asyncio.gather",
+        return_value=mock_gather,
+    ):
+        integration = await async_get_integration_with_requirements(
+            hass, "test_component"
+        )
+        assert integration
+        assert integration.domain == "test_component"
+
+
+async def test_get_integration_with_exception(hass):
+    """Check getting an integration with general exception is raised."""
+    hass.config.skip_pip = False
+    mock_integration(
+        hass,
+        MockModule("test_component_after_dep"),
+    )
+    mock_integration(
+        hass,
+        MockModule(
+            "test_component",
+            dependencies=["test_component_dep"],
+            partial_manifest={"after_dependencies": ["test_component_after_dep"]},
+        ),
+    )
+    mock_gather = Future()
+    mock_gather.set_result(
+        [
+            BaseException("Exception found"),
+        ]
+    )
+    with patch(
+        "homeassistant.requirements.asyncio.gather",
+        return_value=mock_gather,
+    ), pytest.raises(BaseException):
+        await async_get_integration_with_requirements(hass, "test_component")
 
 
 async def test_install_with_wheels_index(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change the behavior of integrationnotfound to only raise for dependencies and not after_dependencies.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48200 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
