### PR TITLE
Add zwave_js.bulk_set_partial_config_parameters service

### DIFF
--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -52,6 +52,7 @@ ATTR_DATA_TYPE = "data_type"
 
 # service constants
 SERVICE_SET_CONFIG_PARAMETER = "set_config_parameter"
+SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS = "bulk_set_partial_config_parameters"
 
 ATTR_CONFIG_PARAMETER = "parameter"
 ATTR_CONFIG_PARAMETER_BITMASK = "bitmask"

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -174,16 +174,21 @@ class ZWaveServices:
         new_value = service.data[const.ATTR_CONFIG_VALUE]
 
         for node in nodes:
-            await async_bulk_set_partial_config_parameters(
+            cmd_status = await async_bulk_set_partial_config_parameters(
                 node,
                 property_,
                 new_value,
             )
-            _LOGGER.info(
-                "Bulk set partials for configuration parameter %s on Node %s",
-                property_,
-                node,
-            )
+
+            if cmd_status == CommandStatus.ACCEPTED:
+                msg = "Bulk set partials for configuration parameter %s on Node %s"
+            else:
+                msg = (
+                    "Added command to queue to bulk set partials for configuration "
+                    "parameter %s on Node %s"
+                )
+
+            _LOGGER.info(msg, property_, node)
 
     async def async_poll_value(self, service: ServiceCall) -> None:
         """Poll value on a node."""

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -6,7 +6,10 @@ import logging
 import voluptuous as vol
 from zwave_js_server.const import CommandStatus
 from zwave_js_server.model.node import Node as ZwaveNode
-from zwave_js_server.util.node import async_set_config_parameter
+from zwave_js_server.util.node import (
+    async_bulk_set_partial_config_parameters,
+    async_set_config_parameter,
+)
 
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceCall, callback
@@ -37,7 +40,13 @@ def parameter_name_does_not_need_bitmask(
 # Validates that a bitmask is provided in hex form and converts it to decimal
 # int equivalent since that's what the library uses
 BITMASK_SCHEMA = vol.All(
-    cv.string, vol.Lower, vol.Match(r"^(0x)?[0-9a-f]+$"), lambda value: int(value, 16)
+    cv.string,
+    vol.Lower,
+    vol.Match(
+        r"^(0x)?[0-9a-f]+$",
+        msg="Must provide an integer (e.g. 255) or a bitmask in hex form (e.g. 0xff)",
+    ),
+    lambda value: int(value, 16),
 )
 
 
@@ -72,6 +81,30 @@ class ZWaveServices:
                 },
                 cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
                 parameter_name_does_not_need_bitmask,
+            ),
+        )
+
+        self._hass.services.async_register(
+            const.DOMAIN,
+            const.SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
+            self.async_bulk_set_partial_config_parameters,
+            schema=vol.All(
+                {
+                    vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
+                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                    vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Any(
+                        vol.Coerce(int), cv.string
+                    ),
+                    vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
+                        vol.Coerce(int),
+                        {
+                            vol.Any(vol.Coerce(int), BITMASK_SCHEMA): vol.Any(
+                                vol.Coerce(int), cv.string
+                            )
+                        },
+                    ),
+                },
+                cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
             ),
         )
 
@@ -121,6 +154,36 @@ class ZWaveServices:
                 )
 
             _LOGGER.info(msg, zwave_value, node, new_value)
+
+    async def async_bulk_set_partial_config_parameters(
+        self, service: ServiceCall
+    ) -> None:
+        """Bulk set multiple partial config values on a node."""
+        nodes: set[ZwaveNode] = set()
+        if ATTR_ENTITY_ID in service.data:
+            nodes |= {
+                async_get_node_from_entity_id(self._hass, entity_id)
+                for entity_id in service.data[ATTR_ENTITY_ID]
+            }
+        if ATTR_DEVICE_ID in service.data:
+            nodes |= {
+                async_get_node_from_device_id(self._hass, device_id)
+                for device_id in service.data[ATTR_DEVICE_ID]
+            }
+        property_ = service.data[const.ATTR_CONFIG_PARAMETER]
+        new_value = service.data[const.ATTR_CONFIG_VALUE]
+
+        for node in nodes:
+            await async_bulk_set_partial_config_parameters(
+                node,
+                property_,
+                new_value,
+            )
+            _LOGGER.info(
+                "Bulk set partials for configuration parameter %s on Node %s",
+                property_,
+                node,
+            )
 
     async def async_poll_value(self, service: ServiceCall) -> None:
         """Poll value on a node."""

--- a/homeassistant/components/zwave_js/services.yaml
+++ b/homeassistant/components/zwave_js/services.yaml
@@ -59,11 +59,37 @@ set_config_parameter:
       example: 5
       required: true
       selector:
-        object:
+        text:
     bitmask:
       name: Bitmask
       description: Target a specific bitmask (see the documentation for more information).
       advanced: true
+      selector:
+        text:
+
+bulk_set_partial_config_parameters:
+  name: Bulk set partial configuration parameters for a Z-Wave device (Advanced).
+  description: Allow for bulk setting partial parameters. Useful when multiple partial parameters have to be set at the same time.
+  target:
+    entity:
+      integration: zwave_js
+  fields:
+    parameter:
+      name: Parameter
+      description: The id of the configuration parameter you want to configure.
+      example: 9
+      required: true
+      selector:
+        text:
+    value:
+      name: Value
+      description: The new value(s) to set for this configuration parameter. Can either be a raw integer value to represent the bulk change or a mapping where the key is the bitmask (either in hex or integer form) and the value is the new value you want to set for that partial parameter.
+      example:
+        "0x1": 1
+        "0x10": 1
+        "0x20": 1
+        "0x40": 1
+      required: true
       selector:
         object:
 

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -13,7 +13,10 @@ from homeassistant.components.zwave_js.const import (
     SERVICE_SET_CONFIG_PARAMETER,
 )
 from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID
-from homeassistant.helpers.device_registry import async_get as async_get_dev_reg
+from homeassistant.helpers.device_registry import (
+    async_entries_for_config_entry,
+    async_get as async_get_dev_reg,
+)
 from homeassistant.helpers.entity_registry import async_get as async_get_ent_reg
 
 from .common import AIR_TEMPERATURE_SENSOR, CLIMATE_RADIO_THERMOSTAT_ENTITY
@@ -346,12 +349,14 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
 
 async def test_bulk_set_config_parameters(hass, client, multisensor_6, integration):
     """Test the bulk_set_partial_config_parameters service."""
+    dev_reg = async_get_dev_reg(hass)
+    device = async_entries_for_config_entry(dev_reg, integration.entry_id)[0]
     # Test setting config parameter by property and property_key
     await hass.services.async_call(
         DOMAIN,
         SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
         {
-            ATTR_ENTITY_ID: AIR_TEMPERATURE_SENSOR,
+            ATTR_DEVICE_ID: device.id,
             ATTR_CONFIG_PARAMETER: 102,
             ATTR_CONFIG_VALUE: 241,
         },

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -8,6 +8,7 @@ from homeassistant.components.zwave_js.const import (
     ATTR_CONFIG_VALUE,
     ATTR_REFRESH_ALL_VALUES,
     DOMAIN,
+    SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
     SERVICE_REFRESH_VALUE,
     SERVICE_SET_CONFIG_PARAMETER,
 )
@@ -341,6 +342,89 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
     assert args["value"] == 1
 
     client.async_send_command.reset_mock()
+
+
+async def test_bulk_set_config_parameters(hass, client, multisensor_6, integration):
+    """Test the bulk_set_partial_config_parameters service."""
+    # Test setting config parameter by property and property_key
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
+        {
+            ATTR_ENTITY_ID: AIR_TEMPERATURE_SENSOR,
+            ATTR_CONFIG_PARAMETER: 102,
+            ATTR_CONFIG_VALUE: 241,
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClass": 112,
+        "property": 102,
+    }
+    assert args["value"] == 241
+
+    client.async_send_command_no_wait.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
+        {
+            ATTR_ENTITY_ID: AIR_TEMPERATURE_SENSOR,
+            ATTR_CONFIG_PARAMETER: 102,
+            ATTR_CONFIG_VALUE: {
+                1: 1,
+                16: 1,
+                32: 1,
+                64: 1,
+                128: 1,
+            },
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClass": 112,
+        "property": 102,
+    }
+    assert args["value"] == 241
+
+    client.async_send_command_no_wait.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
+        {
+            ATTR_ENTITY_ID: AIR_TEMPERATURE_SENSOR,
+            ATTR_CONFIG_PARAMETER: 102,
+            ATTR_CONFIG_VALUE: {
+                "0x1": 1,
+                "0x10": 1,
+                "0x20": 1,
+                "0x40": 1,
+                "0x80": 1,
+            },
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClass": 112,
+        "property": 102,
+    }
+    assert args["value"] == 241
 
 
 async def test_poll_value(


### PR DESCRIPTION
## Proposed change
Adds a new service called `zwave_js.bulk_set_partial_config_parameters`. We had originally discussed extending the existing `zwave_js.set_config_parameter` service to support this functionality, but it's cleaner to keep it as a separate service and we can document it as being for advanced use. The service accepts either a raw integer value to use for the entire parameter or a mapping of bitmasks to values. In the latter case, the library will calculate the correct integer value to send.

This must follow https://github.com/home-assistant/core/pull/48094

Additional resources for background:
- https://github.com/home-assistant-libs/zwave-js-server-python/pull/176
- https://github.com/home-assistant/core/pull/46673#issuecomment-780740766

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17127

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
