### PR TITLE
Add support for custom configurations in ZHA

### DIFF
--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -141,17 +141,13 @@ async def async_unload_entry(hass, config_entry):
     for unsub_dispatcher in dispatchers:
         unsub_dispatcher()
 
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(config_entry, platform)
-                for platform in PLATFORMS
-            ]
-        )
+    # our components don't have unload methods so no need to look at return values
+    await asyncio.gather(
+        *[
+            hass.config_entries.async_forward_entry_unload(config_entry, platform)
+            for platform in PLATFORMS
+        ]
     )
-
-    if not unload_ok:
-        return False
 
     hass.data[DATA_ZHA][DATA_ZHA_SHUTDOWN_TASK]()
 

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -29,6 +29,7 @@ from .core.const import (
     DATA_ZHA_DISPATCHERS,
     DATA_ZHA_GATEWAY,
     DATA_ZHA_PLATFORM_LOADED,
+    DATA_ZHA_SHUTDOWN_TASK,
     DOMAIN,
     PLATFORMS,
     SIGNAL_ADD_ENTITIES,
@@ -121,7 +122,9 @@ async def async_setup_entry(hass, config_entry):
         await zha_data[DATA_ZHA_GATEWAY].shutdown()
         await zha_data[DATA_ZHA_GATEWAY].async_update_device_storage()
 
-    hass.bus.async_listen_once(ha_const.EVENT_HOMEASSISTANT_STOP, async_zha_shutdown)
+    zha_data[DATA_ZHA_SHUTDOWN_TASK] = hass.bus.async_listen_once(
+        ha_const.EVENT_HOMEASSISTANT_STOP, async_zha_shutdown
+    )
     asyncio.create_task(async_load_entities(hass))
     return True
 
@@ -129,6 +132,7 @@ async def async_setup_entry(hass, config_entry):
 async def async_unload_entry(hass, config_entry):
     """Unload ZHA config entry."""
     await hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].shutdown()
+    await hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].async_update_device_storage()
 
     GROUP_PROBE.cleanup()
     api.async_unload_api(hass)
@@ -137,8 +141,19 @@ async def async_unload_entry(hass, config_entry):
     for unsub_dispatcher in dispatchers:
         unsub_dispatcher()
 
-    for platform in PLATFORMS:
-        await hass.config_entries.async_forward_entry_unload(config_entry, platform)
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(config_entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
+
+    if not unload_ok:
+        return False
+
+    hass.data[DATA_ZHA][DATA_ZHA_SHUTDOWN_TASK]()
 
     return True
 

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -890,6 +890,10 @@ async def async_binding_operation(zha_gateway, source_ieee, target_ieee, operati
 @websocket_api.websocket_command({vol.Required(TYPE): "zha/configuration"})
 async def websocket_get_configuration(hass, connection, msg):
     """Get ZHA configuration."""
+    zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
+    custom_configuration = zha_gateway.config_entry.options.get(
+        CUSTOM_CONFIGURATION, {"zha_options": {}}
+    )
     import voluptuous_serialize  # pylint: disable=import-outside-toplevel
 
     def custom_serializer(schema: Any) -> Any:
@@ -909,7 +913,7 @@ async def websocket_get_configuration(hass, connection, msg):
                 CONF_OPTIONS_SCHEMA, custom_serializer=custom_serializer
             )
         },
-        "data": {"zha_options": {}},
+        "data": custom_configuration,
     }
     connection.send_result(msg[ID], data)
 

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -904,11 +904,11 @@ async def websocket_get_configuration(hass, connection, msg):
 
     data = {
         "schemas": {
-            "options": voluptuous_serialize.convert(
+            "zha_options": voluptuous_serialize.convert(
                 CONF_OPTIONS_SCHEMA, custom_serializer=custom_serializer
             )
         },
-        "data": {"options": {}},
+        "data": {"zha_options": {}},
     }
     connection.send_result(msg[ID], data)
 
@@ -921,16 +921,20 @@ async def websocket_get_configuration(hass, connection, msg):
 async def websocket_update_zha_configuration(hass, connection, msg):
     """Update the ZHA configuration."""
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
-    old_config_entry_data = zha_gateway.config_entry.data
-    data_to_save = msg["data"]
+    options = zha_gateway.config_entry.options
+    data_to_save = {**options, **{"custom_configuration": msg["data"]}}
 
     _LOGGER.info(
-        "Updating ZHA configuration from %s to %s", old_config_entry_data, data_to_save
+        "Updating ZHA custom configuration options from %s to %s",
+        options,
+        data_to_save,
     )
 
-    # hass.config_entries.async_update_entry(zha_gateway.config_entry, data=data_to_save)
-    # status = await hass.config_entries.async_reload(zha_gateway.config_entry.entry_id)
-    # connection.send_result(msg[ID], status)
+    hass.config_entries.async_update_entry(
+        zha_gateway.config_entry, options=data_to_save
+    )
+    status = await hass.config_entries.async_reload(zha_gateway.config_entry.entry_id)
+    connection.send_result(msg[ID], status)
 
 
 @callback

--- a/homeassistant/components/zha/api.py
+++ b/homeassistant/components/zha/api.py
@@ -42,6 +42,7 @@ from .core.const import (
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
     CONF_OPTIONS_SCHEMA,
+    CUSTOM_CONFIGURATION,
     DATA_ZHA,
     DATA_ZHA_GATEWAY,
     DOMAIN,
@@ -922,7 +923,7 @@ async def websocket_update_zha_configuration(hass, connection, msg):
     """Update the ZHA configuration."""
     zha_gateway = hass.data[DATA_ZHA][DATA_ZHA_GATEWAY]
     options = zha_gateway.config_entry.options
-    data_to_save = {**options, **{"custom_configuration": msg["data"]}}
+    data_to_save = {**options, **{CUSTOM_CONFIGURATION: msg["data"]}}
 
     _LOGGER.info(
         "Updating ZHA custom configuration options from %s to %s",

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -129,10 +129,10 @@ CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
 CONF_ZIGPY = "zigpy_config"
 
-CONF_OPTIONS_SCHEMA = vol.Schema(
+CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
-        vol.Optional(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
+        vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
     }
 )
 
@@ -190,6 +190,7 @@ PRESET_SCHEDULE = "schedule"
 PRESET_COMPLEX = "complex"
 
 ZHA_OPTIONS = "zha_options"
+ZHA_CONFIG_SCHEMAS = {ZHA_OPTIONS: CONF_ZHA_OPTIONS_SCHEMA}
 
 
 class RadioType(enum.Enum):

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -132,7 +132,7 @@ CONF_ZIGPY = "zigpy_config"
 CONF_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
-        vol.Optional(CONF_ENABLE_IDENTIFY_ON_JOIN): cv.boolean,
+        vol.Optional(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
     }
 )
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -146,6 +146,7 @@ DATA_ZHA_CORE_EVENTS = "zha_core_events"
 DATA_ZHA_DISPATCHERS = "zha_dispatchers"
 DATA_ZHA_GATEWAY = "zha_gateway"
 DATA_ZHA_PLATFORM_LOADED = "platform_loaded"
+DATA_ZHA_SHUTDOWN_TASK = "zha_shutdown_task"
 
 DEBUG_COMP_BELLOWS = "bellows"
 DEBUG_COMP_ZHA = "homeassistant.components.zha"

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -136,6 +136,8 @@ CONF_OPTIONS_SCHEMA = vol.Schema(
     }
 )
 
+CUSTOM_CONFIGURATION = "custom_configuration"
+
 DATA_DEVICE_CONFIG = "zha_device_config"
 DATA_ZHA = "zha"
 DATA_ZHA_CONFIG = "config"
@@ -186,6 +188,8 @@ POWER_BATTERY_OR_UNKNOWN = "Battery or Unknown"
 
 PRESET_SCHEDULE = "schedule"
 PRESET_COMPLEX = "complex"
+
+ZHA_OPTIONS = "zha_options"
 
 
 class RadioType(enum.Enum):

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -5,6 +5,7 @@ import enum
 import logging
 
 import bellows.zigbee.application
+import voluptuous as vol
 from zigpy.config import CONF_DEVICE_PATH  # noqa: F401 # pylint: disable=unused-import
 import zigpy_cc.zigbee.application
 import zigpy_deconz.zigbee.application
@@ -22,6 +23,7 @@ from homeassistant.components.lock import DOMAIN as LOCK
 from homeassistant.components.number import DOMAIN as NUMBER
 from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.switch import DOMAIN as SWITCH
+import homeassistant.helpers.config_validation as cv
 
 from .typing import CALLABLE_T
 
@@ -118,12 +120,21 @@ PLATFORMS = (
 
 CONF_BAUDRATE = "baudrate"
 CONF_DATABASE = "database_path"
+CONF_DEFAULT_LIGHT_TRANSITION = "default_light_transition"
 CONF_DEVICE_CONFIG = "device_config"
+CONF_ENABLE_IDENTIFY_ON_JOIN = "enable_identify_on_join"
 CONF_ENABLE_QUIRKS = "enable_quirks"
 CONF_FLOWCONTROL = "flow_control"
 CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
 CONF_ZIGPY = "zigpy_config"
+
+CONF_OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
+        vol.Optional(CONF_ENABLE_IDENTIFY_ON_JOIN): cv.boolean,
+    }
+)
 
 DATA_DEVICE_CONFIG = "zha_device_config"
 DATA_ZHA = "zha"

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -56,6 +56,7 @@ from .const import (
     CLUSTER_COMMANDS_SERVER,
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
+    CONF_ENABLE_IDENTIFY_ON_JOIN,
     EFFECT_DEFAULT_VARIANT,
     EFFECT_OKAY,
     POWER_BATTERY_OR_UNKNOWN,
@@ -66,7 +67,7 @@ from .const import (
     UNKNOWN_MANUFACTURER,
     UNKNOWN_MODEL,
 )
-from .helpers import LogMixin
+from .helpers import LogMixin, async_get_zha_config_value
 
 _LOGGER = logging.getLogger(__name__)
 CONSIDER_UNAVAILABLE_MAINS = 60 * 60 * 2  # 2 hours
@@ -395,13 +396,20 @@ class ZHADevice(LogMixin):
 
     async def async_configure(self):
         """Configure the device."""
+        should_identify = async_get_zha_config_value(
+            self._zha_gateway.config_entry, CONF_ENABLE_IDENTIFY_ON_JOIN, True
+        )
         self.debug("started configuration")
         await self._channels.async_configure()
         self.debug("completed configuration")
         entry = self.gateway.zha_storage.async_create_or_update_device(self)
         self.debug("stored in registry: %s", entry)
 
-        if self._channels.identify_ch is not None and not self.skip_configuration:
+        if (
+            should_identify
+            and self._channels.identify_ch is not None
+            and not self.skip_configuration
+        ):
             await self._channels.identify_ch.trigger_effect(
                 EFFECT_OKAY, EFFECT_DEFAULT_VARIANT
             )

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -127,7 +127,7 @@ class ZHAGateway:
         }
         self.debug_enabled = False
         self._log_relay_handler = LogRelayHandler(hass, self)
-        self._config_entry = config_entry
+        self.config_entry = config_entry
         self._unsubs = []
 
     async def async_initialize(self):
@@ -139,7 +139,7 @@ class ZHAGateway:
         self.ha_device_registry = await get_dev_reg(self._hass)
         self.ha_entity_registry = await get_ent_reg(self._hass)
 
-        radio_type = self._config_entry.data[CONF_RADIO_TYPE]
+        radio_type = self.config_entry.data[CONF_RADIO_TYPE]
 
         app_controller_cls = RadioType[radio_type].controller
         self.radio_description = RadioType[radio_type].description
@@ -150,7 +150,7 @@ class ZHAGateway:
             os.path.join(self._hass.config.config_dir, DEFAULT_DATABASE_NAME),
         )
         app_config[CONF_DATABASE] = database
-        app_config[CONF_DEVICE] = self._config_entry.data[CONF_DEVICE]
+        app_config[CONF_DEVICE] = self.config_entry.data[CONF_DEVICE]
 
         app_config = app_controller_cls.SCHEMA(app_config)
         try:
@@ -506,7 +506,7 @@ class ZHAGateway:
             zha_device = ZHADevice.new(self._hass, zigpy_device, self, restored)
             self._devices[zigpy_device.ieee] = zha_device
             device_registry_device = self.ha_device_registry.async_get_or_create(
-                config_entry_id=self._config_entry.entry_id,
+                config_entry_id=self.config_entry.entry_id,
                 connections={(CONNECTION_ZIGBEE, str(zha_device.ieee))},
                 identifiers={(DOMAIN, str(zha_device.ieee))},
                 name=zha_device.name,

--- a/homeassistant/components/zha/core/helpers.py
+++ b/homeassistant/components/zha/core/helpers.py
@@ -24,7 +24,14 @@ import zigpy.zdo.types as zdo_types
 
 from homeassistant.core import State, callback
 
-from .const import CLUSTER_TYPE_IN, CLUSTER_TYPE_OUT, DATA_ZHA, DATA_ZHA_GATEWAY
+from .const import (
+    CLUSTER_TYPE_IN,
+    CLUSTER_TYPE_OUT,
+    CUSTOM_CONFIGURATION,
+    DATA_ZHA,
+    DATA_ZHA_GATEWAY,
+    ZHA_OPTIONS,
+)
 from .registries import BINDABLE_CLUSTERS
 from .typing import ZhaDeviceType, ZigpyClusterType
 
@@ -120,6 +127,16 @@ def async_is_bindable_target(source_zha_device, target_zha_device):
             if any(bindable in BINDABLE_CLUSTERS for bindable in matches):
                 return True
     return False
+
+
+@callback
+def async_get_zha_config_value(config_entry, config_key, default):
+    """Get the value for the specified configuration from the zha config entry."""
+    return (
+        config_entry.options.get(CUSTOM_CONFIGURATION, {})
+        .get(ZHA_OPTIONS, {})
+        .get(config_key, default)
+    )
 
 
 async def async_get_zha_device(hass, device_id):

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -47,6 +47,7 @@ from .core.const import (
     CHANNEL_COLOR,
     CHANNEL_LEVEL,
     CHANNEL_ON_OFF,
+    CONF_DEFAULT_LIGHT_TRANSITION,
     DATA_ZHA,
     DATA_ZHA_DISPATCHERS,
     EFFECT_BLINK,
@@ -56,7 +57,7 @@ from .core.const import (
     SIGNAL_ATTR_UPDATED,
     SIGNAL_SET_LEVEL,
 )
-from .core.helpers import LogMixin
+from .core.helpers import LogMixin, async_get_zha_config_value
 from .core.registries import ZHA_ENTITIES
 from .core.typing import ZhaDeviceType
 from .entity import ZhaEntity, ZhaGroupEntity
@@ -139,6 +140,7 @@ class BaseLight(LogMixin, light.LightEntity):
         self._level_channel = None
         self._color_channel = None
         self._identify_channel = None
+        self._default_transition = None
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -207,7 +209,13 @@ class BaseLight(LogMixin, light.LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn the entity on."""
         transition = kwargs.get(light.ATTR_TRANSITION)
-        duration = transition * 10 if transition else DEFAULT_TRANSITION
+        duration = (
+            transition * 10
+            if transition
+            else self._default_transition * 10
+            if self._default_transition
+            else DEFAULT_TRANSITION
+        )
         brightness = kwargs.get(light.ATTR_BRIGHTNESS)
         effect = kwargs.get(light.ATTR_EFFECT)
         flash = kwargs.get(light.ATTR_FLASH)
@@ -389,6 +397,10 @@ class Light(BaseLight, ZhaEntity):
         if effect_list:
             self._effect_list = effect_list
 
+        self._default_transition = async_get_zha_config_value(
+            zha_device.gateway.config_entry, CONF_DEFAULT_LIGHT_TRANSITION, 0
+        )
+
     @callback
     def async_set_state(self, attr_id, attr_name, value):
         """Set the state."""
@@ -544,6 +556,9 @@ class LightGroup(BaseLight, ZhaGroupEntity):
         self._color_channel = group.endpoint[Color.cluster_id]
         self._identify_channel = group.endpoint[Identify.cluster_id]
         self._debounced_member_refresh = None
+        self._default_transition = async_get_zha_config_value(
+            zha_device.gateway.config_entry, CONF_DEFAULT_LIGHT_TRANSITION, 0
+        )
 
     async def async_added_to_hass(self):
         """Run when about to be added to hass."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds websocket APIs that allow users to retrieve and update configurations for ZHA. Initial support is added for setting a default transition time and for enabling / disabling the identity effect when devices are paired. Eventually this will be used for advanced network configuration as well. 

![image](https://user-images.githubusercontent.com/1335687/112736888-80f7f980-8f2c-11eb-9333-6dc28e2b296c.png)

can be a work around to disable the effect in https://github.com/home-assistant/core/issues/48124

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
