### PR TITLE
Add set_wait_time command support to Litter-Robot

### DIFF
--- a/homeassistant/components/litterrobot/__init__.py
+++ b/homeassistant/components/litterrobot/__init__.py
@@ -30,10 +30,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except LitterRobotException as ex:
         raise ConfigEntryNotReady from ex
 
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    if hub.account.robots:
+        for platform in PLATFORMS:
+            hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, platform)
+            )
 
     return True
 

--- a/homeassistant/components/litterrobot/entity.py
+++ b/homeassistant/components/litterrobot/entity.py
@@ -76,7 +76,7 @@ class LitterRobotControlEntity(LitterRobotEntity):
             _LOGGER.error(ex)
             return False
 
-        self.clear()
+        self.async_cancel_refresh_callback()
         self._refresh_callback = async_call_later(
             self.hass, REFRESH_WAIT_TIME_SECONDS, async_call_later_callback
         )
@@ -84,12 +84,14 @@ class LitterRobotControlEntity(LitterRobotEntity):
 
     async def async_will_remove_from_hass(self) -> None:
         """Cancel refresh callback when entity is being removed from hass."""
-        self.clear()
+        self.async_cancel_refresh_callback()
 
-    def clear(self):
+    @callback
+    def async_cancel_refresh_callback(self):
         """Clear the refresh callback if it has not already fired."""
         if self._refresh_callback is not None:
             self._refresh_callback()
+            self._refresh_callback = None
 
     @staticmethod
     def parse_time_at_default_timezone(time_str: str) -> time | None:

--- a/homeassistant/components/litterrobot/entity.py
+++ b/homeassistant/components/litterrobot/entity.py
@@ -9,7 +9,6 @@ from typing import Any
 from pylitterbot import Robot
 from pylitterbot.exceptions import InvalidCommandException
 
-from homeassistant.core import callback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 import homeassistant.util.dt as dt_util
@@ -56,15 +55,14 @@ class LitterRobotEntity(CoordinatorEntity):
 class LitterRobotControlEntity(LitterRobotEntity):
     """A Litter-Robot entity that can control the unit."""
 
-    def __init__(self, robot: Robot, entity_type: str, hub: LitterRobotHub) -> None:
-        """Init a Litter-Robot control entity."""
-        super().__init__(robot=robot, entity_type=entity_type, hub=hub)
-        self._refresh_callback = None
-
     async def perform_action_and_refresh(
         self, action: MethodType, *args: Any, **kwargs: Any
     ) -> bool:
         """Perform an action and initiates a refresh of the robot data after a few seconds."""
+
+        async def async_call_later_callback(*_) -> None:
+            """Perform refresh request on callback."""
+            await self.coordinator.async_request_refresh()
 
         try:
             await action(*args, **kwargs)
@@ -72,27 +70,10 @@ class LitterRobotControlEntity(LitterRobotEntity):
             _LOGGER.error(ex)
             return False
 
-        self.async_cancel_refresh_callback()
-        self._refresh_callback = async_call_later(
-            self.hass, REFRESH_WAIT_TIME_SECONDS, self.async_call_later_callback
+        async_call_later(
+            self.hass, REFRESH_WAIT_TIME_SECONDS, async_call_later_callback
         )
         return True
-
-    async def async_call_later_callback(self, *_) -> None:
-        """Perform refresh request on callback."""
-        self._refresh_callback = None
-        await self.coordinator.async_request_refresh()
-
-    async def async_will_remove_from_hass(self) -> None:
-        """Cancel refresh callback when entity is being removed from hass."""
-        self.async_cancel_refresh_callback()
-
-    @callback
-    def async_cancel_refresh_callback(self):
-        """Clear the refresh callback if it has not already fired."""
-        if self._refresh_callback is not None:
-            self._refresh_callback()
-            self._refresh_callback = None
 
     @staticmethod
     def parse_time_at_default_timezone(time_str: str) -> time | None:

--- a/homeassistant/components/litterrobot/entity.py
+++ b/homeassistant/components/litterrobot/entity.py
@@ -1,0 +1,94 @@
+"""Litter-Robot entities for common data and methods."""
+from __future__ import annotations
+
+from datetime import time
+import logging
+from types import MethodType
+from typing import Any
+
+from pylitterbot import Robot
+from pylitterbot.exceptions import InvalidCommandException
+
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+import homeassistant.util.dt as dt_util
+
+from .const import DOMAIN
+from .hub import LitterRobotHub
+
+_LOGGER = logging.getLogger(__name__)
+
+REFRESH_WAIT_TIME_SECONDS = 8
+
+
+class LitterRobotEntity(CoordinatorEntity):
+    """Generic Litter-Robot entity representing common data and methods."""
+
+    def __init__(self, robot: Robot, entity_type: str, hub: LitterRobotHub) -> None:
+        """Pass coordinator to CoordinatorEntity."""
+        super().__init__(hub.coordinator)
+        self.robot = robot
+        self.entity_type = entity_type
+        self.hub = hub
+
+    @property
+    def name(self) -> str:
+        """Return the name of this entity."""
+        return f"{self.robot.name} {self.entity_type}"
+
+    @property
+    def unique_id(self) -> str:
+        """Return a unique ID."""
+        return f"{self.robot.serial}-{self.entity_type}"
+
+    @property
+    def device_info(self) -> dict[str, Any]:
+        """Return the device information for a Litter-Robot."""
+        return {
+            "identifiers": {(DOMAIN, self.robot.serial)},
+            "name": self.robot.name,
+            "manufacturer": "Litter-Robot",
+            "model": self.robot.model,
+        }
+
+
+class LitterRobotControlEntity(LitterRobotEntity):
+    """A Litter-Robot entity that can control the unit."""
+
+    async def perform_action_and_refresh(
+        self, action: MethodType, *args: Any, **kwargs: Any
+    ) -> bool:
+        """Perform an action and initiates a refresh of the robot data after a few seconds."""
+
+        async def async_call_later_callback(*_) -> None:
+            """Perform refresh request on callback."""
+            await self.coordinator.async_request_refresh()
+
+        try:
+            await action(*args, **kwargs)
+        except InvalidCommandException as ex:
+            _LOGGER.error(ex)
+            return False
+
+        async_call_later(
+            self.hass, REFRESH_WAIT_TIME_SECONDS, async_call_later_callback
+        )
+        return True
+
+    @staticmethod
+    def parse_time_at_default_timezone(time_str: str) -> time | None:
+        """Parse a time string and add default timezone."""
+        parsed_time = dt_util.parse_time(time_str)
+
+        if parsed_time is None:
+            return None
+
+        return (
+            dt_util.start_of_local_day()
+            .replace(
+                hour=parsed_time.hour,
+                minute=parsed_time.minute,
+                second=parsed_time.second,
+            )
+            .timetz()
+        )

--- a/homeassistant/components/litterrobot/hub.py
+++ b/homeassistant/components/litterrobot/hub.py
@@ -1,41 +1,31 @@
-"""A wrapper 'hub' for the Litter-Robot API and base entity for common attributes."""
-from __future__ import annotations
-
-from datetime import time, timedelta
+"""A wrapper 'hub' for the Litter-Robot API."""
+from datetime import timedelta
 import logging
-from types import MethodType
-from typing import Any
 
-import pylitterbot
+from pylitterbot import Account
 from pylitterbot.exceptions import LitterRobotException, LitterRobotLoginException
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
-import homeassistant.util.dt as dt_util
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-REFRESH_WAIT_TIME = 12
-UPDATE_INTERVAL = 10
+UPDATE_INTERVAL_SECONDS = 10
 
 
 class LitterRobotHub:
     """A Litter-Robot hub wrapper class."""
 
-    def __init__(self, hass: HomeAssistant, data: dict):
+    def __init__(self, hass: HomeAssistant, data: dict) -> None:
         """Initialize the Litter-Robot hub."""
         self._data = data
         self.account = None
         self.logged_in = False
 
-        async def _async_update_data():
+        async def _async_update_data() -> bool:
             """Update all device states from the Litter-Robot API."""
             await self.account.refresh_robots()
             return True
@@ -45,13 +35,13 @@ class LitterRobotHub:
             _LOGGER,
             name=DOMAIN,
             update_method=_async_update_data,
-            update_interval=timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=timedelta(seconds=UPDATE_INTERVAL_SECONDS),
         )
 
-    async def login(self, load_robots: bool = False):
+    async def login(self, load_robots: bool = False) -> None:
         """Login to Litter-Robot."""
         self.logged_in = False
-        self.account = pylitterbot.Account()
+        self.account = Account()
         try:
             await self.account.connect(
                 username=self._data[CONF_USERNAME],
@@ -66,61 +56,3 @@ class LitterRobotHub:
         except LitterRobotException as ex:
             _LOGGER.error("Unable to connect to Litter-Robot API")
             raise ex
-
-
-class LitterRobotEntity(CoordinatorEntity):
-    """Generic Litter-Robot entity representing common data and methods."""
-
-    def __init__(self, robot: pylitterbot.Robot, entity_type: str, hub: LitterRobotHub):
-        """Pass coordinator to CoordinatorEntity."""
-        super().__init__(hub.coordinator)
-        self.robot = robot
-        self.entity_type = entity_type
-        self.hub = hub
-
-    @property
-    def name(self):
-        """Return the name of this entity."""
-        return f"{self.robot.name} {self.entity_type}"
-
-    @property
-    def unique_id(self):
-        """Return a unique ID."""
-        return f"{self.robot.serial}-{self.entity_type}"
-
-    @property
-    def device_info(self):
-        """Return the device information for a Litter-Robot."""
-        return {
-            "identifiers": {(DOMAIN, self.robot.serial)},
-            "name": self.robot.name,
-            "manufacturer": "Litter-Robot",
-            "model": self.robot.model,
-        }
-
-    async def perform_action_and_refresh(self, action: MethodType, *args: Any):
-        """Perform an action and initiates a refresh of the robot data after a few seconds."""
-
-        async def async_call_later_callback(*_) -> None:
-            await self.hub.coordinator.async_request_refresh()
-
-        await action(*args)
-        async_call_later(self.hass, REFRESH_WAIT_TIME, async_call_later_callback)
-
-    @staticmethod
-    def parse_time_at_default_timezone(time_str: str) -> time | None:
-        """Parse a time string and add default timezone."""
-        parsed_time = dt_util.parse_time(time_str)
-
-        if parsed_time is None:
-            return None
-
-        return (
-            dt_util.start_of_local_day()
-            .replace(
-                hour=parsed_time.hour,
-                minute=parsed_time.minute,
-                second=parsed_time.second,
-            )
-            .timetz()
-        )

--- a/homeassistant/components/litterrobot/manifest.json
+++ b/homeassistant/components/litterrobot/manifest.json
@@ -3,6 +3,6 @@
   "name": "Litter-Robot",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/litterrobot",
-  "requirements": ["pylitterbot==2021.2.8"],
+  "requirements": ["pylitterbot==2021.3.1"],
   "codeowners": ["@natekspencer"]
 }

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -57,7 +57,7 @@ class LitterRobotSleepTimeSensor(LitterRobotPropertySensor):
     @property
     def state(self):
         """Return the state."""
-        if self.robot.sleep_mode_active:
+        if self.robot.sleep_mode_enabled:
             return super().state.isoformat()
         return None
 
@@ -68,7 +68,7 @@ class LitterRobotSleepTimeSensor(LitterRobotPropertySensor):
 
 
 ROBOT_SENSORS = [
-    (LitterRobotWasteSensor, "Waste Drawer", "waste_drawer_gauge"),
+    (LitterRobotWasteSensor, "Waste Drawer", "waste_drawer_level"),
     (LitterRobotSleepTimeSensor, "Sleep Mode Start Time", "sleep_mode_start_time"),
     (LitterRobotSleepTimeSensor, "Sleep Mode End Time", "sleep_mode_end_time"),
 ]

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -73,7 +73,7 @@ class LitterRobotSleepTimeSensor(LitterRobotPropertySensor):
         return DEVICE_CLASS_TIMESTAMP
 
 
-ROBOT_SENSORS = [
+ROBOT_SENSORS: list[tuple[type[LitterRobotPropertySensor], str, str]] = [
     (LitterRobotWasteSensor, "Waste Drawer", "waste_drawer_level"),
     (LitterRobotSleepTimeSensor, "Sleep Mode Start Time", "sleep_mode_start_time"),
     (LitterRobotSleepTimeSensor, "Sleep Mode End Time", "sleep_mode_end_time"),
@@ -100,4 +100,5 @@ async def async_setup_entry(
                 )
             )
 
-    async_add_entities(entities, True)
+    if entities:
+        async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -100,5 +100,4 @@ async def async_setup_entry(
                 )
             )
 
-    if entities:
-        async_add_entities(entities, True)
+    async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -73,7 +73,7 @@ class LitterRobotSleepTimeSensor(LitterRobotPropertySensor):
         return DEVICE_CLASS_TIMESTAMP
 
 
-ROBOT_SENSORS: list[tuple[type[LitterRobotPropertySensor], str, str]] = [
+ROBOT_SENSORS = [
     (LitterRobotWasteSensor, "Waste Drawer", "waste_drawer_level"),
     (LitterRobotSleepTimeSensor, "Sleep Mode Start Time", "sleep_mode_start_time"),
     (LitterRobotSleepTimeSensor, "Sleep Mode End Time", "sleep_mode_end_time"),

--- a/homeassistant/components/litterrobot/sensor.py
+++ b/homeassistant/components/litterrobot/sensor.py
@@ -1,13 +1,19 @@
 """Support for Litter-Robot sensors."""
 from __future__ import annotations
 
+from typing import Callable
+
 from pylitterbot.robot import Robot
 
 from homeassistant.components.sensor import SensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_CLASS_TIMESTAMP, PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
-from .hub import LitterRobotEntity, LitterRobotHub
+from .entity import LitterRobotEntity
+from .hub import LitterRobotHub
 
 
 def icon_for_gauge_level(gauge_level: int | None = None, offset: int = 0) -> str:
@@ -22,66 +28,77 @@ def icon_for_gauge_level(gauge_level: int | None = None, offset: int = 0) -> str
 
 
 class LitterRobotPropertySensor(LitterRobotEntity, SensorEntity):
-    """Litter-Robot property sensors."""
+    """Litter-Robot property sensor."""
 
     def __init__(
         self, robot: Robot, entity_type: str, hub: LitterRobotHub, sensor_attribute: str
-    ):
-        """Pass coordinator to CoordinatorEntity."""
+    ) -> None:
+        """Pass robot, entity_type and hub to LitterRobotEntity."""
         super().__init__(robot, entity_type, hub)
         self.sensor_attribute = sensor_attribute
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state."""
         return getattr(self.robot, self.sensor_attribute)
 
 
 class LitterRobotWasteSensor(LitterRobotPropertySensor):
-    """Litter-Robot sensors."""
+    """Litter-Robot waste sensor."""
 
     @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return unit of measurement."""
         return PERCENTAGE
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon to use in the frontend, if any."""
         return icon_for_gauge_level(self.state, 10)
 
 
 class LitterRobotSleepTimeSensor(LitterRobotPropertySensor):
-    """Litter-Robot sleep time sensors."""
+    """Litter-Robot sleep time sensor."""
 
     @property
-    def state(self):
+    def state(self) -> str | None:
         """Return the state."""
         if self.robot.sleep_mode_enabled:
             return super().state.isoformat()
         return None
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         """Return the device class, if any."""
         return DEVICE_CLASS_TIMESTAMP
 
 
-ROBOT_SENSORS = [
+ROBOT_SENSORS: list[tuple[type[LitterRobotPropertySensor], str, str]] = [
     (LitterRobotWasteSensor, "Waste Drawer", "waste_drawer_level"),
     (LitterRobotSleepTimeSensor, "Sleep Mode Start Time", "sleep_mode_start_time"),
     (LitterRobotSleepTimeSensor, "Sleep Mode End Time", "sleep_mode_end_time"),
 ]
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[Entity], bool], None],
+) -> None:
     """Set up Litter-Robot sensors using config entry."""
-    hub = hass.data[DOMAIN][config_entry.entry_id]
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
 
     entities = []
     for robot in hub.account.robots:
         for (sensor_class, entity_type, sensor_attribute) in ROBOT_SENSORS:
-            entities.append(sensor_class(robot, entity_type, hub, sensor_attribute))
+            entities.append(
+                sensor_class(
+                    robot=robot,
+                    entity_type=entity_type,
+                    hub=hub,
+                    sensor_attribute=sensor_attribute,
+                )
+            )
 
     if entities:
         async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/services.yaml
+++ b/homeassistant/components/litterrobot/services.yaml
@@ -1,0 +1,48 @@
+# Describes the format for available Litter-Robot services
+
+reset_waste_drawer:
+  name: Reset waste drawer
+  description: Reset the waste drawer level.
+  target:
+
+set_sleep_mode:
+  name: Set sleep mode
+  description: Set the sleep mode and start time.
+  target:
+  fields:
+    enabled:
+      name: Enabled
+      description: Whether sleep mode should be enabled.
+      required: true
+      example: true
+      selector:
+        boolean:
+    start_time:
+      name: Start time
+      description: The start time at which the Litter-Robot will enter sleep mode and prevent an automatic clean cycle for 8 hours.
+      required: false
+      example: '"22:30:00"'
+      selector:
+        time:
+
+set_wait_time:
+  name: Set wait time
+  description: Set the wait time, in minutes, between when your cat uses the Litter-Robot and when the unit cycles automatically.
+  target:
+  fields:
+    minutes:
+      name: Minutes
+      description: Minutes to wait.
+      required: true
+      example: 7
+      values:
+        - 3
+        - 7
+        - 15
+      default: 7
+      selector:
+        select:
+          options:
+            - "3"
+            - "7"
+            - "15"

--- a/homeassistant/components/litterrobot/strings.json
+++ b/homeassistant/components/litterrobot/strings.json
@@ -14,7 +14,7 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
   }
 }

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -11,7 +11,7 @@ class LitterRobotNightLightModeSwitch(LitterRobotEntity, SwitchEntity):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self.robot.night_light_active
+        return self.robot.night_light_mode_enabled
 
     @property
     def icon(self):
@@ -33,7 +33,7 @@ class LitterRobotPanelLockoutSwitch(LitterRobotEntity, SwitchEntity):
     @property
     def is_on(self):
         """Return true if switch is on."""
-        return self.robot.panel_lock_active
+        return self.robot.panel_lock_enabled
 
     @property
     def icon(self):

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -1,7 +1,7 @@
 """Support for Litter-Robot switches."""
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -1,68 +1,80 @@
 """Support for Litter-Robot switches."""
+from __future__ import annotations
+
+from typing import Callable
+
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
-from .hub import LitterRobotEntity
+from .entity import LitterRobotControlEntity
+from .hub import LitterRobotHub
 
 
-class LitterRobotNightLightModeSwitch(LitterRobotEntity, SwitchEntity):
+class LitterRobotNightLightModeSwitch(LitterRobotControlEntity, SwitchEntity):
     """Litter-Robot Night Light Mode Switch."""
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if switch is on."""
         return self.robot.night_light_mode_enabled
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon."""
         return "mdi:lightbulb-on" if self.is_on else "mdi:lightbulb-off"
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         await self.perform_action_and_refresh(self.robot.set_night_light, True)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self.perform_action_and_refresh(self.robot.set_night_light, False)
 
 
-class LitterRobotPanelLockoutSwitch(LitterRobotEntity, SwitchEntity):
+class LitterRobotPanelLockoutSwitch(LitterRobotControlEntity, SwitchEntity):
     """Litter-Robot Panel Lockout Switch."""
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return true if switch is on."""
         return self.robot.panel_lock_enabled
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon."""
         return "mdi:lock" if self.is_on else "mdi:lock-open"
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
 
 
-ROBOT_SWITCHES = {
-    "Night Light Mode": LitterRobotNightLightModeSwitch,
-    "Panel Lockout": LitterRobotPanelLockoutSwitch,
-}
+ROBOT_SWITCHES: list[tuple[type[LitterRobotControlEntity], str]] = [
+    (LitterRobotNightLightModeSwitch, "Night Light Mode"),
+    (LitterRobotPanelLockoutSwitch, "Panel Lockout"),
+]
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[Entity], bool], None],
+) -> None:
     """Set up Litter-Robot switches using config entry."""
-    hub = hass.data[DOMAIN][config_entry.entry_id]
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
 
     entities = []
     for robot in hub.account.robots:
-        for switch_type, switch_class in ROBOT_SWITCHES.items():
-            entities.append(switch_class(robot, switch_type, hub))
+        for switch_class, switch_type in ROBOT_SWITCHES:
+            entities.append(switch_class(robot=robot, entity_type=switch_type, hub=hub))
 
     if entities:
         async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -1,7 +1,7 @@
 """Support for Litter-Robot switches."""
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Callable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -26,11 +26,11 @@ class LitterRobotNightLightModeSwitch(LitterRobotControlEntity, SwitchEntity):
         """Return the icon."""
         return "mdi:lightbulb-on" if self.is_on else "mdi:lightbulb-off"
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         await self.perform_action_and_refresh(self.robot.set_night_light, True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self.perform_action_and_refresh(self.robot.set_night_light, False)
 
@@ -48,11 +48,11 @@ class LitterRobotPanelLockoutSwitch(LitterRobotControlEntity, SwitchEntity):
         """Return the icon."""
         return "mdi:lock" if self.is_on else "mdi:lock-open"
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
 
@@ -76,4 +76,5 @@ async def async_setup_entry(
         for switch_class, switch_type in ROBOT_SWITCHES:
             entities.append(switch_class(robot=robot, entity_type=switch_type, hub=hub))
 
-    async_add_entities(entities, True)
+    if entities:
+        async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -26,11 +26,11 @@ class LitterRobotNightLightModeSwitch(LitterRobotControlEntity, SwitchEntity):
         """Return the icon."""
         return "mdi:lightbulb-on" if self.is_on else "mdi:lightbulb-off"
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.perform_action_and_refresh(self.robot.set_night_light, True)
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.perform_action_and_refresh(self.robot.set_night_light, False)
 
@@ -48,11 +48,11 @@ class LitterRobotPanelLockoutSwitch(LitterRobotControlEntity, SwitchEntity):
         """Return the icon."""
         return "mdi:lock" if self.is_on else "mdi:lock-open"
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, True)
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         await self.perform_action_and_refresh(self.robot.set_panel_lockout, False)
 

--- a/homeassistant/components/litterrobot/switch.py
+++ b/homeassistant/components/litterrobot/switch.py
@@ -76,5 +76,4 @@ async def async_setup_entry(
         for switch_class, switch_type in ROBOT_SWITCHES:
             entities.append(switch_class(robot=robot, entity_type=switch_type, hub=hub))
 
-    if entities:
-        async_add_entities(entities, True)
+    async_add_entities(entities, True)

--- a/homeassistant/components/litterrobot/translations/en.json
+++ b/homeassistant/components/litterrobot/translations/en.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Account is already configured"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -53,8 +53,7 @@ async def async_setup_entry(
             LitterRobotCleaner(robot=robot, entity_type=TYPE_LITTER_BOX, hub=hub)
         )
 
-    if entities:
-        async_add_entities(entities, True)
+    async_add_entities(entities, True)
 
     platform = entity_platform.current_platform.get()
     platform.async_register_entity_service(

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -1,5 +1,5 @@
 """Support for Litter-Robot "Vacuum"."""
-from pylitterbot import Robot
+from pylitterbot.enums import LitterBoxStatus
 
 from homeassistant.components.vacuum import (
     STATE_CLEANING,
@@ -53,22 +53,24 @@ class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
     def state(self):
         """Return the state of the cleaner."""
         switcher = {
-            Robot.UnitStatus.CLEAN_CYCLE: STATE_CLEANING,
-            Robot.UnitStatus.EMPTY_CYCLE: STATE_CLEANING,
-            Robot.UnitStatus.CLEAN_CYCLE_COMPLETE: STATE_DOCKED,
-            Robot.UnitStatus.CAT_SENSOR_TIMING: STATE_DOCKED,
-            Robot.UnitStatus.DRAWER_FULL_1: STATE_DOCKED,
-            Robot.UnitStatus.DRAWER_FULL_2: STATE_DOCKED,
-            Robot.UnitStatus.READY: STATE_DOCKED,
-            Robot.UnitStatus.OFF: STATE_OFF,
+            LitterBoxStatus.CLEAN_CYCLE: STATE_CLEANING,
+            LitterBoxStatus.EMPTY_CYCLE: STATE_CLEANING,
+            LitterBoxStatus.CLEAN_CYCLE_COMPLETE: STATE_DOCKED,
+            LitterBoxStatus.CAT_SENSOR_TIMING: STATE_DOCKED,
+            LitterBoxStatus.DRAWER_FULL_1: STATE_DOCKED,
+            LitterBoxStatus.DRAWER_FULL_2: STATE_DOCKED,
+            LitterBoxStatus.READY: STATE_DOCKED,
+            LitterBoxStatus.OFF: STATE_OFF,
         }
 
-        return switcher.get(self.robot.unit_status, STATE_ERROR)
+        return switcher.get(self.robot.status, STATE_ERROR)
 
     @property
     def status(self):
         """Return the status of the cleaner."""
-        return f"{self.robot.unit_status.label}{' (Sleeping)' if self.robot.is_sleeping else ''}"
+        return (
+            f"{self.robot.status.text}{' (Sleeping)' if self.robot.is_sleeping else ''}"
+        )
 
     async def async_turn_on(self, **kwargs):
         """Turn the cleaner on, starting a clean cycle."""
@@ -116,8 +118,8 @@ class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
         return {
             "clean_cycle_wait_time_minutes": self.robot.clean_cycle_wait_time_minutes,
             "is_sleeping": self.robot.is_sleeping,
-            "sleep_mode_active": self.robot.sleep_mode_active,
+            "sleep_mode_enabled": self.robot.sleep_mode_enabled,
             "power_status": self.robot.power_status,
-            "unit_status_code": self.robot.unit_status.value,
+            "status_code": self.robot.status.value,
             "last_seen": self.robot.last_seen,
         }

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -1,10 +1,15 @@
 """Support for Litter-Robot "Vacuum"."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
 from pylitterbot.enums import LitterBoxStatus
 
 from homeassistant.components.vacuum import (
     STATE_CLEANING,
     STATE_DOCKED,
     STATE_ERROR,
+    STATE_PAUSED,
     SUPPORT_SEND_COMMAND,
     SUPPORT_START,
     SUPPORT_STATE,
@@ -13,10 +18,14 @@ from homeassistant.components.vacuum import (
     SUPPORT_TURN_ON,
     VacuumEntity,
 )
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
-from .hub import LitterRobotEntity
+from .entity import LitterRobotControlEntity
+from .hub import LitterRobotHub
 
 SUPPORT_LITTERROBOT = (
     SUPPORT_SEND_COMMAND
@@ -29,28 +38,34 @@ SUPPORT_LITTERROBOT = (
 TYPE_LITTER_BOX = "Litter Box"
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: Callable[[list[Entity], bool], None],
+) -> None:
     """Set up Litter-Robot cleaner using config entry."""
-    hub = hass.data[DOMAIN][config_entry.entry_id]
+    hub: LitterRobotHub = hass.data[DOMAIN][entry.entry_id]
 
     entities = []
     for robot in hub.account.robots:
-        entities.append(LitterRobotCleaner(robot, TYPE_LITTER_BOX, hub))
+        entities.append(
+            LitterRobotCleaner(robot=robot, entity_type=TYPE_LITTER_BOX, hub=hub)
+        )
 
     if entities:
         async_add_entities(entities, True)
 
 
-class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
+class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
     """Litter-Robot "Vacuum" Cleaner."""
 
     @property
-    def supported_features(self):
+    def supported_features(self) -> int:
         """Flag cleaner robot features that are supported."""
         return SUPPORT_LITTERROBOT
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the cleaner."""
         switcher = {
             LitterBoxStatus.CLEAN_CYCLE: STATE_CLEANING,
@@ -60,31 +75,34 @@ class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
             LitterBoxStatus.DRAWER_FULL_1: STATE_DOCKED,
             LitterBoxStatus.DRAWER_FULL_2: STATE_DOCKED,
             LitterBoxStatus.READY: STATE_DOCKED,
+            LitterBoxStatus.CAT_SENSOR_INTERRUPTED: STATE_PAUSED,
             LitterBoxStatus.OFF: STATE_OFF,
         }
 
         return switcher.get(self.robot.status, STATE_ERROR)
 
     @property
-    def status(self):
+    def status(self) -> str:
         """Return the status of the cleaner."""
         return (
             f"{self.robot.status.text}{' (Sleeping)' if self.robot.is_sleeping else ''}"
         )
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn the cleaner on, starting a clean cycle."""
         await self.perform_action_and_refresh(self.robot.set_power_status, True)
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the unit off, stopping any cleaning in progress as is."""
         await self.perform_action_and_refresh(self.robot.set_power_status, False)
 
-    async def async_start(self):
+    async def async_start(self) -> None:
         """Start a clean cycle."""
         await self.perform_action_and_refresh(self.robot.start_cleaning)
 
-    async def async_send_command(self, command, params=None, **kwargs):
+    async def async_send_command(
+        self, command: str, params: dict[str, Any] | None = None, **kwargs
+    ) -> None:
         """Send command.
 
         Available commands:
@@ -94,6 +112,9 @@ class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
             * params:
               - enabled: bool
               - sleep_time: str (optional)
+          - set_wait_time
+            * params:
+              - wait_time: int (one of [3,7,15])
 
         """
         if command == "reset_waste_drawer":
@@ -102,24 +123,28 @@ class LitterRobotCleaner(LitterRobotEntity, VacuumEntity):
             # data set for the robot. Thus, we only need to tell hass to update the
             # state of devices associated with this robot.
             await self.robot.reset_waste_drawer()
-            self.hub.coordinator.async_set_updated_data(True)
+            self.coordinator.async_set_updated_data(True)
         elif command == "set_sleep_mode":
             await self.perform_action_and_refresh(
                 self.robot.set_sleep_mode,
                 params.get("enabled"),
                 self.parse_time_at_default_timezone(params.get("sleep_time")),
             )
+        elif command == "set_wait_time":
+            await self.perform_action_and_refresh(
+                self.robot.set_wait_time, params.get("wait_time")
+            )
         else:
             raise NotImplementedError()
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return device specific state attributes."""
         return {
             "clean_cycle_wait_time_minutes": self.robot.clean_cycle_wait_time_minutes,
             "is_sleeping": self.robot.is_sleeping,
             "sleep_mode_enabled": self.robot.sleep_mode_enabled,
             "power_status": self.robot.power_status,
-            "status_code": self.robot.status.value,
+            "status_code": self.robot.status_code,
             "last_seen": self.robot.last_seen,
         }

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -109,11 +109,11 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
             f"{self.robot.status.text}{' (Sleeping)' if self.robot.is_sleeping else ''}"
         )
 
-    async def async_turn_on(self, **kwargs) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the cleaner on, starting a clean cycle."""
         await self.perform_action_and_refresh(self.robot.set_power_status, True)
 
-    async def async_turn_off(self, **kwargs) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the unit off, stopping any cleaning in progress as is."""
         await self.perform_action_and_refresh(self.robot.set_power_status, False)
 

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -1,11 +1,5 @@
 """Support for Litter-Robot "Vacuum"."""
-from __future__ import annotations
-
-from typing import Any, Callable
-
 from pylitterbot.enums import LitterBoxStatus
-from pylitterbot.robot import VALID_WAIT_TIMES
-import voluptuous as vol
 
 from homeassistant.components.vacuum import (
     STATE_CLEANING,
@@ -95,7 +89,6 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
             LitterBoxStatus.DRAWER_FULL_1: STATE_DOCKED,
             LitterBoxStatus.DRAWER_FULL_2: STATE_DOCKED,
             LitterBoxStatus.READY: STATE_DOCKED,
-            LitterBoxStatus.CAT_SENSOR_INTERRUPTED: STATE_PAUSED,
             LitterBoxStatus.OFF: STATE_OFF,
         }
 
@@ -147,6 +140,6 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
             "is_sleeping": self.robot.is_sleeping,
             "sleep_mode_enabled": self.robot.sleep_mode_enabled,
             "power_status": self.robot.power_status,
-            "status_code": self.robot.status_code,
+            "status_code": self.robot.status.value,
             "last_seen": self.robot.last_seen,
         }

--- a/homeassistant/components/litterrobot/vacuum.py
+++ b/homeassistant/components/litterrobot/vacuum.py
@@ -1,4 +1,8 @@
 """Support for Litter-Robot "Vacuum"."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
 from pylitterbot.enums import LitterBoxStatus
 
 from homeassistant.components.vacuum import (
@@ -6,6 +10,7 @@ from homeassistant.components.vacuum import (
     STATE_DOCKED,
     STATE_ERROR,
     STATE_PAUSED,
+    SUPPORT_SEND_COMMAND,
     SUPPORT_START,
     SUPPORT_STATE,
     SUPPORT_STATUS,
@@ -16,7 +21,6 @@ from homeassistant.components.vacuum import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
@@ -24,13 +28,14 @@ from .entity import LitterRobotControlEntity
 from .hub import LitterRobotHub
 
 SUPPORT_LITTERROBOT = (
-    SUPPORT_START | SUPPORT_STATE | SUPPORT_STATUS | SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+    SUPPORT_SEND_COMMAND
+    | SUPPORT_START
+    | SUPPORT_STATE
+    | SUPPORT_STATUS
+    | SUPPORT_TURN_OFF
+    | SUPPORT_TURN_ON
 )
 TYPE_LITTER_BOX = "Litter Box"
-
-SERVICE_RESET_WASTE_DRAWER = "reset_waste_drawer"
-SERVICE_SET_SLEEP_MODE = "set_sleep_mode"
-SERVICE_SET_WAIT_TIME = "set_wait_time"
 
 
 async def async_setup_entry(
@@ -47,27 +52,8 @@ async def async_setup_entry(
             LitterRobotCleaner(robot=robot, entity_type=TYPE_LITTER_BOX, hub=hub)
         )
 
-    async_add_entities(entities, True)
-
-    platform = entity_platform.current_platform.get()
-    platform.async_register_entity_service(
-        SERVICE_RESET_WASTE_DRAWER,
-        {},
-        "async_reset_waste_drawer",
-    )
-    platform.async_register_entity_service(
-        SERVICE_SET_SLEEP_MODE,
-        {
-            vol.Required("enabled"): cv.boolean,
-            vol.Optional("start_time"): cv.time,
-        },
-        "async_set_sleep_mode",
-    )
-    platform.async_register_entity_service(
-        SERVICE_SET_WAIT_TIME,
-        {vol.Required("minutes"): vol.In(VALID_WAIT_TIMES)},
-        "async_set_wait_time",
-    )
+    if entities:
+        async_add_entities(entities, True)
 
 
 class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
@@ -89,6 +75,7 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
             LitterBoxStatus.DRAWER_FULL_1: STATE_DOCKED,
             LitterBoxStatus.DRAWER_FULL_2: STATE_DOCKED,
             LitterBoxStatus.READY: STATE_DOCKED,
+            LitterBoxStatus.CAT_SENSOR_INTERRUPTED: STATE_PAUSED,
             LitterBoxStatus.OFF: STATE_OFF,
         }
 
@@ -101,11 +88,11 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
             f"{self.robot.status.text}{' (Sleeping)' if self.robot.is_sleeping else ''}"
         )
 
-    async def async_turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs) -> None:
         """Turn the cleaner on, starting a clean cycle."""
         await self.perform_action_and_refresh(self.robot.set_power_status, True)
 
-    async def async_turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs) -> None:
         """Turn the unit off, stopping any cleaning in progress as is."""
         await self.perform_action_and_refresh(self.robot.set_power_status, False)
 
@@ -113,24 +100,42 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
         """Start a clean cycle."""
         await self.perform_action_and_refresh(self.robot.start_cleaning)
 
-    async def async_reset_waste_drawer(self) -> None:
-        """Reset the waste drawer level."""
-        await self.robot.reset_waste_drawer()
-        self.coordinator.async_set_updated_data(True)
-
-    async def async_set_sleep_mode(
-        self, enabled: bool, start_time: str | None = None
+    async def async_send_command(
+        self, command: str, params: dict[str, Any] | None = None, **kwargs
     ) -> None:
-        """Set the sleep mode."""
-        await self.perform_action_and_refresh(
-            self.robot.set_sleep_mode,
-            enabled,
-            self.parse_time_at_default_timezone(start_time),
-        )
+        """Send command.
 
-    async def async_set_wait_time(self, minutes: int) -> None:
-        """Set the wait time."""
-        await self.perform_action_and_refresh(self.robot.set_wait_time, minutes)
+        Available commands:
+          - reset_waste_drawer
+            * params: none
+          - set_sleep_mode
+            * params:
+              - enabled: bool
+              - sleep_time: str (optional)
+          - set_wait_time
+            * params:
+              - wait_time: int (one of [3,7,15])
+
+        """
+        if command == "reset_waste_drawer":
+            # Normally we need to request a refresh of data after a command is sent.
+            # However, the API for resetting the waste drawer returns a refreshed
+            # data set for the robot. Thus, we only need to tell hass to update the
+            # state of devices associated with this robot.
+            await self.robot.reset_waste_drawer()
+            self.coordinator.async_set_updated_data(True)
+        elif command == "set_sleep_mode":
+            await self.perform_action_and_refresh(
+                self.robot.set_sleep_mode,
+                params.get("enabled"),
+                self.parse_time_at_default_timezone(params.get("sleep_time")),
+            )
+        elif command == "set_wait_time":
+            await self.perform_action_and_refresh(
+                self.robot.set_wait_time, params.get("wait_time")
+            )
+        else:
+            raise NotImplementedError()
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -140,6 +145,6 @@ class LitterRobotCleaner(LitterRobotControlEntity, VacuumEntity):
             "is_sleeping": self.robot.is_sleeping,
             "sleep_mode_enabled": self.robot.sleep_mode_enabled,
             "power_status": self.robot.power_status,
-            "status_code": self.robot.status.value,
+            "status_code": self.robot.status_code,
             "last_seen": self.robot.last_seen,
         }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1512,7 +1512,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.3.0
 
 # homeassistant.components.litterrobot
-pylitterbot==2021.2.8
+pylitterbot==2021.3.1
 
 # homeassistant.components.loopenergy
 pyloopenergy==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -823,7 +823,7 @@ pylibrespot-java==0.1.0
 pylitejet==0.3.0
 
 # homeassistant.components.litterrobot
-pylitterbot==2021.2.8
+pylitterbot==2021.3.1
 
 # homeassistant.components.lutron_caseta
 pylutron-caseta==0.9.0

--- a/tests/components/litterrobot/common.py
+++ b/tests/components/litterrobot/common.py
@@ -24,3 +24,5 @@ ROBOT_DATA = {
     "nightLightActive": "1",
     "sleepModeActive": "112:50:19",
 }
+
+VACUUM_ENTITY_ID = "vacuum.test_litter_box"

--- a/tests/components/litterrobot/common.py
+++ b/tests/components/litterrobot/common.py
@@ -1,4 +1,6 @@
 """Common utils for Litter-Robot tests."""
+from datetime import datetime
+
 from homeassistant.components.litterrobot import DOMAIN
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
@@ -9,7 +11,7 @@ ROBOT_NAME = "Test"
 ROBOT_SERIAL = "LR3C012345"
 ROBOT_DATA = {
     "powerStatus": "AC",
-    "lastSeen": "2021-02-01T15:30:00.000000",
+    "lastSeen": datetime.now().isoformat(),
     "cleanCycleWaitTimeMinutes": "7",
     "unitStatus": "RDY",
     "litterRobotNickname": ROBOT_NAME,

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -33,13 +33,15 @@ def create_mock_robot(
 
 
 def create_mock_account(
-    robot_data: Optional[dict] = None, side_effect: Optional[Any] = None
+    robot_data: Optional[dict] = None,
+    side_effect: Optional[Any] = None,
+    skip_robots: bool = False,
 ) -> MagicMock:
     """Create a mock Litter-Robot account."""
     account = MagicMock(spec=Account)
     account.connect = AsyncMock()
     account.refresh_robots = AsyncMock()
-    account.robots = [create_mock_robot(robot_data, side_effect)]
+    account.robots = [] if skip_robots else [create_mock_robot(robot_data, side_effect)]
     return account
 
 
@@ -47,6 +49,12 @@ def create_mock_account(
 def mock_account() -> MagicMock:
     """Mock a Litter-Robot account."""
     return create_mock_account()
+
+
+@pytest.fixture
+def mock_account_with_no_robots() -> MagicMock:
+    """Mock a Litter-Robot account."""
+    return create_mock_account(skip_robots=True)
 
 
 @pytest.fixture

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -1,55 +1,71 @@
 """Configure pytest for Litter-Robot tests."""
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pylitterbot
-from pylitterbot import Robot
+from pylitterbot import Account, Robot
+from pylitterbot.exceptions import InvalidCommandException
 import pytest
 
 from homeassistant.components import litterrobot
+from homeassistant.core import HomeAssistant
 
 from .common import CONFIG, ROBOT_DATA
 
 from tests.common import MockConfigEntry
 
 
-def create_mock_robot(robot_data: Optional[dict] = None):
+def create_mock_robot(
+    robot_data: Optional[dict] = None, side_effect: Optional[Any] = None
+) -> Robot:
     """Create a mock Litter-Robot device."""
     if not robot_data:
         robot_data = {}
 
     robot = Robot(data={**ROBOT_DATA, **robot_data})
-    robot.start_cleaning = AsyncMock()
-    robot.set_power_status = AsyncMock()
-    robot.reset_waste_drawer = AsyncMock()
-    robot.set_sleep_mode = AsyncMock()
-    robot.set_night_light = AsyncMock()
-    robot.set_panel_lockout = AsyncMock()
+    robot.start_cleaning = AsyncMock(side_effect=side_effect)
+    robot.set_power_status = AsyncMock(side_effect=side_effect)
+    robot.reset_waste_drawer = AsyncMock(side_effect=side_effect)
+    robot.set_sleep_mode = AsyncMock(side_effect=side_effect)
+    robot.set_night_light = AsyncMock(side_effect=side_effect)
+    robot.set_panel_lockout = AsyncMock(side_effect=side_effect)
+    robot.set_wait_time = AsyncMock(side_effect=side_effect)
     return robot
 
 
-def create_mock_account(robot_data: Optional[dict] = None):
+def create_mock_account(
+    robot_data: Optional[dict] = None, side_effect: Optional[Any] = None
+) -> MagicMock:
     """Create a mock Litter-Robot account."""
-    account = MagicMock(spec=pylitterbot.Account)
+    account = MagicMock(spec=Account)
     account.connect = AsyncMock()
     account.refresh_robots = AsyncMock()
-    account.robots = [create_mock_robot(robot_data)]
+    account.robots = [create_mock_robot(robot_data, side_effect)]
     return account
 
 
 @pytest.fixture
-def mock_account():
+def mock_account() -> MagicMock:
     """Mock a Litter-Robot account."""
     return create_mock_account()
 
 
 @pytest.fixture
-def mock_account_with_error():
+def mock_account_with_error() -> MagicMock:
     """Mock a Litter-Robot account with error."""
     return create_mock_account({"unitStatus": "BR"})
 
 
-async def setup_integration(hass, mock_account, platform_domain=None):
+@pytest.fixture
+def mock_account_with_side_effects() -> MagicMock:
+    """Mock a Litter-Robot account with side effects."""
+    return create_mock_account(
+        side_effect=InvalidCommandException("Invalid command: oops")
+    )
+
+
+async def setup_integration(
+    hass: HomeAssistant, mock_account: MagicMock, platform_domain: Optional[str] = None
+) -> MockConfigEntry:
     """Load a Litter-Robot platform with the provided hub."""
     entry = MockConfigEntry(
         domain=litterrobot.DOMAIN,
@@ -57,7 +73,9 @@ async def setup_integration(hass, mock_account, platform_domain=None):
     )
     entry.add_to_hass(hass)
 
-    with patch("pylitterbot.Account", return_value=mock_account), patch(
+    with patch(
+        "homeassistant.components.litterrobot.hub.Account", return_value=mock_account
+    ), patch(
         "homeassistant.components.litterrobot.PLATFORMS",
         [platform_domain] if platform_domain else [],
     ):

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -1,5 +1,5 @@
 """Configure pytest for Litter-Robot tests."""
-from typing import Any, Optional
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pylitterbot import Account, Robot
@@ -14,34 +14,27 @@ from .common import CONFIG, ROBOT_DATA
 from tests.common import MockConfigEntry
 
 
-def create_mock_robot(
-    robot_data: Optional[dict] = None, side_effect: Optional[Any] = None
-) -> Robot:
+def create_mock_robot(robot_data: Optional[dict] = None):
     """Create a mock Litter-Robot device."""
     if not robot_data:
         robot_data = {}
 
     robot = Robot(data={**ROBOT_DATA, **robot_data})
-    robot.start_cleaning = AsyncMock(side_effect=side_effect)
-    robot.set_power_status = AsyncMock(side_effect=side_effect)
-    robot.reset_waste_drawer = AsyncMock(side_effect=side_effect)
-    robot.set_sleep_mode = AsyncMock(side_effect=side_effect)
-    robot.set_night_light = AsyncMock(side_effect=side_effect)
-    robot.set_panel_lockout = AsyncMock(side_effect=side_effect)
-    robot.set_wait_time = AsyncMock(side_effect=side_effect)
+    robot.start_cleaning = AsyncMock()
+    robot.set_power_status = AsyncMock()
+    robot.reset_waste_drawer = AsyncMock()
+    robot.set_sleep_mode = AsyncMock()
+    robot.set_night_light = AsyncMock()
+    robot.set_panel_lockout = AsyncMock()
     return robot
 
 
-def create_mock_account(
-    robot_data: Optional[dict] = None,
-    side_effect: Optional[Any] = None,
-    skip_robots: bool = False,
-) -> MagicMock:
+def create_mock_account(robot_data: Optional[dict] = None):
     """Create a mock Litter-Robot account."""
     account = MagicMock(spec=Account)
     account.connect = AsyncMock()
     account.refresh_robots = AsyncMock()
-    account.robots = [] if skip_robots else [create_mock_robot(robot_data, side_effect)]
+    account.robots = [create_mock_robot(robot_data)]
     return account
 
 
@@ -61,14 +54,6 @@ def mock_account_with_no_robots() -> MagicMock:
 def mock_account_with_error() -> MagicMock:
     """Mock a Litter-Robot account with error."""
     return create_mock_account({"unitStatus": "BR"})
-
-
-@pytest.fixture
-def mock_account_with_side_effects() -> MagicMock:
-    """Mock a Litter-Robot account with side effects."""
-    return create_mock_account(
-        side_effect=InvalidCommandException("Invalid command: oops")
-    )
 
 
 async def setup_integration(

--- a/tests/components/litterrobot/conftest.py
+++ b/tests/components/litterrobot/conftest.py
@@ -1,5 +1,5 @@
 """Configure pytest for Litter-Robot tests."""
-from typing import Optional
+from typing import Any, Optional
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pylitterbot import Account, Robot
@@ -14,27 +14,32 @@ from .common import CONFIG, ROBOT_DATA
 from tests.common import MockConfigEntry
 
 
-def create_mock_robot(robot_data: Optional[dict] = None):
+def create_mock_robot(
+    robot_data: Optional[dict] = None, side_effect: Optional[Any] = None
+) -> Robot:
     """Create a mock Litter-Robot device."""
     if not robot_data:
         robot_data = {}
 
     robot = Robot(data={**ROBOT_DATA, **robot_data})
-    robot.start_cleaning = AsyncMock()
-    robot.set_power_status = AsyncMock()
-    robot.reset_waste_drawer = AsyncMock()
-    robot.set_sleep_mode = AsyncMock()
-    robot.set_night_light = AsyncMock()
-    robot.set_panel_lockout = AsyncMock()
+    robot.start_cleaning = AsyncMock(side_effect=side_effect)
+    robot.set_power_status = AsyncMock(side_effect=side_effect)
+    robot.reset_waste_drawer = AsyncMock(side_effect=side_effect)
+    robot.set_sleep_mode = AsyncMock(side_effect=side_effect)
+    robot.set_night_light = AsyncMock(side_effect=side_effect)
+    robot.set_panel_lockout = AsyncMock(side_effect=side_effect)
+    robot.set_wait_time = AsyncMock(side_effect=side_effect)
     return robot
 
 
-def create_mock_account(robot_data: Optional[dict] = None):
+def create_mock_account(
+    robot_data: Optional[dict] = None, side_effect: Optional[Any] = None
+) -> MagicMock:
     """Create a mock Litter-Robot account."""
     account = MagicMock(spec=Account)
     account.connect = AsyncMock()
     account.refresh_robots = AsyncMock()
-    account.robots = [create_mock_robot(robot_data)]
+    account.robots = [create_mock_robot(robot_data, side_effect)]
     return account
 
 
@@ -45,15 +50,17 @@ def mock_account() -> MagicMock:
 
 
 @pytest.fixture
-def mock_account_with_no_robots() -> MagicMock:
-    """Mock a Litter-Robot account."""
-    return create_mock_account(skip_robots=True)
-
-
-@pytest.fixture
 def mock_account_with_error() -> MagicMock:
     """Mock a Litter-Robot account with error."""
     return create_mock_account({"unitStatus": "BR"})
+
+
+@pytest.fixture
+def mock_account_with_side_effects() -> MagicMock:
+    """Mock a Litter-Robot account with side effects."""
+    return create_mock_account(
+        side_effect=InvalidCommandException("Invalid command: oops")
+    )
 
 
 async def setup_integration(

--- a/tests/components/litterrobot/test_config_flow.py
+++ b/tests/components/litterrobot/test_config_flow.py
@@ -20,7 +20,10 @@ async def test_form(hass, mock_account):
     assert result["type"] == "form"
     assert result["errors"] == {}
 
-    with patch("pylitterbot.Account", return_value=mock_account), patch(
+    with patch(
+        "homeassistant.components.litterrobot.hub.Account",
+        return_value=mock_account,
+    ), patch(
         "homeassistant.components.litterrobot.async_setup", return_value=True
     ) as mock_setup, patch(
         "homeassistant.components.litterrobot.async_setup_entry",

--- a/tests/components/litterrobot/test_sensor.py
+++ b/tests/components/litterrobot/test_sensor.py
@@ -16,14 +16,13 @@ async def test_waste_drawer_sensor(hass, mock_account):
 
     sensor = hass.states.get(WASTE_DRAWER_ENTITY_ID)
     assert sensor
-    assert sensor.state == "50"
+    assert sensor.state == "50.0"
     assert sensor.attributes["unit_of_measurement"] == PERCENTAGE
 
 
 async def test_sleep_time_sensor_with_none_state(hass):
     """Tests the sleep mode start time sensor where sleep mode is inactive."""
-    robot = create_mock_robot()
-    robot.sleep_mode_active = False
+    robot = create_mock_robot({"sleepModeActive": "0"})
     sensor = LitterRobotSleepTimeSensor(
         robot, "Sleep Mode Start Time", Mock(), "sleep_mode_start_time"
     )

--- a/tests/components/litterrobot/test_switch.py
+++ b/tests/components/litterrobot/test_switch.py
@@ -3,7 +3,7 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.components.litterrobot.hub import REFRESH_WAIT_TIME
+from homeassistant.components.litterrobot.entity import REFRESH_WAIT_TIME_SECONDS
 from homeassistant.components.switch import (
     DOMAIN as PLATFORM_DOMAIN,
     SERVICE_TURN_OFF,
@@ -56,6 +56,6 @@ async def test_on_off_commands(hass, mock_account, entity_id, robot_command):
             blocking=True,
         )
 
-        future = utcnow() + timedelta(seconds=REFRESH_WAIT_TIME)
+        future = utcnow() + timedelta(seconds=REFRESH_WAIT_TIME_SECONDS)
         async_fire_time_changed(hass, future)
         assert getattr(mock_account.robots[0], robot_command).call_count == count

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -3,42 +3,52 @@ from datetime import timedelta
 
 import pytest
 
+from homeassistant.components.litterrobot import DOMAIN
 from homeassistant.components.litterrobot.entity import REFRESH_WAIT_TIME_SECONDS
+from homeassistant.components.litterrobot.vacuum import (
+    SERVICE_RESET_WASTE_DRAWER,
+    SERVICE_SET_SLEEP_MODE,
+    SERVICE_SET_WAIT_TIME,
+)
 from homeassistant.components.vacuum import (
-    ATTR_PARAMS,
     DOMAIN as PLATFORM_DOMAIN,
-    SERVICE_SEND_COMMAND,
     SERVICE_START,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_DOCKED,
     STATE_ERROR,
 )
-from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
 from homeassistant.util.dt import utcnow
 
+from .common import VACUUM_ENTITY_ID
 from .conftest import setup_integration
 
 from tests.common import async_fire_time_changed
 
-ENTITY_ID = "vacuum.test_litter_box"
+COMPONENT_SERVICE_DOMAIN = {
+    SERVICE_RESET_WASTE_DRAWER: DOMAIN,
+    SERVICE_SET_SLEEP_MODE: DOMAIN,
+    SERVICE_SET_WAIT_TIME: DOMAIN,
+}
 
 
-async def test_vacuum(hass, mock_account):
+async def test_vacuum(hass: HomeAssistant, mock_account):
     """Tests the vacuum entity was set up."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(ENTITY_ID)
+    vacuum = hass.states.get(VACUUM_ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
     assert vacuum.attributes["is_sleeping"] is False
 
 
-async def test_vacuum_with_error(hass, mock_account_with_error):
+async def test_vacuum_with_error(hass: HomeAssistant, mock_account_with_error):
     """Tests a vacuum entity with an error."""
     await setup_integration(hass, mock_account_with_error, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(ENTITY_ID)
+    vacuum = hass.states.get(VACUUM_ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_ERROR
 
@@ -50,58 +60,46 @@ async def test_vacuum_with_error(hass, mock_account_with_error):
         (SERVICE_TURN_OFF, "set_power_status", None),
         (SERVICE_TURN_ON, "set_power_status", None),
         (
-            SERVICE_SEND_COMMAND,
+            SERVICE_RESET_WASTE_DRAWER,
             "reset_waste_drawer",
-            {ATTR_COMMAND: "reset_waste_drawer"},
+            None,
         ),
         (
-            SERVICE_SEND_COMMAND,
+            SERVICE_SET_SLEEP_MODE,
             "set_sleep_mode",
-            {
-                ATTR_COMMAND: "set_sleep_mode",
-                ATTR_PARAMS: {"enabled": True, "sleep_time": "22:30"},
-            },
+            {"enabled": True, "start_time": "22:30"},
         ),
         (
-            SERVICE_SEND_COMMAND,
+            SERVICE_SET_SLEEP_MODE,
             "set_sleep_mode",
-            {
-                ATTR_COMMAND: "set_sleep_mode",
-                ATTR_PARAMS: {"enabled": True, "sleep_time": None},
-            },
+            {"enabled": True},
         ),
         (
-            SERVICE_SEND_COMMAND,
+            SERVICE_SET_SLEEP_MODE,
             "set_sleep_mode",
-            {
-                ATTR_COMMAND: "set_sleep_mode",
-                ATTR_PARAMS: {"enabled": False},
-            },
+            {"enabled": False},
         ),
         (
-            SERVICE_SEND_COMMAND,
+            SERVICE_SET_WAIT_TIME,
             "set_wait_time",
-            {
-                ATTR_COMMAND: "set_wait_time",
-                ATTR_PARAMS: {"wait_time": 3},
-            },
+            {"minutes": 3},
         ),
     ],
 )
-async def test_commands(hass, mock_account, service, command, extra):
+async def test_commands(hass: HomeAssistant, mock_account, service, command, extra):
     """Test sending commands to the vacuum."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(ENTITY_ID)
+    vacuum = hass.states.get(VACUUM_ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
 
-    data = {ATTR_ENTITY_ID: ENTITY_ID}
+    data = {ATTR_ENTITY_ID: VACUUM_ENTITY_ID}
     if extra:
         data.update(extra)
 
     await hass.services.async_call(
-        PLATFORM_DOMAIN,
+        COMPONENT_SERVICE_DOMAIN.get(service, PLATFORM_DOMAIN),
         service,
         data,
         blocking=True,
@@ -111,22 +109,20 @@ async def test_commands(hass, mock_account, service, command, extra):
     getattr(mock_account.robots[0], command).assert_called_once()
 
 
-async def test_invalid_commands(hass, caplog, mock_account_with_side_effects):
+async def test_invalid_commands(
+    hass: HomeAssistant, caplog, mock_account_with_side_effects
+):
     """Test sending invalid commands to the vacuum."""
     await setup_integration(hass, mock_account_with_side_effects, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(ENTITY_ID)
+    vacuum = hass.states.get(VACUUM_ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
 
     await hass.services.async_call(
-        PLATFORM_DOMAIN,
-        SERVICE_SEND_COMMAND,
-        {
-            ATTR_ENTITY_ID: ENTITY_ID,
-            ATTR_COMMAND: "set_wait_time",
-            ATTR_PARAMS: {"wait_time": 1},
-        },
+        DOMAIN,
+        SERVICE_SET_WAIT_TIME,
+        {ATTR_ENTITY_ID: VACUUM_ENTITY_ID, "minutes": 15},
         blocking=True,
     )
     mock_account_with_side_effects.robots[0].set_wait_time.assert_called_once()

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -37,11 +37,19 @@ COMPONENT_SERVICE_DOMAIN = {
 async def test_vacuum(hass: HomeAssistant, mock_account):
     """Tests the vacuum entity was set up."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
+    assert hass.services.has_service(DOMAIN, SERVICE_RESET_WASTE_DRAWER)
 
     vacuum = hass.states.get(VACUUM_ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
     assert vacuum.attributes["is_sleeping"] is False
+
+
+async def test_no_robots(hass: HomeAssistant, mock_account_with_no_robots):
+    """Tests the vacuum entity was set up."""
+    await setup_integration(hass, mock_account_with_no_robots, PLATFORM_DOMAIN)
+
+    assert not hass.services.has_service(DOMAIN, SERVICE_RESET_WASTE_DRAWER)
 
 
 async def test_vacuum_with_error(hass: HomeAssistant, mock_account_with_error):

--- a/tests/components/litterrobot/test_vacuum.py
+++ b/tests/components/litterrobot/test_vacuum.py
@@ -3,60 +3,42 @@ from datetime import timedelta
 
 import pytest
 
-from homeassistant.components.litterrobot import DOMAIN
 from homeassistant.components.litterrobot.entity import REFRESH_WAIT_TIME_SECONDS
-from homeassistant.components.litterrobot.vacuum import (
-    SERVICE_RESET_WASTE_DRAWER,
-    SERVICE_SET_SLEEP_MODE,
-    SERVICE_SET_WAIT_TIME,
-)
 from homeassistant.components.vacuum import (
+    ATTR_PARAMS,
     DOMAIN as PLATFORM_DOMAIN,
+    SERVICE_SEND_COMMAND,
     SERVICE_START,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_DOCKED,
     STATE_ERROR,
 )
-from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.const import ATTR_COMMAND, ATTR_ENTITY_ID
 from homeassistant.util.dt import utcnow
 
-from .common import VACUUM_ENTITY_ID
 from .conftest import setup_integration
 
 from tests.common import async_fire_time_changed
 
-COMPONENT_SERVICE_DOMAIN = {
-    SERVICE_RESET_WASTE_DRAWER: DOMAIN,
-    SERVICE_SET_SLEEP_MODE: DOMAIN,
-    SERVICE_SET_WAIT_TIME: DOMAIN,
-}
+ENTITY_ID = "vacuum.test_litter_box"
 
 
-async def test_vacuum(hass: HomeAssistant, mock_account):
+async def test_vacuum(hass, mock_account):
     """Tests the vacuum entity was set up."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
-    assert hass.services.has_service(DOMAIN, SERVICE_RESET_WASTE_DRAWER)
 
-    vacuum = hass.states.get(VACUUM_ENTITY_ID)
+    vacuum = hass.states.get(ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
     assert vacuum.attributes["is_sleeping"] is False
 
 
-async def test_no_robots(hass: HomeAssistant, mock_account_with_no_robots):
-    """Tests the vacuum entity was set up."""
-    await setup_integration(hass, mock_account_with_no_robots, PLATFORM_DOMAIN)
-
-    assert not hass.services.has_service(DOMAIN, SERVICE_RESET_WASTE_DRAWER)
-
-
-async def test_vacuum_with_error(hass: HomeAssistant, mock_account_with_error):
+async def test_vacuum_with_error(hass, mock_account_with_error):
     """Tests a vacuum entity with an error."""
     await setup_integration(hass, mock_account_with_error, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(VACUUM_ENTITY_ID)
+    vacuum = hass.states.get(ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_ERROR
 
@@ -68,46 +50,58 @@ async def test_vacuum_with_error(hass: HomeAssistant, mock_account_with_error):
         (SERVICE_TURN_OFF, "set_power_status", None),
         (SERVICE_TURN_ON, "set_power_status", None),
         (
-            SERVICE_RESET_WASTE_DRAWER,
+            SERVICE_SEND_COMMAND,
             "reset_waste_drawer",
-            None,
+            {ATTR_COMMAND: "reset_waste_drawer"},
         ),
         (
-            SERVICE_SET_SLEEP_MODE,
+            SERVICE_SEND_COMMAND,
             "set_sleep_mode",
-            {"enabled": True, "start_time": "22:30"},
+            {
+                ATTR_COMMAND: "set_sleep_mode",
+                ATTR_PARAMS: {"enabled": True, "sleep_time": "22:30"},
+            },
         ),
         (
-            SERVICE_SET_SLEEP_MODE,
+            SERVICE_SEND_COMMAND,
             "set_sleep_mode",
-            {"enabled": True},
+            {
+                ATTR_COMMAND: "set_sleep_mode",
+                ATTR_PARAMS: {"enabled": True, "sleep_time": None},
+            },
         ),
         (
-            SERVICE_SET_SLEEP_MODE,
+            SERVICE_SEND_COMMAND,
             "set_sleep_mode",
-            {"enabled": False},
+            {
+                ATTR_COMMAND: "set_sleep_mode",
+                ATTR_PARAMS: {"enabled": False},
+            },
         ),
         (
-            SERVICE_SET_WAIT_TIME,
+            SERVICE_SEND_COMMAND,
             "set_wait_time",
-            {"minutes": 3},
+            {
+                ATTR_COMMAND: "set_wait_time",
+                ATTR_PARAMS: {"wait_time": 3},
+            },
         ),
     ],
 )
-async def test_commands(hass: HomeAssistant, mock_account, service, command, extra):
+async def test_commands(hass, mock_account, service, command, extra):
     """Test sending commands to the vacuum."""
     await setup_integration(hass, mock_account, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(VACUUM_ENTITY_ID)
+    vacuum = hass.states.get(ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
 
-    data = {ATTR_ENTITY_ID: VACUUM_ENTITY_ID}
+    data = {ATTR_ENTITY_ID: ENTITY_ID}
     if extra:
         data.update(extra)
 
     await hass.services.async_call(
-        COMPONENT_SERVICE_DOMAIN.get(service, PLATFORM_DOMAIN),
+        PLATFORM_DOMAIN,
         service,
         data,
         blocking=True,
@@ -117,20 +111,22 @@ async def test_commands(hass: HomeAssistant, mock_account, service, command, ext
     getattr(mock_account.robots[0], command).assert_called_once()
 
 
-async def test_invalid_commands(
-    hass: HomeAssistant, caplog, mock_account_with_side_effects
-):
+async def test_invalid_commands(hass, caplog, mock_account_with_side_effects):
     """Test sending invalid commands to the vacuum."""
     await setup_integration(hass, mock_account_with_side_effects, PLATFORM_DOMAIN)
 
-    vacuum = hass.states.get(VACUUM_ENTITY_ID)
+    vacuum = hass.states.get(ENTITY_ID)
     assert vacuum
     assert vacuum.state == STATE_DOCKED
 
     await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_WAIT_TIME,
-        {ATTR_ENTITY_ID: VACUUM_ENTITY_ID, "minutes": 15},
+        PLATFORM_DOMAIN,
+        SERVICE_SEND_COMMAND,
+        {
+            ATTR_ENTITY_ID: ENTITY_ID,
+            ATTR_COMMAND: "set_wait_time",
+            ATTR_PARAMS: {"wait_time": 1},
+        },
         blocking=True,
     )
     mock_account_with_side_effects.robots[0].set_wait_time.assert_called_once()


### PR DESCRIPTION
## Breaking change

`reset_waste_drawer`, `set_sleep_mode`, and `set_wait_time` are triggered by `services` instead of `send_command`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds support to adjust the wait time on the Litter-Robot.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
