### PR TITLE
Ignore python-typing-update for pre-commit requirements

### DIFF
--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -8,6 +8,5 @@ flake8-docstrings==1.5.0
 flake8==3.8.4
 isort==5.7.0
 pydocstyle==5.1.1
-python-typing-update==0.3.0
 pyupgrade==2.11.0
 yamllint==1.24.2

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -96,6 +96,7 @@ IGNORE_PRE_COMMIT_HOOK_ID = (
     "check-json",
     "no-commit-to-branch",
     "prettier",
+    "python-typing-update",
 )
 
 


### PR DESCRIPTION
## Proposed change
Add `python-typing-update` to list of ignored pre-commit ids when generating `requirements_test_pre_commit.txt`.
Since it is only intended to be used together with `pre-commit` there is no need to add it as python requirement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
Fixes #48265