### PR TITLE
Handle routers that convert hostnames to lowercase in dhcp

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -126,7 +126,11 @@ class WatcherBase:
                 self.hass.config_entries.flow.async_init(
                     entry["domain"],
                     context={"source": DOMAIN},
-                    data={IP_ADDRESS: ip_address, **data},
+                    data={
+                        IP_ADDRESS: ip_address,
+                        HOSTNAME: lowercase_hostname,
+                        MAC_ADDRESS: data[MAC_ADDRESS],
+                    },
                 )
             )
 

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -80,7 +80,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if self._async_host_already_configured(dhcp_discovery[IP_ADDRESS]):
             return self.async_abort(reason="already_configured")
 
-        if not dhcp_discovery[HOSTNAME].startswith(("iRobot-", "Roomba-")):
+        if not dhcp_discovery[HOSTNAME].startswith(("irobot-", "roomba-")):
             return self.async_abort(reason="not_irobot_device")
 
         blid = _async_blid_from_hostname(dhcp_discovery[HOSTNAME])

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -376,7 +376,7 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
         "device_tracker.august_connect",
         STATE_HOME,
         {
-            ATTR_HOST_NAME: "connect",
+            ATTR_HOST_NAME: "Connect",
             ATTR_IP: "192.168.210.56",
             ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER,
             ATTR_MAC: "B8:B7:F1:6D:B5:33",
@@ -423,7 +423,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start(hass):
             "device_tracker.august_connect",
             STATE_HOME,
             {
-                ATTR_HOST_NAME: "connect",
+                ATTR_HOST_NAME: "Connect",
                 ATTR_IP: "192.168.210.56",
                 ATTR_SOURCE_TYPE: SOURCE_TYPE_ROUTER,
                 ATTR_MAC: "B8:B7:F1:6D:B5:33",

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -19,12 +19,12 @@ DHCP_DISCOVERY_DEVICES = [
     {
         IP_ADDRESS: MOCK_IP,
         MAC_ADDRESS: "50:14:79:DD:EE:FF",
-        HOSTNAME: "iRobot-blid",
+        HOSTNAME: "irobot-blid",
     },
     {
         IP_ADDRESS: MOCK_IP,
         MAC_ADDRESS: "80:A5:89:DD:EE:FF",
-        HOSTNAME: "Roomba-blid",
+        HOSTNAME: "roomba-blid",
     },
 ]
 
@@ -33,12 +33,12 @@ DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP = [
     {
         IP_ADDRESS: "1.1.1.1",
         MAC_ADDRESS: "50:14:79:DD:EE:FF",
-        HOSTNAME: "iRobot-blid",
+        HOSTNAME: "irobot-blid",
     },
     {
         IP_ADDRESS: "1.1.1.1",
         MAC_ADDRESS: "80:A5:89:DD:EE:FF",
-        HOSTNAME: "Roomba-blid",
+        HOSTNAME: "roomba-blid",
     },
 ]
 
@@ -58,7 +58,7 @@ def _mocked_discovery(*_):
     roomba_discovery = MagicMock()
 
     roomba = RoombaInfo(
-        hostname="iRobot-blid",
+        hostname="irobot-blid",
         robot_name="robot_name",
         ip=MOCK_IP,
         mac="mac",
@@ -751,7 +751,7 @@ async def test_dhcp_discovery_with_ignored(hass):
             data={
                 IP_ADDRESS: "1.1.1.1",
                 MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
-                HOSTNAME: "iRobot-blid",
+                HOSTNAME: "irobot-blid",
             },
         )
         await hass.async_block_till_done()
@@ -775,7 +775,7 @@ async def test_dhcp_discovery_already_configured_host(hass):
             data={
                 IP_ADDRESS: "1.1.1.1",
                 MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
-                HOSTNAME: "iRobot-blid",
+                HOSTNAME: "irobot-blid",
             },
         )
         await hass.async_block_till_done()
@@ -802,7 +802,7 @@ async def test_dhcp_discovery_already_configured_blid(hass):
             data={
                 IP_ADDRESS: "1.1.1.1",
                 MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
-                HOSTNAME: "iRobot-blid",
+                HOSTNAME: "irobot-blid",
             },
         )
         await hass.async_block_till_done()
@@ -829,7 +829,7 @@ async def test_dhcp_discovery_not_irobot(hass):
             data={
                 IP_ADDRESS: "1.1.1.1",
                 MAC_ADDRESS: "AA:BB:CC:DD:EE:FF",
-                HOSTNAME: "NotiRobot-blid",
+                HOSTNAME: "Notirobot-blid",
             },
         )
         await hass.async_block_till_done()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some routers will lowercase all the hostnames. Since we
already lowercase hostnames for matching purposes, we now
pass the lowercased hostname to the integration.

Currently only roomba cared about this, and has been adjusted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
