### PR TITLE
Add additional data source to dhcp

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -169,7 +169,7 @@ class NetworkWatcher(WatcherBase):
         if self._unsub:
             self._unsub()
             self._unsub = None
-        if self._discover_task and not self._discover_task.done():
+        if self._discover_task:
             self._discover_task.cancel()
             self._discover_task = None
 
@@ -191,14 +191,11 @@ class NetworkWatcher(WatcherBase):
     async def async_discover(self):
         """Process discovery."""
         for host in await self._discover_hosts.async_discover():
-            ip_address = host[DISCOVERY_IP_ADDRESS]
-            hostname = host[DISCOVERY_HOSTNAME]
-            mac_address = host[DISCOVERY_MAC_ADDRESS]
-
-            if ip_address is None or hostname is None or mac_address is None:
-                continue
-
-            self.process_client(ip_address, hostname, _format_mac(mac_address))
+            self.process_client(
+                host[DISCOVERY_IP_ADDRESS],
+                host[DISCOVERY_HOSTNAME],
+                _format_mac(host[DISCOVERY_MAC_ADDRESS]),
+            )
 
     def create_task(self, task):
         """Pass a task to async_create_task since we are in async context."""

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -99,7 +99,11 @@ class WatcherBase:
 
         data = self._address_data.get(ip_address)
 
-        if data and data[MAC_ADDRESS] == mac_address and data[HOSTNAME] == hostname:
+        if (
+            data
+            and data[MAC_ADDRESS] == mac_address
+            and data[HOSTNAME].startswith(hostname)
+        ):
             # If the address data is the same no need
             # to process it
             return
@@ -198,7 +202,7 @@ class NetworkWatcher(WatcherBase):
 
     def create_task(self, task):
         """Pass a task to async_create_task since we are in async context."""
-        self.hass.async_create_task(task)
+        return self.hass.async_create_task(task)
 
 
 class DeviceTrackerWatcher(WatcherBase):
@@ -250,7 +254,7 @@ class DeviceTrackerWatcher(WatcherBase):
 
     def create_task(self, task):
         """Pass a task to async_create_task since we are in async context."""
-        self.hass.async_create_task(task)
+        return self.hass.async_create_task(task)
 
 
 class DHCPWatcher(WatcherBase):
@@ -328,7 +332,7 @@ class DHCPWatcher(WatcherBase):
 
     def create_task(self, task):
         """Pass a task to hass.add_job since we are in a thread."""
-        self.hass.add_job(task)
+        return self.hass.add_job(task)
 
 
 def _decode_dhcp_option(dhcp_options, key):

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -182,7 +182,7 @@ class NetworkWatcher(WatcherBase):
         self.async_start_discover()
 
     @callback
-    def async_start_discover(self):
+    def async_start_discover(self, *_):
         """Start a new discovery task if one is not running."""
         if self._discover_task and not self._discover_task.done():
             return

--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -1,12 +1,19 @@
 """The dhcp integration."""
 
 from abc import abstractmethod
+from datetime import timedelta
 import fnmatch
 from ipaddress import ip_address as make_ip_address
 import logging
 import os
 import threading
 
+from aiodiscover import DiscoverHosts
+from aiodiscover.discovery import (
+    HOSTNAME as DISCOVERY_HOSTNAME,
+    IP_ADDRESS as DISCOVERY_IP_ADDRESS,
+    MAC_ADDRESS as DISCOVERY_MAC_ADDRESS,
+)
 from scapy.arch.common import compile_filter
 from scapy.config import conf
 from scapy.error import Scapy_Exception
@@ -29,7 +36,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers.device_registry import format_mac
-from homeassistant.helpers.event import async_track_state_added_domain
+from homeassistant.helpers.event import (
+    async_track_state_added_domain,
+    async_track_time_interval,
+)
 from homeassistant.loader import async_get_dhcp
 from homeassistant.util.network import is_link_local
 
@@ -42,6 +52,7 @@ HOSTNAME = "hostname"
 MAC_ADDRESS = "macaddress"
 IP_ADDRESS = "ip"
 DHCP_REQUEST = 3
+SCAN_INTERVAL = timedelta(minutes=60)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -54,7 +65,7 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         integration_matchers = await async_get_dhcp(hass)
         watchers = []
 
-        for cls in (DHCPWatcher, DeviceTrackerWatcher):
+        for cls in (DHCPWatcher, DeviceTrackerWatcher, NetworkWatcher):
             watcher = cls(hass, address_data, integration_matchers)
             await watcher.async_start()
             watchers.append(watcher)
@@ -137,6 +148,57 @@ class WatcherBase:
     @abstractmethod
     def create_task(self, task):
         """Pass a task to async_add_task based on which context we are in."""
+
+
+class NetworkWatcher(WatcherBase):
+    """Class to query ptr records routers."""
+
+    def __init__(self, hass, address_data, integration_matchers):
+        """Initialize class."""
+        super().__init__(hass, address_data, integration_matchers)
+        self._unsub = None
+        self._discover_hosts = None
+        self._discover_task = None
+
+    async def async_stop(self):
+        """Stop scanning for new devices on the network."""
+        if self._unsub:
+            self._unsub()
+            self._unsub = None
+        if self._discover_task and not self._discover_task.done():
+            self._discover_task.cancel()
+            self._discover_task = None
+
+    async def async_start(self):
+        """Start scanning for new devices on the network."""
+        self._discover_hosts = DiscoverHosts()
+        self._unsub = async_track_time_interval(
+            self.hass, self.async_start_discover, SCAN_INTERVAL
+        )
+        self.async_start_discover()
+
+    @callback
+    def async_start_discover(self):
+        """Start a new discovery task if one is not running."""
+        if self._discover_task and not self._discover_task.done():
+            return
+        self._discover_task = self.create_task(self.async_discover())
+
+    async def async_discover(self):
+        """Process discovery."""
+        for host in await self._discover_hosts.async_discover():
+            ip_address = host[DISCOVERY_IP_ADDRESS]
+            hostname = host[DISCOVERY_HOSTNAME]
+            mac_address = host[DISCOVERY_MAC_ADDRESS]
+
+            if ip_address is None or hostname is None or mac_address is None:
+                continue
+
+            self.process_client(ip_address, hostname, _format_mac(mac_address))
+
+    def create_task(self, task):
+        """Pass a task to async_create_task since we are in async context."""
+        self.hass.async_create_task(task)
 
 
 class DeviceTrackerWatcher(WatcherBase):

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -3,7 +3,7 @@
   "name": "DHCP Discovery",
   "documentation": "https://www.home-assistant.io/integrations/dhcp",
   "requirements": [
-    "scapy==2.4.4", "aiodiscovery==1.0.1"
+    "scapy==2.4.4", "aiodiscover==1.0.1"
   ],
   "codeowners": [
     "@bdraco"

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -3,7 +3,7 @@
   "name": "DHCP Discovery",
   "documentation": "https://www.home-assistant.io/integrations/dhcp",
   "requirements": [
-    "scapy==2.4.4", "aiodiscover==1.0.1"
+    "scapy==2.4.4", "aiodiscover==1.1.0"
   ],
   "codeowners": [
     "@bdraco"

--- a/homeassistant/components/dhcp/manifest.json
+++ b/homeassistant/components/dhcp/manifest.json
@@ -3,7 +3,7 @@
   "name": "DHCP Discovery",
   "documentation": "https://www.home-assistant.io/integrations/dhcp",
   "requirements": [
-    "scapy==2.4.4"
+    "scapy==2.4.4", "aiodiscovery==1.0.1"
   ],
   "codeowners": [
     "@bdraco"

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
-aiodiscover==1.0.1
+aiodiscover==1.1.0
 aiohttp==3.7.4.post0
 aiohttp_cors==0.7.0
 astral==1.10.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,6 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
-aiodiscovery==1.0.1
+aiodiscover==1.0.1
 aiohttp==3.7.4.post0
 aiohttp_cors==0.7.0
 astral==1.10.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -1,5 +1,6 @@
 PyJWT==1.7.1
 PyNaCl==1.3.0
+aiodiscovery==1.0.1
 aiohttp==3.7.4.post0
 aiohttp_cors==0.7.0
 astral==1.10.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -146,6 +146,9 @@ aioazuredevops==1.3.5
 # homeassistant.components.aws
 aiobotocore==0.11.1
 
+# homeassistant.components.dhcp
+aiodiscovery==1.0.1
+
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server
 aiodns==2.0.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -147,7 +147,7 @@ aioazuredevops==1.3.5
 aiobotocore==0.11.1
 
 # homeassistant.components.dhcp
-aiodiscovery==1.0.1
+aiodiscover==1.0.1
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -147,7 +147,7 @@ aioazuredevops==1.3.5
 aiobotocore==0.11.1
 
 # homeassistant.components.dhcp
-aiodiscover==1.0.1
+aiodiscover==1.1.0
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -84,7 +84,7 @@ aioazuredevops==1.3.5
 aiobotocore==0.11.1
 
 # homeassistant.components.dhcp
-aiodiscovery==1.0.1
+aiodiscover==1.0.1
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -83,6 +83,9 @@ aioazuredevops==1.3.5
 # homeassistant.components.aws
 aiobotocore==0.11.1
 
+# homeassistant.components.dhcp
+aiodiscovery==1.0.1
+
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server
 aiodns==2.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -84,7 +84,7 @@ aioazuredevops==1.3.5
 aiobotocore==0.11.1
 
 # homeassistant.components.dhcp
-aiodiscover==1.0.1
+aiodiscover==1.1.0
 
 # homeassistant.components.dnsip
 # homeassistant.components.minecraft_server

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed, mock_coro
+from tests.common import async_fire_time_changed
 
 # connect b8:b7:f1:6d:b5:33 192.168.210.56
 RAW_DHCP_REQUEST = (
@@ -61,9 +61,7 @@ async def test_dhcp_match_hostname_and_macaddress(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
         # Ensure no change is ignored
         dhcp_watcher.handle_dhcp_packet(packet)
@@ -86,9 +84,7 @@ async def test_dhcp_match_hostname(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
@@ -109,9 +105,7 @@ async def test_dhcp_match_macaddress(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 1
@@ -132,9 +126,7 @@ async def test_dhcp_nomatch(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -148,9 +140,7 @@ async def test_dhcp_nomatch_hostname(hass):
 
     packet = Ether(RAW_DHCP_REQUEST)
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -164,9 +154,7 @@ async def test_dhcp_nomatch_non_dhcp_packet(hass):
 
     packet = Ether(b"")
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -189,9 +177,7 @@ async def test_dhcp_nomatch_non_dhcp_request_packet(hass):
         ("hostname", b"connect"),
     ]
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -214,9 +200,7 @@ async def test_dhcp_invalid_hostname(hass):
         ("hostname", "connect"),
     ]
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -239,9 +223,7 @@ async def test_dhcp_missing_hostname(hass):
         ("hostname", None),
     ]
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -264,9 +246,7 @@ async def test_dhcp_invalid_option(hass):
         ("hostname"),
     ]
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         dhcp_watcher.handle_dhcp_packet(packet)
 
     assert len(mock_init.mock_calls) == 0
@@ -387,9 +367,7 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
         },
     )
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerWatcher(
             hass,
             {},
@@ -413,9 +391,7 @@ async def test_device_tracker_hostname_and_macaddress_exists_before_start(hass):
 async def test_device_tracker_hostname_and_macaddress_after_start(hass):
     """Test matching based on hostname and macaddress after start."""
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerWatcher(
             hass,
             {},
@@ -450,9 +426,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start(hass):
 async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass):
     """Test matching based on hostname and macaddress after start but not home."""
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerWatcher(
             hass,
             {},
@@ -480,9 +454,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_not_home(hass)
 async def test_device_tracker_hostname_and_macaddress_after_start_not_router(hass):
     """Test matching based on hostname and macaddress after start but not router."""
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerWatcher(
             hass,
             {},
@@ -512,9 +484,7 @@ async def test_device_tracker_hostname_and_macaddress_after_start_hostname_missi
 ):
     """Test matching based on hostname and macaddress after start but missing hostname."""
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerWatcher(
             hass,
             {},
@@ -551,9 +521,7 @@ async def test_device_tracker_ignore_self_assigned_ips_before_start(hass):
         },
     )
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init:
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init:
         device_tracker_watcher = dhcp.DeviceTrackerWatcher(
             hass,
             {},
@@ -569,9 +537,7 @@ async def test_device_tracker_ignore_self_assigned_ips_before_start(hass):
 
 async def test_aiodiscover_finds_new_hosts(hass):
     """Test aiodiscover finds new host."""
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init, patch(
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover",
         return_value=[
             {
@@ -608,9 +574,7 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
     additional discovery where the hostname is longer and then
     reject shorter ones.
     """
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init, patch(
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover",
         return_value=[
             {
@@ -665,9 +629,7 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
 
 async def test_aiodiscover_finds_new_hosts_after_interval(hass):
     """Test aiodiscover finds new host after interval."""
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init, patch(
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover",
         return_value=[],
     ):
@@ -681,9 +643,7 @@ async def test_aiodiscover_finds_new_hosts_after_interval(hass):
 
     assert len(mock_init.mock_calls) == 0
 
-    with patch.object(
-        hass.config_entries.flow, "async_init", return_value=mock_coro()
-    ) as mock_init, patch(
+    with patch.object(hass.config_entries.flow, "async_init") as mock_init, patch(
         "homeassistant.components.dhcp.DiscoverHosts.async_discover",
         return_value=[
             {

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -1,4 +1,5 @@
 """Test the DHCP discovery integration."""
+import datetime
 import threading
 from unittest.mock import patch
 
@@ -21,8 +22,9 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
-from tests.common import mock_coro
+from tests.common import async_fire_time_changed, mock_coro
 
 # connect b8:b7:f1:6d:b5:33 192.168.210.56
 RAW_DHCP_REQUEST = (
@@ -657,5 +659,50 @@ async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
     assert mock_init.mock_calls[1][2]["data"] == {
         dhcp.IP_ADDRESS: "192.168.210.56",
         dhcp.HOSTNAME: "irobot-abcdef",
+        dhcp.MAC_ADDRESS: "b8b7f16db533",
+    }
+
+
+async def test_aiodiscover_finds_new_hosts_after_interval(hass):
+    """Test aiodiscover finds new host after interval."""
+    with patch.object(
+        hass.config_entries.flow, "async_init", return_value=mock_coro()
+    ) as mock_init, patch(
+        "homeassistant.components.dhcp.DiscoverHosts.async_discover",
+        return_value=[],
+    ):
+        device_tracker_watcher = dhcp.NetworkWatcher(
+            hass,
+            {},
+            [{"domain": "mock-domain", "hostname": "connect", "macaddress": "B8B7F1*"}],
+        )
+        await device_tracker_watcher.async_start()
+        await hass.async_block_till_done()
+
+    assert len(mock_init.mock_calls) == 0
+
+    with patch.object(
+        hass.config_entries.flow, "async_init", return_value=mock_coro()
+    ) as mock_init, patch(
+        "homeassistant.components.dhcp.DiscoverHosts.async_discover",
+        return_value=[
+            {
+                dhcp.DISCOVERY_IP_ADDRESS: "192.168.210.56",
+                dhcp.DISCOVERY_HOSTNAME: "connect",
+                dhcp.DISCOVERY_MAC_ADDRESS: "b8b7f16db533",
+            }
+        ],
+    ):
+        async_fire_time_changed(hass, dt_util.utcnow() + datetime.timedelta(minutes=65))
+        await hass.async_block_till_done()
+        await device_tracker_watcher.async_stop()
+        await hass.async_block_till_done()
+
+    assert len(mock_init.mock_calls) == 1
+    assert mock_init.mock_calls[0][1][0] == "mock-domain"
+    assert mock_init.mock_calls[0][2]["context"] == {"source": "dhcp"}
+    assert mock_init.mock_calls[0][2]["data"] == {
+        dhcp.IP_ADDRESS: "192.168.210.56",
+        dhcp.HOSTNAME: "connect",
         dhcp.MAC_ADDRESS: "b8b7f16db533",
     }

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -597,3 +597,65 @@ async def test_aiodiscover_finds_new_hosts(hass):
         dhcp.HOSTNAME: "connect",
         dhcp.MAC_ADDRESS: "b8b7f16db533",
     }
+
+
+async def test_aiodiscover_does_not_call_again_on_shorter_hostname(hass):
+    """Verify longer hostnames generate a new flow but shorter ones do not.
+
+    Some routers will truncate hostnames so we want to accept
+    additional discovery where the hostname is longer and then
+    reject shorter ones.
+    """
+    with patch.object(
+        hass.config_entries.flow, "async_init", return_value=mock_coro()
+    ) as mock_init, patch(
+        "homeassistant.components.dhcp.DiscoverHosts.async_discover",
+        return_value=[
+            {
+                dhcp.DISCOVERY_IP_ADDRESS: "192.168.210.56",
+                dhcp.DISCOVERY_HOSTNAME: "irobot-abc",
+                dhcp.DISCOVERY_MAC_ADDRESS: "b8b7f16db533",
+            },
+            {
+                dhcp.DISCOVERY_IP_ADDRESS: "192.168.210.56",
+                dhcp.DISCOVERY_HOSTNAME: "irobot-abcdef",
+                dhcp.DISCOVERY_MAC_ADDRESS: "b8b7f16db533",
+            },
+            {
+                dhcp.DISCOVERY_IP_ADDRESS: "192.168.210.56",
+                dhcp.DISCOVERY_HOSTNAME: "irobot-abc",
+                dhcp.DISCOVERY_MAC_ADDRESS: "b8b7f16db533",
+            },
+        ],
+    ):
+        device_tracker_watcher = dhcp.NetworkWatcher(
+            hass,
+            {},
+            [
+                {
+                    "domain": "mock-domain",
+                    "hostname": "irobot-*",
+                    "macaddress": "B8B7F1*",
+                }
+            ],
+        )
+        await device_tracker_watcher.async_start()
+        await hass.async_block_till_done()
+        await device_tracker_watcher.async_stop()
+        await hass.async_block_till_done()
+
+    assert len(mock_init.mock_calls) == 2
+    assert mock_init.mock_calls[0][1][0] == "mock-domain"
+    assert mock_init.mock_calls[0][2]["context"] == {"source": "dhcp"}
+    assert mock_init.mock_calls[0][2]["data"] == {
+        dhcp.IP_ADDRESS: "192.168.210.56",
+        dhcp.HOSTNAME: "irobot-abc",
+        dhcp.MAC_ADDRESS: "b8b7f16db533",
+    }
+    assert mock_init.mock_calls[1][1][0] == "mock-domain"
+    assert mock_init.mock_calls[1][2]["context"] == {"source": "dhcp"}
+    assert mock_init.mock_calls[1][2]["data"] == {
+        dhcp.IP_ADDRESS: "192.168.210.56",
+        dhcp.HOSTNAME: "irobot-abcdef",
+        dhcp.MAC_ADDRESS: "b8b7f16db533",
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since many routers provide `PTR` entries for devices on the local network, we have
enough data to find the `hostname`, `mac`, and `ip` to populate `dhcp` discovery
data quickly without having to wait. This provides another avenue to get the data
which can allow the devices to be available at onboarding for networks that
provide `PTR` entries. Additionally this helps close the gap for users who
cannot use `scapy` due to the root requirement.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
