### PR TITLE
Add id to automation triggers

### DIFF
--- a/homeassistant/components/arcam_fmj/device_trigger.py
+++ b/homeassistant/components/arcam_fmj/device_trigger.py
@@ -56,6 +56,7 @@ async def async_attach_trigger(
     automation_info: dict,
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     job = HassJob(action)
 
     if config[CONF_TYPE] == "turn_on":
@@ -66,7 +67,13 @@ async def async_attach_trigger(
             if event.data[ATTR_ENTITY_ID] == entity_id:
                 hass.async_run_hass_job(
                     job,
-                    {"trigger": {**config, "description": f"{DOMAIN} - {entity_id}"}},
+                    {
+                        "trigger": {
+                            **config,
+                            "description": f"{DOMAIN} - {entity_id}",
+                            "id": trigger_id,
+                        }
+                    },
                     event.context,
                 )
 

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -419,7 +419,11 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             automation_trace.set_trigger_description(trigger_description)
 
             # Add initial variables as the trigger step
-            trace_element = TraceElement(variables, "trigger")
+            if "trigger" in variables and "id" in variables["trigger"]:
+                trigger_path = f"trigger/{variables['trigger']['id']}"
+            else:
+                trigger_path = "trigger"
+            trace_element = TraceElement(variables, trigger_path)
             trace_append_element(trace_element)
 
             if (

--- a/homeassistant/components/geo_location/trigger.py
+++ b/homeassistant/components/geo_location/trigger.py
@@ -33,6 +33,7 @@ def source_match(state, source):
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     source = config.get(CONF_SOURCE).lower()
     zone_entity_id = config.get(CONF_ZONE)
     trigger_event = config.get(CONF_EVENT)
@@ -74,6 +75,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                         "zone": zone_state,
                         "event": trigger_event,
                         "description": f"geo_location - {source}",
+                        "id": trigger_id,
                     }
                 },
                 event.context,

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -31,10 +31,9 @@ async def async_attach_trigger(
     hass, config, action, automation_info, *, platform_type="event"
 ):
     """Listen for events based on configuration."""
-    trigger_id = None
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     variables = None
     if automation_info:
-        trigger_id = automation_info.get("trigger_id")
         variables = automation_info.get("variables")
 
     template.attach(hass, config[CONF_EVENT_TYPE])

--- a/homeassistant/components/homeassistant/triggers/event.py
+++ b/homeassistant/components/homeassistant/triggers/event.py
@@ -31,8 +31,10 @@ async def async_attach_trigger(
     hass, config, action, automation_info, *, platform_type="event"
 ):
     """Listen for events based on configuration."""
+    trigger_id = None
     variables = None
     if automation_info:
+        trigger_id = automation_info.get("trigger_id")
         variables = automation_info.get("variables")
 
     template.attach(hass, config[CONF_EVENT_TYPE])
@@ -95,6 +97,7 @@ async def async_attach_trigger(
                     "platform": platform_type,
                     "event": event,
                     "description": f"event '{event.event_type}'",
+                    "id": trigger_id,
                 }
             },
             event.context,

--- a/homeassistant/components/homeassistant/triggers/homeassistant.py
+++ b/homeassistant/components/homeassistant/triggers/homeassistant.py
@@ -19,6 +19,7 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for events based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     event = config.get(CONF_EVENT)
     job = HassJob(action)
 
@@ -34,6 +35,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                         "platform": "homeassistant",
                         "event": event,
                         "description": "Home Assistant stopping",
+                        "id": trigger_id,
                     }
                 },
                 event.context,
@@ -51,6 +53,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     "platform": "homeassistant",
                     "event": event,
                     "description": "Home Assistant starting",
+                    "id": trigger_id,
                 }
             },
         )

--- a/homeassistant/components/homeassistant/triggers/numeric_state.py
+++ b/homeassistant/components/homeassistant/triggers/numeric_state.py
@@ -78,6 +78,7 @@ async def async_attach_trigger(
     attribute = config.get(CONF_ATTRIBUTE)
     job = HassJob(action)
 
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     _variables = {}
     if automation_info:
         _variables = automation_info.get("variables") or {}
@@ -139,6 +140,7 @@ async def async_attach_trigger(
                         "to_state": to_s,
                         "for": time_delta if not time_delta else period[entity_id],
                         "description": f"numeric state of {entity_id}",
+                        "id": trigger_id,
                     }
                 },
                 to_s.context,

--- a/homeassistant/components/homeassistant/triggers/state.py
+++ b/homeassistant/components/homeassistant/triggers/state.py
@@ -87,6 +87,7 @@ async def async_attach_trigger(
     attribute = config.get(CONF_ATTRIBUTE)
     job = HassJob(action)
 
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     _variables = {}
     if automation_info:
         _variables = automation_info.get("variables") or {}
@@ -140,6 +141,7 @@ async def async_attach_trigger(
                         "for": time_delta if not time_delta else period[entity],
                         "attribute": attribute,
                         "description": f"state of {entity}",
+                        "id": trigger_id,
                     }
                 },
                 event.context,

--- a/homeassistant/components/homeassistant/triggers/time.py
+++ b/homeassistant/components/homeassistant/triggers/time.py
@@ -39,6 +39,7 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     entities = {}
     removes = []
     job = HassJob(action)
@@ -54,6 +55,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     "now": now,
                     "description": description,
                     "entity_id": entity_id,
+                    "id": trigger_id,
                 }
             },
         )

--- a/homeassistant/components/homeassistant/triggers/time_pattern.py
+++ b/homeassistant/components/homeassistant/triggers/time_pattern.py
@@ -57,6 +57,7 @@ TRIGGER_SCHEMA = vol.All(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     hours = config.get(CONF_HOURS)
     minutes = config.get(CONF_MINUTES)
     seconds = config.get(CONF_SECONDS)
@@ -78,6 +79,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     "platform": "time_pattern",
                     "now": now,
                     "description": "time pattern",
+                    "id": trigger_id,
                 }
             },
         )

--- a/homeassistant/components/homekit_controller/device_trigger.py
+++ b/homeassistant/components/homekit_controller/device_trigger.py
@@ -75,11 +75,14 @@ class TriggerSource:
         automation_info: dict,
     ) -> CALLBACK_TYPE:
         """Attach a trigger."""
+        trigger_id = automation_info.get("trigger_id") if automation_info else None
 
         def event_handler(char):
             if config[CONF_SUBTYPE] != HK_TO_HA_INPUT_EVENT_VALUES[char["value"]]:
                 return
-            self._hass.async_create_task(action({"trigger": config}))
+            self._hass.async_create_task(
+                action({"trigger": {**config, "id": trigger_id}})
+            )
 
         trigger = self._triggers[config[CONF_TYPE], config[CONF_SUBTYPE]]
         iid = trigger["characteristic"]

--- a/homeassistant/components/kodi/device_trigger.py
+++ b/homeassistant/components/kodi/device_trigger.py
@@ -61,8 +61,13 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
 
 @callback
 def _attach_trigger(
-    hass: HomeAssistant, config: ConfigType, action: AutomationActionType, event_type
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    event_type,
+    automation_info: dict,
 ):
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     job = HassJob(action)
 
     @callback
@@ -70,7 +75,7 @@ def _attach_trigger(
         if event.data[ATTR_ENTITY_ID] == config[CONF_ENTITY_ID]:
             hass.async_run_hass_job(
                 job,
-                {"trigger": {**config, "description": event_type}},
+                {"trigger": {**config, "description": event_type, "id": trigger_id}},
                 event.context,
             )
 
@@ -85,9 +90,9 @@ async def async_attach_trigger(
 ) -> CALLBACK_TYPE:
     """Attach a trigger."""
     if config[CONF_TYPE] == "turn_on":
-        return _attach_trigger(hass, config, action, EVENT_TURN_ON)
+        return _attach_trigger(hass, config, action, EVENT_TURN_ON, automation_info)
 
     if config[CONF_TYPE] == "turn_off":
-        return _attach_trigger(hass, config, action, EVENT_TURN_OFF)
+        return _attach_trigger(hass, config, action, EVENT_TURN_OFF, automation_info)
 
     return lambda: None

--- a/homeassistant/components/litejet/trigger.py
+++ b/homeassistant/components/litejet/trigger.py
@@ -31,6 +31,7 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for events based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     number = config.get(CONF_NUMBER)
     held_more_than = config.get(CONF_HELD_MORE_THAN)
     held_less_than = config.get(CONF_HELD_LESS_THAN)
@@ -50,6 +51,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     CONF_HELD_MORE_THAN: held_more_than,
                     CONF_HELD_LESS_THAN: held_less_than,
                     "description": f"litejet switch #{number}",
+                    "id": trigger_id,
                 }
             },
         )

--- a/homeassistant/components/mqtt/trigger.py
+++ b/homeassistant/components/mqtt/trigger.py
@@ -37,6 +37,7 @@ _LOGGER = logging.getLogger(__name__)
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for state changes based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     topic = config[CONF_TOPIC]
     wanted_payload = config.get(CONF_PAYLOAD)
     value_template = config.get(CONF_VALUE_TEMPLATE)
@@ -78,6 +79,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                 "payload": mqttmsg.payload,
                 "qos": mqttmsg.qos,
                 "description": f"mqtt topic {mqttmsg.topic}",
+                "id": trigger_id,
             }
 
             with suppress(ValueError):

--- a/homeassistant/components/philips_js/device_trigger.py
+++ b/homeassistant/components/philips_js/device_trigger.py
@@ -45,6 +45,7 @@ async def async_attach_trigger(
     automation_info: dict,
 ) -> CALLBACK_TYPE | None:
     """Attach a trigger."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     registry: DeviceRegistry = await async_get_registry(hass)
     if config[CONF_TYPE] == TRIGGER_TYPE_TURN_ON:
         variables = {
@@ -53,6 +54,7 @@ async def async_attach_trigger(
                 "domain": DOMAIN,
                 "device_id": config[CONF_DEVICE_ID],
                 "description": f"philips_js '{config[CONF_TYPE]}' event",
+                "id": trigger_id,
             }
         }
 

--- a/homeassistant/components/sun/trigger.py
+++ b/homeassistant/components/sun/trigger.py
@@ -26,6 +26,7 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for events based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     event = config.get(CONF_EVENT)
     offset = config.get(CONF_OFFSET)
     description = event
@@ -44,6 +45,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     "event": event,
                     "offset": offset,
                     "description": description,
+                    "id": trigger_id,
                 }
             },
         )

--- a/homeassistant/components/tag/trigger.py
+++ b/homeassistant/components/tag/trigger.py
@@ -18,6 +18,7 @@ TRIGGER_SCHEMA = vol.Schema(
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Listen for tag_scanned events based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     tag_ids = set(config[TAG_ID])
     device_ids = set(config[DEVICE_ID]) if DEVICE_ID in config else None
 
@@ -37,6 +38,7 @@ async def async_attach_trigger(hass, config, action, automation_info):
                     "platform": DOMAIN,
                     "event": event,
                     "description": "Tag scanned",
+                    "id": trigger_id,
                 }
             },
             event.context,

--- a/homeassistant/components/template/trigger.py
+++ b/homeassistant/components/template/trigger.py
@@ -31,6 +31,7 @@ async def async_attach_trigger(
     hass, config, action, automation_info, *, platform_type="template"
 ):
     """Listen for state changes based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     value_template = config.get(CONF_VALUE_TEMPLATE)
     value_template.hass = hass
     time_delta = config.get(CONF_FOR)
@@ -100,6 +101,7 @@ async def async_attach_trigger(
         trigger_variables = {
             "for": time_delta,
             "description": description,
+            "id": trigger_id,
         }
 
         @callback

--- a/homeassistant/components/webhook/trigger.py
+++ b/homeassistant/components/webhook/trigger.py
@@ -17,7 +17,7 @@ TRIGGER_SCHEMA = vol.Schema(
 )
 
 
-async def _handle_webhook(job, hass, webhook_id, request):
+async def _handle_webhook(job, trigger_id, hass, webhook_id, request):
     """Handle incoming webhook."""
     result = {"platform": "webhook", "webhook_id": webhook_id}
 
@@ -28,18 +28,20 @@ async def _handle_webhook(job, hass, webhook_id, request):
 
     result["query"] = request.query
     result["description"] = "webhook"
+    result["id"] = trigger_id
     hass.async_run_hass_job(job, {"trigger": result})
 
 
 async def async_attach_trigger(hass, config, action, automation_info):
     """Trigger based on incoming webhooks."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     webhook_id = config.get(CONF_WEBHOOK_ID)
     job = HassJob(action)
     hass.components.webhook.async_register(
         automation_info["domain"],
         automation_info["name"],
         webhook_id,
-        partial(_handle_webhook, job),
+        partial(_handle_webhook, job, trigger_id),
     )
 
     @callback

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -37,6 +37,7 @@ async def async_attach_trigger(
     hass, config, action, automation_info, *, platform_type: str = "zone"
 ) -> CALLBACK_TYPE:
     """Listen for state changes based on configuration."""
+    trigger_id = automation_info.get("trigger_id") if automation_info else None
     entity_id = config.get(CONF_ENTITY_ID)
     zone_entity_id = config.get(CONF_ZONE)
     event = config.get(CONF_EVENT)
@@ -80,6 +81,7 @@ async def async_attach_trigger(
                         "zone": zone_state,
                         "event": event,
                         "description": description,
+                        "id": trigger_id,
                     }
                 },
                 to_s.context,

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -72,8 +72,9 @@ async def async_initialize_triggers(
     }
 
     triggers = []
-    for conf in trigger_config:
+    for idx, conf in enumerate(trigger_config):
         platform = await _async_get_trigger_platform(hass, conf)
+        info = {**info, "trigger_id": f"{idx}"}
         triggers.append(platform.async_attach_trigger(hass, conf, action, info))
 
     attach_results = await asyncio.gather(*triggers, return_exceptions=True)

--- a/script/scaffold/templates/device_trigger/tests/test_device_trigger.py
+++ b/script/scaffold/templates/device_trigger/tests/test_device_trigger.py
@@ -87,7 +87,8 @@ async def test_if_fires_on_state_change(hass, calls):
                             "some": (
                                 "turn_on - {{ trigger.platform}} - "
                                 "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
-                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
                             )
                         },
                     },
@@ -106,7 +107,8 @@ async def test_if_fires_on_state_change(hass, calls):
                             "some": (
                                 "turn_off - {{ trigger.platform}} - "
                                 "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
-                                "{{ trigger.to_state.state}} - {{ trigger.for }}"
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
                             )
                         },
                     },
@@ -119,14 +121,14 @@ async def test_if_fires_on_state_change(hass, calls):
     hass.states.async_set("NEW_DOMAIN.entity", STATE_ON)
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == "turn_on - device - {} - off - on - None".format(
-        "NEW_DOMAIN.entity"
-    )
+    assert calls[0].data[
+        "some"
+    ] == "turn_on - device - {} - off - on - None - 0".format("NEW_DOMAIN.entity")
 
     # Fake that the entity is turning off.
     hass.states.async_set("NEW_DOMAIN.entity", STATE_OFF)
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].data["some"] == "turn_off - device - {} - on - off - None".format(
-        "NEW_DOMAIN.entity"
-    )
+    assert calls[1].data[
+        "some"
+    ] == "turn_off - device - {} - on - off - None - 0".format("NEW_DOMAIN.entity")

--- a/tests/components/arcam_fmj/test_device_trigger.py
+++ b/tests/components/arcam_fmj/test_device_trigger.py
@@ -82,7 +82,10 @@ async def test_if_fires_on_turn_on_request(hass, calls, player_setup, state):
                     },
                     "action": {
                         "service": "test.automation",
-                        "data_template": {"some": "{{ trigger.entity_id }}"},
+                        "data_template": {
+                            "some": "{{ trigger.entity_id }}",
+                            "id": "{{ trigger.id }}",
+                        },
                     },
                 }
             ]
@@ -99,3 +102,4 @@ async def test_if_fires_on_turn_on_request(hass, calls, player_setup, state):
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].data["some"] == player_setup
+    assert calls[0].data["id"] == 0

--- a/tests/components/geo_location/test_trigger.py
+++ b/tests/components/geo_location/test_trigger.py
@@ -68,6 +68,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
                                 "from_state.state",
                                 "to_state.state",
                                 "zone.name",
+                                "id",
                             )
                         )
                     },
@@ -88,7 +89,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
     assert calls[0].context.parent_id == context.id
     assert (
         calls[0].data["some"]
-        == "geo_location - geo_location.entity - hello - hello - test"
+        == "geo_location - geo_location.entity - hello - hello - test - 0"
     )
 
     # Set out of zone again so we can trigger call

--- a/tests/components/homeassistant/triggers/test_event.py
+++ b/tests/components/homeassistant/triggers/test_event.py
@@ -37,7 +37,10 @@ async def test_if_fires_on_event(hass, calls):
         {
             automation.DOMAIN: {
                 "trigger": {"platform": "event", "event_type": "test_event"},
-                "action": {"service": "test.automation"},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
             }
         },
     )
@@ -57,6 +60,7 @@ async def test_if_fires_on_event(hass, calls):
     hass.bus.async_fire("test_event")
     await hass.async_block_till_done()
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_if_fires_on_templated_event(hass, calls):

--- a/tests/components/homeassistant/triggers/test_homeassistant.py
+++ b/tests/components/homeassistant/triggers/test_homeassistant.py
@@ -16,7 +16,10 @@ async def test_if_fires_on_hass_start(hass):
         automation.DOMAIN: {
             "alias": "hello",
             "trigger": {"platform": "homeassistant", "event": "start"},
-            "action": {"service": "test.automation"},
+            "action": {
+                "service": "test.automation",
+                "data_template": {"id": "{{ trigger.id}}"},
+            },
         }
     }
 
@@ -39,6 +42,7 @@ async def test_if_fires_on_hass_start(hass):
 
     assert automation.is_on(hass, "automation.hello")
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_if_fires_on_hass_shutdown(hass):
@@ -53,7 +57,10 @@ async def test_if_fires_on_hass_shutdown(hass):
             automation.DOMAIN: {
                 "alias": "hello",
                 "trigger": {"platform": "homeassistant", "event": "shutdown"},
-                "action": {"service": "test.automation"},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
             }
         },
     )
@@ -68,3 +75,4 @@ async def test_if_fires_on_hass_shutdown(hass):
     with patch.object(hass.loop, "stop"):
         await hass.async_stop()
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -92,7 +92,10 @@ async def test_if_fires_on_entity_change_below(hass, calls, below):
                     "entity_id": "test.entity",
                     "below": below,
                 },
-                "action": {"service": "test.automation"},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
             }
         },
     )
@@ -114,6 +117,7 @@ async def test_if_fires_on_entity_change_below(hass, calls, below):
     hass.states.async_set("test.entity", 9)
     await hass.async_block_till_done()
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 @pytest.mark.parametrize("below", (10, "input_number.value_10"))

--- a/tests/components/homeassistant/triggers/test_state.py
+++ b/tests/components/homeassistant/triggers/test_state.py
@@ -55,6 +55,7 @@ async def test_if_fires_on_entity_change(hass, calls):
                                 "from_state.state",
                                 "to_state.state",
                                 "for",
+                                "id",
                             )
                         )
                     },
@@ -68,7 +69,7 @@ async def test_if_fires_on_entity_change(hass, calls):
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert calls[0].data["some"] == "state - test.entity - hello - world - None"
+    assert calls[0].data["some"] == "state - test.entity - hello - world - None - 0"
 
     await hass.services.async_call(
         automation.DOMAIN,

--- a/tests/components/homeassistant/triggers/test_time.py
+++ b/tests/components/homeassistant/triggers/test_time.py
@@ -51,7 +51,8 @@ async def test_if_fires_using_at(hass, calls):
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": "{{ trigger.platform }} - {{ trigger.now.hour }}"
+                            "some": "{{ trigger.platform }} - {{ trigger.now.hour }}",
+                            "id": "{{ trigger.id}}",
                         },
                     },
                 }
@@ -64,6 +65,7 @@ async def test_if_fires_using_at(hass, calls):
 
     assert len(calls) == 1
     assert calls[0].data["some"] == "time - 5"
+    assert calls[0].data["id"] == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/components/homeassistant/triggers/test_time_pattern.py
+++ b/tests/components/homeassistant/triggers/test_time_pattern.py
@@ -46,7 +46,10 @@ async def test_if_fires_when_hour_matches(hass, calls):
                         "minutes": "*",
                         "seconds": "*",
                     },
-                    "action": {"service": "test.automation"},
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"id": "{{ trigger.id}}"},
+                    },
                 }
             },
         )
@@ -65,6 +68,7 @@ async def test_if_fires_when_hour_matches(hass, calls):
     async_fire_time_changed(hass, now.replace(year=now.year + 1, hour=0))
     await hass.async_block_till_done()
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_if_fires_when_minute_matches(hass, calls):

--- a/tests/components/homekit_controller/test_device_trigger.py
+++ b/tests/components/homekit_controller/test_device_trigger.py
@@ -214,7 +214,8 @@ async def test_handle_events(hass, utcnow, calls):
                         "data_template": {
                             "some": (
                                 "{{ trigger.platform}} - "
-                                "{{ trigger.type }} - {{ trigger.subtype }}"
+                                "{{ trigger.type }} - {{ trigger.subtype }} - "
+                                "{{ trigger.id }}"
                             )
                         },
                     },
@@ -233,7 +234,8 @@ async def test_handle_events(hass, utcnow, calls):
                         "data_template": {
                             "some": (
                                 "{{ trigger.platform}} - "
-                                "{{ trigger.type }} - {{ trigger.subtype }}"
+                                "{{ trigger.type }} - {{ trigger.subtype }} - "
+                                "{{ trigger.id }}"
                             )
                         },
                     },
@@ -249,7 +251,7 @@ async def test_handle_events(hass, utcnow, calls):
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == "device - button1 - single_press"
+    assert calls[0].data["some"] == "device - button1 - single_press - 0"
 
     # Make sure automation doesn't trigger for long press
     helper.pairing.testing.update_named_service(
@@ -274,7 +276,7 @@ async def test_handle_events(hass, utcnow, calls):
 
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].data["some"] == "device - button2 - long_press"
+    assert calls[1].data["some"] == "device - button2 - long_press - 0"
 
     # Turn the automations off
     await hass.services.async_call(

--- a/tests/components/kodi/test_device_trigger.py
+++ b/tests/components/kodi/test_device_trigger.py
@@ -95,7 +95,9 @@ async def test_if_fires_on_state_change(hass, calls, kodi_media_player):
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": ("turn_on - {{ trigger.entity_id }}")
+                            "some": (
+                                "turn_on - {{ trigger.entity_id }} - {{ trigger.id}}"
+                            )
                         },
                     },
                 },
@@ -110,7 +112,9 @@ async def test_if_fires_on_state_change(hass, calls, kodi_media_player):
                     "action": {
                         "service": "test.automation",
                         "data_template": {
-                            "some": ("turn_off - {{ trigger.entity_id }}")
+                            "some": (
+                                "turn_off - {{ trigger.entity_id }} - {{ trigger.id}}"
+                            )
                         },
                     },
                 },
@@ -128,7 +132,7 @@ async def test_if_fires_on_state_change(hass, calls, kodi_media_player):
 
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == f"turn_on - {kodi_media_player}"
+    assert calls[0].data["some"] == f"turn_on - {kodi_media_player} - 0"
 
     await hass.services.async_call(
         MP_DOMAIN,
@@ -139,4 +143,4 @@ async def test_if_fires_on_state_change(hass, calls, kodi_media_player):
 
     await hass.async_block_till_done()
     assert len(calls) == 2
-    assert calls[1].data["some"] == f"turn_off - {kodi_media_player}"
+    assert calls[1].data["some"] == f"turn_off - {kodi_media_player} - 0"

--- a/tests/components/litejet/test_trigger.py
+++ b/tests/components/litejet/test_trigger.py
@@ -82,7 +82,10 @@ async def setup_automation(hass, trigger):
                 {
                     "alias": "My Test",
                     "trigger": trigger,
-                    "action": {"service": "test.automation"},
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"id": "{{ trigger.id}}"},
+                    },
                 }
             ]
         },
@@ -100,6 +103,7 @@ async def test_simple(hass, calls, mock_litejet):
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
 
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_held_more_than_short(hass, calls, mock_litejet):
@@ -134,6 +138,7 @@ async def test_held_more_than_long(hass, calls, mock_litejet):
     assert len(calls) == 0
     await simulate_time(hass, mock_litejet, timedelta(seconds=0.3))
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     assert len(calls) == 1
 
@@ -154,6 +159,7 @@ async def test_held_less_than_short(hass, calls, mock_litejet):
     assert len(calls) == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_held_less_than_long(hass, calls, mock_litejet):
@@ -211,6 +217,7 @@ async def test_held_in_range_just_right(hass, calls, mock_litejet):
     assert len(calls) == 0
     await simulate_release(hass, mock_litejet, ENTITY_OTHER_SWITCH_NUMBER)
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_held_in_range_long(hass, calls, mock_litejet):

--- a/tests/components/mqtt/test_trigger.py
+++ b/tests/components/mqtt/test_trigger.py
@@ -34,9 +34,9 @@ async def test_if_fires_on_topic_match(hass, calls):
                 "action": {
                     "service": "test.automation",
                     "data_template": {
-                        "some": "{{ trigger.platform }} - {{ trigger.topic }}"
-                        " - {{ trigger.payload }} - "
-                        "{{ trigger.payload_json.hello }}"
+                        "some": "{{ trigger.platform }} - {{ trigger.topic }} - "
+                        "{{ trigger.payload }} - {{ trigger.payload_json.hello }} - "
+                        "{{ trigger.id }}"
                     },
                 },
             }
@@ -46,7 +46,9 @@ async def test_if_fires_on_topic_match(hass, calls):
     async_fire_mqtt_message(hass, "test-topic", '{ "hello": "world" }')
     await hass.async_block_till_done()
     assert len(calls) == 1
-    assert calls[0].data["some"] == 'mqtt - test-topic - { "hello": "world" } - world'
+    assert (
+        calls[0].data["some"] == 'mqtt - test-topic - { "hello": "world" } - world - 0'
+    )
 
     await hass.services.async_call(
         automation.DOMAIN,

--- a/tests/components/philips_js/test_device_trigger.py
+++ b/tests/components/philips_js/test_device_trigger.py
@@ -54,7 +54,10 @@ async def test_if_fires_on_turn_on_request(
                     },
                     "action": {
                         "service": "test.automation",
-                        "data_template": {"some": "{{ trigger.device_id }}"},
+                        "data_template": {
+                            "some": "{{ trigger.device_id }}",
+                            "id": "{{ trigger.id}}",
+                        },
                     },
                 }
             ]
@@ -71,3 +74,4 @@ async def test_if_fires_on_turn_on_request(
     await hass.async_block_till_done()
     assert len(calls) == 1
     assert calls[0].data["some"] == mock_device.id
+    assert calls[0].data["id"] == 0

--- a/tests/components/sun/test_trigger.py
+++ b/tests/components/sun/test_trigger.py
@@ -56,7 +56,10 @@ async def test_sunset_trigger(hass, calls, legacy_patchable_time):
             {
                 automation.DOMAIN: {
                     "trigger": {"platform": "sun", "event": SUN_EVENT_SUNSET},
-                    "action": {"service": "test.automation"},
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"id": "{{ trigger.id}}"},
+                    },
                 }
             },
         )
@@ -83,6 +86,7 @@ async def test_sunset_trigger(hass, calls, legacy_patchable_time):
     async_fire_time_changed(hass, trigger_time)
     await hass.async_block_till_done()
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_sunrise_trigger(hass, calls, legacy_patchable_time):

--- a/tests/components/tag/test_trigger.py
+++ b/tests/components/tag/test_trigger.py
@@ -50,7 +50,10 @@ async def test_triggers(hass, tag_setup, calls):
                     "trigger": {"platform": DOMAIN, TAG_ID: "abc123"},
                     "action": {
                         "service": "test.automation",
-                        "data": {"message": "service called"},
+                        "data_template": {
+                            "message": "service called",
+                            "id": "{{ trigger.id}}",
+                        },
                     },
                 }
             ]
@@ -64,6 +67,7 @@ async def test_triggers(hass, tag_setup, calls):
 
     assert len(calls) == 1
     assert calls[0].data["message"] == "service called"
+    assert calls[0].data["id"] == 0
 
     await hass.services.async_call(
         automation.DOMAIN,

--- a/tests/components/template/test_trigger.py
+++ b/tests/components/template/test_trigger.py
@@ -45,7 +45,10 @@ async def test_if_fires_on_change_bool(hass, calls):
                     "platform": "template",
                     "value_template": '{{ states.test.entity.state == "world" and true }}',
                 },
-                "action": {"service": "test.automation"},
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"id": "{{ trigger.id}}"},
+                },
             }
         },
     )
@@ -66,6 +69,7 @@ async def test_if_fires_on_change_bool(hass, calls):
     hass.states.async_set("test.entity", "planet")
     await hass.async_block_till_done()
     assert len(calls) == 1
+    assert calls[0].data["id"] == 0
 
 
 async def test_if_fires_on_change_str(hass, calls):

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -112,7 +112,7 @@ async def test_get_trace(hass, hass_ws_client, domain, prefix):
     trace = response["result"]
     if domain == "automation":
         assert len(trace["trace"]) == 2
-        assert set(trace["trace"]) == {"trigger", f"{prefix}/0"}
+        assert set(trace["trace"]) == {"trigger/0", f"{prefix}/0"}
     else:
         assert len(trace["trace"]) == 1
         assert set(trace["trace"]) == {f"{prefix}/0"}
@@ -163,7 +163,7 @@ async def test_get_trace(hass, hass_ws_client, domain, prefix):
     trace = response["result"]
     if domain == "automation":
         assert len(trace["trace"]) == 3
-        assert set(trace["trace"]) == {"trigger", "condition/0", f"{prefix}/0"}
+        assert set(trace["trace"]) == {"trigger/0", "condition/0", f"{prefix}/0"}
     else:
         assert len(trace["trace"]) == 1
         assert set(trace["trace"]) == {f"{prefix}/0"}
@@ -217,12 +217,7 @@ async def test_get_trace(hass, hass_ws_client, domain, prefix):
     response = await client.receive_json()
     assert response["success"]
     trace = response["result"]
-    if domain == "automation":
-        assert len(trace["trace"]) == 2
-        assert set(trace["trace"]) == {"trigger", "condition/0"}
-    else:
-        assert len(trace["trace"]) == 1
-        assert set(trace["trace"]) == {f"{prefix}/0"}
+    assert set(trace["trace"]) == {"trigger/1", "condition/0"}
     assert len(trace["trace"]["condition/0"]) == 1
     assert trace["trace"]["condition/0"][0]["result"] == {"result": False}
     assert trace["config"] == moon_config
@@ -261,7 +256,7 @@ async def test_get_trace(hass, hass_ws_client, domain, prefix):
     assert response["success"]
     trace = response["result"]
     assert len(trace["trace"]) == 3
-    assert set(trace["trace"]) == {"trigger", "condition/0", f"{prefix}/0"}
+    assert set(trace["trace"]) == {"trigger/0", "condition/0", f"{prefix}/0"}
     assert len(trace["trace"][f"{prefix}/0"]) == 1
     assert "error" not in trace["trace"][f"{prefix}/0"][0]
     assert trace["trace"][f"{prefix}/0"][0]["result"] == moon_action
@@ -591,7 +586,7 @@ async def test_nested_traces(hass, hass_ws_client, domain, prefix):
     trace = response["result"]
     if domain == "automation":
         assert len(trace["trace"]) == 2
-        assert set(trace["trace"]) == {"trigger", f"{prefix}/0"}
+        assert set(trace["trace"]) == {"trigger/0", f"{prefix}/0"}
     else:
         assert len(trace["trace"]) == 1
         assert set(trace["trace"]) == {f"{prefix}/0"}

--- a/tests/components/webhook/test_trigger.py
+++ b/tests/components/webhook/test_trigger.py
@@ -36,7 +36,10 @@ async def test_webhook_json(hass, aiohttp_client):
                 "trigger": {"platform": "webhook", "webhook_id": "json_webhook"},
                 "action": {
                     "event": "test_success",
-                    "event_data_template": {"hello": "yo {{ trigger.json.hello }}"},
+                    "event_data_template": {
+                        "hello": "yo {{ trigger.json.hello }}",
+                        "id": "{{ trigger.id}}",
+                    },
                 },
             }
         },
@@ -50,6 +53,7 @@ async def test_webhook_json(hass, aiohttp_client):
 
     assert len(events) == 1
     assert events[0].data["hello"] == "yo world"
+    assert events[0].data["id"] == 0
 
 
 async def test_webhook_post(hass, aiohttp_client):

--- a/tests/components/zone/test_trigger.py
+++ b/tests/components/zone/test_trigger.py
@@ -66,6 +66,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
                                 "from_state.state",
                                 "to_state.state",
                                 "zone.name",
+                                "id",
                             )
                         )
                     },
@@ -84,7 +85,7 @@ async def test_if_fires_on_zone_enter(hass, calls):
 
     assert len(calls) == 1
     assert calls[0].context.parent_id == context.id
-    assert calls[0].data["some"] == "zone - test.entity - hello - hello - test"
+    assert calls[0].data["some"] == "zone - test.entity - hello - hello - test - 0"
 
     # Set out of zone again so we can trigger call
     hass.states.async_set(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a `trigger_id` to the `automation_info` dict and update all triggers to loop that back in the trigger variables.

Most device_trigger don't need to be updated as they use an `event`, `numeric_state` or `state` trigger under the hood.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
