### PR TITLE
Migrate template to register reload service on async_setup

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -1,20 +1,11 @@
 """The template component."""
-from homeassistant.const import SERVICE_RELOAD
-from homeassistant.helpers.reload import async_reload_integration_platforms
+from homeassistant.helpers.reload import async_setup_reload_service
 
-from .const import DOMAIN, EVENT_TEMPLATE_RELOADED, PLATFORMS
+from .const import DOMAIN, PLATFORMS
 
 
-async def async_setup_reload_service(hass):
-    """Create the reload service for the template domain."""
-    if hass.services.has_service(DOMAIN, SERVICE_RELOAD):
-        return
+async def async_setup(hass, config):
+    """Set up the template integration."""
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
-    async def _reload_config(call):
-        """Reload the template platform config."""
-        await async_reload_integration_platforms(hass, DOMAIN, PLATFORMS)
-        hass.bus.async_fire(EVENT_TEMPLATE_RELOADED, context=call.context)
-
-    hass.helpers.service.async_register_admin_service(
-        DOMAIN, SERVICE_RELOAD, _reload_config
-    )
+    return True

--- a/homeassistant/components/template/alarm_control_panel.py
+++ b/homeassistant/components/template/alarm_control_panel.py
@@ -32,10 +32,8 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.script import Script
 
-from .const import DOMAIN, PLATFORMS
 from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -113,7 +111,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Template Alarm Control Panels."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -22,10 +22,9 @@ from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.template import result_as_boolean
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 CONF_DELAY_ON = "delay_on"
@@ -97,7 +96,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template binary sensors."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -6,8 +6,6 @@ DOMAIN = "template"
 
 PLATFORM_STORAGE_KEY = "template_platforms"
 
-EVENT_TEMPLATE_RELOADED = "event_template_reloaded"
-
 PLATFORMS = [
     "alarm_control_panel",
     "binary_sensor",

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -38,10 +38,9 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.script import Script
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -160,7 +159,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Template cover."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -36,10 +36,9 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.script import Script
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -163,7 +162,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template fans."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/light.py
+++ b/homeassistant/components/template/light.py
@@ -31,10 +31,9 @@ from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.script import Script
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -137,7 +136,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template lights."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -13,10 +13,9 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.script import Script
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 CONF_LOCK = "lock"
@@ -60,7 +59,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template lock."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -25,9 +25,8 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
@@ -96,7 +95,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template sensors."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/switch.py
+++ b/homeassistant/components/template/switch.py
@@ -22,11 +22,10 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.script import Script
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 _VALID_STATES = [STATE_ON, STATE_OFF, "true", "false"]
@@ -90,7 +89,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template switches."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -41,10 +41,9 @@ from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.script import Script
 
-from .const import CONF_AVAILABILITY_TEMPLATE, DOMAIN, PLATFORMS
+from .const import CONF_AVAILABILITY_TEMPLATE
 from .template_entity import TemplateEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -147,7 +146,6 @@ async def _async_create_entities(hass, config):
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template vacuums."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
     async_add_entities(await _async_create_entities(hass, config))
 
 

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -24,9 +24,7 @@ from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import async_generate_entity_id
-from homeassistant.helpers.reload import async_setup_reload_service
 
-from .const import DOMAIN, PLATFORMS
 from .template_entity import TemplateEntity
 
 CONDITION_CLASSES = {
@@ -71,7 +69,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the Template weather."""
-    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
     name = config[CONF_NAME]
     condition_template = config[CONF_CONDITION_TEMPLATE]

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.const import (
 from homeassistant.core import CoreState
 import homeassistant.util.dt as dt_util
 
-from tests.common import assert_setup_component, async_fire_time_changed
+from tests.common import async_fire_time_changed
 
 
 async def test_setup(hass):
@@ -32,85 +32,79 @@ async def test_setup(hass):
             },
         }
     }
-    with assert_setup_component(1):
-        assert await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
+    assert await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
 
 
 async def test_setup_no_sensors(hass):
     """Test setup with no sensors."""
-    with assert_setup_component(0):
-        assert await setup.async_setup_component(
-            hass, binary_sensor.DOMAIN, {"binary_sensor": {"platform": "template"}}
-        )
+    assert await setup.async_setup_component(
+        hass, binary_sensor.DOMAIN, {"binary_sensor": {"platform": "template"}}
+    )
 
 
 async def test_setup_invalid_device(hass):
     """Test the setup with invalid devices."""
-    with assert_setup_component(0):
-        assert await setup.async_setup_component(
-            hass,
-            binary_sensor.DOMAIN,
-            {"binary_sensor": {"platform": "template", "sensors": {"foo bar": {}}}},
-        )
+    assert await setup.async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {"binary_sensor": {"platform": "template", "sensors": {"foo bar": {}}}},
+    )
 
 
 async def test_setup_invalid_device_class(hass):
     """Test setup with invalid sensor class."""
-    with assert_setup_component(0):
-        assert await setup.async_setup_component(
-            hass,
-            binary_sensor.DOMAIN,
-            {
-                "binary_sensor": {
-                    "platform": "template",
-                    "sensors": {
-                        "test": {
-                            "value_template": "{{ foo }}",
-                            "device_class": "foobarnotreal",
-                        }
-                    },
-                }
-            },
-        )
+    assert await setup.async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            "binary_sensor": {
+                "platform": "template",
+                "sensors": {
+                    "test": {
+                        "value_template": "{{ foo }}",
+                        "device_class": "foobarnotreal",
+                    }
+                },
+            }
+        },
+    )
 
 
 async def test_setup_invalid_missing_template(hass):
     """Test setup with invalid and missing template."""
-    with assert_setup_component(0):
-        assert await setup.async_setup_component(
-            hass,
-            binary_sensor.DOMAIN,
-            {
-                "binary_sensor": {
-                    "platform": "template",
-                    "sensors": {"test": {"device_class": "motion"}},
-                }
-            },
-        )
+    assert await setup.async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            "binary_sensor": {
+                "platform": "template",
+                "sensors": {"test": {"device_class": "motion"}},
+            }
+        },
+    )
 
 
 async def test_icon_template(hass):
     """Test icon template."""
-    with assert_setup_component(1):
-        assert await setup.async_setup_component(
-            hass,
-            binary_sensor.DOMAIN,
-            {
-                "binary_sensor": {
-                    "platform": "template",
-                    "sensors": {
-                        "test_template_sensor": {
-                            "value_template": "{{ states.sensor.xyz.state }}",
-                            "icon_template": "{% if "
-                            "states.binary_sensor.test_state.state == "
-                            "'Works' %}"
-                            "mdi:check"
-                            "{% endif %}",
-                        }
-                    },
-                }
-            },
-        )
+    assert await setup.async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            "binary_sensor": {
+                "platform": "template",
+                "sensors": {
+                    "test_template_sensor": {
+                        "value_template": "{{ states.sensor.xyz.state }}",
+                        "icon_template": "{% if "
+                        "states.binary_sensor.test_state.state == "
+                        "'Works' %}"
+                        "mdi:check"
+                        "{% endif %}",
+                    }
+                },
+            }
+        },
+    )
 
     await hass.async_block_till_done()
     await hass.async_start()
@@ -127,26 +121,25 @@ async def test_icon_template(hass):
 
 async def test_entity_picture_template(hass):
     """Test entity_picture template."""
-    with assert_setup_component(1):
-        assert await setup.async_setup_component(
-            hass,
-            binary_sensor.DOMAIN,
-            {
-                "binary_sensor": {
-                    "platform": "template",
-                    "sensors": {
-                        "test_template_sensor": {
-                            "value_template": "{{ states.sensor.xyz.state }}",
-                            "entity_picture_template": "{% if "
-                            "states.binary_sensor.test_state.state == "
-                            "'Works' %}"
-                            "/local/sensor.png"
-                            "{% endif %}",
-                        }
-                    },
-                }
-            },
-        )
+    assert await setup.async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            "binary_sensor": {
+                "platform": "template",
+                "sensors": {
+                    "test_template_sensor": {
+                        "value_template": "{{ states.sensor.xyz.state }}",
+                        "entity_picture_template": "{% if "
+                        "states.binary_sensor.test_state.state == "
+                        "'Works' %}"
+                        "/local/sensor.png"
+                        "{% endif %}",
+                    }
+                },
+            }
+        },
+    )
 
     await hass.async_block_till_done()
     await hass.async_start()
@@ -163,24 +156,23 @@ async def test_entity_picture_template(hass):
 
 async def test_attribute_templates(hass):
     """Test attribute_templates template."""
-    with assert_setup_component(1):
-        assert await setup.async_setup_component(
-            hass,
-            binary_sensor.DOMAIN,
-            {
-                "binary_sensor": {
-                    "platform": "template",
-                    "sensors": {
-                        "test_template_sensor": {
-                            "value_template": "{{ states.sensor.xyz.state }}",
-                            "attribute_templates": {
-                                "test_attribute": "It {{ states.sensor.test_state.state }}."
-                            },
-                        }
-                    },
-                }
-            },
-        )
+    assert await setup.async_setup_component(
+        hass,
+        binary_sensor.DOMAIN,
+        {
+            "binary_sensor": {
+                "platform": "template",
+                "sensors": {
+                    "test_template_sensor": {
+                        "value_template": "{{ states.sensor.xyz.state }}",
+                        "attribute_templates": {
+                            "test_attribute": "It {{ states.sensor.test_state.state }}."
+                        },
+                    }
+                },
+            }
+        },
+    )
 
     await hass.async_block_till_done()
     await hass.async_start()
@@ -202,35 +194,34 @@ async def test_match_all(hass):
         "homeassistant.components.template.binary_sensor."
         "BinarySensorTemplate._update_state"
     ) as _update_state:
-        with assert_setup_component(1):
-            assert await setup.async_setup_component(
-                hass,
-                binary_sensor.DOMAIN,
-                {
-                    "binary_sensor": {
-                        "platform": "template",
-                        "sensors": {
-                            "match_all_template_sensor": {
-                                "value_template": (
-                                    "{% for state in states %}"
-                                    "{% if state.entity_id == 'sensor.humidity' %}"
-                                    "{{ state.entity_id }}={{ state.state }}"
-                                    "{% endif %}"
-                                    "{% endfor %}"
-                                ),
-                            },
+        assert await setup.async_setup_component(
+            hass,
+            binary_sensor.DOMAIN,
+            {
+                "binary_sensor": {
+                    "platform": "template",
+                    "sensors": {
+                        "match_all_template_sensor": {
+                            "value_template": (
+                                "{% for state in states %}"
+                                "{% if state.entity_id == 'sensor.humidity' %}"
+                                "{{ state.entity_id }}={{ state.state }}"
+                                "{% endif %}"
+                                "{% endfor %}"
+                            ),
                         },
-                    }
-                },
-            )
+                    },
+                }
+            },
+        )
 
-            await hass.async_start()
-            await hass.async_block_till_done()
-            init_calls = len(_update_state.mock_calls)
+        await hass.async_start()
+        await hass.async_block_till_done()
+        init_calls = len(_update_state.mock_calls)
 
-            hass.states.async_set("sensor.any_state", "update")
-            await hass.async_block_till_done()
-            assert len(_update_state.mock_calls) == init_calls
+        hass.states.async_set("sensor.any_state", "update")
+        await hass.async_block_till_done()
+        assert len(_update_state.mock_calls) == init_calls
 
 
 async def test_event(hass):
@@ -247,8 +238,7 @@ async def test_event(hass):
             },
         }
     }
-    with assert_setup_component(1):
-        assert await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
+    assert await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
 
     await hass.async_block_till_done()
     await hass.async_start()

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -4,7 +4,8 @@ from os import path
 from unittest.mock import patch
 
 from homeassistant import config
-from homeassistant.components.template import DOMAIN, SERVICE_RELOAD
+from homeassistant.components.template import DOMAIN
+from homeassistant.helpers.reload import SERVICE_RELOAD
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add an `async_setup` to the template integration that registers the reload service.

In preparation of adding #48169 on top.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
