### PR TITLE
Lazy load broadlink storage

### DIFF
--- a/homeassistant/components/broadlink/remote.py
+++ b/homeassistant/components/broadlink/remote.py
@@ -34,7 +34,6 @@ from homeassistant.components.remote import (
 )
 from homeassistant.const import CONF_HOST, STATE_OFF
 from homeassistant.core import callback
-from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.storage import Store
@@ -110,12 +109,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         Store(hass, CODE_STORAGE_VERSION, f"broadlink_remote_{device.unique_id}_codes"),
         Store(hass, FLAG_STORAGE_VERSION, f"broadlink_remote_{device.unique_id}_flags"),
     )
-
-    loaded = await remote.async_load_storage_files()
-    if not loaded:
-        _LOGGER.error("Failed to create '%s Remote' entity: Storage error", device.name)
-        return
-
     async_add_entities([remote], False)
 
 
@@ -128,6 +121,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         self._coordinator = device.update_manager.coordinator
         self._code_storage = codes
         self._flag_storage = flags
+        self._storage_loaded = False
         self._codes = {}
         self._flags = defaultdict(int)
         self._state = True
@@ -214,12 +208,12 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         return code_list
 
     @callback
-    def get_codes(self):
+    def _get_codes(self):
         """Return a dictionary of codes."""
         return self._codes
 
     @callback
-    def get_flags(self):
+    def _get_flags(self):
         """Return a dictionary of toggle flags.
 
         A toggle flag indicates whether the remote should send an
@@ -250,16 +244,13 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         self._state = False
         self.async_write_ha_state()
 
-    async def async_load_storage_files(self):
-        """Load codes and toggle flags from storage files."""
-        try:
-            self._codes.update(await self._code_storage.async_load() or {})
-            self._flags.update(await self._flag_storage.async_load() or {})
-
-        except HomeAssistantError:
-            return False
-
-        return True
+    async def _async_load_storage(self):
+        """Load code and flag storage from disk."""
+        # Exception is intentionally not trapped to
+        # provide feedback if something fails.
+        self._codes.update(await self._code_storage.async_load() or {})
+        self._flags.update(await self._flag_storage.async_load() or {})
+        self._storage_loaded = True
 
     async def async_send_command(self, command, **kwargs):
         """Send a list of commands to a device."""
@@ -276,6 +267,9 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 "%s canceled: %s entity is turned off", service, self.entity_id
             )
             return
+
+        if not self._storage_loaded:
+            await self._async_load_storage()
 
         try:
             code_list = self._extract_codes(commands, device)
@@ -312,7 +306,7 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
             at_least_one_sent = True
 
         if at_least_one_sent:
-            self._flag_storage.async_delay_save(self.get_flags, FLAG_SAVE_DELAY)
+            self._flag_storage.async_delay_save(self._get_flags, FLAG_SAVE_DELAY)
 
     async def async_learn_command(self, **kwargs):
         """Learn a list of commands from a remote."""
@@ -328,6 +322,9 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
                 "%s canceled: %s entity is turned off", service, self.entity_id
             )
             return
+
+        if not self._storage_loaded:
+            await self._async_load_storage()
 
         async with self._lock:
             if command_type == COMMAND_TYPE_IR:
@@ -486,6 +483,9 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
             )
             return
 
+        if not self._storage_loaded:
+            await self._async_load_storage()
+
         try:
             codes = self._codes[device]
         except KeyError as err:
@@ -516,6 +516,6 @@ class BroadlinkRemote(RemoteEntity, RestoreEntity):
         if not codes:
             del self._codes[device]
             if self._flags.pop(device, None) is not None:
-                self._flag_storage.async_delay_save(self.get_flags, FLAG_SAVE_DELAY)
+                self._flag_storage.async_delay_save(self._get_flags, FLAG_SAVE_DELAY)
 
-        self._code_storage.async_delay_save(self.get_codes, CODE_SAVE_DELAY)
+        self._code_storage.async_delay_save(self._get_codes, CODE_SAVE_DELAY)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Delay loading storage until it is needed.

With many broadlink devices (12), the storage load, in combination with
other integrations, overwhelmed the executor at startup. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
