### PR TITLE
Upgrade flake8 and dependencies, enable flake8-noqa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - pycodestyle==2.7.0
           - pyflakes==2.3.1
           - flake8-docstrings==1.6.0
           - pydocstyle==6.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,10 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
-          - flake8-docstrings==1.5.0
-          # Temporarily every now and then for noqa cleanup; not done by
-          # default yet due to https://github.com/plinss/flake8-noqa/issues/1
-          # - flake8-noqa==1.1.0
+          - flake8-docstrings==1.6.0
           - pydocstyle==6.0.0
           - flake8-comprehensions==3.4.0
+          - flake8-noqa==1.1.0
         files: ^(homeassistant|script|tests)/.+\.py$
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
           # Temporarily every now and then for noqa cleanup; not done by
           # default yet due to https://github.com/plinss/flake8-noqa/issues/1
           # - flake8-noqa==1.1.0
-          - pydocstyle==5.1.1
+          - pydocstyle==6.0.0
           - flake8-comprehensions==3.4.0
         files: ^(homeassistant|script|tests)/.+\.py$
   - repo: https://github.com/PyCQA/bandit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude_types: [csv, json]
         exclude: ^tests/fixtures/
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
     hooks:
       - id: flake8
         additional_dependencies:
+          - pyflakes==2.3.1
           - flake8-docstrings==1.6.0
           - pydocstyle==6.0.0
           - flake8-comprehensions==3.4.0

--- a/homeassistant/components/http/web_runner.py
+++ b/homeassistant/components/http/web_runner.py
@@ -23,7 +23,7 @@ class HomeAssistantTCPSite(web.BaseSite):
 
     __slots__ = ("_host", "_port", "_reuse_address", "_reuse_port", "_hosturl")
 
-    def __init__(
+    def __init__(  # noqa: D107
         self,
         runner: web.BaseRunner,
         host: None | str | list[str],
@@ -34,7 +34,7 @@ class HomeAssistantTCPSite(web.BaseSite):
         backlog: int = 128,
         reuse_address: bool | None = None,
         reuse_port: bool | None = None,
-    ) -> None:  # noqa: D107
+    ) -> None:
         super().__init__(
             runner,
             shutdown_timeout=shutdown_timeout,

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -5,7 +5,7 @@ black==20.8b1
 codespell==2.0.0
 flake8-comprehensions==3.4.0
 flake8-docstrings==1.5.0
-flake8==3.8.4
+flake8==3.9.0
 isort==5.7.0
 pydocstyle==5.1.1
 pyupgrade==2.11.0

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -9,5 +9,6 @@ flake8-noqa==1.1.0
 flake8==3.9.0
 isort==5.7.0
 pydocstyle==6.0.0
+pyflakes==2.3.1
 pyupgrade==2.11.0
 yamllint==1.24.2

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -8,6 +8,7 @@ flake8-docstrings==1.6.0
 flake8-noqa==1.1.0
 flake8==3.9.0
 isort==5.7.0
+pycodestyle==2.7.0
 pydocstyle==6.0.0
 pyflakes==2.3.1
 pyupgrade==2.11.0

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -7,6 +7,6 @@ flake8-comprehensions==3.4.0
 flake8-docstrings==1.5.0
 flake8==3.9.0
 isort==5.7.0
-pydocstyle==5.1.1
+pydocstyle==6.0.0
 pyupgrade==2.11.0
 yamllint==1.24.2

--- a/requirements_test_pre_commit.txt
+++ b/requirements_test_pre_commit.txt
@@ -4,7 +4,8 @@ bandit==1.7.0
 black==20.8b1
 codespell==2.0.0
 flake8-comprehensions==3.4.0
-flake8-docstrings==1.5.0
+flake8-docstrings==1.6.0
+flake8-noqa==1.1.0
 flake8==3.9.0
 isort==5.7.0
 pydocstyle==6.0.0

--- a/tests/components/seventeentrack/test_sensor.py
+++ b/tests/components/seventeentrack/test_sensor.py
@@ -106,7 +106,7 @@ class ProfileMock:
         show_archived: bool = False,
         tz: str = "UTC",
     ) -> list:
-        """Packages mock."""
+        """Packages mock."""  # noqa: D401
         return self.__class__.package_list[:]
 
     async def summary(self, show_archived: bool = False) -> dict:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

https://flake8.pycqa.org/en/latest/release-notes/3.9.0.html

https://www.pydocstyle.org/en/latest/release_notes.html#september-13th-2020
https://www.pydocstyle.org/en/latest/release_notes.html#march-18th-2021

https://gitlab.com/pycqa/flake8-docstrings/-/blob/1.6.0/HISTORY.rst
https://github.com/plinss/flake8-noqa/issues/1

https://github.com/PyCQA/pyflakes/blob/2.3.1/NEWS.rst

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
