### PR TITLE
Add emonitor integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -237,6 +237,8 @@ omit =
     homeassistant/components/emby/media_player.py
     homeassistant/components/emoncms/sensor.py
     homeassistant/components/emoncms_history/*
+    homeassistant/components/emonitor/__init__.py
+    homeassistant/components/emonitor/sensor.py
     homeassistant/components/enigma2/media_player.py
     homeassistant/components/enocean/__init__.py
     homeassistant/components/enocean/binary_sensor.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -132,6 +132,7 @@ homeassistant/components/elkm1/* @gwww @bdraco
 homeassistant/components/elv/* @majuss
 homeassistant/components/emby/* @mezz64
 homeassistant/components/emoncms/* @borpin
+homeassistant/components/emonitor/* @bdraco
 homeassistant/components/emulated_kasa/* @kbickar
 homeassistant/components/enigma2/* @fbradyirl
 homeassistant/components/enocean/* @bdurrer

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
-        name="Emonitor power update",
+        name=entry.title,
         update_method=emonitor.async_get_status,
         update_interval=timedelta(seconds=DEFAULT_UPDATE_RATE),
     )

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -1,0 +1,77 @@
+"""The SiteSage Emonitor integration."""
+import asyncio
+from datetime import timedelta
+import logging
+
+from aioemonitor import Emonitor
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DEFAULT_UPDATE_RATE = 60
+
+PLATFORMS = ["sensor"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the SiteSage Emonitor component."""
+    hass.data[DOMAIN] = {}
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up SiteSage Emonitor from a config entry."""
+
+    conf = entry.data
+    host = conf[CONF_HOST]
+
+    session = aiohttp_client.async_get_clientsession(hass)
+    emonitor = Emonitor(host, session)
+
+    async def _async_update_data():
+        return await emonitor.async_get_status()
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="Emonitor power update",
+        update_method=_async_update_data,
+        update_interval=timedelta(seconds=DEFAULT_UPDATE_RATE),
+    )
+
+    await coordinator.async_refresh()
+    if not coordinator.last_update_success:
+        raise ConfigEntryNotReady
+
+    hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -40,7 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass,
         _LOGGER,
         name="Emonitor power update",
-        update_method=_async_update_data,
+        update_method=emonitor.async_get_status,
         update_interval=timedelta(seconds=DEFAULT_UPDATE_RATE),
     )
 

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -75,3 +75,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+def name_short_mac(short_mac):
+    """Name from short mac."""
+    return f"Emonitor {short_mac}"

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -30,11 +30,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up SiteSage Emonitor from a config entry."""
 
-    conf = entry.data
-    host = conf[CONF_HOST]
-
     session = aiohttp_client.async_get_clientsession(hass)
-    emonitor = Emonitor(host, session)
+    emonitor = Emonitor(entry.data[CONF_HOST], session)
 
     coordinator = DataUpdateCoordinator(
         hass,

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -42,7 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await coordinator.async_config_entry_first_refresh()
 
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 
     for platform in PLATFORMS:
         hass.async_create_task(

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -36,9 +36,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     session = aiohttp_client.async_get_clientsession(hass)
     emonitor = Emonitor(host, session)
 
-    async def _async_update_data():
-        return await emonitor.async_get_status()
-
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -8,7 +8,6 @@ from aioemonitor import Emonitor
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -41,9 +40,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         update_interval=timedelta(seconds=DEFAULT_UPDATE_RATE),
     )
 
-    await coordinator.async_refresh()
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = coordinator
 

--- a/homeassistant/components/emonitor/__init__.py
+++ b/homeassistant/components/emonitor/__init__.py
@@ -20,12 +20,6 @@ DEFAULT_UPDATE_RATE = 60
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the SiteSage Emonitor component."""
-    hass.data[DOMAIN] = {}
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up SiteSage Emonitor from a config entry."""
 

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -87,6 +87,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         self._set_confirm_only()
+        self.context["title_placeholders"] = {"name": self.discovered_info["title"]}
         return self.async_show_form(
             step_id="confirm",
             description_placeholders={

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -1,0 +1,104 @@
+"""Config flow for SiteSage Emonitor integration."""
+import logging
+
+from aioemonitor import Emonitor
+import aiohttp
+import voluptuous as vol
+
+from homeassistant import config_entries, core
+from homeassistant.components.dhcp import IP_ADDRESS, MAC_ADDRESS
+from homeassistant.const import CONF_HOST, CONF_NAME
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.device_registry import format_mac
+
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def fetch_mac_and_title(hass: core.HomeAssistant, host):
+    """Validate the user input allows us to connect."""
+    session = aiohttp_client.async_get_clientsession(hass)
+    emonitor = Emonitor(host, session)
+    status = await emonitor.async_get_status()
+    mac_address = status.network.mac_address
+    # Return info that you want to store in the config entry.
+    return {"title": name_short_mac(mac_address[-6:]), "mac_address": mac_address}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for SiteSage Emonitor."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    def __init__(self):
+        """Initialize Emonitor ConfigFlow."""
+        self.discovered_ip = None
+        self.discovered_info = None
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        errors = {}
+        if user_input is not None:
+            try:
+                info = await fetch_mac_and_title(self.hass, user_input[CONF_HOST])
+            except aiohttp.ClientError:
+                errors[CONF_HOST] = "cannot_connect"
+            except Exception:  # pylint: disable=broad-except
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(format_mac(info["mac_address"]))
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required("host", default=self.discovered_ip): str}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_dhcp(self, dhcp_discovery):
+        """Handle dhcp discovery."""
+        self.discovered_ip = dhcp_discovery[IP_ADDRESS]
+        await self.async_set_unique_id(format_mac(dhcp_discovery[MAC_ADDRESS]))
+        self._abort_if_unique_id_configured(updates={CONF_HOST: self.discovered_ip})
+        name = name_short_mac(short_mac(dhcp_discovery[MAC_ADDRESS]))
+        self.context["title_placeholders"] = {"name": name}
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(self, user_input=None):
+        """Attempt to confim."""
+        if user_input is not None:
+            return self.async_create_entry(
+                title=self.discovered_info["title"],
+                data={CONF_HOST: self.discovered_ip},
+            )
+
+        try:
+            self.discovered_info = await fetch_mac_and_title(
+                self.hass, self.discovered_ip
+            )
+        except Exception:  # pylint: disable=broad-except
+            return await self.async_step_user()
+
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="confirm",
+            description_placeholders={
+                CONF_HOST: self.discovered_ip,
+                CONF_NAME: self.discovered_info["title"],
+            },
+        )
+
+
+def name_short_mac(short_mac):
+    """Name from mac."""
+    return f"Emonitor {short_mac}"
+
+
+def short_mac(mac):
+    """Short version of the mac."""
+    return "-".join(mac.split(":")[3:]).upper()

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -71,7 +71,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.discovered_info = await fetch_mac_and_title(
                 self.hass, self.discovered_ip
             )
-        except Exception:  # pylint: disable=broad-except
+        except Exception as ex:  # pylint: disable=broad-except
+            _LOGGER.debug(
+                "Unable to fetch status, falling back to manual entry", exc_info=ex
+            )
             return await self.async_step_user()
         return await self.async_step_confirm()
 

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.device_registry import format_mac
 
+from . import name_short_mac
 from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,11 +94,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-def name_short_mac(short_mac):
-    """Name from mac."""
-    return f"Emonitor {short_mac}"
-
-
 def short_mac(mac):
     """Short version of the mac."""
-    return "-".join(mac.split(":")[3:]).upper()
+    return "".join(mac.split(":")[3:]).upper()

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -22,7 +22,6 @@ async def fetch_mac_and_title(hass: core.HomeAssistant, host):
     emonitor = Emonitor(host, session)
     status = await emonitor.async_get_status()
     mac_address = status.network.mac_address
-    # Return info that you want to store in the config entry.
     return {"title": name_short_mac(mac_address[-6:]), "mac_address": mac_address}
 
 

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -49,7 +49,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(format_mac(info["mac_address"]), raise_on_progress=False)
+                await self.async_set_unique_id(
+                    format_mac(info["mac_address"]), raise_on_progress=False
+                )
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/emonitor/config_flow.py
+++ b/homeassistant/components/emonitor/config_flow.py
@@ -49,7 +49,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
-                await self.async_set_unique_id(format_mac(info["mac_address"]))
+                await self.async_set_unique_id(format_mac(info["mac_address"]), raise_on_progress=False)
                 return self.async_create_entry(title=info["title"], data=user_input)
 
         return self.async_show_form(

--- a/homeassistant/components/emonitor/const.py
+++ b/homeassistant/components/emonitor/const.py
@@ -1,0 +1,3 @@
+"""Constants for the SiteSage Emonitor integration."""
+
+DOMAIN = "emonitor"

--- a/homeassistant/components/emonitor/manifest.json
+++ b/homeassistant/components/emonitor/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/emonitor",
   "requirements": [
-    "aioemonitor==1.0.4"
+    "aioemonitor==1.0.5"
   ],
   "dhcp": [{"hostname":"emonitor*","macaddress":"0090C2*"}],
   "codeowners": [

--- a/homeassistant/components/emonitor/manifest.json
+++ b/homeassistant/components/emonitor/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "emonitor",
+  "name": "SiteSage Emonitor",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/emonitor",
+  "requirements": [
+    "aioemonitor==1.0.4"
+  ],
+  "dhcp": [{"hostname":"emonitor*","macaddress":"0090C2*"}],
+  "codeowners": [
+    "@bdraco"
+  ]
+}

--- a/homeassistant/components/emonitor/sensor.py
+++ b/homeassistant/components/emonitor/sensor.py
@@ -1,0 +1,107 @@
+"""Support for a Emonitor channel sensor."""
+
+from aioemonitor.monitor import EmonitorChannel
+
+from homeassistant.components.sensor import DEVICE_CLASS_POWER, SensorEntity
+from homeassistant.const import POWER_WATT
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.typing import StateType
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
+
+from .const import DOMAIN
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up entry."""
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    channels = coordinator.data.channels
+    entities = []
+    seen_channels = set()
+    for channel_number, channel in channels.items():
+        seen_channels.add(channel_number)
+        if not channel.active:
+            continue
+        if channel.paired_with_channel in seen_channels:
+            continue
+
+        entities.append(EmonitorPowerSensor(coordinator, channel_number))
+
+    async_add_entities(entities)
+
+
+class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
+    """Representation of an Emonitor power sensor entity."""
+
+    def __init__(self, coordinator: DataUpdateCoordinator, channel_number: int):
+        """Initialize the channel sensor."""
+        self.channel_number = channel_number
+        super().__init__(coordinator)
+
+    @property
+    def unique_id(self) -> str:
+        """Channel unique id."""
+        return f"{self.mac_address}_{self.channel_number}"
+
+    @property
+    def channel_data(self) -> EmonitorChannel:
+        """Channel data."""
+        return self.coordinator.data.channels[self.channel_number]
+
+    @property
+    def paired_channel_data(self) -> EmonitorChannel:
+        """Channel data."""
+        return self.coordinator.data.channels[self.channel_data.paired_with_channel]
+
+    @property
+    def name(self) -> str:
+        """Name of the sensor."""
+        return self.channel_data.label
+
+    @property
+    def unit_of_measurement(self) -> str:
+        """Return the unit of measurement."""
+        return POWER_WATT
+
+    @property
+    def device_class(self) -> str:
+        """Device class of the sensor."""
+        return DEVICE_CLASS_POWER
+
+    def _paired_attr(self, attr_name: str) -> float:
+        """Cumulative attributes for channel and paired channel."""
+        attr_val = getattr(self.channel_data, attr_name)
+        if self.channel_data.paired_with_channel:
+            attr_val += getattr(self.paired_channel_data, attr_name)
+        return attr_val
+
+    @property
+    def state(self) -> StateType:
+        """State of the sensor."""
+        return self._paired_attr("inst_power")
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return the device specific state attributes."""
+        return {
+            "channel": self.channel_number,
+            "avg_power": self._paired_attr("avg_power"),
+            "max_power": self._paired_attr("max_power"),
+        }
+
+    @property
+    def mac_address(self) -> str:
+        """Return the mac address of the device."""
+        return self.coordinator.data.network.mac_address
+
+    @property
+    def device_info(self) -> dict:
+        """Return info about the emonitor device."""
+        return {
+            "name": f"Emonitor {self.mac_address[-6:]}",
+            "connections": {(dr.CONNECTION_NETWORK_MAC, self.mac_address)},
+            "manufacturer": "Powerhouse Dynamics, Inc.",
+            "sw_version": self.coordinator.data.hardware.firmware_version,
+        }

--- a/homeassistant/components/emonitor/sensor.py
+++ b/homeassistant/components/emonitor/sensor.py
@@ -11,6 +11,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
+from . import name_short_mac
 from .const import DOMAIN
 
 
@@ -100,7 +101,7 @@ class EmonitorPowerSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> dict:
         """Return info about the emonitor device."""
         return {
-            "name": f"Emonitor {self.mac_address[-6:]}",
+            "name": name_short_mac(self.mac_address[-6:]),
             "connections": {(dr.CONNECTION_NETWORK_MAC, self.mac_address)},
             "manufacturer": "Powerhouse Dynamics, Inc.",
             "sw_version": self.coordinator.data.hardware.firmware_version,

--- a/homeassistant/components/emonitor/strings.json
+++ b/homeassistant/components/emonitor/strings.json
@@ -1,0 +1,23 @@
+{
+  "config": {
+    "flow_title": "SiteSage {name}",
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      },
+      "confirm": {
+        "title": "Setup SiteSage Emonitor",
+        "description": "Do you want to setup {name} ({host})?"
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/emonitor/translations/en.json
+++ b/homeassistant/components/emonitor/translations/en.json
@@ -1,0 +1,23 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "flow_title": "SiteSage {name}",
+        "step": {
+            "confirm": {
+                "description": "Do you want to setup {name} ({host})?",
+                "title": "Setup SiteSage Emonitor"
+            },
+            "user": {
+                "data": {
+                    "host": "Host"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -60,6 +60,7 @@ FLOWS = [
     "econet",
     "elgato",
     "elkm1",
+    "emonitor",
     "emulated_roku",
     "enocean",
     "epson",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -58,6 +58,11 @@ DHCP = [
         "macaddress": "B4430D*"
     },
     {
+        "domain": "emonitor",
+        "hostname": "emonitor*",
+        "macaddress": "0090C2*"
+    },
+    {
         "domain": "flume",
         "hostname": "flume-gw-*",
         "macaddress": "ECFABC*"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -157,7 +157,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.emonitor
-aioemonitor==1.0.4
+aioemonitor==1.0.5
 
 # homeassistant.components.esphome
 aioesphomeapi==2.6.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -156,6 +156,9 @@ aiodns==2.0.0
 # homeassistant.components.eafm
 aioeafm==0.1.2
 
+# homeassistant.components.emonitor
+aioemonitor==1.0.4
+
 # homeassistant.components.esphome
 aioesphomeapi==2.6.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -93,6 +93,9 @@ aiodns==2.0.0
 # homeassistant.components.eafm
 aioeafm==0.1.2
 
+# homeassistant.components.emonitor
+aioemonitor==1.0.4
+
 # homeassistant.components.esphome
 aioesphomeapi==2.6.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -94,7 +94,7 @@ aiodns==2.0.0
 aioeafm==0.1.2
 
 # homeassistant.components.emonitor
-aioemonitor==1.0.4
+aioemonitor==1.0.5
 
 # homeassistant.components.esphome
 aioesphomeapi==2.6.6

--- a/tests/components/emonitor/__init__.py
+++ b/tests/components/emonitor/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the SiteSage Emonitor integration."""

--- a/tests/components/emonitor/test_config_flow.py
+++ b/tests/components/emonitor/test_config_flow.py
@@ -1,0 +1,189 @@
+"""Test the SiteSage Emonitor config flow."""
+from unittest.mock import MagicMock, patch
+
+from aioemonitor.monitor import EmonitorNetwork, EmonitorStatus
+import aiohttp
+
+from homeassistant import config_entries, setup
+from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
+from homeassistant.components.emonitor.const import DOMAIN
+from homeassistant.const import CONF_HOST
+
+from tests.common import MockConfigEntry
+
+
+def _mock_emonitor():
+    return EmonitorStatus(
+        MagicMock(), EmonitorNetwork("AABBCCDDEEFF", "1.2.3.4"), MagicMock()
+    )
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
+        return_value=_mock_emonitor(),
+    ), patch(
+        "homeassistant.components.emonitor.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.emonitor.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.2.3.4",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Emonitor DDEEFF"
+    assert result2["data"] == {
+        "host": "1.2.3.4",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_unknown_error(hass):
+    """Test we handle unknown error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.2.3.4",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "unknown"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
+        side_effect=aiohttp.ClientError,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.2.3.4",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {CONF_HOST: "cannot_connect"}
+
+
+async def test_dhcp_can_confirm(hass):
+    """Test DHCP discovery flow can confirm right away."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
+        return_value=_mock_emonitor(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "dhcp"},
+            data={
+                HOSTNAME: "emonitor",
+                IP_ADDRESS: "1.2.3.4",
+                MAC_ADDRESS: "aa:bb:cc:dd:ee:ff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "confirm"
+
+    with patch(
+        "homeassistant.components.emonitor.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.emonitor.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "Emonitor DDEEFF"
+    assert result2["data"] == {
+        "host": "1.2.3.4",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_dhcp_fails_to_connect(hass):
+    """Test DHCP discovery flow that fails to connect."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
+        side_effect=aiohttp.ClientError,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "dhcp"},
+            data={
+                HOSTNAME: "emonitor",
+                IP_ADDRESS: "1.2.3.4",
+                MAC_ADDRESS: "aa:bb:cc:dd:ee:ff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+
+
+async def test_dhcp_already_exists(hass):
+    """Test DHCP discovery flow that fails to connect."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "1.2.3.4"},
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
+        return_value=_mock_emonitor(),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "dhcp"},
+            data={
+                HOSTNAME: "emonitor",
+                IP_ADDRESS: "1.2.3.4",
+                MAC_ADDRESS: "aa:bb:cc:dd:ee:ff",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == "abort"

--- a/tests/components/emonitor/test_config_flow.py
+++ b/tests/components/emonitor/test_config_flow.py
@@ -116,6 +116,10 @@ async def test_dhcp_can_confirm(hass):
 
     assert result["type"] == "form"
     assert result["step_id"] == "confirm"
+    assert result["description_placeholders"] == {
+        "host": "1.2.3.4",
+        "name": "Emonitor DDEEFF",
+    }
 
     with patch(
         "homeassistant.components.emonitor.async_setup", return_value=True

--- a/tests/components/emonitor/test_config_flow.py
+++ b/tests/components/emonitor/test_config_flow.py
@@ -31,8 +31,6 @@ async def test_form(hass):
         "homeassistant.components.emonitor.config_flow.Emonitor.async_get_status",
         return_value=_mock_emonitor(),
     ), patch(
-        "homeassistant.components.emonitor.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.emonitor.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -49,7 +47,6 @@ async def test_form(hass):
     assert result2["data"] == {
         "host": "1.2.3.4",
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -122,8 +119,6 @@ async def test_dhcp_can_confirm(hass):
     }
 
     with patch(
-        "homeassistant.components.emonitor.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.emonitor.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -138,7 +133,6 @@ async def test_dhcp_can_confirm(hass):
     assert result2["data"] == {
         "host": "1.2.3.4",
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The SiteSage Emonitor allows local power monitoring on a per circuit basis via an [Emonitor](https://powerhousedynamics.com/solutions/sitesage/) device.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17129

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
