### PR TITLE
Do not load ignored or disabled integrations at startup

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -624,17 +624,18 @@ class ConfigEntries:
         EntityRegistryDisabledHandler(hass).async_setup()
 
     @callback
-    def async_domains(self) -> list[str]:
+    def async_domains(
+        self, include_ignore: bool = False, include_disabled: bool = False
+    ) -> list[str]:
         """Return domains for which we have entries."""
-        seen: set[str] = set()
-        result = []
-
-        for entry in self._entries.values():
-            if entry.domain not in seen:
-                seen.add(entry.domain)
-                result.append(entry.domain)
-
-        return result
+        return list(
+            {
+                entry.domain: None
+                for entry in self._entries.values()
+                if (include_ignore or entry.source != SOURCE_IGNORE)
+                and (include_disabled or not entry.disabled_by)
+            }
+        )
 
     @callback
     def async_get_entry(self, entry_id: str) -> ConfigEntry | None:

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -473,7 +473,7 @@ async def test_entries_gets_entries(manager):
     assert manager.async_entries("test2") == [entry1, entry2]
 
 
-async def test_domains_gets_uniques(manager):
+async def test_domains_gets_domains_uniques(manager):
     """Test we only return each domain once."""
     MockConfigEntry(domain="test").add_to_manager(manager)
     MockConfigEntry(domain="test2").add_to_manager(manager)
@@ -482,6 +482,46 @@ async def test_domains_gets_uniques(manager):
     MockConfigEntry(domain="test3").add_to_manager(manager)
 
     assert manager.async_domains() == ["test", "test2", "test3"]
+
+
+async def test_domains_gets_domains_excludes_ignore_and_disabled(manager):
+    """Test we only return each domain once."""
+    MockConfigEntry(domain="test").add_to_manager(manager)
+    MockConfigEntry(domain="test2").add_to_manager(manager)
+    MockConfigEntry(domain="test2").add_to_manager(manager)
+    MockConfigEntry(
+        domain="ignored", source=config_entries.SOURCE_IGNORE
+    ).add_to_manager(manager)
+    MockConfigEntry(domain="test3").add_to_manager(manager)
+    MockConfigEntry(domain="disabled", disabled_by="user").add_to_manager(manager)
+    assert manager.async_domains() == ["test", "test2", "test3"]
+    assert manager.async_domains(include_ignore=False) == ["test", "test2", "test3"]
+    assert manager.async_domains(include_disabled=False) == ["test", "test2", "test3"]
+    assert manager.async_domains(include_ignore=False, include_disabled=False) == [
+        "test",
+        "test2",
+        "test3",
+    ]
+
+    assert manager.async_domains(include_ignore=True) == [
+        "test",
+        "test2",
+        "ignored",
+        "test3",
+    ]
+    assert manager.async_domains(include_disabled=True) == [
+        "test",
+        "test2",
+        "test3",
+        "disabled",
+    ]
+    assert manager.async_domains(include_ignore=True, include_disabled=True) == [
+        "test",
+        "test2",
+        "ignored",
+        "test3",
+        "disabled",
+    ]
 
 
 async def test_saving_and_loading(hass):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
config_entries.async_setup will skip ignored and disabled integrations
but bootstrap would still load them in memory and process their
requirements even though they would never be setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
