### PR TITLE
Add 'for' to cover device triggers

### DIFF
--- a/homeassistant/components/cover/device_trigger.py
+++ b/homeassistant/components/cover/device_trigger.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_FOR,
     CONF_PLATFORM,
     CONF_TYPE,
     CONF_VALUE_TEMPLATE,
@@ -59,6 +60,7 @@ STATE_TRIGGER_SCHEMA = TRIGGER_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_ENTITY_ID): cv.entity_id,
         vol.Required(CONF_TYPE): vol.In(STATE_TRIGGER_TYPES),
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
     }
 )
 
@@ -146,8 +148,12 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
 
 async def async_get_trigger_capabilities(hass: HomeAssistant, config: dict) -> dict:
     """List trigger capabilities."""
-    if config[CONF_TYPE] not in ["position", "tilt_position"]:
-        return {}
+    if config[CONF_TYPE] not in POSITION_TRIGGER_TYPES:
+        return {
+            "extra_fields": vol.Schema(
+                {vol.Optional(CONF_FOR): cv.positive_time_period_dict}
+            )
+        }
 
     return {
         "extra_fields": vol.Schema(
@@ -170,8 +176,6 @@ async def async_attach_trigger(
     automation_info: dict,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
-    config = TRIGGER_SCHEMA(config)
-
     if config[CONF_TYPE] in STATE_TRIGGER_TYPES:
         if config[CONF_TYPE] == "opened":
             to_state = STATE_OPEN
@@ -187,6 +191,8 @@ async def async_attach_trigger(
             CONF_ENTITY_ID: config[CONF_ENTITY_ID],
             state_trigger.CONF_TO: to_state,
         }
+        if CONF_FOR in config:
+            state_config[CONF_FOR] = config[CONF_FOR]
         state_config = state_trigger.TRIGGER_SCHEMA(state_config)
         return await state_trigger.async_attach_trigger(
             hass, state_config, action, automation_info, platform_type="device"

--- a/tests/components/cover/test_device_trigger.py
+++ b/tests/components/cover/test_device_trigger.py
@@ -1,4 +1,6 @@
 """The tests for Cover device triggers."""
+from datetime import timedelta
+
 import pytest
 
 import homeassistant.components.automation as automation
@@ -12,10 +14,12 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
     assert_lists_same,
+    async_fire_time_changed,
     async_get_device_automation_capabilities,
     async_get_device_automations,
     async_mock_service,
@@ -234,7 +238,11 @@ async def test_get_trigger_capabilities(hass, device_reg, entity_reg):
         capabilities = await async_get_device_automation_capabilities(
             hass, "trigger", trigger
         )
-        assert capabilities == {"extra_fields": []}
+        assert capabilities == {
+            "extra_fields": [
+                {"name": "for", "optional": True, "type": "positive_time_period_dict"}
+            ]
+        }
 
 
 async def test_get_trigger_capabilities_set_pos(hass, device_reg, entity_reg):
@@ -284,7 +292,15 @@ async def test_get_trigger_capabilities_set_pos(hass, device_reg, entity_reg):
         if trigger["type"] == "position":
             assert capabilities == expected_capabilities
         else:
-            assert capabilities == {"extra_fields": []}
+            assert capabilities == {
+                "extra_fields": [
+                    {
+                        "name": "for",
+                        "optional": True,
+                        "type": "positive_time_period_dict",
+                    }
+                ]
+            }
 
 
 async def test_get_trigger_capabilities_set_tilt_pos(hass, device_reg, entity_reg):
@@ -334,7 +350,15 @@ async def test_get_trigger_capabilities_set_tilt_pos(hass, device_reg, entity_re
         if trigger["type"] == "tilt_position":
             assert capabilities == expected_capabilities
         else:
-            assert capabilities == {"extra_fields": []}
+            assert capabilities == {
+                "extra_fields": [
+                    {
+                        "name": "for",
+                        "optional": True,
+                        "type": "positive_time_period_dict",
+                    }
+                ]
+            }
 
 
 async def test_if_fires_on_state_change(hass, calls):
@@ -457,6 +481,61 @@ async def test_if_fires_on_state_change(hass, calls):
     assert calls[3].data[
         "some"
     ] == "closing - device - {} - opening - closing - None".format("cover.entity")
+
+
+async def test_if_fires_on_state_change_with_for(hass, calls):
+    """Test for triggers firing with delay."""
+    entity_id = "cover.entity"
+    hass.states.async_set(entity_id, STATE_CLOSED)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": entity_id,
+                        "type": "opened",
+                        "for": {"seconds": 5},
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "turn_off {{ trigger.%s }}"
+                            % "}} - {{ trigger.".join(
+                                (
+                                    "platform",
+                                    "entity_id",
+                                    "from_state.state",
+                                    "to_state.state",
+                                    "for",
+                                )
+                            )
+                        },
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_CLOSED
+    assert len(calls) == 0
+
+    hass.states.async_set(entity_id, STATE_OPEN)
+    await hass.async_block_till_done()
+    assert len(calls) == 0
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    await hass.async_block_till_done()
+    assert (
+        calls[0].data["some"]
+        == f"turn_off device - {entity_id} - closed - open - 0:00:05"
+    )
 
 
 async def test_if_fires_on_position(hass, calls):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add 'for' to cover device triggers to allow triggers like "Garage door has been open for 5 minutes"

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
