### PR TITLE
Include platform only integrations in the manifest list api

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -221,7 +221,7 @@ class DeviceTrackerPlatform:
 
     async def async_setup_legacy(self, hass, tracker, discovery_info=None):
         """Set up a legacy platform."""
-        LOGGER.info("Setting up %s.%s", DOMAIN, self.type)
+        LOGGER.info("Setting up %s.%s", DOMAIN, self.name)
         try:
             scanner = None
             setup = None
@@ -248,6 +248,9 @@ class DeviceTrackerPlatform:
             else:
                 raise HomeAssistantError("Invalid legacy device_tracker platform.")
 
+            if setup:
+                hass.config.components.add(f"{DOMAIN}.{self.name}")
+
             if scanner:
                 async_setup_scanner_platform(
                     hass, self.config, scanner, tracker.async_see, self.type
@@ -255,11 +258,11 @@ class DeviceTrackerPlatform:
                 return
 
             if not setup:
-                LOGGER.error("Error setting up platform %s", self.type)
+                LOGGER.error("Error setting up platform %s %s", self.type, self.name)
                 return
 
         except Exception:  # pylint: disable=broad-except
-            LOGGER.exception("Error setting up platform %s", self.type)
+            LOGGER.exception("Error setting up platform %s %s", self.type, self.name)
 
 
 async def async_extract_config(hass, config):

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -17,6 +17,7 @@ from homeassistant.helpers import config_validation as cv, entity, template
 from homeassistant.helpers.event import TrackTemplate, async_track_template_result
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import IntegrationNotFound, async_get_integration
+from homeassistant.setup import async_get_loaded_integrations
 
 from . import const, decorators, messages
 
@@ -215,13 +216,9 @@ def handle_get_config(hass, connection, msg):
 @decorators.async_response
 async def handle_manifest_list(hass, connection, msg):
     """Handle integrations command."""
+    loaded_integrations = async_get_loaded_integrations(hass)
     integrations = await asyncio.gather(
-        *[
-            async_get_integration(hass, domain)
-            for domain in hass.config.components
-            # Filter out platforms.
-            if "." not in domain
-        ]
+        *[async_get_integration(hass, domain) for domain in loaded_integrations]
     )
     connection.send_result(
         msg["id"], [integration.manifest for integration in integrations]

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 ATTR_COMPONENT = "component"
 
 BASE_PLATFORMS = {
+    "air_quality",
     "alarm_control_panel",
     "binary_sensor",
     "climate",
@@ -30,6 +31,7 @@ BASE_PLATFORMS = {
     "light",
     "lock",
     "media_player",
+    "notify",
     "remote",
     "scene",
     "sensor",

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -18,6 +18,26 @@ _LOGGER = logging.getLogger(__name__)
 
 ATTR_COMPONENT = "component"
 
+BASE_PLATFORMS = {
+    "alarm_control_panel",
+    "binary_sensor",
+    "climate",
+    "cover",
+    "device_tracker",
+    "fan",
+    "humidifier",
+    "image_processing",
+    "light",
+    "lock",
+    "media_player",
+    "remote",
+    "scene",
+    "sensor",
+    "switch",
+    "vacuum",
+    "water_heater",
+}
+
 DATA_SETUP_DONE = "setup_done"
 DATA_SETUP_STARTED = "setup_started"
 DATA_SETUP = "setup_tasks"
@@ -381,3 +401,17 @@ def async_when_setup(
         await when_setup()
 
     unsub = hass.bus.async_listen(EVENT_COMPONENT_LOADED, loaded_event)
+
+
+@core.callback
+def async_get_loaded_integrations(hass: core.HomeAssistant) -> set:
+    """Return the complete list of loaded integrations."""
+    integrations = set()
+    for component in hass.config.components:
+        if "." not in component:
+            integrations.add(component)
+            continue
+        domain, platform = component.split(".", 1)
+        if domain in BASE_PLATFORMS:
+            integrations.add(platform)
+    return integrations

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -5,6 +5,7 @@ import ast
 from pathlib import Path
 
 from homeassistant.requirements import DISCOVERY_INTEGRATIONS
+from homeassistant.setup import BASE_PLATFORMS
 
 from .model import Integration
 
@@ -107,7 +108,6 @@ ALLOWED_USED_COMPONENTS = {
     "onboarding",
     "persistent_notification",
     "person",
-    "remote",
     "script",
     "shopping_list",
     "sun",
@@ -118,22 +118,7 @@ ALLOWED_USED_COMPONENTS = {
     "websocket_api",
     "zone",
     # Entity integrations with platforms
-    "alarm_control_panel",
-    "binary_sensor",
-    "climate",
-    "cover",
-    "device_tracker",
-    "fan",
-    "humidifier",
-    "image_processing",
-    "light",
-    "lock",
-    "media_player",
-    "scene",
-    "sensor",
-    "switch",
-    "vacuum",
-    "water_heater",
+    *BASE_PLATFORMS,
     # Other
     "mjpeg",  # base class, has no reqs or component to load.
     "stream",  # Stream cannot install on all systems, can be imported without reqs.

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -600,3 +600,21 @@ async def test_integration_disabled(hass, caplog):
     result = await setup.async_setup_component(hass, "test_component1", {})
     assert not result
     assert disabled_reason in caplog.text
+
+
+async def test_async_get_loaded_integrations(hass):
+    """Test we can enumerate loaded integations."""
+    hass.config.components.add("notbase")
+    hass.config.components.add("switch")
+    hass.config.components.add("notbase.switch")
+    hass.config.components.add("myintegration")
+    hass.config.components.add("device_tracker")
+    hass.config.components.add("device_tracker.other")
+    hass.config.components.add("myintegration.light")
+    assert setup.async_get_loaded_integrations(hass) == {
+        "other",
+        "switch",
+        "notbase",
+        "myintegration",
+        "device_tracker",
+    }


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This should solve the bug reports that are missing some integrations
which make them ridiculously hard to track down.

Integrations that are platform only are missing from
the `/config/info` page. A frontend change is needed to address this,
and a `core` change (this change) is needed to provide the manifest data.

Include integrations that are platform only in the manifest list api

Ensure legacy device trackers get add to `hass.config.components` as
they were previously all called `device_tracker.legacy`. ex
`device_tracker.ping` is now in the list.

frontend: https://github.com/home-assistant/frontend/pull/8698

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
