### PR TITLE
Improve Plex device handling

### DIFF
--- a/homeassistant/components/plex/__init__.py
+++ b/homeassistant/components/plex/__init__.py
@@ -35,7 +35,6 @@ from .const import (
     DOMAIN as PLEX_DOMAIN,
     GDM_DEBOUNCER,
     GDM_SCANNER,
-    IGNORED_DEVICE_MODELS,
     PLATFORMS,
     PLATFORMS_COMPLETED,
     PLEX_SERVER_CONFIG,
@@ -266,12 +265,6 @@ async def cleanup_plex_devices(hass, entry):
     )
 
     for device_entry in device_entries:
-        if device_entry.model in IGNORED_DEVICE_MODELS:
-            _LOGGER.debug(
-                "Removing device: %s / %s", device_entry.name, device_entry.identifiers
-            )
-            device_registry.async_remove_device(device_entry.id)
-
         if (
             len(
                 hass.helpers.entity_registry.async_entries_for_device(

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -4,7 +4,7 @@ from homeassistant.const import __version__
 DOMAIN = "plex"
 NAME_FORMAT = "Plex ({})"
 COMMON_PLAYERS = ["Plex Web"]
-IGNORED_DEVICE_MODELS = ["Plex Web", "Plex for Sonos"]
+TRANSIENT_DEVICE_MODELS = ["Plex Web", "Plex for Sonos"]
 
 DEFAULT_PORT = 32400
 DEFAULT_SSL = False

--- a/homeassistant/components/plex/const.py
+++ b/homeassistant/components/plex/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import __version__
 DOMAIN = "plex"
 NAME_FORMAT = "Plex ({})"
 COMMON_PLAYERS = ["Plex Web"]
+IGNORED_DEVICE_MODELS = ["Plex Web", "Plex for Sonos"]
 
 DEFAULT_PORT = 32400
 DEFAULT_SSL = False

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -35,13 +35,13 @@ from .const import (
     CONF_SERVER_IDENTIFIER,
     DISPATCHERS,
     DOMAIN as PLEX_DOMAIN,
-    IGNORED_DEVICE_MODELS,
     NAME_FORMAT,
     PLEX_NEW_MP_SIGNAL,
     PLEX_UPDATE_MEDIA_PLAYER_SESSION_SIGNAL,
     PLEX_UPDATE_MEDIA_PLAYER_SIGNAL,
     PLEX_UPDATE_SENSOR_SIGNAL,
     SERVERS,
+    TRANSIENT_DEVICE_MODELS,
 )
 from .media_browser import browse_media
 
@@ -545,8 +545,14 @@ class PlexMediaPlayer(MediaPlayerEntity):
         if self.machine_identifier is None:
             return None
 
-        if self.device_product in IGNORED_DEVICE_MODELS:
-            return None
+        if self.device_product in TRANSIENT_DEVICE_MODELS:
+            return {
+                "identifiers": {(PLEX_DOMAIN, "plex.tv-clients")},
+                "name": "Plex Client Service",
+                "manufacturer": "Plex",
+                "model": "Plex Clients",
+                "entry_type": "service",
+            }
 
         return {
             "identifiers": {(PLEX_DOMAIN, self.machine_identifier)},

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_SERVER_IDENTIFIER,
     DISPATCHERS,
     DOMAIN as PLEX_DOMAIN,
+    IGNORED_DEVICE_MODELS,
     NAME_FORMAT,
     PLEX_NEW_MP_SIGNAL,
     PLEX_UPDATE_MEDIA_PLAYER_SESSION_SIGNAL,
@@ -542,6 +543,9 @@ class PlexMediaPlayer(MediaPlayerEntity):
     def device_info(self):
         """Return a device description for device registry."""
         if self.machine_identifier is None:
+            return None
+
+        if self.device_product in IGNORED_DEVICE_MODELS:
             return None
 
         return {

--- a/tests/components/plex/test_device_handling.py
+++ b/tests/components/plex/test_device_handling.py
@@ -1,0 +1,137 @@
+"""Tests for handling the device registry."""
+
+from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
+from homeassistant.components.plex.const import DOMAIN
+
+
+async def test_cleanup_orphaned_devices(hass, entry, setup_plex_server):
+    """Test cleaning up orphaned devices on startup."""
+    test_device_id = {(DOMAIN, "temporary_device_123")}
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    test_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers=test_device_id,
+    )
+    assert test_device is not None
+
+    test_entity = entity_registry.async_get_or_create(
+        MP_DOMAIN, DOMAIN, "entity_unique_id_123", device_id=test_device.id
+    )
+    assert test_entity is not None
+
+    # Ensure device is not removed with an entity
+    await setup_plex_server()
+    device = device_registry.async_get_device(identifiers=test_device_id)
+    assert device is not None
+
+    await hass.config_entries.async_unload(entry.entry_id)
+
+    # Ensure device is removed without an entity
+    entity_registry.async_remove(test_entity.entity_id)
+    await setup_plex_server()
+    device = device_registry.async_get_device(identifiers=test_device_id)
+    assert device is None
+
+
+async def test_migrate_transient_devices(
+    hass, entry, setup_plex_server, requests_mock, player_plexweb_resources
+):
+    """Test cleaning up transient devices on startup."""
+    plexweb_device_id = {(DOMAIN, "plexweb_id")}
+    non_plexweb_device_id = {(DOMAIN, "1234567890123456-com-plexapp-android")}
+    plex_client_service_device_id = {(DOMAIN, "plex.tv-clients")}
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    # Pre-create devices and entities to test device migration
+    plexweb_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers=plexweb_device_id,
+        model="Plex Web",
+    )
+    # plexweb_entity = entity_registry.async_get_or_create(MP_DOMAIN, DOMAIN, "unique_id_123:plexweb_id", suggested_object_id="plex_plex_web_chrome", device_id=plexweb_device.id)
+    entity_registry.async_get_or_create(
+        MP_DOMAIN,
+        DOMAIN,
+        "unique_id_123:plexweb_id",
+        suggested_object_id="plex_plex_web_chrome",
+        device_id=plexweb_device.id,
+    )
+
+    non_plexweb_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers=non_plexweb_device_id,
+        model="Plex for Android (TV)",
+    )
+    entity_registry.async_get_or_create(
+        MP_DOMAIN,
+        DOMAIN,
+        "unique_id_123:1234567890123456-com-plexapp-android",
+        suggested_object_id="plex_plex_for_android_tv_shield_android_tv",
+        device_id=non_plexweb_device.id,
+    )
+
+    # Ensure the Plex Web client is available
+    requests_mock.get("/resources", text=player_plexweb_resources)
+
+    plexweb_device = device_registry.async_get_device(identifiers=plexweb_device_id)
+    non_plexweb_device = device_registry.async_get_device(
+        identifiers=non_plexweb_device_id
+    )
+    plex_service_device = device_registry.async_get_device(
+        identifiers=plex_client_service_device_id
+    )
+
+    assert (
+        len(
+            hass.helpers.entity_registry.async_entries_for_device(
+                entity_registry, device_id=plexweb_device.id
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            hass.helpers.entity_registry.async_entries_for_device(
+                entity_registry, device_id=non_plexweb_device.id
+            )
+        )
+        == 1
+    )
+    assert plex_service_device is None
+
+    # Ensure Plex Web entity is migrated to a service
+    await setup_plex_server()
+
+    plex_service_device = device_registry.async_get_device(
+        identifiers=plex_client_service_device_id
+    )
+
+    assert (
+        len(
+            hass.helpers.entity_registry.async_entries_for_device(
+                entity_registry, device_id=plexweb_device.id
+            )
+        )
+        == 0
+    )
+    assert (
+        len(
+            hass.helpers.entity_registry.async_entries_for_device(
+                entity_registry, device_id=non_plexweb_device.id
+            )
+        )
+        == 1
+    )
+    assert (
+        len(
+            hass.helpers.entity_registry.async_entries_for_device(
+                entity_registry, device_id=plex_service_device.id
+            )
+        )
+        == 1
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Devices representing Plex Web `media_player` devices will be removed. Any automations, scenes, or scripts based on the device will need to be changed to use the `media_player` entity.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR removes orphaned devices where the user has removed the associated `media_player` entity.

The method for assigning devices for certain Plex `media_player` entities is also changing. Plex Web and Plex for Sonos `media_player` entities represent potentially transient apps or external services. For example, a new Plex Web device is created for each browser login. These should not have permanent devices attached to them. This PR migrates the entities to a new shared "Plex Clients" service. This will also allow cleanup of the old individual devices during a subsequent restart.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #42317
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
