### PR TITLE
Clean up superfluous integration setup - part 1

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -8,7 +8,6 @@ from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
 
 from homeassistant.const import CONF_API_KEY
-from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -24,12 +23,6 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor", "weather"]
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured AccuWeather."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
 
 
 async def async_setup_entry(hass, config_entry) -> bool:
@@ -52,7 +45,7 @@ async def async_setup_entry(hass, config_entry) -> bool:
 
     undo_listener = config_entry.add_update_listener(update_listener)
 
-    hass.data[DOMAIN][config_entry.entry_id] = {
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {
         COORDINATOR: coordinator,
         UNDO_UPDATE_LISTENER: undo_listener,
     }

--- a/homeassistant/components/acmeda/__init__.py
+++ b/homeassistant/components/acmeda/__init__.py
@@ -11,11 +11,6 @@ CONF_HUBS = "hubs"
 PLATFORMS = ["cover", "sensor"]
 
 
-async def async_setup(hass: core.HomeAssistant, config: dict):
-    """Set up the Rollease Acmeda Automate component."""
-    return True
-
-
 async def async_setup_entry(
     hass: core.HomeAssistant, config_entry: config_entries.ConfigEntry
 ):

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -34,7 +34,6 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,11 +46,6 @@ SERVICE_REFRESH_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["sensor", "switch"]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the AdGuard Home components."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/agent_dvr/__init__.py
+++ b/homeassistant/components/agent_dvr/__init__.py
@@ -16,11 +16,6 @@ DEFAULT_BRAND = "Agent DVR by ispyconnect.com"
 FORWARDS = ["alarm_control_panel", "camera"]
 
 
-async def async_setup(hass, config):
-    """Old way to set up integrations."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up the Agent component."""
     hass.data.setdefault(AGENT_DOMAIN, {})

--- a/homeassistant/components/airly/__init__.py
+++ b/homeassistant/components/airly/__init__.py
@@ -10,7 +10,6 @@ from airly.exceptions import AirlyError
 import async_timeout
 
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
-from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -42,11 +41,6 @@ def set_update_interval(hass, instances):
             instance.update_interval = interval
 
     return interval
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured Airly."""
-    return True
 
 
 async def async_setup_entry(hass, config_entry):

--- a/homeassistant/components/airnow/__init__.py
+++ b/homeassistant/components/airnow/__init__.py
@@ -38,11 +38,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the AirNow component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up AirNow from a config entry."""
     api_key = entry.data[CONF_API_KEY]

--- a/homeassistant/components/alarmdecoder/__init__.py
+++ b/homeassistant/components/alarmdecoder/__init__.py
@@ -39,11 +39,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["alarm_control_panel", "sensor", "binary_sensor"]
 
 
-async def async_setup(hass, config):
-    """Set up for the AlarmDecoder devices."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up AlarmDecoder config flow."""
     undo_listener = entry.add_update_listener(_update_listener)

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -42,11 +42,6 @@ SIGNAL_DISCONNECTED = "apple_tv_disconnected"
 PLATFORMS = [MP_DOMAIN, REMOTE_DOMAIN]
 
 
-async def async_setup(hass, config):
-    """Set up the Apple TV integration."""
-    return True
-
-
 async def async_setup_entry(hass, entry):
     """Set up a config entry for Apple TV."""
     manager = AppleTVManager(hass, entry)

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -24,11 +24,6 @@ DOMAIN = "atag"
 PLATFORMS = [CLIMATE, WATER_HEATER, SENSOR]
 
 
-async def async_setup(hass: HomeAssistant, config):
-    """Set up the Atag component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Atag integration from a config entry."""
 

--- a/homeassistant/components/awair/__init__.py
+++ b/homeassistant/components/awair/__init__.py
@@ -9,7 +9,6 @@ from python_awair import Awair
 from python_awair.exceptions import AuthError
 
 from homeassistant.const import CONF_ACCESS_TOKEN
-from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -17,11 +16,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import API_TIMEOUT, DOMAIN, LOGGER, UPDATE_INTERVAL, AwairResult
 
 PLATFORMS = ["sensor"]
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up Awair integration."""
-    return True
 
 
 async def async_setup_entry(hass, config_entry) -> bool:

--- a/homeassistant/components/axis/__init__.py
+++ b/homeassistant/components/axis/__init__.py
@@ -13,11 +13,6 @@ from .device import AxisNetworkDevice
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass, config):
-    """Old way to set up Axis devices."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up the Axis component."""
     hass.data.setdefault(AXIS_DOMAIN, {})

--- a/homeassistant/components/azure_devops/__init__.py
+++ b/homeassistant/components/azure_devops/__init__.py
@@ -22,11 +22,6 @@ from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
-    """Set up the Azure DevOps components."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up Azure DevOps from a config entry."""
     client = DevOpsClient()

--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -22,11 +22,6 @@ PLATFORMS = ["cover", "sensor", "switch", "air_quality", "light", "climate"]
 PARALLEL_UPDATES = 0
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the BleBox devices component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up BleBox devices from a config entry."""
 

--- a/homeassistant/components/braviatv/__init__.py
+++ b/homeassistant/components/braviatv/__init__.py
@@ -10,11 +10,6 @@ from .const import BRAVIARC, DOMAIN, UNDO_UPDATE_LISTENER
 PLATFORMS = ["media_player"]
 
 
-async def async_setup(hass, config):
-    """Set up the Bravia TV component."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up a config entry."""
     host = config_entry.data[CONF_HOST]

--- a/homeassistant/components/brother/__init__.py
+++ b/homeassistant/components/brother/__init__.py
@@ -7,7 +7,7 @@ from brother import Brother, SnmpError, UnsupportedModel
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TYPE
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -19,11 +19,6 @@ PLATFORMS = ["sensor"]
 SCAN_INTERVAL = timedelta(seconds=30)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistant, config: Config):
-    """Set up the Brother component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/homeassistant/components/cert_expiry/__init__.py
+++ b/homeassistant/components/cert_expiry/__init__.py
@@ -19,11 +19,6 @@ _LOGGER = logging.getLogger(__name__)
 SCAN_INTERVAL = timedelta(hours=12)
 
 
-async def async_setup(hass, config):
-    """Platform setup, do nothing."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry):
     """Load the saved entities."""
     host = entry.data[CONF_HOST]

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -20,11 +20,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass, config):
-    """Old way of setting up deCONZ integrations."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up a deCONZ bridge for a config entry.
 

--- a/homeassistant/components/devolo_home_control/__init__.py
+++ b/homeassistant/components/devolo_home_control/__init__.py
@@ -15,11 +15,6 @@ from homeassistant.helpers.typing import HomeAssistantType
 from .const import CONF_MYDEVOLO, DOMAIN, GATEWAY_SERIAL_PATTERN, PLATFORMS
 
 
-async def async_setup(hass, config):
-    """Get all devices and add them to hass."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up the devolo account from a config entry."""
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/dialogflow/__init__.py
+++ b/homeassistant/components/dialogflow/__init__.py
@@ -24,11 +24,6 @@ class DialogFlowError(HomeAssistantError):
     """Raised when a DialogFlow error happens."""
 
 
-async def async_setup(hass, config):
-    """Set up the Dialogflow component."""
-    return True
-
-
 async def handle_webhook(hass, webhook_id, request):
     """Handle incoming webhook with Dialogflow requests."""
     message = await request.json()

--- a/homeassistant/components/dunehd/__init__.py
+++ b/homeassistant/components/dunehd/__init__.py
@@ -10,11 +10,6 @@ from .const import DOMAIN
 PLATFORMS = ["media_player"]
 
 
-async def async_setup(hass, config):
-    """Set up the Dune HD component."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up a config entry."""
     host = config_entry.data[CONF_HOST]

--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -9,14 +9,8 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_ELGATO_CLIENT, DOMAIN
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Elgato Key Light components."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -42,7 +42,7 @@ from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 
 # Import config flow so that it's added to the registry
 from .entry_data import RuntimeEntryData
@@ -54,11 +54,6 @@ STORAGE_VERSION = 1
 
 # No config schema - only configuration entry
 CONFIG_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
-
-
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
-    """Stub to allow setting up this component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/ipma/__init__.py
+++ b/homeassistant/components/ipma/__init__.py
@@ -1,15 +1,8 @@
 """Component for the Portuguese weather service - IPMA."""
-from homeassistant.core import Config, HomeAssistant
-
 from .config_flow import IpmaFlowHandler  # noqa: F401
 from .const import DOMAIN  # noqa: F401
 
 DEFAULT_NAME = "ipma"
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured IPMA."""
-    return True
 
 
 async def async_setup_entry(hass, config_entry):

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -24,7 +24,6 @@ from homeassistant.helpers.device_registry import (
     EVENT_DEVICE_REGISTRY_UPDATED,
     async_entries_for_config_entry,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import device_automation, discovery
 from .const import (
@@ -36,11 +35,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistantType, config: dict):
-    """Set up the Tasmota component."""
-    return True
 
 
 async def async_setup_entry(hass, entry):

--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.const import ATTR_NAME, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -35,11 +34,6 @@ SCAN_INTERVAL = timedelta(seconds=5)
 PLATFORMS = (LIGHT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the WLED components."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -147,7 +147,7 @@ async def _async_setup_component(
         return False
 
     if integration.disabled:
-        log_error(f"dependency is disabled - {integration.disabled}")
+        log_error(f"Dependency is disabled - {integration.disabled}")
         return False
 
     # Validate all dependencies exist and there are no circular dependencies
@@ -197,6 +197,8 @@ async def _async_setup_component(
             SLOW_SETUP_WARNING,
         )
 
+    task = None
+    result = True
     try:
         if hasattr(component, "async_setup"):
             task = component.async_setup(hass, processed_config)  # type: ignore
@@ -206,13 +208,14 @@ async def _async_setup_component(
             task = hass.loop.run_in_executor(
                 None, component.setup, hass, processed_config  # type: ignore
             )
-        else:
-            log_error("No setup function defined.")
+        elif not hasattr(component, "async_setup_entry"):
+            log_error("No setup or config entry setup function defined.")
             hass.data[DATA_SETUP_STARTED].pop(domain)
             return False
 
-        async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
-            result = await task
+        if task:
+            async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
+                result = await task
     except asyncio.TimeoutError:
         _LOGGER.error(
             "Setup of %s is taking longer than %s seconds."

--- a/script/scaffold/templates/config_flow/integration/__init__.py
+++ b/script/scaffold/templates/config_flow/integration/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -12,11 +11,6 @@ from .const import DOMAIN
 # TODO List the platforms that you want to support.
 # For your initial PR, limit it to 1 platform.
 PLATFORMS = ["light"]
-
-
-async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
-    """Set up the NEW_NAME component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -20,8 +20,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "homeassistant.components.NEW_DOMAIN.config_flow.PlaceholderHub.authenticate",
         return_value=True,
     ), patch(
-        "homeassistant.components.NEW_DOMAIN.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.NEW_DOMAIN.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -42,7 +40,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "username": "test-username",
         "password": "test-password",
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/script/scaffold/templates/config_flow_discovery/integration/__init__.py
+++ b/script/scaffold/templates/config_flow_discovery/integration/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -12,11 +11,6 @@ from .const import DOMAIN
 # TODO List the platforms that you want to support.
 # For your initial PR, limit it to 1 platform.
 PLATFORMS = ["light"]
-
-
-async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
-    """Set up the NEW_NAME component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/common.py
+++ b/tests/common.py
@@ -566,7 +566,7 @@ class MockModule:
         if platform_schema_base is not None:
             self.PLATFORM_SCHEMA_BASE = platform_schema_base
 
-        if setup is not None:
+        if setup:
             # We run this in executor, wrap it in function
             self.setup = lambda *args: setup(*args)
 

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -75,9 +75,7 @@ async def test_form(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
-    with patch("pyairnow.WebServiceAPI._get", return_value=MOCK_RESPONSE,), patch(
-        "homeassistant.components.airnow.async_setup", return_value=True
-    ) as mock_setup, patch(
+    with patch("pyairnow.WebServiceAPI._get", return_value=MOCK_RESPONSE), patch(
         "homeassistant.components.airnow.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -90,7 +88,6 @@ async def test_form(hass):
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["data"] == CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/alarmdecoder/test_config_flow.py
+++ b/tests/components/alarmdecoder/test_config_flow.py
@@ -76,8 +76,6 @@ async def test_setups(hass: HomeAssistant, protocol, connection, title):
     with patch("homeassistant.components.alarmdecoder.config_flow.AdExt.open"), patch(
         "homeassistant.components.alarmdecoder.config_flow.AdExt.close"
     ), patch(
-        "homeassistant.components.alarmdecoder.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.alarmdecoder.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -92,7 +90,6 @@ async def test_setups(hass: HomeAssistant, protocol, connection, title):
         }
         await hass.async_block_till_done()
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/azure_devops/test_config_flow.py
+++ b/tests/components/azure_devops/test_config_flow.py
@@ -228,8 +228,6 @@ async def test_reauth_flow(hass: HomeAssistant) -> None:
 async def test_full_flow_implementation(hass: HomeAssistant) -> None:
     """Test registering an integration and finishing flow works."""
     with patch(
-        "homeassistant.components.azure_devops.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.azure_devops.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
@@ -255,7 +253,6 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
             FIXTURE_USER_INPUT,
         )
         await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
 
         assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -539,8 +539,6 @@ async def test_flow_hassio_discovery(hass):
     assert result["description_placeholders"] == {"addon": "Mock Addon"}
 
     with patch(
-        "homeassistant.components.deconz.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.deconz.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -555,7 +553,6 @@ async def test_flow_hassio_discovery(hass):
         CONF_PORT: 80,
         CONF_API_KEY: API_KEY,
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -20,9 +20,6 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.devolo_home_control.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
         "homeassistant.components.devolo_home_control.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
@@ -43,7 +40,6 @@ async def test_form(hass):
         "mydevolo_url": "https://www.mydevolo.com",
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -90,9 +86,6 @@ async def test_form_advanced_options(hass):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.devolo_home_control.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
         "homeassistant.components.devolo_home_control.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
@@ -117,5 +110,4 @@ async def test_form_advanced_options(hass):
         "mydevolo_url": "https://test_mydevolo_url.test",
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 import threading
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import voluptuous as vol
@@ -600,3 +600,29 @@ async def test_integration_disabled(hass, caplog):
     result = await setup.async_setup_component(hass, "test_component1", {})
     assert not result
     assert disabled_reason in caplog.text
+
+
+async def test_integration_no_setup(hass, caplog):
+    """Test we fail integration setup without setup functions."""
+    mock_integration(
+        hass,
+        MockModule("test_integration_without_setup", setup=False),
+    )
+    result = await setup.async_setup_component(
+        hass, "test_integration_without_setup", {}
+    )
+    assert not result
+    assert "No setup or config entry setup function defined" in caplog.text
+
+
+async def test_integration_only_setup_entry(hass):
+    """Test we have an integration with only a setup entry method."""
+    mock_integration(
+        hass,
+        MockModule(
+            "test_integration_only_entry",
+            setup=False,
+            async_setup_entry=AsyncMock(return_value=True),
+        ),
+    )
+    assert await setup.async_setup_component(hass, "test_integration_only_entry", {})


### PR DESCRIPTION
🚫 Depends on / Blocked by #48381, needs to be rebased after that one is merged.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#48381 remove the need for an integration `setup` or `async_setup` in case the integration provides a `async_setup_entry`. For example:

```py
async def async_setup(hass, config):
    """Component setup, do nothing."""
    return True
```

This PR is cleanup for those.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
