### PR TITLE
Bump httpx to 0.17.1

### DIFF
--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import sys
-from types import TracebackType
 from typing import Any, Callable
 
 import httpx
@@ -47,14 +46,8 @@ class HassHttpXAsyncClient(httpx.AsyncClient):
         """Prevent an integration from reopen of the client via context manager."""
         return self
 
-    async def __aexit__(  # type: ignore
-        self,
-        exc_type: type[BaseException],
-        exc_value: BaseException,
-        traceback: TracebackType,
-    ) -> None:
+    async def __aexit__(self, *args: Any) -> None:  # pylint: disable=signature-differs
         """Prevent an integration from close of the client via context manager."""
-        pass
 
 
 @callback

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import sys
+from types import TracebackType
 from typing import Any, Callable
 
 import httpx
@@ -42,11 +43,16 @@ def get_async_client(
 class HassHttpXAsyncClient(httpx.AsyncClient):
     """httpx AsyncClient that suppresses context management."""
 
-    async def __aenter__(self, *args: Any, **kwargs: Any) -> HassHttpXAsyncClient:
+    async def __aenter__(self: HassHttpXAsyncClient) -> HassHttpXAsyncClient:
         """Prevent an integration from reopen of the client via context manager."""
         return self
 
-    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+    async def __aexit__(  # type: ignore
+        self,
+        exc_type: type[BaseException],
+        exc_value: BaseException,
+        traceback: TracebackType,
+    ) -> None:
         """Prevent an integration from close of the client via context manager."""
         pass
 

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -39,6 +39,18 @@ def get_async_client(
     return client
 
 
+class HassHttpXAsyncClient(httpx.AsyncClient):
+    """httpx AsyncClient that suppresses context management."""
+
+    async def __aenter__(self, *args: Any, **kwargs: Any) -> HassHttpXAsyncClient:
+        """Prevent an integration from reopen of the client via context manager."""
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Prevent an integration from close of the client via context manager."""
+        pass
+
+
 @callback
 def create_async_httpx_client(
     hass: HomeAssistantType,
@@ -53,7 +65,7 @@ def create_async_httpx_client(
 
     This method must be run in the event loop.
     """
-    client = httpx.AsyncClient(
+    client = HassHttpXAsyncClient(
         verify=verify_ssl,
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs,

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ distro==1.5.0
 emoji==1.2.0
 hass-nabucasa==0.42.0
 home-assistant-frontend==20210324.0
-httpx==0.16.1
+httpx==0.17.1
 jinja2>=2.11.3
 netdisco==2.8.2
 paho-mqtt==1.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ awesomeversion==21.2.3
 bcrypt==3.1.7
 certifi>=2020.12.5
 ciso8601==2.1.3
-httpx==0.16.1
+httpx==0.17.1
 jinja2>=2.11.3
 PyJWT==1.7.1
 cryptography==3.3.2

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIRES = [
     "bcrypt==3.1.7",
     "certifi>=2020.12.5",
     "ciso8601==2.1.3",
-    "httpx==0.16.1",
+    "httpx==0.17.1",
     "jinja2>=2.11.3",
     "PyJWT==1.7.1",
     # PyJWT has loose dependency. We want the latest one.

--- a/tests/helpers/test_httpx_client.py
+++ b/tests/helpers/test_httpx_client.py
@@ -80,6 +80,19 @@ async def test_get_async_client_patched_close(hass):
         assert mock_aclose.call_count == 0
 
 
+async def test_get_async_client_context_manager(hass):
+    """Test using the async client with a context manager does not close the session."""
+
+    with patch("httpx.AsyncClient.aclose") as mock_aclose:
+        httpx_session = client.get_async_client(hass)
+        assert isinstance(hass.data[client.DATA_ASYNC_CLIENT], httpx.AsyncClient)
+
+        async with httpx_session:
+            pass
+
+        assert mock_aclose.call_count == 0
+
+
 async def test_warning_close_session_integration(hass, caplog):
     """Test log warning message when closing the session from integration context."""
     with patch(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump httpx to 0.17.1

Changelog: http://github.com/encode/httpx/compare/0.16.1...0.17.1

Fixes another avenue that integrations could close the connection pool out from under Home Assistant.
```
2021-03-27 03:21:47 ERROR (MainThread) [homeassistant.components.rest] Unexpected error fetching rest data data: Cannot send a request, as the client has been closed.
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 155, in async_refresh
    self.data = await self._async_update_data()
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 143, in _async_update_data
    return await self.update_method()
  File "/usr/src/homeassistant/homeassistant/components/rest/data.py", line 55, in async_update
    response = await self._async_client.request(
  File "/usr/local/lib/python3.8/site-packages/httpx/_client.py", line 1371, in request
    response = await self.send(
  File "/usr/local/lib/python3.8/site-packages/httpx/_client.py", line 1399, in send
    raise RuntimeError("Cannot send a request, as the client has been closed.")
RuntimeError: Cannot send a request, as the client has been closed.

```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
