### PR TITLE
Add support for selective config parameter entity discovery

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Generator
+from typing import Any, Generator
 
 from zwave_js_server.const import CommandClass
 from zwave_js_server.model.device_class import DeviceClassItem
@@ -41,6 +41,12 @@ class ZWaveValueDiscoverySchema:
     endpoint: set[int] | None = None
     # [optional] the value's property must match ANY of these values
     property: set[str | int] | None = None
+    # [optional] the value's property name must match ANY of these values
+    property_name: set[str] | None = None
+    # [optional] the value's property key must match ANY of these values
+    property_key: set[str | int] | None = None
+    # [optional] the value's property key name must match ANY of these values
+    property_key_name: set[str] | None = None
     # [optional] the value's metadata_type must match ANY of these values
     type: set[str] | None = None
 
@@ -80,6 +86,34 @@ class ZWaveDiscoverySchema:
     absent_values: list[ZWaveValueDiscoverySchema] | None = None
     # [optional] bool to specify if this primary value may be discovered by multiple platforms
     allow_multi: bool = False
+
+
+def get_config_parameter_discovery_schema(
+    property: set[str | int] | None = None,
+    property_name: set[str] | None = None,
+    property_key: set[str | int] | None = None,
+    property_key_name: set[str] | None = None,
+    **kwargs: Any,
+) -> ZWaveDiscoverySchema:
+    """
+    Return a discovery schema for a config parameter.
+
+    Supports all keyword arguments to ZWaveValueDiscoverySchema except platform, hint,
+    and primary_value.
+    """
+    return ZWaveDiscoverySchema(
+        platform="sensor",
+        hint="config_parameter",
+        primary_value=ZWaveValueDiscoverySchema(
+            command_class={CommandClass.CONFIGURATION},
+            property=property,
+            property_name=property_name,
+            property_key=property_key,
+            property_key_name=property_key_name,
+            type={"number"},
+        ),
+        **kwargs,
+    )
 
 
 SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA = ZWaveValueDiscoverySchema(
@@ -161,6 +195,19 @@ DISCOVERY_SCHEMAS = [
         product_id={0x000D},
         product_type={0x0003},
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
+    ),
+    # ====== START OF CONFIG PARAMETER SPECIFIC MAPPING SCHEMAS =======
+    # Door lock mode config parameter. Functionality equivalent to Notification CC
+    # list sensors.
+    get_config_parameter_discovery_schema(
+        property_name={"Door lock mode"},
+        device_class_generic={"Entry Control"},
+        device_class_specific={
+            "Door Lock",
+            "Advanced Door Lock",
+            "Secure Keypad Door Lock",
+            "Secure Lockbox",
+        },
     ),
     # ====== START OF GENERIC MAPPING SCHEMAS =======
     # locks
@@ -479,6 +526,24 @@ def check_value(value: ZwaveValue, schema: ZWaveValueDiscoverySchema) -> bool:
         return False
     # check property
     if schema.property is not None and value.property_ not in schema.property:
+        return False
+    # check property_name
+    if (
+        schema.property_name is not None
+        and value.property_name not in schema.property_name
+    ):
+        return False
+    # check property_key
+    if (
+        schema.property_key is not None
+        and value.property_key not in schema.property_key
+    ):
+        return False
+    # check property_key_name
+    if (
+        schema.property_key_name is not None
+        and value.property_key_name not in schema.property_key_name
+    ):
         return False
     # check metadata_type
     if schema.type is not None and value.metadata.type not in schema.type:

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -89,7 +89,7 @@ class ZWaveDiscoverySchema:
 
 
 def get_config_parameter_discovery_schema(
-    property: set[str | int] | None = None,
+    property_: set[str | int] | None = None,
     property_name: set[str] | None = None,
     property_key: set[str | int] | None = None,
     property_key_name: set[str] | None = None,
@@ -106,7 +106,7 @@ def get_config_parameter_discovery_schema(
         hint="config_parameter",
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.CONFIGURATION},
-            property=property,
+            property=property_,
             property_name=property_name,
             property_key=property_key,
             property_key_name=property_key_name,

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -99,6 +99,7 @@ class ZWaveBaseEntity(Entity):
         include_value_name: bool = False,
         alternate_value_name: str | None = None,
         additional_info: list[str] | None = None,
+        name_suffix: str | None = None,
     ) -> str:
         """Generate entity name."""
         if additional_info is None:
@@ -108,6 +109,8 @@ class ZWaveBaseEntity(Entity):
             or self.info.node.device_config.description
             or f"Node {self.info.node.node_id}"
         )
+        if name_suffix:
+            name = f"{name} {name_suffix}"
         if include_value_name:
             value_name = (
                 alternate_value_name

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -2,10 +2,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
+from typing import Callable, cast
 
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.const import CommandClass
+from zwave_js_server.const import CommandClass, ConfigurationValueType
+from zwave_js_server.model.value import ConfigurationValue
 
 from homeassistant.components.sensor import (
     DEVICE_CLASS_BATTERY,
@@ -48,6 +49,8 @@ async def async_setup_entry(
             entities.append(ZWaveNumericSensor(config_entry, client, info))
         elif info.platform_hint == "list_sensor":
             entities.append(ZWaveListSensor(config_entry, client, info))
+        elif info.platform_hint == "config_parameter":
+            entities.append(ZWaveConfigParameterSensor(config_entry, client, info))
         else:
             LOGGER.warning(
                 "Sensor not implemented for %s/%s",
@@ -107,6 +110,7 @@ class ZwaveSensorBase(ZWaveBaseEntity):
         # We hide some of the more advanced sensors by default to not overwhelm users
         if self.info.primary_value.command_class in [
             CommandClass.BASIC,
+            CommandClass.CONFIGURATION,
             CommandClass.INDICATOR,
             CommandClass.NOTIFICATION,
         ]:
@@ -208,5 +212,50 @@ class ZWaveListSensor(ZwaveSensorBase):
     @property
     def extra_state_attributes(self) -> dict[str, str] | None:
         """Return the device specific state attributes."""
+        # add the value's int value as property for multi-value (list) items
+        return {"value": self.info.primary_value.value}
+
+
+class ZWaveConfigParameterSensor(ZwaveSensorBase):
+    """Representation of a Z-Wave config parameter sensor."""
+
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        client: ZwaveClient,
+        info: ZwaveDiscoveryInfo,
+    ) -> None:
+        """Initialize a ZWaveConfigParameterSensor entity."""
+        super().__init__(config_entry, client, info)
+        self._name = self.generate_name(
+            include_value_name=True,
+            alternate_value_name=self.info.primary_value.property_name,
+            additional_info=[self.info.primary_value.property_key_name],
+            name_suffix="Config Parameter",
+        )
+        self._primary_value = cast(ConfigurationValue, self.info.primary_value)
+
+    @property
+    def state(self) -> str | None:
+        """Return state of the sensor."""
+        if self.info.primary_value.value is None:
+            return None
+        if (
+            self._primary_value.configuration_value_type == ConfigurationValueType.RANGE
+            or (
+                not str(self.info.primary_value.value)
+                in self.info.primary_value.metadata.states
+            )
+        ):
+            return str(self.info.primary_value.value)
+        return str(
+            self.info.primary_value.metadata.states[str(self.info.primary_value.value)]
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the device specific state attributes."""
+        if self._primary_value.configuration_value_type == ConfigurationValueType.RANGE:
+            return None
         # add the value's int value as property for multi-value (list) items
         return {"value": self.info.primary_value.value}

--- a/tests/components/zwave_js/common.py
+++ b/tests/components/zwave_js/common.py
@@ -22,3 +22,6 @@ CLIMATE_MAIN_HEAT_ACTIONNER = "climate.main_heat_actionner"
 BULB_6_MULTI_COLOR_LIGHT_ENTITY = "light.bulb_6_multi_color"
 EATON_RF9640_ENTITY = "light.allloaddimmer"
 AEON_SMART_SWITCH_LIGHT_ENTITY = "light.smart_switch_6"
+ID_LOCK_CONFIG_PARAMETER_SENSOR = (
+    "sensor.z_wave_module_for_id_lock_150_and_101_config_parameter_door_lock_mode"
+)

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -306,6 +306,12 @@ def null_name_check_state_fixture():
     return json.loads(load_fixture("zwave_js/null_name_check_state.json"))
 
 
+@pytest.fixture(name="lock_id_lock_as_id150_state", scope="session")
+def lock_id_lock_as_id150_state_fixture():
+    """Load the id lock id-150 lock node state fixture data."""
+    return json.loads(load_fixture("zwave_js/lock_id_lock_as_id150_state.json"))
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state):
     """Mock a client."""
@@ -566,5 +572,13 @@ def ge_12730_fixture(client, ge_12730_state):
 def inovelli_lzw36_fixture(client, inovelli_lzw36_state):
     """Mock a Inovelli LZW36 fan controller node."""
     node = Node(client, copy.deepcopy(inovelli_lzw36_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="lock_id_lock_as_id150")
+def lock_id_lock_as_id150(client, lock_id_lock_as_id150_state):
+    """Mock an id lock id-150 lock node."""
+    node = Node(client, copy.deepcopy(lock_id_lock_as_id150_state))
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -83,4 +83,5 @@ async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration)
     """Test config parameter sensor is created."""
     ent_reg = er.async_get(hass)
     entity_entry = ent_reg.async_get(ID_LOCK_CONFIG_PARAMETER_SENSOR)
+    assert entity_entry
     assert entity_entry.disabled

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -14,6 +14,7 @@ from .common import (
     AIR_TEMPERATURE_SENSOR,
     ENERGY_SENSOR,
     HUMIDITY_SENSOR,
+    ID_LOCK_CONFIG_PARAMETER_SENSOR,
     NOTIFICATION_MOTION_SENSOR,
     POWER_SENSOR,
 )
@@ -76,3 +77,10 @@ async def test_disabled_notification_sensor(hass, multisensor_6, integration):
     state = hass.states.get(NOTIFICATION_MOTION_SENSOR)
     assert state.state == "Motion detection"
     assert state.attributes["value"] == 8
+
+
+async def test_config_parameter_sensor(hass, lock_id_lock_as_id150, integration):
+    """Test config parameter sensor is created."""
+    ent_reg = er.async_get(hass)
+    entity_entry = ent_reg.async_get(ID_LOCK_CONFIG_PARAMETER_SENSOR)
+    assert entity_entry.disabled

--- a/tests/fixtures/zwave_js/lock_id_lock_as_id150_state.json
+++ b/tests/fixtures/zwave_js/lock_id_lock_as_id150_state.json
@@ -1,0 +1,2618 @@
+{
+	"nodeId": 60,
+	"index": 0,
+	"installerIcon": 768,
+	"userIcon": 768,
+	"status": 4,
+	"ready": true,
+	"deviceClass": {
+		"basic": {"key": 4, "label":"Routing Slave"},
+        "generic": {"key": 64, "label":"Entry Control"},
+        "specific": {"key": 3, "label":"Secure Keypad Door Lock"},
+		"mandatorySupportedCCs": [
+			"Basic",
+			"Door Lock",
+			"User Code",
+			"Manufacturer Specific",
+			"Security",
+			"Version"
+		],
+		"mandatoryControlCCs": []
+	},
+	"isListening": false,
+	"isFrequentListening": true,
+	"isRouting": true,
+	"maxBaudRate": 40000,
+	"isSecure": true,
+	"version": 4,
+	"isBeaming": true,
+	"manufacturerId": 883,
+	"productId": 1,
+	"productType": 3,
+	"firmwareVersion": "1.6",
+	"zwavePlusVersion": 1,
+	"nodeType": 0,
+	"roleType": 7,
+	"deviceConfig": {
+		"manufacturerId": 883,
+		"manufacturer": "ID Lock AS",
+		"label": "ID-150",
+		"description": "Z wave module for ID Lock 150 and 101",
+		"devices": [{ "productType": "0x0003", "productId": "0x0001" }],
+		"firmwareVersion": { "min": "1.6", "max": "255.255" },
+		"paramInformation": { "_map": {} }
+	},
+	"label": "ID-150",
+	"neighbors": [1, 10, 22, 30, 33, 34, 41, 43, 53, 55, 70, 71, 93],
+	"interviewAttempts": 1,
+	"endpoints": [
+		{ "nodeId": 60, "index": 0, "installerIcon": 768, "userIcon": 768 }
+	],
+    "commandClasses": [],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "currentMode",
+			"propertyName": "currentMode",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 255,
+				"label": "Current lock mode",
+				"states": {
+					"0": "Unsecured",
+					"1": "UnsecuredWithTimeout",
+					"16": "InsideUnsecured",
+					"17": "InsideUnsecuredWithTimeout",
+					"32": "OutsideUnsecured",
+					"33": "OutsideUnsecuredWithTimeout",
+					"254": "Unknown",
+					"255": "Secured"
+				}
+			},
+			"value": 255
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "targetMode",
+			"propertyName": "targetMode",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"min": 0,
+				"max": 255,
+				"label": "Target lock mode",
+				"states": {
+					"0": "Unsecured",
+					"1": "UnsecuredWithTimeout",
+					"16": "InsideUnsecured",
+					"17": "InsideUnsecuredWithTimeout",
+					"32": "OutsideUnsecured",
+					"33": "OutsideUnsecuredWithTimeout",
+					"254": "Unknown",
+					"255": "Secured"
+				}
+			},
+			"value": 255
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "outsideHandlesCanOpenDoor",
+			"propertyName": "outsideHandlesCanOpenDoor",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Which outside handles can open the door (actual status)"
+			},
+			"value": [false, false, false, false]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "insideHandlesCanOpenDoor",
+			"propertyName": "insideHandlesCanOpenDoor",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Which inside handles can open the door (actual status)"
+			},
+			"value": [false, false, false, false]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "latchStatus",
+			"propertyName": "latchStatus",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "The current status of the latch"
+			},
+			"value": "open"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "boltStatus",
+			"propertyName": "boltStatus",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "The current status of the bolt"
+			},
+			"value": "locked"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "doorStatus",
+			"propertyName": "doorStatus",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "The current status of the door"
+			},
+			"value": "closed"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "lockTimeout",
+			"propertyName": "lockTimeout",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Seconds until lock mode times out"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "operationType",
+			"propertyName": "operationType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"min": 0,
+				"max": 255,
+				"label": "Lock operation type",
+				"states": { "1": "Constant", "2": "Timed" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "outsideHandlesCanOpenDoorConfiguration",
+			"propertyName": "outsideHandlesCanOpenDoorConfiguration",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true,
+				"label": "Which outside handles can open the door (configuration)"
+			},
+			"value": [true, true, true, true]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "insideHandlesCanOpenDoorConfiguration",
+			"propertyName": "insideHandlesCanOpenDoorConfiguration",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true,
+				"label": "Which inside handles can open the door (configuration)"
+			},
+			"value": [true, true, true, true]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 98,
+			"commandClassName": "Door Lock",
+			"property": "lockTimeoutConfiguration",
+			"propertyName": "lockTimeoutConfiguration",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"min": 0,
+				"max": 65535,
+				"label": "Duration of timed mode in seconds"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 1,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "1",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (1)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 1,
+			"propertyName": "userCode",
+			"propertyKeyName": "1",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (1)"
+			},
+			"value": "0000"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 2,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "2",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (2)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 2,
+			"propertyName": "userCode",
+			"propertyKeyName": "2",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (2)"
+			},
+			"value": "1111"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 3,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "3",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (3)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 3,
+			"propertyName": "userCode",
+			"propertyKeyName": "3",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (3)"
+			},
+			"value": "2222"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 4,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "4",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (4)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 4,
+			"propertyName": "userCode",
+			"propertyKeyName": "4",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (4)"
+			},
+			"value": "3333"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 5,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "5",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (5)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 5,
+			"propertyName": "userCode",
+			"propertyKeyName": "5",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (5)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 6,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "6",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (6)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 6,
+			"propertyName": "userCode",
+			"propertyKeyName": "6",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (6)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 7,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "7",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (7)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 7,
+			"propertyName": "userCode",
+			"propertyKeyName": "7",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (7)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 8,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "8",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (8)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 8,
+			"propertyName": "userCode",
+			"propertyKeyName": "8",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (8)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 9,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "9",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (9)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 9,
+			"propertyName": "userCode",
+			"propertyKeyName": "9",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (9)"
+			},
+			"value": "111111"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 10,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "10",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (10)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 10,
+			"propertyName": "userCode",
+			"propertyKeyName": "10",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (10)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 11,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "11",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (11)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 11,
+			"propertyName": "userCode",
+			"propertyKeyName": "11",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (11)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 12,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "12",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (12)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 12,
+			"propertyName": "userCode",
+			"propertyKeyName": "12",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (12)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 13,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "13",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (13)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 13,
+			"propertyName": "userCode",
+			"propertyKeyName": "13",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (13)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 14,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "14",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (14)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 14,
+			"propertyName": "userCode",
+			"propertyKeyName": "14",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (14)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 15,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "15",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (15)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 15,
+			"propertyName": "userCode",
+			"propertyKeyName": "15",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (15)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 16,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "16",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (16)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 16,
+			"propertyName": "userCode",
+			"propertyKeyName": "16",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (16)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 17,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "17",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (17)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 17,
+			"propertyName": "userCode",
+			"propertyKeyName": "17",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (17)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 18,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "18",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (18)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 18,
+			"propertyName": "userCode",
+			"propertyKeyName": "18",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (18)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 19,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "19",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (19)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 19,
+			"propertyName": "userCode",
+			"propertyKeyName": "19",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (19)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 20,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "20",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (20)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 20,
+			"propertyName": "userCode",
+			"propertyKeyName": "20",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (20)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 21,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "21",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (21)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 21,
+			"propertyName": "userCode",
+			"propertyKeyName": "21",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (21)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 22,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "22",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (22)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 22,
+			"propertyName": "userCode",
+			"propertyKeyName": "22",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (22)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 23,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "23",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (23)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 23,
+			"propertyName": "userCode",
+			"propertyKeyName": "23",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (23)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 24,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "24",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (24)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 24,
+			"propertyName": "userCode",
+			"propertyKeyName": "24",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (24)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 25,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "25",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (25)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 25,
+			"propertyName": "userCode",
+			"propertyKeyName": "25",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (25)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 26,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "26",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (26)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 26,
+			"propertyName": "userCode",
+			"propertyKeyName": "26",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (26)"
+			},
+			"value": "2222222222"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 27,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "27",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (27)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 27,
+			"propertyName": "userCode",
+			"propertyKeyName": "27",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (27)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 28,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "28",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (28)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 28,
+			"propertyName": "userCode",
+			"propertyKeyName": "28",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (28)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 29,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "29",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (29)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 29,
+			"propertyName": "userCode",
+			"propertyKeyName": "29",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (29)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 30,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "30",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (30)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 30,
+			"propertyName": "userCode",
+			"propertyKeyName": "30",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (30)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 31,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "31",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (31)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 31,
+			"propertyName": "userCode",
+			"propertyKeyName": "31",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (31)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 32,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "32",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (32)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 32,
+			"propertyName": "userCode",
+			"propertyKeyName": "32",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (32)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 33,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "33",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (33)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 33,
+			"propertyName": "userCode",
+			"propertyKeyName": "33",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (33)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 34,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "34",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (34)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 34,
+			"propertyName": "userCode",
+			"propertyKeyName": "34",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (34)"
+			},
+			"value": "3333333333"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 35,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "35",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (35)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 35,
+			"propertyName": "userCode",
+			"propertyKeyName": "35",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (35)"
+			},
+			"value": "4444444444"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 36,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "36",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (36)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 36,
+			"propertyName": "userCode",
+			"propertyKeyName": "36",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (36)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 37,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "37",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (37)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 37,
+			"propertyName": "userCode",
+			"propertyKeyName": "37",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (37)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 38,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "38",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (38)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 38,
+			"propertyName": "userCode",
+			"propertyKeyName": "38",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (38)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 39,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "39",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (39)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 39,
+			"propertyName": "userCode",
+			"propertyKeyName": "39",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (39)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 40,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "40",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (40)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 40,
+			"propertyName": "userCode",
+			"propertyKeyName": "40",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (40)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 42,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "42",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (42)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 42,
+			"propertyName": "userCode",
+			"propertyKeyName": "42",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (42)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 44,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "44",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (44)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 44,
+			"propertyName": "userCode",
+			"propertyKeyName": "44",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (44)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 46,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "46",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (46)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 46,
+			"propertyName": "userCode",
+			"propertyKeyName": "46",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (46)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 48,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "48",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (48)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 48,
+			"propertyName": "userCode",
+			"propertyKeyName": "48",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (48)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 50,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "50",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (50)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 50,
+			"propertyName": "userCode",
+			"propertyKeyName": "50",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (50)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 41,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "41",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (41)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 41,
+			"propertyName": "userCode",
+			"propertyKeyName": "41",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (41)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 43,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "43",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (43)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 43,
+			"propertyName": "userCode",
+			"propertyKeyName": "43",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (43)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 45,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "45",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (45)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 45,
+			"propertyName": "userCode",
+			"propertyKeyName": "45",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (45)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 47,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "47",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (47)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 47,
+			"propertyName": "userCode",
+			"propertyKeyName": "47",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (47)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 49,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "49",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (49)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 49,
+			"propertyName": "userCode",
+			"propertyKeyName": "49",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (49)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 108,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "108",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (108)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 108,
+			"propertyName": "userCode",
+			"propertyKeyName": "108",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (108)"
+			},
+			"value": ""
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userIdStatus",
+			"propertyKey": 109,
+			"propertyName": "userIdStatus",
+			"propertyKeyName": "109",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "User ID status (109)",
+				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 99,
+			"commandClassName": "User Code",
+			"property": "userCode",
+			"propertyKey": 109,
+			"propertyName": "userCode",
+			"propertyKeyName": "109",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "string",
+				"readable": true,
+				"writeable": true,
+				"minLength": 4,
+				"maxLength": 10,
+				"label": "User Code (109)"
+			},
+			"value": "5555555555"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 1,
+			"propertyName": "Door lock mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 3,
+				"default": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": {
+					"0": "Disable Away Manual Lock",
+					"1": "Disable Away Auto Lock",
+					"2": "Enable Away Manual Lock",
+					"3": "Enable Away Auto Lock"
+				},
+				"label": "Door lock mode",
+				"description": "Set if the lock is in away mode and if automatic locking should be enabled",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 2,
+			"propertyName": "RFID Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 5,
+				"max": 9,
+				"default": 5,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": { "5": "RFID activated", "9": "RFID deactivated" },
+				"label": "RFID Mode",
+				"description": "RFID Mode",
+				"isFromConfig": true
+			},
+			"value": 5
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 3,
+			"propertyName": "Door Hinge Position Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 1,
+				"default": 0,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": {
+					"0": "Right hinged operation",
+					"1": "Left hinged operation"
+				},
+				"label": "Door Hinge Position Mode",
+				"description": "Tell the lock which side your hinges are on seen from the outside",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 4,
+			"propertyName": "Door Audio Volume Level",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 6,
+				"default": 5,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": {
+					"0": "No sound",
+					"1": "Level 1",
+					"2": "Level 2",
+					"3": "Level 3",
+					"4": "Level 4",
+					"5": "Level 5",
+					"6": "Max. sound level"
+				},
+				"label": "Door Audio Volume Level",
+				"description": "Set the Audio Volume Level of the Lock",
+				"isFromConfig": true
+			},
+			"value": 5
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 5,
+			"propertyName": "Door ReLock Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 1,
+				"default": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": { "0": "Disabled", "1": "Enabled" },
+				"label": "Door ReLock Mode",
+				"description": "Sets if the door should relock or not",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 6,
+			"propertyName": "Service PIN Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 254,
+				"default": 0,
+				"format": 1,
+				"allowManualEntry": false,
+				"states": {
+					"0": "Deactivated",
+					"1": "Valid 1 time",
+					"2": "Valid 2 times",
+					"3": "Valid 5 times",
+					"4": "Valid 10 times",
+					"5": "Generate Random PIN 1x use",
+					"6": "Generate Random PIN 24h use",
+					"7": "Always Valid",
+					"8": "Valid for 12h",
+					"9": "Valid for 24h",
+					"254": "Disabled"
+				},
+				"label": "Service PIN Mode",
+				"description": "Sets the validity of the service PIN",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 7,
+			"propertyName": "Door Lock Model Type",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"valueSize": 1,
+				"min": 0,
+				"max": 0,
+				"default": 0,
+				"format": 0,
+				"allowManualEntry": true,
+				"label": "Door Lock Model Type",
+				"description": "Sends information if the model of the lock is 101 or 150",
+				"isFromConfig": true
+			},
+			"value": -106
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 8,
+			"propertyName": "Updater Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 3,
+				"default": 0,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": {
+					"0": "Disabled (no sound)",
+					"1": "Enabled (no sound)",
+					"2": "Disabled",
+					"3": "Enabled"
+				},
+				"label": "Updater Mode",
+				"description": "Enables use of the Updater app",
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 9,
+			"propertyName": "Master PIN Unlock Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"valueSize": 1,
+				"min": 0,
+				"max": 1,
+				"default": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"states": { "0": "Disabled", "1": "Enabled" },
+				"label": "Master PIN Unlock Mode",
+				"description": "Configures if the Master PIN can unlock",
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 113,
+			"commandClassName": "Notification",
+			"property": "Access Control",
+			"propertyKey": "Lock state",
+			"propertyName": "Access Control",
+			"propertyKeyName": "Lock state",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 255,
+				"label": "Lock state",
+				"states": { "0": "idle", "11": "Lock jammed" },
+				"ccSpecific": { "notificationType": 6 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 113,
+			"commandClassName": "Notification",
+			"property": "Home Security",
+			"propertyKey": "Cover status",
+			"propertyName": "Home Security",
+			"propertyKeyName": "Cover status",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 255,
+				"label": "Cover status",
+				"states": { "0": "idle", "3": "Tampering, product cover removed" },
+				"ccSpecific": { "notificationType": 7 }
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Manufacturer ID"
+			},
+			"value": 883
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Product type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 65535,
+				"label": "Product ID"
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "level",
+			"propertyName": "level",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"min": 0,
+				"max": 100,
+				"unit": "%",
+				"label": "Battery level"
+			},
+			"value": 55
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "isLow",
+			"propertyName": "isLow",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Low battery level"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "4.5"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["1.6"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hardwareVersion",
+			"propertyName": "hardwareVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip hardware version"
+			}
+		}
+	]
+}

--- a/tests/fixtures/zwave_js/lock_id_lock_as_id150_state.json
+++ b/tests/fixtures/zwave_js/lock_id_lock_as_id150_state.json
@@ -5,20 +5,6 @@
 	"userIcon": 768,
 	"status": 4,
 	"ready": true,
-	"deviceClass": {
-		"basic": {"key": 4, "label":"Routing Slave"},
-        "generic": {"key": 64, "label":"Entry Control"},
-        "specific": {"key": 3, "label":"Secure Keypad Door Lock"},
-		"mandatorySupportedCCs": [
-			"Basic",
-			"Door Lock",
-			"User Code",
-			"Manufacturer Specific",
-			"Security",
-			"Version"
-		],
-		"mandatoryControlCCs": []
-	},
 	"isListening": false,
 	"isFrequentListening": true,
 	"isRouting": true,
@@ -34,21 +20,37 @@
 	"nodeType": 0,
 	"roleType": 7,
 	"deviceConfig": {
+		"filename": "/usr/src/node_modules/@zwave-js/config/config/devices/0x0373/id-150_1.6.json",
 		"manufacturerId": 883,
 		"manufacturer": "ID Lock AS",
 		"label": "ID-150",
 		"description": "Z wave module for ID Lock 150 and 101",
-		"devices": [{ "productType": "0x0003", "productId": "0x0001" }],
-		"firmwareVersion": { "min": "1.6", "max": "255.255" },
-		"paramInformation": { "_map": {} }
+		"devices": [
+			{
+				"productType": "0x0003",
+				"productId": "0x0001"
+			}
+		],
+		"firmwareVersion": {
+			"min": "1.6",
+			"max": "255.255"
+		},
+		"paramInformation": {
+			"_map": {}
+		}
 	},
 	"label": "ID-150",
-	"neighbors": [1, 10, 22, 30, 33, 34, 41, 43, 53, 55, 70, 71, 93],
+	"neighbors": [1, 10, 22, 30, 33, 34, 41, 43, 53, 55, 70, 71, 84, 93],
 	"interviewAttempts": 1,
+	"interviewStage": 7,
 	"endpoints": [
-		{ "nodeId": 60, "index": 0, "installerIcon": 768, "userIcon": 768 }
+		{
+			"nodeId": 60,
+			"index": 0,
+			"installerIcon": 768,
+			"userIcon": 768
+		}
 	],
-    "commandClasses": [],
 	"values": [
 		{
 			"endpoint": 0,
@@ -61,9 +63,9 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Current lock mode",
 				"min": 0,
 				"max": 255,
-				"label": "Current lock mode",
 				"states": {
 					"0": "Unsecured",
 					"1": "UnsecuredWithTimeout",
@@ -88,9 +90,9 @@
 				"type": "number",
 				"readable": true,
 				"writeable": true,
+				"label": "Target lock mode",
 				"min": 0,
 				"max": 255,
-				"label": "Target lock mode",
 				"states": {
 					"0": "Unsecured",
 					"1": "UnsecuredWithTimeout",
@@ -204,10 +206,13 @@
 				"type": "number",
 				"readable": true,
 				"writeable": true,
+				"label": "Lock operation type",
 				"min": 0,
 				"max": 255,
-				"label": "Lock operation type",
-				"states": { "1": "Constant", "2": "Timed" }
+				"states": {
+					"1": "Constant",
+					"2": "Timed"
+				}
 			},
 			"value": 1
 		},
@@ -252,9 +257,9 @@
 				"type": "number",
 				"readable": true,
 				"writeable": true,
+				"label": "Duration of timed mode in seconds",
 				"min": 0,
-				"max": 65535,
-				"label": "Duration of timed mode in seconds"
+				"max": 65535
 			}
 		},
 		{
@@ -271,7 +276,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (1)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -288,11 +297,11 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (1)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (1)"
+				"maxLength": 10
 			},
-			"value": "0000"
+			"value": "5555"
 		},
 		{
 			"endpoint": 0,
@@ -308,7 +317,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (2)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -325,11 +338,11 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (2)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (2)"
+				"maxLength": 10
 			},
-			"value": "1111"
+			"value": "5555"
 		},
 		{
 			"endpoint": 0,
@@ -345,7 +358,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (3)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -362,11 +379,11 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (3)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (3)"
+				"maxLength": 10
 			},
-			"value": "2222"
+			"value": "5555"
 		},
 		{
 			"endpoint": 0,
@@ -382,7 +399,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (4)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -399,11 +420,11 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (4)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (4)"
+				"maxLength": 10
 			},
-			"value": "3333"
+			"value": "5555"
 		},
 		{
 			"endpoint": 0,
@@ -419,7 +440,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (5)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -436,9 +461,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (5)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (5)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -456,7 +481,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (6)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -473,9 +502,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (6)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (6)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -493,7 +522,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (7)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -510,9 +543,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (7)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (7)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -530,7 +563,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (8)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -547,9 +584,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (8)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (8)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -567,7 +604,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (9)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -584,11 +625,11 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (9)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (9)"
+				"maxLength": 10
 			},
-			"value": "111111"
+			"value": "5555"
 		},
 		{
 			"endpoint": 0,
@@ -604,7 +645,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (10)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -621,9 +666,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (10)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (10)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -641,7 +686,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (11)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -658,9 +707,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (11)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (11)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -678,7 +727,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (12)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -695,9 +748,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (12)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (12)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -715,7 +768,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (13)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -732,9 +789,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (13)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (13)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -752,7 +809,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (14)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -769,9 +830,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (14)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (14)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -789,7 +850,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (15)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -806,9 +871,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (15)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (15)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -826,7 +891,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (16)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -843,9 +912,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (16)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (16)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -863,7 +932,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (17)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -880,9 +953,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (17)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (17)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -900,7 +973,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (18)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -917,9 +994,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (18)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (18)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -937,7 +1014,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (19)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -954,9 +1035,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (19)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (19)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -974,7 +1055,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (20)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -991,9 +1076,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (20)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (20)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1011,7 +1096,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (21)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1028,9 +1117,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (21)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (21)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1048,7 +1137,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (22)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1065,9 +1158,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (22)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (22)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1085,7 +1178,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (23)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1102,9 +1199,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (23)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (23)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1122,7 +1219,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (24)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1139,9 +1240,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (24)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (24)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1159,7 +1260,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (25)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1176,9 +1281,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (25)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (25)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1196,7 +1301,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (26)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -1213,11 +1322,14 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (26)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (26)"
+				"maxLength": 10
 			},
-			"value": "2222222222"
+			"value": {
+				"type": "Buffer",
+				"data": [0, 52, 50, 54, 53, 50, 50, 50, 51, 56]
+			}
 		},
 		{
 			"endpoint": 0,
@@ -1233,7 +1345,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (27)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1250,9 +1366,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (27)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (27)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1270,7 +1386,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (28)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1287,9 +1407,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (28)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (28)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1307,7 +1427,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (29)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1324,9 +1448,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (29)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (29)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1344,7 +1468,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (30)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1361,9 +1489,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (30)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (30)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1381,7 +1509,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (31)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1398,9 +1530,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (31)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (31)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1418,7 +1550,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (32)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1435,9 +1571,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (32)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (32)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1455,7 +1591,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (33)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1472,9 +1612,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (33)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (33)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1492,7 +1632,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (34)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -1509,11 +1653,14 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (34)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (34)"
+				"maxLength": 10
 			},
-			"value": "3333333333"
+			"value": {
+				"type": "Buffer",
+				"data": [0, 52, 53, 0, 49, 49, 50, 50, 51, 56]
+			}
 		},
 		{
 			"endpoint": 0,
@@ -1529,7 +1676,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (35)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -1546,11 +1697,14 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (35)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (35)"
+				"maxLength": 10
 			},
-			"value": "4444444444"
+			"value": {
+				"type": "Buffer",
+				"data": [0, 52, 52, 69, 56, 56, 50, 50, 51, 56]
+			}
 		},
 		{
 			"endpoint": 0,
@@ -1566,7 +1720,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (36)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1583,9 +1741,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (36)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (36)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1603,7 +1761,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (37)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1620,9 +1782,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (37)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (37)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1640,7 +1802,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (38)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1657,9 +1823,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (38)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (38)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1677,7 +1843,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (39)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1694,9 +1864,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (39)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (39)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1714,7 +1884,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (40)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1731,9 +1905,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (40)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (40)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1751,7 +1925,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (42)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1768,9 +1946,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (42)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (42)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1788,7 +1966,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (44)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1805,9 +1987,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (44)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (44)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1825,7 +2007,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (46)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1842,9 +2028,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (46)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (46)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1862,7 +2048,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (48)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1879,9 +2069,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (48)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (48)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1899,7 +2089,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (50)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1916,9 +2110,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (50)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (50)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1936,7 +2130,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (41)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1953,9 +2151,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (41)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (41)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -1973,7 +2171,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (43)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -1990,9 +2192,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (43)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (43)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -2010,7 +2212,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (45)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -2027,9 +2233,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (45)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (45)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -2047,7 +2253,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (47)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -2064,9 +2274,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (47)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (47)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -2084,7 +2294,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (49)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -2101,9 +2315,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (49)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (49)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -2121,7 +2335,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (108)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 0
 		},
@@ -2138,9 +2356,9 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (108)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (108)"
+				"maxLength": 10
 			},
 			"value": ""
 		},
@@ -2158,7 +2376,11 @@
 				"readable": true,
 				"writeable": true,
 				"label": "User ID status (109)",
-				"states": { "0": "Available", "1": "Enabled", "2": "Disabled" }
+				"states": {
+					"0": "Available",
+					"1": "Enabled",
+					"2": "Disabled"
+				}
 			},
 			"value": 1
 		},
@@ -2175,11 +2397,11 @@
 				"type": "string",
 				"readable": true,
 				"writeable": true,
+				"label": "User Code (109)",
 				"minLength": 4,
-				"maxLength": 10,
-				"label": "User Code (109)"
+				"maxLength": 10
 			},
-			"value": "5555555555"
+			"value": "51816472"
 		},
 		{
 			"endpoint": 0,
@@ -2190,23 +2412,19 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 1,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Set if the lock is in away mode and if automatic locking should be enabled",
+				"label": "Door lock mode",
 				"min": 0,
 				"max": 3,
-				"default": 1,
-				"format": 0,
-				"allowManualEntry": false,
 				"states": {
 					"0": "Disable Away Manual Lock",
 					"1": "Disable Away Auto Lock",
 					"2": "Enable Away Manual Lock",
 					"3": "Enable Away Auto Lock"
-				},
-				"label": "Door lock mode",
-				"description": "Set if the lock is in away mode and if automatic locking should be enabled",
-				"isFromConfig": true
+				}
 			},
 			"value": 0
 		},
@@ -2219,18 +2437,16 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 5,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"label": "RFID Mode",
 				"min": 5,
 				"max": 9,
-				"default": 5,
-				"format": 0,
-				"allowManualEntry": false,
-				"states": { "5": "RFID activated", "9": "RFID deactivated" },
-				"label": "RFID Mode",
-				"description": "RFID Mode",
-				"isFromConfig": true
+				"states": {
+					"5": "RFID activated",
+					"9": "RFID deactivated"
+				}
 			},
 			"value": 5
 		},
@@ -2243,21 +2459,17 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 0,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Tell the lock which side your hinges are on seen from the outside",
+				"label": "Door Hinge Position Mode",
 				"min": 0,
 				"max": 1,
-				"default": 0,
-				"format": 0,
-				"allowManualEntry": false,
 				"states": {
 					"0": "Right hinged operation",
 					"1": "Left hinged operation"
-				},
-				"label": "Door Hinge Position Mode",
-				"description": "Tell the lock which side your hinges are on seen from the outside",
-				"isFromConfig": true
+				}
 			},
 			"value": 0
 		},
@@ -2270,14 +2482,13 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 5,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Set the Audio Volume Level of the Lock",
+				"label": "Door Audio Volume Level",
 				"min": 0,
 				"max": 6,
-				"default": 5,
-				"format": 0,
-				"allowManualEntry": false,
 				"states": {
 					"0": "No sound",
 					"1": "Level 1",
@@ -2286,10 +2497,7 @@
 					"4": "Level 4",
 					"5": "Level 5",
 					"6": "Max. sound level"
-				},
-				"label": "Door Audio Volume Level",
-				"description": "Set the Audio Volume Level of the Lock",
-				"isFromConfig": true
+				}
 			},
 			"value": 5
 		},
@@ -2302,18 +2510,17 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 1,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Sets if the door should relock or not",
+				"label": "Door ReLock Mode",
 				"min": 0,
 				"max": 1,
-				"default": 1,
-				"format": 0,
-				"allowManualEntry": false,
-				"states": { "0": "Disabled", "1": "Enabled" },
-				"label": "Door ReLock Mode",
-				"description": "Sets if the door should relock or not",
-				"isFromConfig": true
+				"states": {
+					"0": "Disabled",
+					"1": "Enabled"
+				}
 			},
 			"value": 0
 		},
@@ -2326,14 +2533,13 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 0,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Sets the validity of the service PIN",
+				"label": "Service PIN Mode",
 				"min": 0,
 				"max": 254,
-				"default": 0,
-				"format": 1,
-				"allowManualEntry": false,
 				"states": {
 					"0": "Deactivated",
 					"1": "Valid 1 time",
@@ -2346,10 +2552,7 @@
 					"8": "Valid for 12h",
 					"9": "Valid for 24h",
 					"254": "Disabled"
-				},
-				"label": "Service PIN Mode",
-				"description": "Sets the validity of the service PIN",
-				"isFromConfig": true
+				}
 			},
 			"value": 0
 		},
@@ -2362,17 +2565,14 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 0,
 				"readable": true,
 				"writeable": false,
-				"valueSize": 1,
+				"description": "Sends information if the model of the lock is 101 or 150",
+				"label": "Door Lock Model Type",
 				"min": 0,
 				"max": 0,
-				"default": 0,
-				"format": 0,
-				"allowManualEntry": true,
-				"label": "Door Lock Model Type",
-				"description": "Sends information if the model of the lock is 101 or 150",
-				"isFromConfig": true
+				"states": {}
 			},
 			"value": -106
 		},
@@ -2385,23 +2585,19 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 0,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Enables use of the Updater app",
+				"label": "Updater Mode",
 				"min": 0,
 				"max": 3,
-				"default": 0,
-				"format": 0,
-				"allowManualEntry": false,
 				"states": {
 					"0": "Disabled (no sound)",
 					"1": "Enabled (no sound)",
 					"2": "Disabled",
 					"3": "Enabled"
-				},
-				"label": "Updater Mode",
-				"description": "Enables use of the Updater app",
-				"isFromConfig": true
+				}
 			},
 			"value": 0
 		},
@@ -2414,18 +2610,17 @@
 			"ccVersion": 1,
 			"metadata": {
 				"type": "number",
+				"default": 1,
 				"readable": true,
 				"writeable": true,
-				"valueSize": 1,
+				"description": "Configures if the Master PIN can unlock",
+				"label": "Master PIN Unlock Mode",
 				"min": 0,
 				"max": 1,
-				"default": 1,
-				"format": 0,
-				"allowManualEntry": false,
-				"states": { "0": "Disabled", "1": "Enabled" },
-				"label": "Master PIN Unlock Mode",
-				"description": "Configures if the Master PIN can unlock",
-				"isFromConfig": true
+				"states": {
+					"0": "Disabled",
+					"1": "Enabled"
+				}
 			},
 			"value": 1
 		},
@@ -2442,11 +2637,16 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Lock state",
+				"ccSpecific": {
+					"notificationType": 6
+				},
 				"min": 0,
 				"max": 255,
-				"label": "Lock state",
-				"states": { "0": "idle", "11": "Lock jammed" },
-				"ccSpecific": { "notificationType": 6 }
+				"states": {
+					"0": "idle",
+					"11": "Lock jammed"
+				}
 			},
 			"value": 0
 		},
@@ -2463,11 +2663,16 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Cover status",
+				"ccSpecific": {
+					"notificationType": 7
+				},
 				"min": 0,
 				"max": 255,
-				"label": "Cover status",
-				"states": { "0": "idle", "3": "Tampering, product cover removed" },
-				"ccSpecific": { "notificationType": 7 }
+				"states": {
+					"0": "idle",
+					"3": "Tampering, product cover removed"
+				}
 			},
 			"value": 0
 		},
@@ -2482,9 +2687,9 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Manufacturer ID",
 				"min": 0,
-				"max": 65535,
-				"label": "Manufacturer ID"
+				"max": 65535
 			},
 			"value": 883
 		},
@@ -2499,9 +2704,9 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Product type",
 				"min": 0,
-				"max": 65535,
-				"label": "Product type"
+				"max": 65535
 			},
 			"value": 3
 		},
@@ -2516,9 +2721,9 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Product ID",
 				"min": 0,
-				"max": 65535,
-				"label": "Product ID"
+				"max": 65535
 			},
 			"value": 1
 		},
@@ -2533,12 +2738,12 @@
 				"type": "number",
 				"readable": true,
 				"writeable": false,
+				"label": "Battery level",
 				"min": 0,
 				"max": 100,
-				"unit": "%",
-				"label": "Battery level"
+				"unit": "%"
 			},
-			"value": 55
+			"value": 70
 		},
 		{
 			"endpoint": 0,
@@ -2613,6 +2818,102 @@
 				"writeable": false,
 				"label": "Z-Wave chip hardware version"
 			}
+		}
+	],
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 64,
+			"label": "Entry Control"
+		},
+		"specific": {
+			"key": 3,
+			"label": "Secure Keypad Door Lock"
+		},
+		"mandatorySupportedCCs": [32, 98, 99, 114, 152, 134],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 89,
+			"name": "Association Group Information",
+			"version": 1,
+			"isSecure": true
+		},
+		{
+			"id": 90,
+			"name": "Device Reset Locally",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 94,
+			"name": "Z-Wave Plus Info",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 98,
+			"name": "Door Lock",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 99,
+			"name": "User Code",
+			"version": 1,
+			"isSecure": true
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 113,
+			"name": "Notification",
+			"version": 4,
+			"isSecure": true
+		},
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 122,
+			"name": "Firmware Update Meta Data",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 128,
+			"name": "Battery",
+			"version": 1,
+			"isSecure": true
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 2,
+			"isSecure": true
+		},
+		{
+			"id": 152,
+			"name": "Security",
+			"version": 1,
+			"isSecure": true
 		}
 	]
 }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed in Discord, we don't want to discover all config parameters but there may be selective config parameters that we do want to discover by request. I added some new properties to value discovery, added a helper function to generate a config parameter discovery schema, and created a new sensor entity type to handle config parameters. As part of this I implemented a single config parameter discovery.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/45746
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
