### PR TITLE
Clean up superfluous integration setup - part 2

### DIFF
--- a/homeassistant/components/accuweather/__init__.py
+++ b/homeassistant/components/accuweather/__init__.py
@@ -8,7 +8,6 @@ from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
 
 from homeassistant.const import CONF_API_KEY
-from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -24,12 +23,6 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["sensor", "weather"]
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured AccuWeather."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
 
 
 async def async_setup_entry(hass, config_entry) -> bool:
@@ -52,7 +45,7 @@ async def async_setup_entry(hass, config_entry) -> bool:
 
     undo_listener = config_entry.add_update_listener(update_listener)
 
-    hass.data[DOMAIN][config_entry.entry_id] = {
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {
         COORDINATOR: coordinator,
         UNDO_UPDATE_LISTENER: undo_listener,
     }

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -34,7 +34,6 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -47,11 +46,6 @@ SERVICE_REFRESH_SCHEMA = vol.Schema(
 )
 
 PLATFORMS = ["sensor", "switch"]
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the AdGuard Home components."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/airnow/__init__.py
+++ b/homeassistant/components/airnow/__init__.py
@@ -38,11 +38,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the AirNow component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up AirNow from a config entry."""
     api_key = entry.data[CONF_API_KEY]

--- a/homeassistant/components/deconz/__init__.py
+++ b/homeassistant/components/deconz/__init__.py
@@ -20,11 +20,6 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass, config):
-    """Old way of setting up deCONZ integrations."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up a deCONZ bridge for a config entry.
 

--- a/homeassistant/components/dsmr/__init__.py
+++ b/homeassistant/components/dsmr/__init__.py
@@ -9,11 +9,6 @@ from homeassistant.core import HomeAssistant
 from .const import DATA_LISTENER, DATA_TASK, DOMAIN, PLATFORMS
 
 
-async def async_setup(hass, config: dict):
-    """Set up the DSMR platform."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up DSMR from a config entry."""
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -9,14 +9,8 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DATA_ELGATO_CLIENT, DOMAIN
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Elgato Key Light components."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -42,7 +42,7 @@ from homeassistant.helpers.json import JSONEncoder
 from homeassistant.helpers.service import async_set_service_schema
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 
 # Import config flow so that it's added to the registry
 from .entry_data import RuntimeEntryData
@@ -54,11 +54,6 @@ STORAGE_VERSION = 1
 
 # No config schema - only configuration entry
 CONFIG_SCHEMA = vol.Schema({}, extra=vol.ALLOW_EXTRA)
-
-
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
-    """Stub to allow setting up this component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/fireservicerota/__init__.py
+++ b/homeassistant/components/fireservicerota/__init__.py
@@ -29,12 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [SENSOR_DOMAIN, BINARYSENSOR_DOMAIN, SWITCH_DOMAIN]
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    """Set up the FireServiceRota component."""
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up FireServiceRota from a config entry."""
 

--- a/homeassistant/components/forked_daapd/__init__.py
+++ b/homeassistant/components/forked_daapd/__init__.py
@@ -4,11 +4,6 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from .const import DOMAIN, HASS_DATA_REMOVE_LISTENERS_KEY, HASS_DATA_UPDATER_KEY
 
 
-async def async_setup(hass, config):
-    """Set up the forked-daapd component."""
-    return True
-
-
 async def async_setup_entry(hass, entry):
     """Set up forked-daapd from a config entry by forwarding to platform."""
     hass.async_create_task(

--- a/homeassistant/components/fritzbox_callmonitor/__init__.py
+++ b/homeassistant/components/fritzbox_callmonitor/__init__.py
@@ -21,11 +21,6 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass, config):
-    """Set up the fritzbox_callmonitor integration."""
-    return True
-
-
 async def async_setup_entry(hass, config_entry):
     """Set up the fritzbox_callmonitor platforms."""
     fritzbox_phonebook = FritzBoxPhonebook(

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -5,7 +5,6 @@ from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
 from gios import ApiError, Gios, InvalidSensorsData, NoStationError
 
-from homeassistant.core import Config, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -13,11 +12,6 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import CONF_STATION_ID, DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured GIOS."""
-    return True
 
 
 async def async_setup_entry(hass, config_entry):

--- a/homeassistant/components/gogogate2/__init__.py
+++ b/homeassistant/components/gogogate2/__init__.py
@@ -14,11 +14,6 @@ from .const import DEVICE_TYPE_GOGOGATE2
 PLATFORMS = [COVER, SENSOR]
 
 
-async def async_setup(hass: HomeAssistant, base_config: dict) -> bool:
-    """Set up for Gogogate2 controllers."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Do setup of Gogogate2."""
 

--- a/homeassistant/components/squeezebox/__init__.py
+++ b/homeassistant/components/squeezebox/__init__.py
@@ -11,11 +11,6 @@ from .const import DISCOVERY_TASK, DOMAIN, PLAYER_DISCOVERY_UNSUB
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Logitech Squeezebox component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Logitech Squeezebox from a config entry."""
     hass.async_create_task(

--- a/homeassistant/components/starline/__init__.py
+++ b/homeassistant/components/starline/__init__.py
@@ -3,7 +3,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_SCAN_INTERVAL
-from homeassistant.core import Config, HomeAssistant
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .account import StarlineAccount
@@ -17,11 +17,6 @@ from .const import (
     SERVICE_SET_SCAN_OBD_INTERVAL,
     SERVICE_UPDATE_STATE,
 )
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured StarLine."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -24,7 +24,6 @@ from homeassistant.helpers.device_registry import (
     EVENT_DEVICE_REGISTRY_UPDATED,
     async_entries_for_config_entry,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import device_automation, discovery
 from .const import (
@@ -36,11 +35,6 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistantType, config: dict):
-    """Set up the Tasmota component."""
-    return True
 
 
 async def async_setup_entry(hass, entry):

--- a/homeassistant/components/upb/__init__.py
+++ b/homeassistant/components/upb/__init__.py
@@ -4,9 +4,8 @@ import asyncio
 import upb_lib
 
 from homeassistant.const import ATTR_COMMAND, CONF_FILE_PATH, CONF_HOST
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ATTR_ADDRESS,
@@ -17,11 +16,6 @@ from .const import (
 )
 
 PLATFORMS = ["light", "scene"]
-
-
-async def async_setup(hass: HomeAssistant, hass_config: ConfigType) -> bool:
-    """Set up the UPB platform."""
-    return True
 
 
 async def async_setup_entry(hass, config_entry):

--- a/homeassistant/components/volumio/__init__.py
+++ b/homeassistant/components/volumio/__init__.py
@@ -14,11 +14,6 @@ from .const import DATA_INFO, DATA_VOLUMIO, DOMAIN
 PLATFORMS = ["media_player"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Volumio component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Volumio from a config entry."""
 

--- a/homeassistant/components/wiffi/__init__.py
+++ b/homeassistant/components/wiffi/__init__.py
@@ -33,11 +33,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["sensor", "binary_sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the wiffi component. config contains data from configuration.yaml."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Set up wiffi from a config entry, config_entry contains data from config entry database."""
     if not config_entry.update_listeners:

--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -16,7 +16,6 @@ from homeassistant.const import ATTR_NAME, CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -35,11 +34,6 @@ SCAN_INTERVAL = timedelta(seconds=5)
 PLATFORMS = (LIGHT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the WLED components."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -147,7 +147,7 @@ async def _async_setup_component(
         return False
 
     if integration.disabled:
-        log_error(f"dependency is disabled - {integration.disabled}")
+        log_error(f"Dependency is disabled - {integration.disabled}")
         return False
 
     # Validate all dependencies exist and there are no circular dependencies
@@ -197,6 +197,8 @@ async def _async_setup_component(
             SLOW_SETUP_WARNING,
         )
 
+    task = None
+    result = True
     try:
         if hasattr(component, "async_setup"):
             task = component.async_setup(hass, processed_config)  # type: ignore
@@ -206,13 +208,14 @@ async def _async_setup_component(
             task = hass.loop.run_in_executor(
                 None, component.setup, hass, processed_config  # type: ignore
             )
-        else:
-            log_error("No setup function defined.")
+        elif not hasattr(component, "async_setup_entry"):
+            log_error("No setup or config entry setup function defined.")
             hass.data[DATA_SETUP_STARTED].pop(domain)
             return False
 
-        async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
-            result = await task
+        if task:
+            async with hass.timeout.async_timeout(SLOW_SETUP_MAX_WAIT, domain):
+                result = await task
     except asyncio.TimeoutError:
         _LOGGER.error(
             "Setup of %s is taking longer than %s seconds."

--- a/script/scaffold/templates/config_flow/integration/__init__.py
+++ b/script/scaffold/templates/config_flow/integration/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -12,11 +11,6 @@ from .const import DOMAIN
 # TODO List the platforms that you want to support.
 # For your initial PR, limit it to 1 platform.
 PLATFORMS = ["light"]
-
-
-async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
-    """Set up the NEW_NAME component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/script/scaffold/templates/config_flow/tests/test_config_flow.py
+++ b/script/scaffold/templates/config_flow/tests/test_config_flow.py
@@ -20,8 +20,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "homeassistant.components.NEW_DOMAIN.config_flow.PlaceholderHub.authenticate",
         return_value=True,
     ), patch(
-        "homeassistant.components.NEW_DOMAIN.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.NEW_DOMAIN.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -42,7 +40,6 @@ async def test_form(hass: HomeAssistant) -> None:
         "username": "test-username",
         "password": "test-password",
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/script/scaffold/templates/config_flow_discovery/integration/__init__.py
+++ b/script/scaffold/templates/config_flow_discovery/integration/__init__.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -12,11 +11,6 @@ from .const import DOMAIN
 # TODO List the platforms that you want to support.
 # For your initial PR, limit it to 1 platform.
 PLATFORMS = ["light"]
-
-
-async def async_setup(hass: HomeAssistant, config: dict[str, Any]) -> bool:
-    """Set up the NEW_NAME component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/tests/common.py
+++ b/tests/common.py
@@ -566,7 +566,7 @@ class MockModule:
         if platform_schema_base is not None:
             self.PLATFORM_SCHEMA_BASE = platform_schema_base
 
-        if setup is not None:
+        if setup:
             # We run this in executor, wrap it in function
             self.setup = lambda *args: setup(*args)
 

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -75,9 +75,7 @@ async def test_form(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
-    with patch("pyairnow.WebServiceAPI._get", return_value=MOCK_RESPONSE,), patch(
-        "homeassistant.components.airnow.async_setup", return_value=True
-    ) as mock_setup, patch(
+    with patch("pyairnow.WebServiceAPI._get", return_value=MOCK_RESPONSE), patch(
         "homeassistant.components.airnow.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -90,7 +88,6 @@ async def test_form(hass):
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["data"] == CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/deconz/test_config_flow.py
+++ b/tests/components/deconz/test_config_flow.py
@@ -539,8 +539,6 @@ async def test_flow_hassio_discovery(hass):
     assert result["description_placeholders"] == {"addon": "Mock Addon"}
 
     with patch(
-        "homeassistant.components.deconz.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.deconz.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -555,7 +553,6 @@ async def test_flow_hassio_discovery(hass):
         CONF_PORT: 80,
         CONF_API_KEY: API_KEY,
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -39,7 +39,7 @@ async def test_setup_platform(hass, dsmr_connection_fixture):
 
     serial_data = {"serial_id": "1234", "serial_id_gas": "5678"}
 
-    with patch("homeassistant.components.dsmr.async_setup", return_value=True), patch(
+    with patch(
         "homeassistant.components.dsmr.async_setup_entry", return_value=True
     ), patch(
         "homeassistant.components.dsmr.config_flow._validate_dsmr_connection",

--- a/tests/components/fireservicerota/test_config_flow.py
+++ b/tests/components/fireservicerota/test_config_flow.py
@@ -78,8 +78,6 @@ async def test_step_user(hass):
     with patch(
         "homeassistant.components.fireservicerota.config_flow.FireServiceRota"
     ) as mock_fsr, patch(
-        "homeassistant.components.fireservicerota.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.fireservicerota.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -108,5 +106,4 @@ async def test_step_user(hass):
             },
         }
 
-        assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/gogogate2/test_config_flow.py
+++ b/tests/components/gogogate2/test_config_flow.py
@@ -26,11 +26,10 @@ from tests.common import MockConfigEntry
 MOCK_MAC_ADDR = "AA:BB:CC:DD:EE:FF"
 
 
-@patch("homeassistant.components.gogogate2.async_setup", return_value=True)
 @patch("homeassistant.components.gogogate2.async_setup_entry", return_value=True)
 @patch("homeassistant.components.gogogate2.common.GogoGate2Api")
 async def test_auth_fail(
-    gogogate2api_mock, async_setup_entry_mock, async_setup_mock, hass: HomeAssistant
+    gogogate2api_mock, async_setup_entry_mock, hass: HomeAssistant
 ) -> None:
     """Test authorization failures."""
     api: GogoGate2Api = MagicMock(spec=GogoGate2Api)

--- a/tests/components/squeezebox/test_config_flow.py
+++ b/tests/components/squeezebox/test_config_flow.py
@@ -45,8 +45,6 @@ async def patch_async_query_unauthorized(self, *args):
 async def test_user_form(hass):
     """Test user-initiated flow, including discovery and the edit step."""
     with patch("pysqueezebox.Server.async_query", return_value={"uuid": UUID},), patch(
-        "homeassistant.components.squeezebox.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.squeezebox.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry, patch(
@@ -77,7 +75,6 @@ async def test_user_form(hass):
         }
 
         await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -111,8 +108,6 @@ async def test_user_form_duplicate(hass):
         "homeassistant.components.squeezebox.config_flow.async_discover",
         mock_discover,
     ), patch("homeassistant.components.squeezebox.config_flow.TIMEOUT", 0.1), patch(
-        "homeassistant.components.squeezebox.async_setup", return_value=True
-    ), patch(
         "homeassistant.components.squeezebox.async_setup_entry",
         return_value=True,
     ):
@@ -204,8 +199,6 @@ async def test_discovery_no_uuid(hass):
 async def test_import(hass):
     """Test handling of configuration imported."""
     with patch("pysqueezebox.Server.async_query", return_value={"uuid": UUID},), patch(
-        "homeassistant.components.squeezebox.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.squeezebox.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -217,7 +210,6 @@ async def test_import(hass):
         assert result["type"] == RESULT_TYPE_CREATE_ENTRY
 
         await hass.async_block_till_done()
-        assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -253,8 +245,6 @@ async def test_import_bad_auth(hass):
 async def test_import_existing(hass):
     """Test handling of configuration import of existing server."""
     with patch(
-        "homeassistant.components.squeezebox.async_setup", return_value=True
-    ), patch(
         "homeassistant.components.squeezebox.async_setup_entry",
         return_value=True,
     ), patch(

--- a/tests/components/upb/test_config_flow.py
+++ b/tests/components/upb/test_config_flow.py
@@ -43,8 +43,6 @@ async def test_full_upb_flow_with_serial_port(hass):
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     with mocked_upb(), patch(
-        "homeassistant.components.upb.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.upb.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         flow = await hass.config_entries.flow.async_init(
@@ -69,7 +67,6 @@ async def test_full_upb_flow_with_serial_port(hass):
         "host": "serial:///dev/ttyS0:115200",
         "file_path": "upb.upe",
     }
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -116,8 +113,6 @@ async def test_form_import(hass):
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     with mocked_upb(), patch(
-        "homeassistant.components.upb.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.upb.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
@@ -131,7 +126,6 @@ async def test_form_import(hass):
     assert result["title"] == "UPB"
 
     assert result["data"] == {"host": "tcp://42.4.2.42", "file_path": "upb.upe"}
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/volumio/test_config_flow.py
+++ b/tests/components/volumio/test_config_flow.py
@@ -42,8 +42,6 @@ async def test_form(hass):
         "homeassistant.components.volumio.config_flow.Volumio.get_system_info",
         return_value=TEST_SYSTEM_INFO,
     ), patch(
-        "homeassistant.components.volumio.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.volumio.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -57,7 +55,6 @@ async def test_form(hass):
     assert result2["title"] == "TestVolumio"
     assert result2["data"] == {**TEST_SYSTEM_INFO, **TEST_CONNECTION}
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -82,7 +79,7 @@ async def test_form_updates_unique_id(hass):
     with patch(
         "homeassistant.components.volumio.config_flow.Volumio.get_system_info",
         return_value=TEST_SYSTEM_INFO,
-    ), patch("homeassistant.components.volumio.async_setup", return_value=True), patch(
+    ), patch(
         "homeassistant.components.volumio.async_setup_entry",
         return_value=True,
     ):
@@ -110,8 +107,6 @@ async def test_empty_system_info(hass):
         "homeassistant.components.volumio.config_flow.Volumio.get_system_info",
         return_value={},
     ), patch(
-        "homeassistant.components.volumio.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.volumio.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -130,7 +125,6 @@ async def test_empty_system_info(hass):
         "id": None,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -183,8 +177,6 @@ async def test_discovery(hass):
         "homeassistant.components.volumio.config_flow.Volumio.get_system_info",
         return_value=TEST_SYSTEM_INFO,
     ), patch(
-        "homeassistant.components.volumio.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.volumio.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -201,7 +193,6 @@ async def test_discovery(hass):
     assert result2["result"]
     assert result2["result"].unique_id == TEST_DISCOVERY_RESULT["id"]
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -257,8 +248,6 @@ async def test_discovery_updates_unique_id(hass):
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.volumio.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.volumio.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -271,5 +260,4 @@ async def test_discovery_updates_unique_id(hass):
     assert result["reason"] == "already_configured"
 
     assert entry.data == TEST_DISCOVERY_RESULT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -3,7 +3,7 @@
 import asyncio
 import os
 import threading
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import voluptuous as vol
@@ -600,3 +600,29 @@ async def test_integration_disabled(hass, caplog):
     result = await setup.async_setup_component(hass, "test_component1", {})
     assert not result
     assert disabled_reason in caplog.text
+
+
+async def test_integration_no_setup(hass, caplog):
+    """Test we fail integration setup without setup functions."""
+    mock_integration(
+        hass,
+        MockModule("test_integration_without_setup", setup=False),
+    )
+    result = await setup.async_setup_component(
+        hass, "test_integration_without_setup", {}
+    )
+    assert not result
+    assert "No setup or config entry setup function defined" in caplog.text
+
+
+async def test_integration_only_setup_entry(hass):
+    """Test we have an integration with only a setup entry method."""
+    mock_integration(
+        hass,
+        MockModule(
+            "test_integration_only_entry",
+            setup=False,
+            async_setup_entry=AsyncMock(return_value=True),
+        ),
+    )
+    assert await setup.async_setup_component(hass, "test_integration_only_entry", {})


### PR DESCRIPTION
🚫 Depends on / Blocked by #48381, needs to be rebased after that one is merged.
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#48381 remove the need for an integration `setup` or `async_setup` in case the integration provides a `async_setup_entry`. For example:

```py
async def async_setup(hass, config):
    """Component setup, do nothing."""
    return True
```

This PR is cleanup for those.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
