### PR TITLE
Add opentherm_gw option for setpoint override mode

### DIFF
--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -70,7 +70,7 @@ class OpenThermClimate(ClimateEntity):
         self.floor_temp = options.get(CONF_FLOOR_TEMP, DEFAULT_FLOOR_TEMP)
         self.temp_read_precision = options.get(CONF_READ_PRECISION)
         self.temp_set_precision = options.get(CONF_SET_PRECISION)
-        self.temporary_ovrd_mode = options.get(CONF_TEMPORARY_OVRD_MODE)
+        self.temporary_ovrd_mode = options.get(CONF_TEMPORARY_OVRD_MODE, True)
         self._available = False
         self._current_operation = None
         self._current_temperature = None

--- a/homeassistant/components/opentherm_gw/climate.py
+++ b/homeassistant/components/opentherm_gw/climate.py
@@ -32,6 +32,7 @@ from .const import (
     CONF_FLOOR_TEMP,
     CONF_READ_PRECISION,
     CONF_SET_PRECISION,
+    CONF_TEMPORARY_OVRD_MODE,
     DATA_GATEWAYS,
     DATA_OPENTHERM_GW,
 )
@@ -69,6 +70,7 @@ class OpenThermClimate(ClimateEntity):
         self.floor_temp = options.get(CONF_FLOOR_TEMP, DEFAULT_FLOOR_TEMP)
         self.temp_read_precision = options.get(CONF_READ_PRECISION)
         self.temp_set_precision = options.get(CONF_SET_PRECISION)
+        self.temporary_ovrd_mode = options.get(CONF_TEMPORARY_OVRD_MODE)
         self._available = False
         self._current_operation = None
         self._current_temperature = None
@@ -88,6 +90,7 @@ class OpenThermClimate(ClimateEntity):
         self.floor_temp = entry.options[CONF_FLOOR_TEMP]
         self.temp_read_precision = entry.options[CONF_READ_PRECISION]
         self.temp_set_precision = entry.options[CONF_SET_PRECISION]
+        self.temporary_ovrd_mode = entry.options[CONF_TEMPORARY_OVRD_MODE]
         self.async_write_ha_state()
 
     async def async_added_to_hass(self):
@@ -271,7 +274,7 @@ class OpenThermClimate(ClimateEntity):
             if temp == self.target_temperature:
                 return
             self._new_target_temperature = await self._gateway.gateway.set_target_temp(
-                temp
+                temp, self.temporary_ovrd_mode
             )
             self.async_write_ha_state()
 

--- a/homeassistant/components/opentherm_gw/config_flow.py
+++ b/homeassistant/components/opentherm_gw/config_flow.py
@@ -19,7 +19,12 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from . import DOMAIN
-from .const import CONF_FLOOR_TEMP, CONF_READ_PRECISION, CONF_SET_PRECISION
+from .const import (
+    CONF_FLOOR_TEMP,
+    CONF_READ_PRECISION,
+    CONF_SET_PRECISION,
+    CONF_TEMPORARY_OVRD_MODE,
+)
 
 
 class OpenThermGwConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -138,6 +143,12 @@ class OpenThermGwOptionsFlow(config_entries.OptionsFlow):
                             [0, PRECISION_TENTHS, PRECISION_HALVES, PRECISION_WHOLE]
                         ),
                     ),
+                    vol.Optional(
+                        CONF_TEMPORARY_OVRD_MODE,
+                        default=self.config_entry.options.get(
+                            CONF_TEMPORARY_OVRD_MODE, True
+                        ),
+                    ): bool,
                     vol.Optional(
                         CONF_FLOOR_TEMP,
                         default=self.config_entry.options.get(CONF_FLOOR_TEMP, False),

--- a/homeassistant/components/opentherm_gw/const.py
+++ b/homeassistant/components/opentherm_gw/const.py
@@ -21,6 +21,7 @@ CONF_FLOOR_TEMP = "floor_temperature"
 CONF_PRECISION = "precision"
 CONF_READ_PRECISION = "read_precision"
 CONF_SET_PRECISION = "set_precision"
+CONF_TEMPORARY_OVRD_MODE = "temporary_override_mode"
 
 DATA_GATEWAYS = "gateways"
 DATA_OPENTHERM_GW = "opentherm_gw"

--- a/homeassistant/components/opentherm_gw/strings.json
+++ b/homeassistant/components/opentherm_gw/strings.json
@@ -23,7 +23,8 @@
         "data": {
           "floor_temperature": "Floor Temperature",
           "read_precision": "Read Precision",
-          "set_precision": "Set Precision"
+          "set_precision": "Set Precision",
+          "temporary_override_mode": "Temporary Setpoint Override Mode"
         }
       }
     }

--- a/tests/components/opentherm_gw/test_config_flow.py
+++ b/tests/components/opentherm_gw/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.opentherm_gw.const import (
     CONF_PRECISION,
     CONF_READ_PRECISION,
     CONF_SET_PRECISION,
+    CONF_TEMPORARY_OVRD_MODE,
     DOMAIN,
 )
 from homeassistant.const import (
@@ -251,12 +252,14 @@ async def test_options_form(hass):
             CONF_FLOOR_TEMP: True,
             CONF_READ_PRECISION: PRECISION_HALVES,
             CONF_SET_PRECISION: PRECISION_HALVES,
+            CONF_TEMPORARY_OVRD_MODE: True,
         },
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"][CONF_READ_PRECISION] == PRECISION_HALVES
     assert result["data"][CONF_SET_PRECISION] == PRECISION_HALVES
+    assert result["data"][CONF_TEMPORARY_OVRD_MODE] is True
     assert result["data"][CONF_FLOOR_TEMP] is True
 
     result = await hass.config_entries.options.async_init(
@@ -270,6 +273,7 @@ async def test_options_form(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"][CONF_READ_PRECISION] == 0.0
     assert result["data"][CONF_SET_PRECISION] == PRECISION_HALVES
+    assert result["data"][CONF_TEMPORARY_OVRD_MODE] is True
     assert result["data"][CONF_FLOOR_TEMP] is True
 
     result = await hass.config_entries.options.async_init(
@@ -282,10 +286,12 @@ async def test_options_form(hass):
             CONF_FLOOR_TEMP: False,
             CONF_READ_PRECISION: PRECISION_TENTHS,
             CONF_SET_PRECISION: PRECISION_HALVES,
+            CONF_TEMPORARY_OVRD_MODE: False,
         },
     )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"][CONF_READ_PRECISION] == PRECISION_TENTHS
     assert result["data"][CONF_SET_PRECISION] == PRECISION_HALVES
+    assert result["data"][CONF_TEMPORARY_OVRD_MODE] is False
     assert result["data"][CONF_FLOOR_TEMP] is False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Added an option to change the setpoint override mode. Temporary setpoint override mode can now be set on or off. 'Constant' setpoint override mode will be used when Temporary is set to off


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17169

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
