### PR TITLE
Provide api to see which integrations are being loaded

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -560,7 +560,7 @@ async def _async_set_up_integrations(
         "Integration setup times: %s",
         {
             integration: timedelta.total_seconds()
-            for integration, timedelta in setup_time
+            for integration, timedelta in setup_time.items()
         },
     )
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -421,9 +421,7 @@ async def async_setup_multi_components(
         domain: hass.async_create_task(async_setup_component(hass, domain, config))
         for domain in domains
     }
-    log_task = asyncio.create_task(_async_watch_pending_setups(hass))
     await asyncio.wait(futures.values())
-    log_task.cancel()
     errors = [domain for domain in domains if futures[domain].exception()]
     for domain in errors:
         exception = futures[domain].exception()
@@ -441,6 +439,8 @@ async def _async_set_up_integrations(
     """Set up all the integrations."""
     hass.data[DATA_SETUP_STARTED] = {}
     setup_time = hass.data[DATA_SETUP_TIME] = {}
+
+    log_task = asyncio.create_task(_async_watch_pending_setups(hass))
 
     domains_to_setup = _get_domains(hass, config)
 
@@ -564,3 +564,4 @@ async def _async_set_up_integrations(
         _LOGGER.warning("Setup timed out for bootstrap - moving forward")
 
     _LOGGER.debug("Setup times: %s", setup_time)
+    log_task.cancel()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -555,6 +555,9 @@ async def _async_set_up_integrations(
         except asyncio.TimeoutError:
             _LOGGER.warning("Setup timed out for stage 2 - moving forward")
 
+    log_task.cancel()
+    _LOGGER.debug("Setup times: %s", setup_time)
+
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")
     try:
@@ -562,6 +565,3 @@ async def _async_set_up_integrations(
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
         _LOGGER.warning("Setup timed out for bootstrap - moving forward")
-
-    _LOGGER.debug("Setup times: %s", setup_time)
-    log_task.cancel()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -402,7 +402,7 @@ async def _async_watch_pending_setups(
         await asyncio.sleep(SLOW_STARTUP_CHECK_INTERVAL)
         loop_count += SLOW_STARTUP_CHECK_INTERVAL
 
-        if loop_count > LOG_SLOW_STARTUP_INTERVAL and remaining:
+        if loop_count >= LOG_SLOW_STARTUP_INTERVAL and remaining:
             _LOGGER.warning(
                 "Waiting on integrations to complete setup: %s",
                 ", ".join(remaining),

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -557,7 +557,7 @@ async def _async_set_up_integrations(
             _LOGGER.warning("Setup timed out for stage 2 - moving forward")
 
     log_task.cancel()
-    _LOGGER.info(
+    _LOGGER.debug(
         "Integration setup times: %s",
         {
             integration: timedelta.total_seconds()

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -395,6 +395,7 @@ async def _async_watch_pending_setups(
         remaining_with_setup_started = {
             domain: (now - setup_started[domain]).seconds for domain in remaining
         }
+        _LOGGER.debug("Integration remaining: %s", remaining_with_setup_started)
         async_dispatcher_send(
             hass, SIGNAL_BOOTSTRAP_INTEGRATONS, remaining_with_setup_started
         )

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -440,7 +440,7 @@ async def _async_set_up_integrations(
 ) -> None:
     """Set up all the integrations."""
     hass.data[DATA_SETUP_STARTED] = {}
-    hass.data[DATA_SETUP_TIME] = {}
+    setup_time = hass.data[DATA_SETUP_TIME] = {}
 
     domains_to_setup = _get_domains(hass, config)
 
@@ -562,3 +562,5 @@ async def _async_set_up_integrations(
             await hass.async_block_till_done()
     except asyncio.TimeoutError:
         _LOGGER.warning("Setup timed out for bootstrap - moving forward")
+
+    _LOGGER.debug("Setup times: %s", setup_time)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -560,7 +560,9 @@ async def _async_set_up_integrations(
         "Integration setup times: %s",
         {
             integration: timedelta.total_seconds()
-            for integration, timedelta in setup_time.items()
+            for integration, timedelta in sorted(
+                setup_time.items(), key=lambda item: item[1].total_seconds()  # type: ignore
+            )
         },
     )
 

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -556,7 +556,13 @@ async def _async_set_up_integrations(
             _LOGGER.warning("Setup timed out for stage 2 - moving forward")
 
     log_task.cancel()
-    _LOGGER.debug("Setup times: %s", setup_time)
+    _LOGGER.info(
+        "Integration setup times: %s",
+        {
+            integration: timedelta.total_seconds()
+            for integration, timedelta in setup_time
+        },
+    )
 
     # Wrap up startup
     _LOGGER.debug("Waiting for startup to wrap up")

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -391,7 +391,6 @@ async def _async_watch_pending_setups(hass: core.HomeAssistant) -> None:
     setup_started: dict[str, datetime] = hass.data[DATA_SETUP_STARTED]
     while True:
         now = dt_util.utcnow()
-        remaining = setup_started.keys()
         remaining_with_setup_started = {
             domain: (now - setup_started[domain]).total_seconds()
             for domain in setup_started
@@ -403,10 +402,10 @@ async def _async_watch_pending_setups(hass: core.HomeAssistant) -> None:
         await asyncio.sleep(SLOW_STARTUP_CHECK_INTERVAL)
         loop_count += SLOW_STARTUP_CHECK_INTERVAL
 
-        if loop_count >= LOG_SLOW_STARTUP_INTERVAL and remaining:
+        if loop_count >= LOG_SLOW_STARTUP_INTERVAL and setup_started:
             _LOGGER.warning(
                 "Waiting on integrations to complete setup: %s",
-                ", ".join(remaining),
+                ", ".join(setup_started),
             )
             loop_count = 0
         _LOGGER.debug("Running timeout Zones: %s", hass.timeout.zones)

--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -393,7 +393,8 @@ async def _async_watch_pending_setups(hass: core.HomeAssistant) -> None:
         now = dt_util.utcnow()
         remaining = setup_started.keys()
         remaining_with_setup_started = {
-            domain: (now - setup_started[domain]).seconds for domain in setup_started
+            domain: (now - setup_started[domain]).total_seconds()
+            for domain in setup_started
         }
         _LOGGER.debug("Integration remaining: %s", remaining_with_setup_started)
         async_dispatcher_send(

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -38,7 +38,7 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, GPSType
-from homeassistant.setup import async_prepare_setup_platform
+from homeassistant.setup import async_prepare_setup_platform, async_start_setup
 from homeassistant.util import dt as dt_util
 from homeassistant.util.yaml import dump
 
@@ -221,48 +221,54 @@ class DeviceTrackerPlatform:
 
     async def async_setup_legacy(self, hass, tracker, discovery_info=None):
         """Set up a legacy platform."""
-        LOGGER.info("Setting up %s.%s", DOMAIN, self.name)
-        try:
-            scanner = None
-            setup = None
-            if hasattr(self.platform, "async_get_scanner"):
-                scanner = await self.platform.async_get_scanner(
-                    hass, {DOMAIN: self.config}
-                )
-            elif hasattr(self.platform, "get_scanner"):
-                scanner = await hass.async_add_executor_job(
-                    self.platform.get_scanner, hass, {DOMAIN: self.config}
-                )
-            elif hasattr(self.platform, "async_setup_scanner"):
-                setup = await self.platform.async_setup_scanner(
-                    hass, self.config, tracker.async_see, discovery_info
-                )
-            elif hasattr(self.platform, "setup_scanner"):
-                setup = await hass.async_add_executor_job(
-                    self.platform.setup_scanner,
-                    hass,
-                    self.config,
-                    tracker.see,
-                    discovery_info,
-                )
-            else:
-                raise HomeAssistantError("Invalid legacy device_tracker platform.")
+        full_name = f"{DOMAIN}.{self.name}"
+        LOGGER.info("Setting up %s", full_name)
+        with async_start_setup(hass, [full_name]):
+            try:
+                scanner = None
+                setup = None
+                if hasattr(self.platform, "async_get_scanner"):
+                    scanner = await self.platform.async_get_scanner(
+                        hass, {DOMAIN: self.config}
+                    )
+                elif hasattr(self.platform, "get_scanner"):
+                    scanner = await hass.async_add_executor_job(
+                        self.platform.get_scanner, hass, {DOMAIN: self.config}
+                    )
+                elif hasattr(self.platform, "async_setup_scanner"):
+                    setup = await self.platform.async_setup_scanner(
+                        hass, self.config, tracker.async_see, discovery_info
+                    )
+                elif hasattr(self.platform, "setup_scanner"):
+                    setup = await hass.async_add_executor_job(
+                        self.platform.setup_scanner,
+                        hass,
+                        self.config,
+                        tracker.see,
+                        discovery_info,
+                    )
+                else:
+                    raise HomeAssistantError("Invalid legacy device_tracker platform.")
 
-            if setup:
-                hass.config.components.add(f"{DOMAIN}.{self.name}")
+                if setup:
+                    hass.config.components.add(f"{DOMAIN}.{self.name}")
 
-            if scanner:
-                async_setup_scanner_platform(
-                    hass, self.config, scanner, tracker.async_see, self.type
+                if scanner:
+                    async_setup_scanner_platform(
+                        hass, self.config, scanner, tracker.async_see, self.type
+                    )
+                    return
+
+                if not setup:
+                    LOGGER.error(
+                        "Error setting up platform %s %s", self.type, self.name
+                    )
+                    return
+
+            except Exception:  # pylint: disable=broad-except
+                LOGGER.exception(
+                    "Error setting up platform %s %s", self.type, self.name
                 )
-                return
-
-            if not setup:
-                LOGGER.error("Error setting up platform %s %s", self.type, self.name)
-                return
-
-        except Exception:  # pylint: disable=broad-except
-            LOGGER.exception("Error setting up platform %s %s", self.type, self.name)
 
 
 async def async_extract_config(hass, config):

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -251,7 +251,7 @@ class DeviceTrackerPlatform:
                     raise HomeAssistantError("Invalid legacy device_tracker platform.")
 
                 if setup:
-                    hass.config.components.add(f"{DOMAIN}.{self.name}")
+                    hass.config.components.add(full_name)
 
                 if scanner:
                     async_setup_scanner_platform(

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -279,7 +279,7 @@ async def handle_manifest_get(hass, connection, msg):
         connection.send_error(msg["id"], const.ERR_NOT_FOUND, "Integration not found")
 
 
-@decorators.websocket_command({vol.Required("type"): "integration/setup"})
+@decorators.websocket_command({vol.Required("type"): "integration/setup_info"})
 @decorators.async_response
 async def handle_integration_setup(hass, connection, msg):
     """Handle integrations command."""

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -36,7 +36,7 @@ def async_register_commands(hass, async_reg):
     async_reg(hass, handle_get_services)
     async_reg(hass, handle_get_states)
     async_reg(hass, handle_manifest_get)
-    async_reg(hass, handle_integration_setup)
+    async_reg(hass, handle_integration_setup_info)
     async_reg(hass, handle_manifest_list)
     async_reg(hass, handle_ping)
     async_reg(hass, handle_render_template)

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -265,7 +265,7 @@ async def handle_manifest_get(hass, connection, msg):
 
 @decorators.websocket_command({vol.Required("type"): "integration/setup_info"})
 @decorators.async_response
-async def handle_integration_setup(hass, connection, msg):
+async def handle_integration_setup_info(hass, connection, msg):
     """Handle integrations command."""
     connection.send_result(
         msg["id"],

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -133,7 +133,7 @@ def handle_unsubscribe_bootstrap_integrations(hass, connection, msg):
     # Currently these are the same as events so we pass on the request
     # This api call only exists in case we change the implementation
     # details.
-    return handle_unsubscribe_events(hass, connection, msg)
+    handle_unsubscribe_events(hass, connection, msg)
 
 
 @callback

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -45,7 +45,6 @@ def async_register_commands(hass, async_reg):
     async_reg(hass, handle_subscribe_trigger)
     async_reg(hass, handle_test_condition)
     async_reg(hass, handle_unsubscribe_events)
-    async_reg(hass, handle_unsubscribe_bootstrap_integrations)
 
 
 def pong_message(iden):
@@ -119,21 +118,6 @@ def handle_subscribe_bootstrap_integrations(hass, connection, msg):
     )
 
     connection.send_message(messages.result_message(msg["id"]))
-
-
-@callback
-@decorators.websocket_command(
-    {
-        vol.Required("type"): "unsubscribe_bootstrap_integrations",
-        vol.Required("subscription"): cv.positive_int,
-    }
-)
-def handle_unsubscribe_bootstrap_integrations(hass, connection, msg):
-    """Handle unsubscribe bootstrap integrations command."""
-    # Currently these are the same as events so we pass on the request
-    # This api call only exists in case we change the implementation
-    # details.
-    handle_unsubscribe_events(hass, connection, msg)
 
 
 @callback

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -4,6 +4,7 @@ import asyncio
 import voluptuous as vol
 
 from homeassistant.auth.permissions.const import CAT_ENTITIES, POLICY_READ
+from homeassistant.bootstrap import SIGNAL_BOOTSTRAP_INTEGRATONS
 from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 from homeassistant.const import EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL
 from homeassistant.core import DOMAIN as HASS_DOMAIN, callback
@@ -14,6 +15,7 @@ from homeassistant.exceptions import (
     Unauthorized,
 )
 from homeassistant.helpers import config_validation as cv, entity, template
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.event import TrackTemplate, async_track_template_result
 from homeassistant.helpers.service import async_get_all_descriptions
 from homeassistant.loader import IntegrationNotFound, async_get_integration
@@ -37,10 +39,12 @@ def async_register_commands(hass, async_reg):
     async_reg(hass, handle_manifest_list)
     async_reg(hass, handle_ping)
     async_reg(hass, handle_render_template)
+    async_reg(hass, handle_subscribe_bootstrap_integrations)
     async_reg(hass, handle_subscribe_events)
     async_reg(hass, handle_subscribe_trigger)
     async_reg(hass, handle_test_condition)
     async_reg(hass, handle_unsubscribe_events)
+    async_reg(hass, handle_unsubscribe_bootstrap_integrations)
 
 
 def pong_message(iden):
@@ -93,6 +97,42 @@ def handle_subscribe_events(hass, connection, msg):
     )
 
     connection.send_message(messages.result_message(msg["id"]))
+
+
+@callback
+@decorators.websocket_command(
+    {
+        vol.Required("type"): "subscribe_bootstrap_integrations",
+    }
+)
+def handle_subscribe_bootstrap_integrations(hass, connection, msg):
+    """Handle subscribe bootstrap integrations command."""
+
+    @callback
+    def forward_bootstrap_integrations(message):
+        """Forward bootstrap integrations to websocket."""
+        connection.send_message(messages.result_message(msg["id"], message))
+
+    connection.subscriptions[msg["id"]] = async_dispatcher_connect(
+        hass, SIGNAL_BOOTSTRAP_INTEGRATONS, forward_bootstrap_integrations
+    )
+
+    connection.send_message(messages.result_message(msg["id"]))
+
+
+@callback
+@decorators.websocket_command(
+    {
+        vol.Required("type"): "unsubscribe_bootstrap_integrations",
+        vol.Required("subscription"): cv.positive_int,
+    }
+)
+def handle_unsubscribe_bootstrap_integrations(hass, connection, msg):
+    """Handle unsubscribe bootstrap integrations command."""
+    # Currently these are the same as events so we pass on the request
+    # This api call only exists in case we change the implementation
+    # details.
+    return handle_unsubscribe_events(hass, connection, msg)
 
 
 @callback

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from contextvars import ContextVar
 from datetime import datetime, timedelta
+import logging
 from logging import Logger
 from types import ModuleType
 from typing import TYPE_CHECKING, Callable, Coroutine, Iterable
@@ -30,6 +31,7 @@ from homeassistant.helpers import (
     entity_registry as ent_reg,
     service,
 )
+from homeassistant.setup import async_start_setup
 from homeassistant.util.async_ import run_callback_threadsafe
 
 from .entity_registry import DISABLED_INTEGRATION
@@ -47,6 +49,8 @@ SLOW_ADD_MIN_TIMEOUT = 500
 PLATFORM_NOT_READY_RETRIES = 10
 DATA_ENTITY_PLATFORM = "entity_platform"
 PLATFORM_NOT_READY_BASE_WAIT_TIME = 30  # seconds
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class EntityPlatform:
@@ -202,77 +206,77 @@ class EntityPlatform:
             self.platform_name,
             SLOW_SETUP_WARNING,
         )
+        with async_start_setup(hass, [full_name]):
+            try:
+                task = async_create_setup_task()
 
-        try:
-            task = async_create_setup_task()
+                async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, self.domain):
+                    await asyncio.shield(task)
 
-            async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, self.domain):
-                await asyncio.shield(task)
+                # Block till all entities are done
+                while self._tasks:
+                    pending = [task for task in self._tasks if not task.done()]
+                    self._tasks.clear()
 
-            # Block till all entities are done
-            while self._tasks:
-                pending = [task for task in self._tasks if not task.done()]
-                self._tasks.clear()
+                    if pending:
+                        await asyncio.gather(*pending)
 
-                if pending:
-                    await asyncio.gather(*pending)
+                hass.config.components.add(full_name)
+                self._setup_complete = True
+                return True
+            except PlatformNotReady as ex:
+                tries += 1
+                wait_time = min(tries, 6) * PLATFORM_NOT_READY_BASE_WAIT_TIME
+                message = str(ex)
+                if not message and ex.__cause__:
+                    message = str(ex.__cause__)
+                ready_message = f"ready yet: {message}" if message else "ready yet"
+                if tries == 1:
+                    logger.warning(
+                        "Platform %s not %s; Retrying in background in %d seconds",
+                        self.platform_name,
+                        ready_message,
+                        wait_time,
+                    )
+                else:
+                    logger.debug(
+                        "Platform %s not %s; Retrying in %d seconds",
+                        self.platform_name,
+                        ready_message,
+                        wait_time,
+                    )
 
-            hass.config.components.add(full_name)
-            self._setup_complete = True
-            return True
-        except PlatformNotReady as ex:
-            tries += 1
-            wait_time = min(tries, 6) * PLATFORM_NOT_READY_BASE_WAIT_TIME
-            message = str(ex)
-            if not message and ex.__cause__:
-                message = str(ex.__cause__)
-            ready_message = f"ready yet: {message}" if message else "ready yet"
-            if tries == 1:
-                logger.warning(
-                    "Platform %s not %s; Retrying in background in %d seconds",
+                async def setup_again(*_):  # type: ignore[no-untyped-def]
+                    """Run setup again."""
+                    self._async_cancel_retry_setup = None
+                    await self._async_setup_platform(async_create_setup_task, tries)
+
+                if hass.state == CoreState.running:
+                    self._async_cancel_retry_setup = async_call_later(
+                        hass, wait_time, setup_again
+                    )
+                else:
+                    self._async_cancel_retry_setup = hass.bus.async_listen_once(
+                        EVENT_HOMEASSISTANT_STARTED, setup_again
+                    )
+                return False
+            except asyncio.TimeoutError:
+                logger.error(
+                    "Setup of platform %s is taking longer than %s seconds."
+                    " Startup will proceed without waiting any longer.",
                     self.platform_name,
-                    ready_message,
-                    wait_time,
+                    SLOW_SETUP_MAX_WAIT,
                 )
-            else:
-                logger.debug(
-                    "Platform %s not %s; Retrying in %d seconds",
+                return False
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    "Error while setting up %s platform for %s",
                     self.platform_name,
-                    ready_message,
-                    wait_time,
+                    self.domain,
                 )
-
-            async def setup_again(*_):  # type: ignore[no-untyped-def]
-                """Run setup again."""
-                self._async_cancel_retry_setup = None
-                await self._async_setup_platform(async_create_setup_task, tries)
-
-            if hass.state == CoreState.running:
-                self._async_cancel_retry_setup = async_call_later(
-                    hass, wait_time, setup_again
-                )
-            else:
-                self._async_cancel_retry_setup = hass.bus.async_listen_once(
-                    EVENT_HOMEASSISTANT_STARTED, setup_again
-                )
-            return False
-        except asyncio.TimeoutError:
-            logger.error(
-                "Setup of platform %s is taking longer than %s seconds."
-                " Startup will proceed without waiting any longer.",
-                self.platform_name,
-                SLOW_SETUP_MAX_WAIT,
-            )
-            return False
-        except Exception:  # pylint: disable=broad-except
-            logger.exception(
-                "Error while setting up %s platform for %s",
-                self.platform_name,
-                self.domain,
-            )
-            return False
-        finally:
-            warn_task.cancel()
+                return False
+            finally:
+                warn_task.cancel()
 
     def _schedule_add_entities(
         self, new_entities: Iterable[Entity], update_before_add: bool = False
@@ -643,6 +647,7 @@ class EntityPlatform:
             for entity in self.entities.values():
                 if not entity.should_poll:
                     continue
+                _LOGGER.debug("Entity: %s is using polling", entity.entity_id)
                 tasks.append(entity.async_update_ha_state(True))
 
             if tasks:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -647,7 +647,6 @@ class EntityPlatform:
             for entity in self.entities.values():
                 if not entity.should_poll:
                     continue
-                _LOGGER.debug("Entity: %s is using polling", entity.entity_id)
                 tasks.append(entity.async_update_ha_state(True))
 
             if tasks:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging.handlers
 from timeit import default_timer as timer
 from types import ModuleType
-from typing import Awaitable, Callable
+from typing import Awaitable, Callable, Generator, Iterable
 
 from homeassistant import config as conf_util, core, loader, requirements
 from homeassistant.config import async_notify_setup_error
@@ -42,6 +43,8 @@ BASE_PLATFORMS = {
 
 DATA_SETUP_DONE = "setup_done"
 DATA_SETUP_STARTED = "setup_started"
+DATA_SETUP_TIME = "setup_time"
+
 DATA_SETUP = "setup_tasks"
 DATA_DEPS_REQS = "deps_reqs_processed"
 
@@ -205,84 +208,78 @@ async def _async_setup_component(
 
     start = timer()
     _LOGGER.info("Setting up %s", domain)
-    hass.data.setdefault(DATA_SETUP_STARTED, {})[domain] = dt_util.utcnow()
-
-    if hasattr(component, "PLATFORM_SCHEMA"):
-        # Entity components have their own warning
-        warn_task = None
-    else:
-        warn_task = hass.loop.call_later(
-            SLOW_SETUP_WARNING,
-            _LOGGER.warning,
-            "Setup of %s is taking over %s seconds.",
-            domain,
-            SLOW_SETUP_WARNING,
-        )
-
-    task = None
-    result = True
-    try:
-        if hasattr(component, "async_setup"):
-            task = component.async_setup(hass, processed_config)  # type: ignore
-        elif hasattr(component, "setup"):
-            # This should not be replaced with hass.async_add_executor_job because
-            # we don't want to track this task in case it blocks startup.
-            task = hass.loop.run_in_executor(
-                None, component.setup, hass, processed_config  # type: ignore
+    with async_start_setup(hass, [domain]):
+        if hasattr(component, "PLATFORM_SCHEMA"):
+            # Entity components have their own warning
+            warn_task = None
+        else:
+            warn_task = hass.loop.call_later(
+                SLOW_SETUP_WARNING,
+                _LOGGER.warning,
+                "Setup of %s is taking over %s seconds.",
+                domain,
+                SLOW_SETUP_WARNING,
             )
-        elif not hasattr(component, "async_setup_entry"):
-            log_error("No setup or config entry setup function defined.")
-            hass.data[DATA_SETUP_STARTED].pop(domain)
+
+        task = None
+        result = True
+        try:
+            if hasattr(component, "async_setup"):
+                task = component.async_setup(hass, processed_config)  # type: ignore
+            elif hasattr(component, "setup"):
+                # This should not be replaced with hass.async_add_executor_job because
+                # we don't want to track this task in case it blocks startup.
+                task = hass.loop.run_in_executor(
+                    None, component.setup, hass, processed_config  # type: ignore
+                )
+            elif not hasattr(component, "async_setup_entry"):
+                log_error("No setup or config entry setup function defined.")
+                hass.data[DATA_SETUP_STARTED].pop(domain)
+                return False
+
+            if task:
+                async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
+                    result = await task
+        except asyncio.TimeoutError:
+            _LOGGER.error(
+                "Setup of %s is taking longer than %s seconds."
+                " Startup will proceed without waiting any longer",
+                domain,
+                SLOW_SETUP_MAX_WAIT,
+            )
+            return False
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Error during setup of component %s", domain)
+            async_notify_setup_error(hass, domain, integration.documentation)
+            return False
+        finally:
+            end = timer()
+            if warn_task:
+                warn_task.cancel()
+        _LOGGER.info("Setup of domain %s took %.1f seconds", domain, end - start)
+
+        if result is False:
+            log_error("Integration failed to initialize.")
+            return False
+        if result is not True:
+            log_error(
+                f"Integration {domain!r} did not return boolean if setup was "
+                "successful. Disabling component."
+            )
             return False
 
-        if task:
-            async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
-                result = await task
-    except asyncio.TimeoutError:
-        _LOGGER.error(
-            "Setup of %s is taking longer than %s seconds."
-            " Startup will proceed without waiting any longer",
-            domain,
-            SLOW_SETUP_MAX_WAIT,
+        # Flush out async_setup calling create_task. Fragile but covered by test.
+        await asyncio.sleep(0)
+        await hass.config_entries.flow.async_wait_init_flow_finish(domain)
+
+        await asyncio.gather(
+            *[
+                entry.async_setup(hass, integration=integration)
+                for entry in hass.config_entries.async_entries(domain)
+            ]
         )
-        hass.data[DATA_SETUP_STARTED].pop(domain)
-        return False
-    except Exception:  # pylint: disable=broad-except
-        _LOGGER.exception("Error during setup of component %s", domain)
-        async_notify_setup_error(hass, domain, integration.documentation)
-        hass.data[DATA_SETUP_STARTED].pop(domain)
-        return False
-    finally:
-        end = timer()
-        if warn_task:
-            warn_task.cancel()
-    _LOGGER.info("Setup of domain %s took %.1f seconds", domain, end - start)
 
-    if result is False:
-        log_error("Integration failed to initialize.")
-        hass.data[DATA_SETUP_STARTED].pop(domain)
-        return False
-    if result is not True:
-        log_error(
-            f"Integration {domain!r} did not return boolean if setup was "
-            "successful. Disabling component."
-        )
-        hass.data[DATA_SETUP_STARTED].pop(domain)
-        return False
-
-    # Flush out async_setup calling create_task. Fragile but covered by test.
-    await asyncio.sleep(0)
-    await hass.config_entries.flow.async_wait_init_flow_finish(domain)
-
-    await asyncio.gather(
-        *[
-            entry.async_setup(hass, integration=integration)
-            for entry in hass.config_entries.async_entries(domain)
-        ]
-    )
-
-    hass.config.components.add(domain)
-    hass.data[DATA_SETUP_STARTED].pop(domain)
+        hass.config.components.add(domain)
 
     # Cleanup
     if domain in hass.data[DATA_SETUP]:
@@ -420,3 +417,23 @@ def async_get_loaded_integrations(hass: core.HomeAssistant) -> set:
         if domain in BASE_PLATFORMS:
             integrations.add(platform)
     return integrations
+
+
+@contextlib.contextmanager
+def async_start_setup(hass: core.HomeAssistant, components: Iterable) -> Generator:
+    """Keep track of when setup starts and finishes."""
+    hass.data.setdefault(DATA_SETUP_STARTED, {})
+
+    started = dt_util.utcnow()
+    for domain in components:
+        hass.data[DATA_SETUP_STARTED][domain] = started
+
+    yield
+
+    if domain in hass.data[DATA_SETUP_STARTED]:
+        del hass.data[DATA_SETUP_STARTED][domain]
+
+    hass.data.setdefault(DATA_SETUP_TIME, {})
+    time_taken = dt_util.utcnow() - started
+    for domain in components:
+        hass.data[DATA_SETUP_TIME][domain] = time_taken

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -422,6 +422,7 @@ def async_get_loaded_integrations(hass: core.HomeAssistant) -> set:
 @contextlib.contextmanager
 def async_start_setup(hass: core.HomeAssistant, components: Iterable) -> Generator:
     """Keep track of when setup starts and finishes."""
+    hass.data.setdefault(DATA_SETUP_STARTED, {})
     started = dt_util.utcnow()
     unique_components = []
     for domain in components:
@@ -431,6 +432,7 @@ def async_start_setup(hass: core.HomeAssistant, components: Iterable) -> Generat
 
     yield
 
+    hass.data.setdefault(DATA_SETUP_TIME, {})
     time_taken = dt_util.utcnow() - started
     for domain in unique_components:
         del hass.data[DATA_SETUP_STARTED][domain]

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -234,7 +234,6 @@ async def _async_setup_component(
                 )
             elif not hasattr(component, "async_setup_entry"):
                 log_error("No setup or config entry setup function defined.")
-                hass.data[DATA_SETUP_STARTED].pop(domain)
                 return False
 
             if task:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -422,8 +422,6 @@ def async_get_loaded_integrations(hass: core.HomeAssistant) -> set:
 @contextlib.contextmanager
 def async_start_setup(hass: core.HomeAssistant, components: Iterable) -> Generator:
     """Keep track of when setup starts and finishes."""
-    hass.data.setdefault(DATA_SETUP_STARTED, {})
-
     started = dt_util.utcnow()
     unique_components = []
     for domain in components:
@@ -433,7 +431,6 @@ def async_start_setup(hass: core.HomeAssistant, components: Iterable) -> Generat
 
     yield
 
-    hass.data.setdefault(DATA_SETUP_TIME, {})
     time_taken = dt_util.utcnow() - started
     for domain in unique_components:
         del hass.data[DATA_SETUP_STARTED][domain]

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -13,7 +13,7 @@ from homeassistant.config import async_notify_setup_error
 from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util
+from homeassistant.util import dt as dt_util, ensure_unique_string
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -425,15 +425,16 @@ def async_start_setup(hass: core.HomeAssistant, components: Iterable) -> Generat
     hass.data.setdefault(DATA_SETUP_STARTED, {})
 
     started = dt_util.utcnow()
+    unique_components = []
     for domain in components:
-        hass.data[DATA_SETUP_STARTED][domain] = started
+        unique = ensure_unique_string(domain, hass.data[DATA_SETUP_STARTED])
+        unique_components.append(unique)
+        hass.data[DATA_SETUP_STARTED][unique] = started
 
     yield
 
-    if domain in hass.data[DATA_SETUP_STARTED]:
-        del hass.data[DATA_SETUP_STARTED][domain]
-
     hass.data.setdefault(DATA_SETUP_TIME, {})
     time_taken = dt_util.utcnow() - started
-    for domain in components:
+    for domain in unique_components:
+        del hass.data[DATA_SETUP_STARTED][domain]
         hass.data[DATA_SETUP_TIME][domain] = time_taken

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1151,15 +1151,6 @@ async def test_subscribe_unsubscribe_bootstrap_integrations(
     assert msg["type"] == "result"
     assert msg["result"] == message
 
-    await websocket_client.send_json(
-        {"id": 8, "type": "unsubscribe_bootstrap_integrations", "subscription": 7}
-    )
-    msg = await websocket_client.receive_json()
-    assert msg["id"] == 8
-    assert msg["success"] is True
-    assert msg["type"] == "result"
-    assert msg["result"] is None
-
 
 async def test_integration_setup(hass, websocket_client, hass_admin_user):
     """Test subscribe/unsubscribe bootstrap_integrations."""

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1152,13 +1152,13 @@ async def test_subscribe_unsubscribe_bootstrap_integrations(
     assert msg["result"] == message
 
 
-async def test_integration_setup(hass, websocket_client, hass_admin_user):
+async def test_integration_setup_info(hass, websocket_client, hass_admin_user):
     """Test subscribe/unsubscribe bootstrap_integrations."""
     hass.data[DATA_SETUP_TIME] = {
         "august": datetime.timedelta(seconds=12.5),
         "isy994": datetime.timedelta(seconds=12.8),
     }
-    await websocket_client.send_json({"id": 7, "type": "integration/setup"})
+    await websocket_client.send_json({"id": 7, "type": "integration/setup_info"})
 
     msg = await websocket_client.receive_json()
     assert msg["id"] == 7

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -1,10 +1,12 @@
 """Tests for WebSocket API commands."""
+import datetime
 from unittest.mock import ANY, patch
 
 from async_timeout import timeout
 import pytest
 import voluptuous as vol
 
+from homeassistant.bootstrap import SIGNAL_BOOTSTRAP_INTEGRATONS
 from homeassistant.components.websocket_api import const
 from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH,
@@ -15,9 +17,10 @@ from homeassistant.components.websocket_api.const import URL
 from homeassistant.core import Context, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import async_get_integration
-from homeassistant.setup import async_setup_component
+from homeassistant.setup import DATA_SETUP_TIME, async_setup_component
 
 from tests.common import MockEntity, MockEntityPlatform, async_mock_service
 
@@ -1124,3 +1127,53 @@ async def test_execute_script(hass, websocket_client):
     assert call.service == "test_service"
     assert call.data == {"hello": "From variable"}
     assert call.context.as_dict() == msg_var["result"]["context"]
+
+
+async def test_subscribe_unsubscribe_bootstrap_integrations(
+    hass, websocket_client, hass_admin_user
+):
+    """Test subscribe/unsubscribe bootstrap_integrations."""
+    await websocket_client.send_json(
+        {"id": 7, "type": "subscribe_bootstrap_integrations"}
+    )
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 7
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+
+    message = {"august": 12.5, "isy994": 12.8}
+
+    async_dispatcher_send(hass, SIGNAL_BOOTSTRAP_INTEGRATONS, message)
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 7
+    assert msg["success"] is True
+    assert msg["type"] == "result"
+    assert msg["result"] == message
+
+    await websocket_client.send_json(
+        {"id": 8, "type": "unsubscribe_bootstrap_integrations", "subscription": 7}
+    )
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 8
+    assert msg["success"] is True
+    assert msg["type"] == "result"
+    assert msg["result"] is None
+
+
+async def test_integration_setup(hass, websocket_client, hass_admin_user):
+    """Test subscribe/unsubscribe bootstrap_integrations."""
+    hass.data[DATA_SETUP_TIME] = {
+        "august": datetime.timedelta(seconds=12.5),
+        "isy994": datetime.timedelta(seconds=12.8),
+    }
+    await websocket_client.send_json({"id": 7, "type": "integration/setup"})
+
+    msg = await websocket_client.receive_json()
+    assert msg["id"] == 7
+    assert msg["type"] == const.TYPE_RESULT
+    assert msg["success"]
+    assert msg["result"] == [
+        {"domain": "august", "seconds": 12.5},
+        {"domain": "isy994", "seconds": 12.8},
+    ]

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -431,7 +431,9 @@ async def test_setup_hass_takes_longer_than_log_slow_startup(
     with patch(
         "homeassistant.config.async_hass_config_yaml",
         return_value={"browser": {}, "frontend": {}},
-    ), patch.object(bootstrap, "LOG_SLOW_STARTUP_INTERVAL", 0.3), patch(
+    ), patch.object(bootstrap, "LOG_SLOW_STARTUP_INTERVAL", 0.3), patch.object(
+        bootstrap, "SLOW_STARTUP_CHECK_INTERVAL", 0.05
+    ), patch(
         "homeassistant.components.frontend.async_setup",
         side_effect=_async_setup_that_blocks_startup,
     ):

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,6 +1,7 @@
 """Test component/platform setup."""
 # pylint: disable=protected-access
 import asyncio
+import datetime
 import os
 import threading
 from unittest.mock import AsyncMock, Mock, patch
@@ -644,3 +645,31 @@ async def test_integration_only_setup_entry(hass):
         ),
     )
     assert await setup.async_setup_component(hass, "test_integration_only_entry", {})
+
+
+async def test_async_start_setup(hass):
+    """Test setup started context manager keeps track of setup times."""
+    with setup.async_start_setup(hass, ["august"]):
+        assert isinstance(
+            hass.data[setup.DATA_SETUP_STARTED]["august"], datetime.datetime
+        )
+        with setup.async_start_setup(hass, ["august"]):
+            assert isinstance(
+                hass.data[setup.DATA_SETUP_STARTED]["august_2"], datetime.datetime
+            )
+
+    assert "august" not in hass.data[setup.DATA_SETUP_STARTED]
+    assert isinstance(hass.data[setup.DATA_SETUP_TIME]["august"], datetime.timedelta)
+    assert "august_2" not in hass.data[setup.DATA_SETUP_TIME]
+
+
+async def test_async_start_setup_platforms(hass):
+    """Test setup started context manager keeps track of setup times for platforms."""
+    with setup.async_start_setup(hass, ["sensor.august"]):
+        assert isinstance(
+            hass.data[setup.DATA_SETUP_STARTED]["sensor.august"], datetime.datetime
+        )
+
+    assert "august" not in hass.data[setup.DATA_SETUP_STARTED]
+    assert isinstance(hass.data[setup.DATA_SETUP_TIME]["august"], datetime.timedelta)
+    assert "sensor" not in hass.data[setup.DATA_SETUP_TIME]


### PR DESCRIPTION
Needs #48269 since device trackers are not being added to the components 


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

*This is much easier to review without whitespace changes due to the context manager addition*

Goals
- Show the integration that is taking the most time to startup during startup
- Show how longer each integration took in total on the config info page to call out slow or misbehaving integrations so Home Assistant doesn't take the blame for slow ones (esp custom ones)

Frontend https://github.com/home-assistant/frontend/pull/8720

<img width="617" alt="Screen Shot 2021-03-25 at 8 46 55 AM" src="https://user-images.githubusercontent.com/663432/112527199-decaec80-8d46-11eb-8942-0d2edbe176fe.png">

`2021-03-26 08:59:01 INFO (MainThread) [homeassistant.bootstrap] Integration setup times: {'logger': 0.001837, 'onboarding': 0.002468, 'search': 0.002993, 'lock': 0.004147, 'webhook': 0.004786, 'frontend': 0.005408, 'alexa': 0.00748, 'stream': 0.009616, 'http': 0.011046, 'image': 0.012741, 'cover': 0.0138, 'system_log': 0.017852, 'device_automation': 0.019021, 'config': 0.044177, 'sensor': 0.045179, 'fan': 0.051967, 'cloud': 0.053339, 'my': 0.054587, 'recorder': 0.055922, 'vacuum': 0.080255, 'api': 0.081303, 'auth': 0.088869, 'light': 0.091841, 'default_config': 0.093249, 'rest_command': 0.100522, 'lovelace': 0.103624, 'dhcp': 0.105445, 'websocket_api': 0.110111, 'script': 0.113537, 'emulated_hue': 0.120521, 'binary_sensor': 0.145037, 'weather': 0.197711, 'media_player': 0.204634, 'switch': 0.241131, 'cast': 0.313861, 'person': 0.341786, 'homekit': 0.344398, 'ssdp': 0.444936, 'homekit_controller': 0.670873, 'doorbird': 0.714473, 'climate': 0.740771, 'history': 0.783979, 'blueprint': 0.806934, 'media_source': 0.869515, 'sun': 0.876625, 'shell_command': 0.880883, 'threading': 0.881798, 'remote': 0.885051, 'map': 0.913215, 'trace': 0.937068, 'autelis': 0.937501, 'filter': 0.958175, 'enphase_envoy': 0.961878, 'somfy': 0.96544, 'automation': 0.967931, 'homeassistant': 1.117395, 'sonos': 1.231818, 'systemmonitor': 1.297367, 'zeroconf': 1.421767, 'logbook': 1.541961, 'system_health': 1.574957, 'flume': 1.658237, 'scene': 1.676498, 'profiler': 1.678715, 'tag': 1.729499, 'upnp': 1.809989, 'heos': 1.91246, 'unifi': 1.951867, 'timer': 1.978993, 'camera': 2.00041, 'ffmpeg': 2.001187, 'denonavr': 2.070011, 'mobile_app': 2.25135, 'template': 2.261124, 'nut': 2.53838, 'apple_tv': 2.602957, 'counter': 2.717594, 'input_datetime': 2.730172, 'tts': 2.778089, 'updater': 2.853858, 'openweathermap': 3.065485, 'samsungtv': 3.203091, 'group': 3.27649, 'harmony': 3.696712, 'rachio': 4.201295, 'ipp': 4.290456, 'roku': 4.433694, 'input_text': 4.929488, 'synology_dsm': 4.958669, 'zone': 4.987181, 'input_number': 4.996274, 'bond': 5.327438, 'input_boolean': 5.853331, 'screenlogic': 5.921358, 'notify': 5.929316, 'lutron_caseta': 6.010032, 'input_select': 6.024482, 'rest': 6.607305, 'sense': 6.637527, 'smartir': 6.648064, 'august': 6.659398, 'faa_delays': 6.986708, 'icloud3': 7.141761, 'device_tracker': 7.340055, 'unifiprotect': 7.423218, 'roomba': 7.626561, 'senseme': 7.818574, 'hacs': 8.534149, 'tesla': 9.586424, 'emonitor': 9.692194, 'isy994': 11.400433, 'ping': 15.259365, 'esphome': 21.798107, 'broadlink': 32.379421}`

This has already helped identify some integrations that could be sped up:

- [x] ping: https://github.com/home-assistant/core/pull/43869
- [x] senseme: https://github.com/mikelawrence/aiosenseme/pull/10
- [x] do not load disabled/ignored integrations: https://github.com/home-assistant/core/pull/48355
- [x] small optimizations of adding entities: https://github.com/home-assistant/core/pull/48353
- [x] group creating storage collection entities: https://github.com/home-assistant/core/pull/48352
- [x] broadlink storage loads: https://github.com/home-assistant/core/pull/48391
- [x] bond setup concurrency https://github.com/home-assistant/core/pull/48454
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
