### PR TITLE
Remove HomeAssistantType alias from entity components - Part 1

### DIFF
--- a/homeassistant/components/air_quality/group.py
+++ b/homeassistant/components/air_quality/group.py
@@ -2,13 +2,12 @@
 
 
 from homeassistant.components.group import GroupIntegrationRegistry
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.exclude_domain()

--- a/homeassistant/components/alarm_control_panel/group.py
+++ b/homeassistant/components/alarm_control_panel/group.py
@@ -10,13 +10,12 @@ from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
     STATE_OFF,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(

--- a/homeassistant/components/alarm_control_panel/reproduce_state.py
+++ b/homeassistant/components/alarm_control_panel/reproduce_state.py
@@ -20,8 +20,7 @@ from homeassistant.const import (
     STATE_ALARM_DISARMED,
     STATE_ALARM_TRIGGERED,
 )
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import DOMAIN
 
@@ -38,7 +37,7 @@ VALID_STATES = {
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -82,7 +81,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/alert/reproduce_state.py
+++ b/homeassistant/components/alert/reproduce_state.py
@@ -12,8 +12,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import DOMAIN
 
@@ -23,7 +22,7 @@ VALID_STATES = {STATE_ON, STATE_OFF}
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -60,7 +59,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/automation/reproduce_state.py
+++ b/homeassistant/components/automation/reproduce_state.py
@@ -12,8 +12,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import DOMAIN
 
@@ -23,7 +22,7 @@ VALID_STATES = {STATE_ON, STATE_OFF}
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -59,7 +58,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/binary_sensor/group.py
+++ b/homeassistant/components/binary_sensor/group.py
@@ -3,13 +3,12 @@
 
 from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     STATE_ON,
     TEMP_CELSIUS,
 )
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
@@ -28,7 +29,7 @@ from homeassistant.helpers.config_validation import (  # noqa: F401
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.temperature import display_temp as show_temp
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType, ServiceDataType
+from homeassistant.helpers.typing import ConfigType, ServiceDataType
 from homeassistant.util.temperature import convert as convert_temperature
 
 from .const import (
@@ -102,7 +103,7 @@ SET_TEMPERATURE_SCHEMA = vol.All(
 )
 
 
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up climate entities."""
     component = hass.data[DOMAIN] = EntityComponent(
         _LOGGER, DOMAIN, hass, SCAN_INTERVAL
@@ -156,12 +157,12 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
     return True
 
 
-async def async_setup_entry(hass: HomeAssistantType, entry):
+async def async_setup_entry(hass: HomeAssistant, entry):
     """Set up a config entry."""
     return await hass.data[DOMAIN].async_setup_entry(entry)
 
 
-async def async_unload_entry(hass: HomeAssistantType, entry):
+async def async_unload_entry(hass: HomeAssistant, entry):
     """Unload a config entry."""
     return await hass.data[DOMAIN].async_unload_entry(entry)
 

--- a/homeassistant/components/climate/group.py
+++ b/homeassistant/components/climate/group.py
@@ -3,15 +3,14 @@
 
 from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 from .const import HVAC_MODE_OFF, HVAC_MODES
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(

--- a/homeassistant/components/climate/reproduce_state.py
+++ b/homeassistant/components/climate/reproduce_state.py
@@ -5,8 +5,7 @@ import asyncio
 from typing import Any, Iterable
 
 from homeassistant.const import ATTR_TEMPERATURE
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from .const import (
     ATTR_AUX_HEAT,
@@ -28,7 +27,7 @@ from .const import (
 
 
 async def _async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -75,7 +74,7 @@ async def _async_reproduce_states(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/cloud/client.py
+++ b/homeassistant/components/cloud/client.py
@@ -15,10 +15,9 @@ from homeassistant.components.alexa import (
 )
 from homeassistant.components.google_assistant import const as gc, smart_home as ga
 from homeassistant.const import HTTP_OK
-from homeassistant.core import Context, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.aiohttp import MockRequest
 
 from . import alexa_config, google_config, utils
@@ -31,7 +30,7 @@ class CloudClient(Interface):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         prefs: CloudPreferences,
         websession: aiohttp.ClientSession,
         alexa_user_config: dict[str, Any],

--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -6,9 +6,8 @@ from homeassistant.components.group import (
 )
 from homeassistant.config import GROUP_CONFIG_PATH
 from homeassistant.const import SERVICE_RELOAD
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistant
 
 from . import EditKeyBasedConfigView
 

--- a/homeassistant/components/config/group.py
+++ b/homeassistant/components/config/group.py
@@ -8,7 +8,7 @@ from homeassistant.config import GROUP_CONFIG_PATH
 from homeassistant.const import SERVICE_RELOAD
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistant
 
 from . import EditKeyBasedConfigView
 
@@ -35,7 +35,7 @@ async def async_setup(hass):
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     return

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -13,13 +13,13 @@ from homeassistant.const import (
     CONF_MINIMUM,
     CONF_NAME,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import collection
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.storage import Store
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -101,7 +101,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the counters."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     id_manager = collection.IDManager()

--- a/homeassistant/components/counter/reproduce_state.py
+++ b/homeassistant/components/counter/reproduce_state.py
@@ -6,8 +6,7 @@ import logging
 from typing import Any, Iterable
 
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import (
     ATTR_INITIAL,
@@ -23,7 +22,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -69,7 +68,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/cover/group.py
+++ b/homeassistant/components/cover/group.py
@@ -3,13 +3,12 @@
 
 from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_CLOSED, STATE_OPEN
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     # On means open, Off means closed

--- a/homeassistant/components/cover/reproduce_state.py
+++ b/homeassistant/components/cover/reproduce_state.py
@@ -24,8 +24,7 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import DOMAIN
 
@@ -35,7 +34,7 @@ VALID_STATES = {STATE_CLOSED, STATE_CLOSING, STATE_OPEN, STATE_OPENING}
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -116,7 +115,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/device_tracker/__init__.py
+++ b/homeassistant/components/device_tracker/__init__.py
@@ -1,6 +1,7 @@
 """Provide functionality to keep track of devices."""
 from homeassistant.const import ATTR_GPS_ACCURACY, STATE_HOME  # noqa: F401
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from .config_entry import async_setup_entry, async_unload_entry  # noqa: F401
@@ -36,12 +37,12 @@ from .legacy import (  # noqa: F401
 
 
 @bind_hass
-def is_on(hass: HomeAssistantType, entity_id: str):
+def is_on(hass: HomeAssistant, entity_id: str):
     """Return the state if any or a specified device is home."""
     return hass.states.is_state(entity_id, STATE_HOME)
 
 
-async def async_setup(hass: HomeAssistantType, config: ConfigType):
+async def async_setup(hass: HomeAssistant, config: ConfigType):
     """Set up the device tracker."""
     await async_setup_legacy_integration(hass, config)
 

--- a/homeassistant/components/device_tracker/group.py
+++ b/homeassistant/components/device_tracker/group.py
@@ -3,13 +3,12 @@
 
 from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_HOME, STATE_NOT_HOME
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states({STATE_HOME}, STATE_NOT_HOME)

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     STATE_HOME,
     STATE_NOT_HOME,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_per_platform, discovery
 import homeassistant.helpers.config_validation as cv
@@ -37,7 +37,7 @@ from homeassistant.helpers.event import (
     async_track_utc_time_change,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import ConfigType, GPSType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType, GPSType
 from homeassistant.setup import async_prepare_setup_platform
 from homeassistant.util import dt as dt_util
 from homeassistant.util.yaml import dump
@@ -119,7 +119,7 @@ EVENT_NEW_DEVICE = "device_tracker_new_device"
 
 
 def see(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     mac: str = None,
     dev_id: str = None,
     host_name: str = None,
@@ -148,7 +148,7 @@ def see(
     hass.services.call(DOMAIN, SERVICE_SEE, data)
 
 
-async def async_setup_integration(hass: HomeAssistantType, config: ConfigType) -> None:
+async def async_setup_integration(hass: HomeAssistant, config: ConfigType) -> None:
     """Set up the legacy integration."""
     tracker = await get_tracker(hass, config)
 
@@ -302,7 +302,7 @@ async def async_create_platform_type(
 
 @callback
 def async_setup_scanner_platform(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config: ConfigType,
     scanner: Any,
     async_see_device: Callable,
@@ -392,7 +392,7 @@ class DeviceTracker:
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         consider_home: timedelta,
         track_new: bool,
         defaults: dict,
@@ -609,7 +609,7 @@ class Device(RestoreEntity):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         consider_home: timedelta,
         track: bool,
         dev_id: str,
@@ -790,7 +790,7 @@ class Device(RestoreEntity):
 class DeviceScanner:
     """Device scanner object."""
 
-    hass: HomeAssistantType = None
+    hass: HomeAssistant = None
 
     def scan_devices(self) -> list[str]:
         """Scan for devices."""
@@ -817,9 +817,7 @@ class DeviceScanner:
         return await self.hass.async_add_executor_job(self.get_extra_attributes, device)
 
 
-async def async_load_config(
-    path: str, hass: HomeAssistantType, consider_home: timedelta
-):
+async def async_load_config(path: str, hass: HomeAssistant, consider_home: timedelta):
     """Load devices from YAML configuration file.
 
     This method is a coroutine.

--- a/homeassistant/components/fan/group.py
+++ b/homeassistant/components/fan/group.py
@@ -3,13 +3,12 @@
 
 from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states({STATE_ON}, STATE_OFF)

--- a/homeassistant/components/fan/reproduce_state.py
+++ b/homeassistant/components/fan/reproduce_state.py
@@ -13,8 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import (
     ATTR_DIRECTION,
@@ -43,7 +42,7 @@ ATTRIBUTES = {  # attribute: service
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -97,7 +96,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`HomeAssistantType` is an alias for the core `HomeAssistant` definition.
This PR removes cleans up bits to use `HomeAssistant` in typing directly.

This is a cleaner approach and makes click-though actually useful.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
