### PR TITLE
Xknx unneeded expose

### DIFF
--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -114,12 +114,15 @@ class KNXExposeSensor:
         if new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             return
 
+        old_state = event.data.get("old_state")
+
         if self.expose_attribute is None:
-            await self._async_set_knx_value(new_state.state)
+            if old_state is None or old_state.state != new_state.state:
+                # don't send same value sequentially
+                await self._async_set_knx_value(new_state.state)
             return
 
         new_attribute = new_state.attributes.get(self.expose_attribute)
-        old_state = event.data.get("old_state")
 
         if old_state is not None:
             old_attribute = old_state.attributes.get(self.expose_attribute)

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1201,6 +1201,9 @@ wolf_smartset==0.1.8
 # homeassistant.components.xbox
 xbox-webapi==2.0.8
 
+# homeassistant.components.knx
+xknx==0.17.4
+
 # homeassistant.components.bluesound
 # homeassistant.components.rest
 # homeassistant.components.startca

--- a/tests/components/knx/__init__.py
+++ b/tests/components/knx/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for KNX integration."""

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -1,0 +1,67 @@
+"""Test knx expose."""
+from unittest.mock import AsyncMock, Mock
+
+from homeassistant.components.knx.expose import KNXExposeSensor
+
+
+async def test_binary_expose(hass):
+    """Test that a binary expose sends only telegrams on state change."""
+    e_id = "fake.entity"
+    xknxMock = Mock()
+    xknxMock.telegrams = AsyncMock()
+    KNXExposeSensor(hass, xknxMock, "binary", e_id, None, "0", "1/1/8")
+    assert xknxMock.devices.add.call_count == 1, "Expected one device add"
+
+    # Change state to on
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "on", {})
+    await hass.async_block_till_done()
+    assert xknxMock.telegrams.put.call_count == 1, "Expected telegram for state change"
+
+    # Change attribute; keep state
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "on", {"brightness": 180})
+    await hass.async_block_till_done()
+    assert (
+        xknxMock.telegrams.put.call_count == 0
+    ), "Expected no telegram; state not changed"
+
+    # Change attribute and state
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "off", {"brightness": 0})
+    await hass.async_block_till_done()
+    assert xknxMock.telegrams.put.call_count == 1, "Expected telegram for state change"
+
+
+async def test_expose_attribute(hass):
+    """Test that an expose sends only telegrams on attribute change."""
+    e_id = "fake.entity"
+    a_id = "fakeAttribute"
+    xknxMock = Mock()
+    xknxMock.telegrams = AsyncMock()
+    KNXExposeSensor(hass, xknxMock, "percentU8", e_id, a_id, None, "1/1/8")
+    assert xknxMock.devices.add.call_count == 1, "Expected one device add"
+
+    # Change state to on; no attribute
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "on", {})
+    await hass.async_block_till_done()
+    assert xknxMock.telegrams.put.call_count == 0
+
+    # Change attribute; keep state
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "on", {a_id: 1})
+    await hass.async_block_till_done()
+    assert xknxMock.telegrams.put.call_count == 1
+
+    # Change state keep attribute
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "off", {a_id: 1})
+    await hass.async_block_till_done()
+    assert xknxMock.telegrams.put.call_count == 0
+
+    # Change state and attribute
+    xknxMock.reset_mock()
+    hass.states.async_set(e_id, "on", {a_id: 0})
+    await hass.async_block_till_done()
+    assert xknxMock.telegrams.put.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When an entity state is exposed to KNX it is expected that any state change of the entity leads to a KNX telegram.
The unexpected behavior here is that also any _attribute_ change of the entity leads to a KNX telegram.
This PR fixes this unexpected behavior.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
knx:
  expose:
    - type: "binary"
      entity_id: light.labor
      address: "1/1/8"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes XKNX/xknx#643
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
