### PR TITLE
Optimize storage collection entity operations with asyncio.gather

### DIFF
--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -329,31 +329,31 @@ def sync_entity_lifecycle(
     entities = {}
     ent_reg = entity_registry.async_get(hass)
 
+    async def _add_entity(change_set: CollectionChangeSet) -> Entity:
+        entities[change_set.item_id] = create_entity(change_set.item)
+        return entities[change_set.item_id]
+
+    async def _remove_entity(change_set: CollectionChangeSet) -> None:
+        ent_to_remove = ent_reg.async_get_entity_id(
+            domain, platform, change_set.item_id
+        )
+        if ent_to_remove is not None:
+            ent_reg.async_remove(ent_to_remove)
+        else:
+            await entities[change_set.item_id].async_remove(force_remove=True)
+        entities.pop(change_set.item_id)
+
+    async def _update_entity(change_set: CollectionChangeSet) -> None:
+        await entities[change_set.item_id].async_update_config(change_set.item)  # type: ignore
+
+    _func_map = {
+        CHANGE_ADDED: _add_entity,
+        CHANGE_REMOVED: _remove_entity,
+        CHANGE_UPDATED: _update_entity,
+    }
+
     async def _collection_changed(change_sets: Iterable[CollectionChangeSet]) -> None:
         """Handle a collection change."""
-
-        async def _add_entity(change_set: CollectionChangeSet) -> Entity:
-            entities[change_set.item_id] = create_entity(change_set.item)
-            return entities[change_set.item_id]
-
-        async def _remove_entity(change_set: CollectionChangeSet) -> None:
-            ent_to_remove = ent_reg.async_get_entity_id(
-                domain, platform, change_set.item_id
-            )
-            if ent_to_remove is not None:
-                ent_reg.async_remove(ent_to_remove)
-            else:
-                await entities[change_set.item_id].async_remove(force_remove=True)
-            entities.pop(change_set.item_id)
-
-        async def _update_entity(change_set: CollectionChangeSet) -> None:
-            await entities[change_set.item_id].async_update_config(change_set.item)  # type: ignore
-
-        _func_map = {
-            CHANGE_ADDED: _add_entity,
-            CHANGE_REMOVED: _remove_entity,
-            CHANGE_UPDATED: _update_entity,
-        }
         # Create a new bucket every time we have a different change type
         # to ensure operations happen in order. We only group
         # the same change type.

--- a/homeassistant/helpers/collection.py
+++ b/homeassistant/helpers/collection.py
@@ -55,6 +55,8 @@ ChangeListener = Callable[
     Awaitable[None],
 ]
 
+ChangeSetListener = Callable[[Iterable[CollectionChangeSet]], Awaitable[None]]
+
 
 class CollectionError(HomeAssistantError):
     """Base class for collection related errors."""
@@ -106,6 +108,7 @@ class ObservableCollection(ABC):
         self.id_manager = id_manager or IDManager()
         self.data: dict[str, dict] = {}
         self.listeners: list[ChangeListener] = []
+        self.change_set_listeners: list[ChangeSetListener] = []
 
         self.id_manager.add_collection(self.data)
 
@@ -122,6 +125,14 @@ class ObservableCollection(ABC):
         """
         self.listeners.append(listener)
 
+    @callback
+    def async_add_change_set_listener(self, listener: ChangeSetListener) -> None:
+        """Add a listener for a full change set.
+
+        Will be called with [(change_type, item_id, updated_config), ...]
+        """
+        self.change_set_listeners.append(listener)
+
     async def notify_changes(self, change_sets: Iterable[CollectionChangeSet]) -> None:
         """Notify listeners of a change."""
         await asyncio.gather(
@@ -129,7 +140,11 @@ class ObservableCollection(ABC):
                 listener(change_set.change_type, change_set.item_id, change_set.item)
                 for listener in self.listeners
                 for change_set in change_sets
-            ]
+            ],
+            *[
+                change_set_listener(change_sets)
+                for change_set_listener in self.change_set_listeners
+            ],
         )
 
 
@@ -312,29 +327,53 @@ def sync_entity_lifecycle(
 ) -> None:
     """Map a collection to an entity component."""
     entities = {}
+    ent_reg = entity_registry.async_get(hass)
 
-    async def _collection_changed(change_type: str, item_id: str, config: dict) -> None:
+    async def _collection_changed(change_sets: Iterable[CollectionChangeSet]) -> None:
         """Handle a collection change."""
-        if change_type == CHANGE_ADDED:
-            entity = create_entity(config)
-            await entity_component.async_add_entities([entity])
-            entities[item_id] = entity
-            return
 
-        if change_type == CHANGE_REMOVED:
-            ent_reg = await entity_registry.async_get_registry(hass)
-            ent_to_remove = ent_reg.async_get_entity_id(domain, platform, item_id)
+        async def _add_entity(change_set: CollectionChangeSet) -> Entity:
+            entities[change_set.item_id] = create_entity(change_set.item)
+            return entities[change_set.item_id]
+
+        async def _remove_entity(change_set: CollectionChangeSet) -> None:
+            ent_to_remove = ent_reg.async_get_entity_id(
+                domain, platform, change_set.item_id
+            )
             if ent_to_remove is not None:
                 ent_reg.async_remove(ent_to_remove)
             else:
-                await entities[item_id].async_remove(force_remove=True)
-            entities.pop(item_id)
-            return
+                await entities[change_set.item_id].async_remove(force_remove=True)
+            entities.pop(change_set.item_id)
 
-        # CHANGE_UPDATED
-        await entities[item_id].async_update_config(config)  # type: ignore
+        async def _update_entity(change_set: CollectionChangeSet) -> None:
+            await entities[change_set.item_id].async_update_config(change_set.item)  # type: ignore
 
-    collection.async_add_listener(_collection_changed)
+        _func_map = {
+            CHANGE_ADDED: _add_entity,
+            CHANGE_REMOVED: _remove_entity,
+            CHANGE_UPDATED: _update_entity,
+        }
+        # Create a new bucket every time we have a different change type
+        # to ensure operations happen in order. We only group
+        # the same change type.
+        task_buckets: list = []
+        previous_change_type = None
+        for change_set in change_sets:
+            if previous_change_type != change_set.change_type:
+                task_buckets.append([])
+            task_buckets[-1].append(_func_map[change_set.change_type](change_set))
+
+        for task_bucket in task_buckets:
+            new_entities = [
+                entity
+                for entity in await asyncio.gather(*task_bucket)
+                if entity is not None
+            ]
+            if new_entities:
+                await entity_component.async_add_entities(new_entities)
+
+    collection.async_add_change_set_listener(_collection_changed)
 
 
 class StorageCollectionWebsocket:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We can group like operations which speeds up startup
by adding entities concurrently

I couldn't figure out a safe way to do this in #42497,
but I realized that we can bucket like operations which
in practice gets us a new speed up during startup

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
