### PR TITLE
Fallback to current temperature unit for zwave_js climate

### DIFF
--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -152,6 +152,8 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             add_to_watched_value_ids=True,
             check_all_endpoints=True,
         )
+        if not self._unit_value:
+            self._unit_value = self._current_temp
         self._current_humidity = self.get_zwave_value(
             "Humidity",
             command_class=CommandClass.SENSOR_MULTILEVEL,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -139,7 +139,11 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 add_to_watched_value_ids=True,
             )
             # Use the first found setpoint value to always determine the temperature unit
-            if self._setpoint_values[enum] and not self._unit_value:
+            if (
+                not self._unit_value
+                and enum != ThermostatSetpointType.NA
+                and self._setpoint_values[enum]
+            ):
                 self._unit_value = self._setpoint_values[enum]
         self._operating_state = self.get_zwave_value(
             THERMOSTAT_OPERATING_STATE_PROPERTY,

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -138,7 +138,8 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
                 value_property_key=enum.value.key,
                 add_to_watched_value_ids=True,
             )
-            # Use the first found setpoint value to always determine the temperature unit
+            # Use the first found non N/A setpoint value to always determine the
+            # temperature unit
             if (
                 not self._unit_value
                 and enum != ThermostatSetpointType.NA

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -312,6 +312,31 @@ def lock_id_lock_as_id150_state_fixture():
     return json.loads(load_fixture("zwave_js/lock_id_lock_as_id150_state.json"))
 
 
+@pytest.fixture(
+    name="climate_radio_thermostat_ct101_multiple_temp_units_state", scope="session"
+)
+def climate_radio_thermostat_ct101_multiple_temp_units_state_fixture():
+    """Load the climate multiple temp units node state fixture data."""
+    return json.loads(
+        load_fixture(
+            "zwave_js/climate_radio_thermostat_ct101_multiple_temp_units_state.json"
+        )
+    )
+
+
+@pytest.fixture(
+    name="climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state",
+    scope="session",
+)
+def climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state_fixture():
+    """Load the climate device with mode and setpoint on different endpoints node state fixture data."""
+    return json.loads(
+        load_fixture(
+            "zwave_js/climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state.json"
+        )
+    )
+
+
 @pytest.fixture(name="client")
 def mock_client_fixture(controller_state, version_state):
     """Mock a client."""
@@ -580,5 +605,35 @@ def inovelli_lzw36_fixture(client, inovelli_lzw36_state):
 def lock_id_lock_as_id150(client, lock_id_lock_as_id150_state):
     """Mock an id lock id-150 lock node."""
     node = Node(client, copy.deepcopy(lock_id_lock_as_id150_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="climate_radio_thermostat_ct101_multiple_temp_units")
+def climate_radio_thermostat_ct101_multiple_temp_units_fixture(
+    client, climate_radio_thermostat_ct101_multiple_temp_units_state
+):
+    """Mock a climate device with multiple temp units node."""
+    node = Node(
+        client, copy.deepcopy(climate_radio_thermostat_ct101_multiple_temp_units_state)
+    )
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(
+    name="climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints"
+)
+def climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_fixture(
+    client,
+    climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state,
+):
+    """Mock a climate device with mode and setpoint on differenet endpoints node."""
+    node = Node(
+        client,
+        copy.deepcopy(
+            climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state
+        ),
+    )
     client.driver.controller.nodes[node.node_id] = node
     return node

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -578,3 +578,20 @@ async def test_preset_and_no_setpoint(
     assert args["value"] == 1
 
     client.async_send_command.reset_mock()
+
+
+async def test_temp_unit_fix(
+    hass,
+    client,
+    climate_radio_thermostat_ct101_multiple_temp_units,
+    climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints,
+    integration,
+):
+    """Test temperaturee unit fix."""
+    state = hass.states.get("climate.thermostat")
+    assert state
+    assert state.attributes["current_temperature"] == 18.3
+
+    state = hass.states.get("climate.z_wave_thermostat")
+    assert state
+    assert state.attributes["current_temperature"] == 21.1

--- a/tests/fixtures/zwave_js/climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state.json
+++ b/tests/fixtures/zwave_js/climate_radio_thermostat_ct100_mode_and_setpoint_on_different_endpoints_state.json
@@ -1,0 +1,830 @@
+{
+	"nodeId": 8,
+	"index": 0,
+	"status": 4,
+	"ready": true,
+	"isListening": true,
+	"isRouting": true,
+	"isSecure": false,
+	"manufacturerId": 152,
+	"productId": 263,
+	"productType": 25601,
+	"firmwareVersion": "9.1",
+	"deviceConfig": {
+		"filename": "/usr/src/node_modules/@zwave-js/config/config/devices/0x0098/ct100.json",
+		"manufacturer": "Radio Thermostat Company of America (RTC)",
+		"manufacturerId": 152,
+		"label": "CT100",
+		"description": "Z-Wave Thermostat",
+		"devices": [
+			{
+				"productType": 25601,
+				"productId": 21
+			},
+			{
+				"productType": 25601,
+				"productId": 259
+			},
+			{
+				"productType": 25601,
+				"productId": 261
+			},
+			{
+				"productType": 25601,
+				"productId": 262
+			},
+			{
+				"productType": 25601,
+				"productId": 263
+			},
+			{
+				"productType": 25601,
+				"productId": 509
+			},
+			{
+				"productType": 25602,
+				"productId": 1
+			}
+		],
+		"firmwareVersion": {
+			"min": "0.0",
+			"max": "255.255"
+		},
+		"associations": {}
+	},
+	"label": "CT100",
+	"neighbors": [2, 3, 4, 5, 6, 7, 9],
+	"endpointCountIsDynamic": false,
+	"endpointsHaveIdenticalCapabilities": true,
+	"individualEndpointCount": 2,
+	"interviewAttempts": 0,
+	"interviewStage": 6,
+	"endpoints": [
+		{
+			"nodeId": 8,
+			"index": 0
+		},
+		{
+			"nodeId": 8,
+			"index": 1
+		},
+		{
+			"nodeId": 8,
+			"index": 2
+		}
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 66,
+			"commandClassName": "Thermostat Operating State",
+			"property": "state",
+			"propertyName": "state",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Operating state",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Idle",
+					"1": "Heating",
+					"2": "Cooling",
+					"3": "Fan Only",
+					"4": "Pending Heat",
+					"5": "Pending Cool",
+					"6": "Vent/Economizer",
+					"7": "Aux Heating",
+					"8": "2nd Stage Heating",
+					"9": "2nd Stage Cooling",
+					"10": "2nd Stage Aux Heat",
+					"11": "3rd Stage Aux Heat"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 1,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Heating",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 69
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 2,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Cooling",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 2
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 72
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 68,
+			"commandClassName": "Thermostat Fan Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat fan mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Auto low",
+					"1": "Low"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 69,
+			"commandClassName": "Thermostat Fan State",
+			"property": "state",
+			"propertyName": "state",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Thermostat fan state",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Idle / off",
+					"1": "Running / running low",
+					"2": "Running high",
+					"3": "Running medium",
+					"4": "Circulation mode",
+					"5": "Humidity circulation mode",
+					"6": "Right - left circulation mode",
+					"7": "Up - down circulation mode",
+					"8": "Quiet circulation mode"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 152
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 25601
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 263
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "level",
+			"propertyName": "level",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Battery level",
+				"min": 0,
+				"max": 100,
+				"unit": "%"
+			},
+			"value": 100
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "isLow",
+			"propertyName": "isLow",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Low battery level"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "3.28"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["9.1"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 135,
+			"commandClassName": "Indicator",
+			"property": "value",
+			"propertyName": "value",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Indicator value",
+				"ccSpecific": {
+					"indicatorId": 0
+				},
+				"min": 0,
+				"max": 255
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Off",
+					"1": "Heat",
+					"2": "Cool",
+					"3": "Auto",
+					"4": "Auxiliary",
+					"5": "Resume (on)",
+					"6": "Fan",
+					"7": "Furnace",
+					"8": "Dry",
+					"9": "Moist",
+					"10": "Auto changeover",
+					"11": "Energy heat",
+					"12": "Energy cool",
+					"13": "Away",
+					"15": "Full power",
+					"31": "Manufacturer specific"
+				}
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "manufacturerData",
+			"propertyName": "manufacturerData",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 70
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Off",
+					"1": "Heat",
+					"2": "Cool",
+					"3": "Auto",
+					"4": "Auxiliary",
+					"5": "Resume (on)",
+					"6": "Fan",
+					"7": "Furnace",
+					"8": "Dry",
+					"9": "Moist",
+					"10": "Auto changeover",
+					"11": "Energy heat",
+					"12": "Energy cool",
+					"13": "Away",
+					"15": "Full power",
+					"31": "Manufacturer specific"
+				}
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "manufacturerData",
+			"propertyName": "manufacturerData",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Humidity",
+			"propertyName": "Humidity",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Humidity",
+				"ccSpecific": {
+					"sensorType": 5,
+					"scale": 0
+				},
+				"unit": "%"
+			},
+			"value": 60
+		}
+	],
+	"isFrequentListening": null,
+	"maxBaudRate": 40000,
+	"version": 3,
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 8,
+			"label": "Thermostat"
+		},
+		"specific": {
+			"key": 6,
+			"label": "General Thermostat V2"
+		},
+		"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 49,
+			"name": "Multilevel Sensor",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 64,
+			"name": "Thermostat Mode",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 66,
+			"name": "Thermostat Operating State",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 67,
+			"name": "Thermostat Setpoint",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 68,
+			"name": "Thermostat Fan Mode",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 69,
+			"name": "Thermostat Fan State",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 96,
+			"name": "Multi Channel",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 128,
+			"name": "Battery",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 129,
+			"name": "Clock",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 135,
+			"name": "Indicator",
+			"version": 1,
+			"isSecure": false
+		}
+	]
+}

--- a/tests/fixtures/zwave_js/climate_radio_thermostat_ct101_multiple_temp_units_state.json
+++ b/tests/fixtures/zwave_js/climate_radio_thermostat_ct101_multiple_temp_units_state.json
@@ -1,0 +1,962 @@
+{
+	"nodeId": 4,
+	"index": 0,
+	"status": 4,
+	"ready": true,
+	"isListening": false,
+	"isRouting": true,
+	"isSecure": false,
+	"manufacturerId": 152,
+	"productId": 12,
+	"productType": 25857,
+	"firmwareVersion": "9.0",
+	"name": "Thermostat",
+	"deviceConfig": {
+		"filename": "/usr/src/app/node_modules/@zwave-js/config/config/devices/0x0098/ct101.json",
+		"manufacturer": "Radio Thermostat Company of America (RTC)",
+		"manufacturerId": 152,
+		"label": "CT101",
+		"description": "Z-Wave Thermostat",
+		"devices": [
+			{
+				"productType": 25857,
+				"productId": 0
+			},
+			{
+				"productType": 25857,
+				"productId": 11
+			},
+			{
+				"productType": 25857,
+				"productId": 12
+			},
+			{
+				"productType": 25857,
+				"productId": 13
+			}
+		],
+		"firmwareVersion": {
+			"min": "0.0",
+			"max": "255.255"
+		},
+		"associations": {},
+		"paramInformation": {
+			"_map": {}
+		}
+	},
+	"label": "CT101",
+	"neighbors": [1, 11, 13, 14, 2, 3],
+	"endpointCountIsDynamic": false,
+	"endpointsHaveIdenticalCapabilities": true,
+	"individualEndpointCount": 2,
+	"interviewAttempts": 0,
+	"interviewStage": 6,
+	"endpoints": [
+		{
+			"nodeId": 4,
+			"index": 0
+		},
+		{
+			"nodeId": 4,
+			"index": 1
+		},
+		{
+			"nodeId": 4,
+			"index": 2
+		}
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 66,
+			"commandClassName": "Thermostat Operating State",
+			"property": "state",
+			"propertyName": "state",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Operating state",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Idle",
+					"1": "Heating",
+					"2": "Cooling",
+					"3": "Fan Only",
+					"4": "Pending Heat",
+					"5": "Pending Cool",
+					"6": "Vent/Economizer",
+					"7": "Aux Heating",
+					"8": "2nd Stage Heating",
+					"9": "2nd Stage Cooling",
+					"10": "2nd Stage Aux Heat",
+					"11": "3rd Stage Aux Heat"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 68,
+			"commandClassName": "Thermostat Fan Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat fan mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Auto low",
+					"1": "Low"
+				}
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 69,
+			"commandClassName": "Thermostat Fan State",
+			"property": "state",
+			"propertyName": "state",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Thermostat fan state",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Idle / off",
+					"1": "Running / running low",
+					"2": "Running high",
+					"3": "Running medium",
+					"4": "Circulation mode",
+					"5": "Humidity circulation mode",
+					"6": "Right - left circulation mode",
+					"7": "Up - down circulation mode",
+					"8": "Quiet circulation mode"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 1,
+			"propertyName": "Temperature Reporting Threshold",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"default": 2,
+				"readable": true,
+				"writeable": true,
+				"description": "Reporting threshold for changes in the ambient temperature.",
+				"label": "Temperature Reporting Threshold",
+				"min": 0,
+				"max": 4,
+				"states": {
+					"0": "Disabled",
+					"1": "0.5\u00b0",
+					"2": "1.0\u00b0",
+					"3": "1.5\u00b0",
+					"4": "2.0\u00b0"
+				}
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 7,
+			"propertyName": "Thermostat Swing Temperature",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"default": 2,
+				"readable": true,
+				"writeable": true,
+				"description": "Variance allowed from setpoint",
+				"label": "Thermostat Swing Temperature",
+				"min": 1,
+				"max": 8,
+				"states": {
+					"1": "0.5\u00b0",
+					"2": "1.0\u00b0",
+					"3": "1.5\u00b0",
+					"4": "2.0\u00b0",
+					"5": "2.5\u00b0",
+					"6": "3.0\u00b0",
+					"7": "3.5\u00b0",
+					"8": "4.0\u00b0"
+				}
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 9,
+			"propertyName": "Thermostat Recovery Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"default": 2,
+				"readable": true,
+				"writeable": true,
+				"description": "Fast or Economy recovery mode.",
+				"label": "Thermostat Recovery Mode",
+				"min": 1,
+				"max": 2,
+				"states": {
+					"1": "Fast recovery Mode",
+					"2": "Economy recovery Mode"
+				}
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 3,
+			"propertyName": "Utility Lock Enable/Disable",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"default": 0,
+				"readable": true,
+				"writeable": true,
+				"description": "Prevents setpoint changes at thermostat.",
+				"label": "Utility Lock Enable/Disable",
+				"min": 0,
+				"max": 1,
+				"states": {
+					"0": "Utility lock disabled",
+					"1": "Utility lock enabled"
+				}
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 152
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 25857
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 12
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "level",
+			"propertyName": "level",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Battery level",
+				"min": 0,
+				"max": 100,
+				"unit": "%"
+			},
+			"value": 90
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "isLow",
+			"propertyName": "isLow",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Low battery level"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "3.28"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["9.0"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 135,
+			"commandClassName": "Indicator",
+			"property": "value",
+			"propertyName": "value",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Indicator value",
+				"ccSpecific": {
+					"indicatorId": 0
+				},
+				"min": 0,
+				"max": 255
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Off",
+					"1": "Heat",
+					"2": "Cool",
+					"3": "Auto",
+					"4": "Auxiliary",
+					"5": "Resume (on)",
+					"6": "Fan",
+					"7": "Furnace",
+					"8": "Dry",
+					"9": "Moist",
+					"10": "Auto changeover",
+					"11": "Energy heat",
+					"12": "Energy cool",
+					"13": "Away",
+					"15": "Full power",
+					"31": "Manufacturer specific"
+				}
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "manufacturerData",
+			"propertyName": "manufacturerData",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 1,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Heating",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 55
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 2,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Cooling",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 2
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 78
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 0,
+			"propertyName": "setpoint",
+			"propertyKeyName": "N/A",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 0
+				},
+				"unit": "\u00b0C"
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 65
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Off",
+					"1": "Heat",
+					"2": "Cool",
+					"3": "Auto",
+					"4": "Auxiliary",
+					"5": "Resume (on)",
+					"6": "Fan",
+					"7": "Furnace",
+					"8": "Dry",
+					"9": "Moist",
+					"10": "Auto changeover",
+					"11": "Energy heat",
+					"12": "Energy cool",
+					"13": "Away",
+					"15": "Full power",
+					"31": "Manufacturer specific"
+				}
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "manufacturerData",
+			"propertyName": "manufacturerData",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Humidity",
+			"propertyName": "Humidity",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Humidity",
+				"ccSpecific": {
+					"sensorType": 5,
+					"scale": 0
+				},
+				"unit": "%"
+			},
+			"value": 56
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 62.5
+		}
+	],
+	"isFrequentListening": true,
+	"maxBaudRate": 40000,
+	"version": 3,
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 8,
+			"label": "Thermostat"
+		},
+		"specific": {
+			"key": 6,
+			"label": "General Thermostat V2"
+		},
+		"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 49,
+			"name": "Multilevel Sensor",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 64,
+			"name": "Thermostat Mode",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 66,
+			"name": "Thermostat Operating State",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 67,
+			"name": "Thermostat Setpoint",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 68,
+			"name": "Thermostat Fan Mode",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 69,
+			"name": "Thermostat Fan State",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 96,
+			"name": "Multi Channel",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 128,
+			"name": "Battery",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 129,
+			"name": "Clock",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 135,
+			"name": "Indicator",
+			"version": 1,
+			"isSecure": false
+		}
+	]
+}


### PR DESCRIPTION
## Proposed change
Right now we set the temperature unit for a `zwave_js` climate device to the unit of the first setpoint value we can find. If, for some reason, a setpoint value can't be found, we will always return Celsius. In this PR, we use the current temperature's unit as a fallback to attempt to return the proper unit. We also do not use the `N/A` setpoint to set the unit since it may not be accurate


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48285
- This PR is related to issue: https://community.home-assistant.io/t/do-not-update-to-the-z-wave-js-version-0-1-14/293400
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
