### PR TITLE
Create homekit locks according to spec

### DIFF
--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -18,7 +18,7 @@
                     "mode": "[%key:common::config_flow::data::mode%]",
                     "entities": "Entities"
                 },
-                "description": "Choose the entities to be included. In accessory mode, only a single entity is included. In bridge include mode, all entities in the domain will be included unless specific entities are selected. In bridge exclude mode, all entities in the domain will be included except for the excluded entities. For best performance, a separate HomeKit accessory will be created for each tv media player and camera.",
+                "description": "Choose the entities to be included. In accessory mode, only a single entity is included. In bridge include mode, all entities in the domain will be included unless specific entities are selected. In bridge exclude mode, all entities in the domain will be included except for the excluded entities. For best performance, a separate HomeKit accessory will be created for each tv media player, activity based remote, lock, and camera.",
                 "title": "Select entities to be included"
             },
             "cameras": {

--- a/homeassistant/components/homekit/translations/en.json
+++ b/homeassistant/components/homekit/translations/en.json
@@ -4,29 +4,13 @@
             "port_name_in_use": "An accessory or bridge with the same name or port is already configured."
         },
         "step": {
-            "accessory_mode": {
-                "data": {
-                    "entity_id": "Entity"
-                },
-                "description": "Choose the entity to be included. In accessory mode, only a single entity is included.",
-                "title": "Select entity to be included"
-            },
-            "bridge_mode": {
-                "data": {
-                    "include_domains": "Domains to include"
-                },
-                "description": "Choose the domains to be included. All supported entities in the domain will be included.",
-                "title": "Select domains to be included"
-            },
             "pairing": {
                 "description": "To complete pairing following the instructions in \u201cNotifications\u201d under \u201cHomeKit Pairing\u201d.",
                 "title": "Pair HomeKit"
             },
             "user": {
                 "data": {
-                    "auto_start": "Autostart (disable if using Z-Wave or other delayed start system)",
-                    "include_domains": "Domains to include",
-                    "mode": "Mode"
+                    "include_domains": "Domains to include"
                 },
                 "description": "Choose the domains to be included. All supported entities in the domain will be included. A separate HomeKit instance in accessory mode will be created for each tv media player and camera.",
                 "title": "Select domains to be included"
@@ -37,8 +21,7 @@
         "step": {
             "advanced": {
                 "data": {
-                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)",
-                    "safe_mode": "Safe Mode (enable only if pairing fails)"
+                    "auto_start": "Autostart (disable if you are calling the homekit.start service manually)"
                 },
                 "description": "These settings only need to be adjusted if HomeKit is not functional.",
                 "title": "Advanced Configuration"
@@ -55,7 +38,7 @@
                     "entities": "Entities",
                     "mode": "Mode"
                 },
-                "description": "Choose the entities to be included. In accessory mode, only a single entity is included. In bridge include mode, all entities in the domain will be included unless specific entities are selected. In bridge exclude mode, all entities in the domain will be included except for the excluded entities. For best performance, a separate HomeKit accessory will be created for each tv media player and camera.",
+                "description": "Choose the entities to be included. In accessory mode, only a single entity is included. In bridge include mode, all entities in the domain will be included unless specific entities are selected. In bridge exclude mode, all entities in the domain will be included except for the excluded entities. For best performance, a separate HomeKit accessory will be created for each tv media player, activity based remote, lock, and camera.",
                 "title": "Select entities to be included"
             },
             "init": {

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -12,6 +12,7 @@ import voluptuous as vol
 
 from homeassistant.components import binary_sensor, media_player, sensor
 from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.media_player import (
     DEVICE_CLASS_TV,
     DOMAIN as MEDIA_PLAYER_DOMAIN,
@@ -502,7 +503,8 @@ def state_needs_accessory_mode(state):
         return True
 
     return (
-        state.domain == MEDIA_PLAYER_DOMAIN
+        state.domain == LOCK_DOMAIN
+        or state.domain == MEDIA_PLAYER_DOMAIN
         and state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TV
         or state.domain == REMOTE_DOMAIN
         and state.attributes.get(ATTR_SUPPORTED_FEATURES) & SUPPORT_ACTIVITY

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -33,6 +33,7 @@ from homeassistant.components.homekit.util import (
     format_sw_version,
     port_is_available,
     show_setup_message,
+    state_needs_accessory_mode,
     temperature_to_homekit,
     temperature_to_states,
     validate_entity_config as vec,
@@ -298,3 +299,9 @@ async def test_accessory_friendly_name():
     assert accessory_friendly_name("hass title", accessory) == "hass title (same)"
     accessory.display_name = "Hass title 123"
     assert accessory_friendly_name("hass title", accessory) == "Hass title 123"
+
+
+async def test_lock_state_needs_accessory_mode(hass):
+    """Test that locks are setup as accessories."""
+    hass.states.async_set("lock.mine", "locked")
+    assert state_needs_accessory_mode(hass.states.get("lock.mine")) is True


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create homekit locks according to spec

The spec states: "Any accessories, regardless of transport, that enable physical access to the home, such as door locks, must not be bridged."


We were bridging them by default which explains why the notifications were unreliable and there was problem with discovery by iOS


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
