### PR TITLE
Fix template fan default speed count

### DIFF
--- a/homeassistant/components/fan/__init__.py
+++ b/homeassistant/components/fan/__init__.py
@@ -422,21 +422,21 @@ class FanEntity(ToggleEntity):
         return self.speed not in [SPEED_OFF, None]
 
     @property
-    def _implemented_percentage(self):
+    def _implemented_percentage(self) -> bool:
         """Return true if percentage has been implemented."""
         return not hasattr(self.set_percentage, _FAN_NATIVE) or not hasattr(
             self.async_set_percentage, _FAN_NATIVE
         )
 
     @property
-    def _implemented_preset_mode(self):
+    def _implemented_preset_mode(self) -> bool:
         """Return true if preset_mode has been implemented."""
         return not hasattr(self.set_preset_mode, _FAN_NATIVE) or not hasattr(
             self.async_set_preset_mode, _FAN_NATIVE
         )
 
     @property
-    def _implemented_speed(self):
+    def _implemented_speed(self) -> bool:
         """Return true if speed has been implemented."""
         return not hasattr(self.set_speed, _FAN_NATIVE) or not hasattr(
             self.async_set_speed, _FAN_NATIVE

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -273,16 +273,6 @@ class TemplateFan(TemplateEntity, FanEntity):
         self._preset_modes = preset_modes
 
     @property
-    def _implemented_percentage(self) -> bool:
-        """Return true if percentage has been implemented."""
-        return bool(self._set_percentage_script or self._percentage_template)
-
-    @property
-    def _implemented_preset_mode(self):
-        """Return true if preset_mode has been implemented."""
-        return bool(self._set_preset_mode_script or self._preset_mode_template)
-
-    @property
     def _implemented_speed(self):
         """Return true if speed has been implemented."""
         return bool(self._set_speed_script or self._speed_template)

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -273,6 +273,21 @@ class TemplateFan(TemplateEntity, FanEntity):
         self._preset_modes = preset_modes
 
     @property
+    def _implemented_percentage(self) -> bool:
+        """Return true if percentage has been implemented."""
+        return bool(self._set_percentage_script or self._percentage_template)
+
+    @property
+    def _implemented_preset_mode(self):
+        """Return true if preset_mode has been implemented."""
+        return bool(self._set_preset_mode_script or self._preset_mode_template)
+
+    @property
+    def _implemented_speed(self):
+        """Return true if speed has been implemented."""
+        return bool(self._set_speed_script or self._speed_template)
+
+    @property
     def name(self):
         """Return the display name of this fan."""
         return self._name
@@ -290,7 +305,7 @@ class TemplateFan(TemplateEntity, FanEntity):
     @property
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
-        return self._speed_count or super().speed_count
+        return self._speed_count or 100
 
     @property
     def speed_list(self) -> list:

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -1219,3 +1219,144 @@ async def test_implemented_percentage(hass, speed_count, percentage_step):
     state = hass.states.get("fan.mechanical_ventilation")
     attributes = state.attributes
     assert attributes["percentage_step"] == percentage_step
+
+
+async def test_implemented_preset_mode(hass):
+    """Test a fan that implements preset_mode."""
+    await setup.async_setup_component(
+        hass,
+        "fan",
+        {
+            "fan": {
+                "platform": "template",
+                "fans": {
+                    "mechanical_ventilation": {
+                        "friendly_name": "Mechanische ventilatie",
+                        "unique_id": "a2fd2e38-674b-4b47-b5ef-cc2362211a72",
+                        "value_template": "{{ states('light.mv_snelheid') }}",
+                        "preset_mode_template": "{{ 'any' }}",
+                        "preset_modes": ["any"],
+                        "set_preset_mode": [
+                            {
+                                "service": "light.turn_on",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                                "data": {"brightness_pct": "{{ percentage }}"},
+                            }
+                        ],
+                        "turn_on": [
+                            {
+                                "service": "switch.turn_off",
+                                "target": {
+                                    "entity_id": "switch.mv_automatisch",
+                                },
+                            },
+                            {
+                                "service": "light.turn_on",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                                "data": {"brightness_pct": 40},
+                            },
+                        ],
+                        "turn_off": [
+                            {
+                                "service": "light.turn_off",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                            },
+                            {
+                                "service": "switch.turn_on",
+                                "target": {
+                                    "entity_id": "switch.mv_automatisch",
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 1
+
+    state = hass.states.get("fan.mechanical_ventilation")
+    attributes = state.attributes
+    assert attributes["percentage"] is None
+
+
+async def test_implemented_speed(hass):
+    """Test a fan that implements speed."""
+    await setup.async_setup_component(
+        hass,
+        "fan",
+        {
+            "fan": {
+                "platform": "template",
+                "fans": {
+                    "mechanical_ventilation": {
+                        "friendly_name": "Mechanische ventilatie",
+                        "unique_id": "a2fd2e38-674b-4b47-b5ef-cc2362211a72",
+                        "value_template": "{{ states('light.mv_snelheid') }}",
+                        "speed_template": "{{ 'fast' }}",
+                        "speeds": ["slow", "fast"],
+                        "set_preset_mode": [
+                            {
+                                "service": "light.turn_on",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                                "data": {"brightness_pct": "{{ percentage }}"},
+                            }
+                        ],
+                        "turn_on": [
+                            {
+                                "service": "switch.turn_off",
+                                "target": {
+                                    "entity_id": "switch.mv_automatisch",
+                                },
+                            },
+                            {
+                                "service": "light.turn_on",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                                "data": {"brightness_pct": 40},
+                            },
+                        ],
+                        "turn_off": [
+                            {
+                                "service": "light.turn_off",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                            },
+                            {
+                                "service": "switch.turn_on",
+                                "target": {
+                                    "entity_id": "switch.mv_automatisch",
+                                },
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 1
+
+    state = hass.states.get("fan.mechanical_ventilation")
+    attributes = state.attributes
+    assert attributes["percentage"] == 100
+    assert attributes["speed"] == "fast"

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -654,8 +654,8 @@ async def test_set_percentage(hass, calls):
 
 
 async def test_increase_decrease_speed(hass, calls):
-    """Test set valid increase and derease speed."""
-    await _register_components(hass)
+    """Test set valid increase and decrease speed."""
+    await _register_components(hass, speed_count=3)
 
     # Turn on fan
     await common.async_turn_on(hass, _TEST_FAN)
@@ -691,6 +691,42 @@ async def test_increase_decrease_speed(hass, calls):
     assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 33
 
     _verify(hass, STATE_ON, SPEED_LOW, 33, None, None, None)
+
+
+async def test_increase_decrease_speed_default_speed_count(hass, calls):
+    """Test set valid increase and decrease speed."""
+    await _register_components(
+        hass,
+    )
+
+    # Turn on fan
+    await common.async_turn_on(hass, _TEST_FAN)
+
+    # Set fan's percentage speed to 100
+    await common.async_set_percentage(hass, _TEST_FAN, 100)
+
+    # verify
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 100
+
+    _verify(hass, STATE_ON, SPEED_HIGH, 100, None, None, None)
+
+    # Set fan's percentage speed to 99
+    await common.async_decrease_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 99
+
+    _verify(hass, STATE_ON, SPEED_HIGH, 99, None, None, None)
+
+    # Set fan's percentage speed to 98
+    await common.async_decrease_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 98
+
+    _verify(hass, STATE_ON, SPEED_HIGH, 98, None, None, None)
+
+    for _ in range(32):
+        await common.async_decrease_speed(hass, _TEST_FAN)
+    assert int(float(hass.states.get(_PERCENTAGE_INPUT_NUMBER).state)) == 66
+
+    _verify(hass, STATE_ON, SPEED_MEDIUM, 66, None, None, None)
 
 
 async def test_set_invalid_speed_from_initial_stage(hass, calls):
@@ -926,7 +962,9 @@ def _verify(
     assert attributes.get(ATTR_PRESET_MODE) == expected_preset_mode
 
 
-async def _register_components(hass, speed_list=None, preset_modes=None):
+async def _register_components(
+    hass, speed_list=None, preset_modes=None, speed_count=None
+):
     """Register basic components for testing."""
     with assert_setup_component(1, "input_boolean"):
         assert await setup.async_setup_component(
@@ -1051,6 +1089,9 @@ async def _register_components(hass, speed_list=None, preset_modes=None):
         if preset_modes:
             test_fan_config["preset_modes"] = preset_modes
 
+        if speed_count:
+            test_fan_config["speed_count"] = speed_count
+
         assert await setup.async_setup_component(
             hass,
             "fan",
@@ -1105,3 +1146,76 @@ async def test_unique_id(hass):
     await hass.async_block_till_done()
 
     assert len(hass.states.async_all()) == 1
+
+
+@pytest.mark.parametrize(
+    "speed_count, percentage_step", [(0, 1), (100, 1), (3, 100 / 3)]
+)
+async def test_implemented_percentage(hass, speed_count, percentage_step):
+    """Test a fan that implements percentage."""
+    await setup.async_setup_component(
+        hass,
+        "fan",
+        {
+            "fan": {
+                "platform": "template",
+                "fans": {
+                    "mechanical_ventilation": {
+                        "friendly_name": "Mechanische ventilatie",
+                        "unique_id": "a2fd2e38-674b-4b47-b5ef-cc2362211a72",
+                        "value_template": "{{ states('light.mv_snelheid') }}",
+                        "percentage_template": "{{ (state_attr('light.mv_snelheid','brightness') | int / 255 * 100) | int }}",
+                        "turn_on": [
+                            {
+                                "service": "switch.turn_off",
+                                "target": {
+                                    "entity_id": "switch.mv_automatisch",
+                                },
+                            },
+                            {
+                                "service": "light.turn_on",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                                "data": {"brightness_pct": 40},
+                            },
+                        ],
+                        "turn_off": [
+                            {
+                                "service": "light.turn_off",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                            },
+                            {
+                                "service": "switch.turn_on",
+                                "target": {
+                                    "entity_id": "switch.mv_automatisch",
+                                },
+                            },
+                        ],
+                        "set_percentage": [
+                            {
+                                "service": "light.turn_on",
+                                "target": {
+                                    "entity_id": "light.mv_snelheid",
+                                },
+                                "data": {"brightness_pct": "{{ percentage }}"},
+                            }
+                        ],
+                        "speed_count": speed_count,
+                    },
+                },
+            },
+        },
+    )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert len(hass.states.async_all()) == 1
+
+    state = hass.states.get("fan.mechanical_ventilation")
+    attributes = state.attributes
+    assert attributes["percentage_step"] == percentage_step


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The default speed count was defaulting to 3 when percentage
was implemented instead of the documented value of 100


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48234
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
