### PR TITLE
Evaluate AirVisual interval on reboot

### DIFF
--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,8 +192,7 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """Get new data from the API."""
-            """Ressess the interval between 2 requests to Cloud Server."""
+            """Reassess interval for requests and get new data from the API."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,8 +192,9 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """Reevaluate interval since all coordinators are created at same time on reboot,"""
-            """And so the 1rst evaluation may be wrong."""
+            """Reevaluate interval:"""
+            """-since all coordinators are created at same time on reboot,"""
+            """-And so the 1rst evaluation may be wrong."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,10 +192,7 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """Reassess interval for requests and get new data from the API."""
-            async_sync_geo_coordinator_update_intervals(
-                hass, config_entry.data[CONF_API_KEY]
-            )
+            """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],
@@ -246,10 +243,6 @@ async def async_setup_entry(hass, config_entry):
             update_method=async_update_data,
         )
 
-        async_sync_geo_coordinator_update_intervals(
-            hass, config_entry.data[CONF_API_KEY]
-        )
-
         # Only geography-based entries have options:
         hass.data[DOMAIN][DATA_LISTENER][
             config_entry.entry_id
@@ -280,6 +273,12 @@ async def async_setup_entry(hass, config_entry):
         raise ConfigEntryNotReady
 
     hass.data[DOMAIN][DATA_COORDINATOR][config_entry.entry_id] = coordinator
+
+    # Reassess the interval between 2 server requests
+    if CONF_API_KEY in config_entry.data:
+        async_sync_geo_coordinator_update_intervals(
+            hass, config_entry.data[CONF_API_KEY]
+        )
 
     for platform in PLATFORMS:
         hass.async_create_task(
@@ -346,10 +345,7 @@ async def async_unload_entry(hass, config_entry):
         remove_listener = hass.data[DOMAIN][DATA_LISTENER].pop(config_entry.entry_id)
         remove_listener()
 
-        if (
-            config_entry.data[CONF_INTEGRATION_TYPE]
-            == INTEGRATION_TYPE_GEOGRAPHY_COORDS
-        ):
+        if CONF_API_KEY in config_entry.data:
             # Re-calculate the update interval period for any remaining consumers of
             # this API key:
             async_sync_geo_coordinator_update_intervals(

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -196,7 +196,6 @@ async def async_setup_entry(hass, config_entry):
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )
-
             """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -197,7 +197,7 @@ async def async_setup_entry(hass, config_entry):
                 hass, config_entry.data[CONF_API_KEY]
             )
 
-            # Get new data from the API
+            """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,11 +192,11 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """Reevaluate interval since all coordinators are created at same time on reboot (and so do not see each other), and so the 1rst evaluation may be wrong. """
-            if CONF_API_KEY in config_entry.data:
-                async_sync_geo_coordinator_update_intervals(
+            """Reevaluate interval since all coordinators are created at same time on reboot,"""
+            """And so the 1rst evaluation may be wrong."""
+            async_sync_geo_coordinator_update_intervals(
                     hass, config_entry.data[CONF_API_KEY]
-                )
+            )
 
             """Get new data from the API."""
             if CONF_CITY in config_entry.data:

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,12 +192,12 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            #update interval periodically
+            # Update interval periodically
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )
 
-            #Get new data from the API
+            # Get new data from the API
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,12 +192,12 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            # ReAssess the interval between 2 requests to Cloud Server
+            """ReAssess the interval between 2 requests to Cloud Server."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )
 
-            # Get new data from the API
+            """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,11 +192,12 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
+            #update interval periodically
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )
 
-            """Get new data from the API."""
+            #Get new data from the API
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,7 +192,6 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """Reevaluate interval."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,9 +192,7 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """Reevaluate interval:"""
-            """-since all coordinators are created at same time on reboot,"""
-            """-And so the 1rst evaluation may be wrong."""
+            """Reevaluate interval."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,12 +192,12 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            # Update interval periodically
+            # ReAssess the interval between 2 requests to Cloud Server
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )
 
-            """Get new data from the API."""
+            # Get new data from the API
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -195,7 +195,7 @@ async def async_setup_entry(hass, config_entry):
             """Reevaluate interval since all coordinators are created at same time on reboot,"""
             """And so the 1rst evaluation may be wrong."""
             async_sync_geo_coordinator_update_intervals(
-                    hass, config_entry.data[CONF_API_KEY]
+                hass, config_entry.data[CONF_API_KEY]
             )
 
             """Get new data from the API."""

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,11 +192,11 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
+            """Get new data from the API."""
             """Ressess the interval between 2 requests to Cloud Server."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )
-            """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(
                     config_entry.data[CONF_CITY],

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,7 +192,7 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """ReAssess the interval between 2 requests to Cloud Server."""
+            """Ressess the interval between 2 requests to Cloud Server."""
             async_sync_geo_coordinator_update_intervals(
                 hass, config_entry.data[CONF_API_KEY]
             )

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,7 +192,7 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """reevaluate interval since all coordinators are created at same time on reboot (and so do see each other), and so the 1rst evaluation may be wrong """
+            """reevaluate interval since all coordinators are created at same time on reboot (and so do not see each other), and so the 1rst evaluation may be wrong """
             if  CONF_API_KEY in config_entry.data:
                 async_sync_geo_coordinator_update_intervals(
                     hass, config_entry.data[CONF_API_KEY]

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,12 +192,12 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
-            """reevaluate interval since all coordinators are created at same time on reboot (and so do not see each other), and so the 1rst evaluation may be wrong """
+            """Reevaluate interval since all coordinators are created at same time on reboot (and so do not see each other), and so the 1rst evaluation may be wrong. """
             if CONF_API_KEY in config_entry.data:
                 async_sync_geo_coordinator_update_intervals(
                     hass, config_entry.data[CONF_API_KEY]
                 )
-                
+
             """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -192,6 +192,12 @@ async def async_setup_entry(hass, config_entry):
         cloud_api = CloudAPI(config_entry.data[CONF_API_KEY], session=websession)
 
         async def async_update_data():
+            """reevaluate interval since all coordinators are created at same time on reboot (and so do see each other), and so the 1rst evaluation may be wrong """
+            if  CONF_API_KEY in config_entry.data:
+                async_sync_geo_coordinator_update_intervals(
+                    hass, config_entry.data[CONF_API_KEY]
+                 )
+                
             """Get new data from the API."""
             if CONF_CITY in config_entry.data:
                 api_coro = cloud_api.air_quality.city(

--- a/homeassistant/components/airvisual/__init__.py
+++ b/homeassistant/components/airvisual/__init__.py
@@ -193,10 +193,10 @@ async def async_setup_entry(hass, config_entry):
 
         async def async_update_data():
             """reevaluate interval since all coordinators are created at same time on reboot (and so do not see each other), and so the 1rst evaluation may be wrong """
-            if  CONF_API_KEY in config_entry.data:
+            if CONF_API_KEY in config_entry.data:
                 async_sync_geo_coordinator_update_intervals(
                     hass, config_entry.data[CONF_API_KEY]
-                 )
+                )
                 
             """Get new data from the API."""
             if CONF_CITY in config_entry.data:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upon HA initialisation, all AirVisual coordinators are initialized in asynchroneous way : they can be initialised at same time and so don't see each other. The server request interval is then not correct.  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48204
- This PR is related to issue: 
- Link to documentation pull request: https://www.home-assistant.io/integrations/airvisual/

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
