### PR TITLE
Improve traces for nested script runs

### DIFF
--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -6,7 +6,12 @@ from itertools import count
 from typing import Any, Deque
 
 from homeassistant.core import Context
-from homeassistant.helpers.trace import TraceElement, trace_id_set
+from homeassistant.helpers.trace import (
+    TraceElement,
+    trace_id_get,
+    trace_id_set,
+    trace_set_child_id,
+)
 import homeassistant.util.dt as dt_util
 
 from . import websocket_api
@@ -55,6 +60,8 @@ class ActionTrace:
         self._timestamp_start: dt.datetime = dt_util.utcnow()
         self.key: tuple[str, str] = key
         self._variables: dict[str, Any] | None = None
+        if trace_id_get():
+            trace_set_child_id(self.key, self.run_id)
         trace_id_set((key, self.run_id))
 
     def set_action_trace(self, trace: dict[str, Deque[TraceElement]]) -> None:

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -16,6 +16,8 @@ class TraceElement:
 
     def __init__(self, variables: TemplateVarsType, path: str):
         """Container for trace data."""
+        self._child_key: tuple[str, str] | None = None
+        self._child_run_id: str | None = None
         self._error: Exception | None = None
         self.path: str = path
         self._result: dict | None = None
@@ -36,6 +38,11 @@ class TraceElement:
         """Container for trace data."""
         return str(self.as_dict())
 
+    def set_child_id(self, child_key: tuple[str, str], child_run_id: str) -> None:
+        """Set trace id of a nested script run."""
+        self._child_key = child_key
+        self._child_run_id = child_run_id
+
     def set_error(self, ex: Exception) -> None:
         """Set error."""
         self._error = ex
@@ -47,6 +54,12 @@ class TraceElement:
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this TraceElement."""
         result: dict[str, Any] = {"path": self.path, "timestamp": self._timestamp}
+        if self._child_key is not None:
+            result["child_id"] = {
+                "domain": self._child_key[0],
+                "item_id": self._child_key[1],
+                "run_id": str(self._child_run_id),
+            }
         if self._variables:
             result["changed_variables"] = self._variables
         if self._error is not None:
@@ -159,6 +172,12 @@ def trace_clear() -> None:
     trace_stack_cv.set(None)
     trace_path_stack_cv.set(None)
     variables_cv.set(None)
+
+
+def trace_set_child_id(child_key: tuple[str, str], child_run_id: str) -> None:
+    """Set child trace_id of TraceElement at the top of the stack."""
+    node = cast(TraceElement, trace_stack_top(trace_stack_cv))
+    node.set_child_id(child_key, child_run_id)
 
 
 def trace_set_result(**kwargs: Any) -> None:

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -177,7 +177,8 @@ def trace_clear() -> None:
 def trace_set_child_id(child_key: tuple[str, str], child_run_id: str) -> None:
     """Set child trace_id of TraceElement at the top of the stack."""
     node = cast(TraceElement, trace_stack_top(trace_stack_cv))
-    node.set_child_id(child_key, child_run_id)
+    if node:
+        node.set_child_id(child_key, child_run_id)
 
 
 def trace_set_result(**kwargs: Any) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve traces for nested script runs

This adds a `child_id` member to `TraceElement` which will be populated when a script is started from within another script or automation.

Note that it doesn't work when an automation is triggered by another automation such as in this example where automation hello will trigger automation bye.
```python
                {
                    "alias": "hello",
                    "trigger": {"platform": "event", "event_type": "test_event"},
                    "action": {"event": "test_event2"},
                },
                {
                    "alias": "bye",
                    "trigger": {"platform": "event", "event_type": "test_event2"},
                    "action": {"service": "test.automation"},
                },
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
