### PR TITLE
Use Mapping[str, Any] instead of dict in Entity

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -162,7 +162,7 @@ class Entity(ABC):
         return None
 
     @property
-    def state_attributes(self) -> Mapping[str, Any] | None:
+    def state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes.
 
         Implemented by component base class, should not be extended by integrations.

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 
 from abc import ABC
 import asyncio
+from collections.abc import Mapping
 from datetime import datetime, timedelta
 import functools as ft
 import logging
 from timeit import default_timer as timer
-from typing import Any, Awaitable, Iterable, Mapping
+from typing import Any, Awaitable, Iterable
 
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 import functools as ft
 import logging
 from timeit import default_timer as timer
-from typing import Any, Awaitable, Iterable
+from typing import Any, Awaitable, Iterable, Mapping
 
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (
@@ -151,7 +151,7 @@ class Entity(ABC):
         return STATE_UNKNOWN
 
     @property
-    def capability_attributes(self) -> dict[str, Any] | None:
+    def capability_attributes(self) -> Mapping[str, Any] | None:
         """Return the capability attributes.
 
         Attributes that explain the capabilities of an entity.
@@ -162,7 +162,7 @@ class Entity(ABC):
         return None
 
     @property
-    def state_attributes(self) -> dict[str, Any] | None:
+    def state_attributes(self) -> Mapping[str, Any] | None:
         """Return the state attributes.
 
         Implemented by component base class, should not be extended by integrations.
@@ -171,7 +171,7 @@ class Entity(ABC):
         return None
 
     @property
-    def device_state_attributes(self) -> dict[str, Any] | None:
+    def device_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes.
 
         This method is deprecated, platform classes should implement
@@ -180,7 +180,7 @@ class Entity(ABC):
         return None
 
     @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """Return entity specific state attributes.
 
         Implemented by platform classes. Convention for attribute names
@@ -189,7 +189,7 @@ class Entity(ABC):
         return None
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> Mapping[str, Any] | None:
         """Return device specific attributes.
 
         Implemented by platform classes.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This will allow components to use strictly typed `TypedDict` for return values of these methods. `Mapping` is covariant and `TypedDict` is compatible with `Mapping[str, Any]` but not with `dict[str, Any]`. 

There was discussion in mypy about if `TypedDict` should be compatible with`dict[str, Any]` and the outcome of that discussion is that `Mapping` should be used instead: https://github.com/python/mypy/issues/4976

The idea is to make it possible to annotate components with types without using `Any`. So, for example, overrided `device_info` in component can return `TypedDict` instead of `dict[str, Any]`. This will allow making components a bit safer.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
