### PR TITLE
Fix device discovery of OAuth2 config flows

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1049,11 +1049,13 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         }
 
     @callback
-    def _async_in_progress(self) -> list[dict]:
+    def _async_in_progress(self, include_uninitialized: bool = False) -> list[dict]:
         """Return other in progress flows for current domain."""
         return [
             flw
-            for flw in self.hass.config_entries.flow.async_progress()
+            for flw in self.hass.config_entries.flow.async_progress(
+                include_uninitialized=include_uninitialized
+            )
             if flw["handler"] == self.handler and flw["flow_id"] != self.flow_id
         ]
 
@@ -1093,7 +1095,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         self._abort_if_unique_id_configured()
 
         # Abort if any other flow for this handler is already in progress
-        if self._async_in_progress():
+        if self._async_in_progress(include_uninitialized=True):
             raise data_entry_flow.AbortFlow("already_in_progress")
 
     async def async_step_discovery(

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -94,17 +94,17 @@ class FlowManager(abc.ABC):
         """Entry has finished executing its first step asynchronously."""
 
     @callback
-    def async_progress(self) -> list[dict]:
+    def async_progress(self, include_uninitialized: bool = False) -> list[dict]:
         """Return the flows in progress."""
         return [
             {
                 "flow_id": flow.flow_id,
                 "handler": flow.handler,
                 "context": flow.context,
-                "step_id": flow.cur_step["step_id"],
+                "step_id": flow.cur_step["step_id"] if flow.cur_step else None,
             }
             for flow in self._progress.values()
-            if flow.cur_step is not None
+            if include_uninitialized or flow.cur_step is not None
         ]
 
     async def async_init(

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -245,8 +245,10 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
         if not implementations:
             return self.async_abort(reason="missing_configuration")
 
-        if len(implementations) == 1:
-            # Pick first implementation as we have only one.
+        req = http.current_request.get()
+        if len(implementations) == 1 and req is not None:
+            # Pick first implementation if we have only one, but only
+            # if this is triggered by a user interaction (request).
             self.flow_impl = list(implementations.values())[0]
             return await self.async_step_auth()
 
@@ -313,23 +315,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
         """
         return self.async_create_entry(title=self.flow_impl.name, data=data)
 
-    async def async_step_discovery(
-        self, discovery_info: dict[str, Any]
-    ) -> dict[str, Any]:
-        """Handle a flow initialized by discovery."""
-        await self.async_set_unique_id(self.DOMAIN)
-
-        if self.hass.config_entries.async_entries(self.DOMAIN):
-            return self.async_abort(reason="already_configured")
-
-        return await self.async_step_pick_implementation()
-
     async_step_user = async_step_pick_implementation
-    async_step_mqtt = async_step_discovery
-    async_step_ssdp = async_step_discovery
-    async_step_zeroconf = async_step_discovery
-    async_step_homekit = async_step_discovery
-    async_step_dhcp = async_step_discovery
 
     @classmethod
     def async_register_implementation(

--- a/tests/components/cloud/test_account_link.py
+++ b/tests/components/cloud/test_account_link.py
@@ -108,7 +108,7 @@ async def test_get_services_error(hass):
         assert account_link.DATA_SERVICES not in hass.data
 
 
-async def test_implementation(hass, flow_handler):
+async def test_implementation(hass, flow_handler, current_request_with_host):
     """Test Cloud OAuth2 implementation."""
     hass.data["cloud"] = None
 

--- a/tests/components/somfy/test_config_flow.py
+++ b/tests/components/somfy/test_config_flow.py
@@ -123,7 +123,9 @@ async def test_full_flow(
     assert entry.state == config_entries.ENTRY_STATE_NOT_LOADED
 
 
-async def test_abort_if_authorization_timeout(hass, mock_impl):
+async def test_abort_if_authorization_timeout(
+    hass, mock_impl, current_request_with_host
+):
     """Check Somfy authorization timeout."""
     flow = config_flow.SomfyFlowHandler()
     flow.hass = hass

--- a/tests/components/withings/test_binary_sensor.py
+++ b/tests/components/withings/test_binary_sensor.py
@@ -15,7 +15,7 @@ from .common import ComponentFactory, new_profile_config
 
 
 async def test_binary_sensor(
-    hass: HomeAssistant, component_factory: ComponentFactory
+    hass: HomeAssistant, component_factory: ComponentFactory, current_request_with_host
 ) -> None:
     """Test binary sensor."""
     in_bed_attribute = WITHINGS_MEASUREMENTS_MAP[Measurement.IN_BED]

--- a/tests/components/withings/test_common.py
+++ b/tests/components/withings/test_common.py
@@ -74,6 +74,7 @@ async def test_webhook_post(
     arg_user_id: Any,
     arg_appli: Any,
     expected_code: int,
+    current_request_with_host,
 ) -> None:
     """Test webhook callback."""
     person0 = new_profile_config("person0", user_id)
@@ -107,6 +108,7 @@ async def test_webhook_head(
     hass: HomeAssistant,
     component_factory: ComponentFactory,
     aiohttp_client,
+    current_request_with_host,
 ) -> None:
     """Test head method on webhook view."""
     person0 = new_profile_config("person0", 0)
@@ -124,6 +126,7 @@ async def test_webhook_put(
     hass: HomeAssistant,
     component_factory: ComponentFactory,
     aiohttp_client,
+    current_request_with_host,
 ) -> None:
     """Test webhook callback."""
     person0 = new_profile_config("person0", 0)

--- a/tests/components/withings/test_config_flow.py
+++ b/tests/components/withings/test_config_flow.py
@@ -34,7 +34,7 @@ async def test_config_non_unique_profile(hass: HomeAssistant) -> None:
 
 
 async def test_config_reauth_profile(
-    hass: HomeAssistant, aiohttp_client, aioclient_mock
+    hass: HomeAssistant, aiohttp_client, aioclient_mock, current_request_with_host
 ) -> None:
     """Test reauth an existing profile re-creates the config entry."""
     hass_config = {

--- a/tests/components/withings/test_init.py
+++ b/tests/components/withings/test_init.py
@@ -125,7 +125,10 @@ async def test_async_setup_no_config(hass: HomeAssistant) -> None:
     ],
 )
 async def test_auth_failure(
-    hass: HomeAssistant, component_factory: ComponentFactory, exception: Exception
+    hass: HomeAssistant,
+    component_factory: ComponentFactory,
+    exception: Exception,
+    current_request_with_host,
 ) -> None:
     """Test auth failure."""
     person0 = new_profile_config(

--- a/tests/components/withings/test_sensor.py
+++ b/tests/components/withings/test_sensor.py
@@ -302,7 +302,7 @@ def async_assert_state_equals(
 
 
 async def test_sensor_default_enabled_entities(
-    hass: HomeAssistant, component_factory: ComponentFactory
+    hass: HomeAssistant, component_factory: ComponentFactory, current_request_with_host
 ) -> None:
     """Test entities enabled by default."""
     entity_registry: EntityRegistry = er.async_get(hass)
@@ -343,7 +343,7 @@ async def test_sensor_default_enabled_entities(
 
 
 async def test_all_entities(
-    hass: HomeAssistant, component_factory: ComponentFactory
+    hass: HomeAssistant, component_factory: ComponentFactory, current_request_with_host
 ) -> None:
     """Test all entities."""
     entity_registry: EntityRegistry = er.async_get(hass)

--- a/tests/helpers/test_config_entry_oauth2_flow.py
+++ b/tests/helpers/test_config_entry_oauth2_flow.py
@@ -113,7 +113,9 @@ async def test_abort_if_no_implementation(hass, flow_handler):
     assert result["reason"] == "missing_configuration"
 
 
-async def test_abort_if_authorization_timeout(hass, flow_handler, local_impl):
+async def test_abort_if_authorization_timeout(
+    hass, flow_handler, local_impl, current_request_with_host
+):
     """Check timeout generating authorization url."""
     flow_handler.async_register_implementation(hass, local_impl)
 
@@ -129,7 +131,9 @@ async def test_abort_if_authorization_timeout(hass, flow_handler, local_impl):
     assert result["reason"] == "authorize_url_timeout"
 
 
-async def test_abort_if_no_url_available(hass, flow_handler, local_impl):
+async def test_abort_if_no_url_available(
+    hass, flow_handler, local_impl, current_request_with_host
+):
     """Check no_url_available generating authorization url."""
     flow_handler.async_register_implementation(hass, local_impl)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR fixes 3 issues with device discovery triggered OAuth2 configuration flows.

- Triggering discovery with a single OAuth2 implementation, failed because it tried to get the current request (which is not there when not user triggered).
- OAuth2 flows, had their own discovery implementation, however, we now have a (better) default discovery implemented in our main flows. This PR removes the obsolete discovery implementation for Oauth2.
- For default discovery, uninitialized flows need to be taken into account, or else, zeroconf could spawn, e.g., 3 Spotify flows with the same unique ID.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47044
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
