### PR TITLE
Update pylint to 2.7.3

### DIFF
--- a/homeassistant/components/abode/config_flow.py
+++ b/homeassistant/components/abode/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, HTTP_BAD_REQUEST
 
-from .const import DEFAULT_CACHEDB, DOMAIN, LOGGER  # pylint: disable=unused-import
+from .const import DEFAULT_CACHEDB, DOMAIN, LOGGER
 
 CONF_MFA = "mfa_code"
 CONF_POLLING = "polling"

--- a/homeassistant/components/accuweather/config_flow.py
+++ b/homeassistant/components/accuweather/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_FORECAST, DOMAIN  # pylint:disable=unused-import
+from .const import CONF_FORECAST, DOMAIN
 
 
 class AccuWeatherFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/acmeda/config_flow.py
+++ b/homeassistant/components/acmeda/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class AcmedaFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/aemet/config_flow.py
+++ b/homeassistant/components/aemet/config_flow.py
@@ -6,8 +6,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 import homeassistant.helpers.config_validation as cv
 
-from .const import DEFAULT_NAME
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DEFAULT_NAME, DOMAIN
 
 
 class AemetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/agent_dvr/config_flow.py
+++ b/homeassistant/components/agent_dvr/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, SERVER_URL  # pylint:disable=unused-import
+from .const import DOMAIN, SERVER_URL
 from .helpers import generate_url
 
 DEFAULT_PORT = 8090

--- a/homeassistant/components/airly/config_flow.py
+++ b/homeassistant/components/airly/config_flow.py
@@ -16,11 +16,7 @@ from homeassistant.const import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import (  # pylint:disable=unused-import
-    CONF_USE_NEAREST,
-    DOMAIN,
-    NO_AIRLY_SENSORS,
-)
+from .const import CONF_USE_NEAREST, DOMAIN, NO_AIRLY_SENSORS
 
 
 class AirlyFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CON
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/airvisual/config_flow.py
+++ b/homeassistant/components/airvisual/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
 from . import async_get_geography_id
-from .const import (  # pylint: disable=unused-import
+from .const import (
     CONF_CITY,
     CONF_COUNTRY,
     CONF_INTEGRATION_TYPE,

--- a/homeassistant/components/alarmdecoder/config_flow.py
+++ b/homeassistant/components/alarmdecoder/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import DEVICE_CLASSES
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_PROTOCOL
 from homeassistant.core import callback
 
-from .const import (  # pylint: disable=unused-import
+from .const import (
     CONF_ALT_NIGHT_MODE,
     CONF_AUTO_BYPASS,
     CONF_CODE_ARM_REQUIRED,

--- a/homeassistant/components/alexa/intent.py
+++ b/homeassistant/components/alexa/intent.py
@@ -18,7 +18,6 @@ INTENTS_API_ENDPOINT = "/api/alexa"
 
 
 class SpeechType(enum.Enum):
-    # pylint: disable=invalid-name
     """The Alexa speech types."""
 
     plaintext = "PlainText"
@@ -29,7 +28,6 @@ SPEECH_MAPPINGS = {"plain": SpeechType.plaintext, "ssml": SpeechType.ssml}
 
 
 class CardType(enum.Enum):
-    # pylint: disable=invalid-name
     """The Alexa card types."""
 
     simple = "Simple"

--- a/homeassistant/components/ambient_station/config_flow.py
+++ b/homeassistant/components/ambient_station/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_APP_KEY, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_APP_KEY, DOMAIN
 
 
 class AmbientStationFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -21,8 +21,7 @@ from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_CREDENTIALS, CONF_IDENTIFIER, CONF_START_OFF
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_CREDENTIALS, CONF_IDENTIFIER, CONF_START_OFF, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -31,12 +31,12 @@ from .const import (
     DEFAULT_INTERFACE,
     DEFAULT_SSH_PORT,
     DEFAULT_TRACK_UNKNOWN,
+    DOMAIN,
     MODE_AP,
     MODE_ROUTER,
     PROTOCOL_SSH,
     PROTOCOL_TELNET,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 from .router import get_api
 
 RESULT_CONN_ERROR = "cannot_connect"

--- a/homeassistant/components/atag/config_flow.py
+++ b/homeassistant/components/atag/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from . import DOMAIN  # pylint: disable=unused-import
+from . import DOMAIN
 
 DATA_SCHEMA = {
     vol.Required(CONF_HOST): str,

--- a/homeassistant/components/august/config_flow.py
+++ b/homeassistant/components/august/config_flow.py
@@ -7,8 +7,7 @@ from yalexs.authenticator import ValidationResult
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import CONF_LOGIN_METHOD, LOGIN_METHODS, VERIFICATION_CODE_KEY
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_LOGIN_METHOD, DOMAIN, LOGIN_METHODS, VERIFICATION_CODE_KEY
 from .exceptions import CannotConnect, InvalidAuth, RequireValidation
 from .gateway import AugustGateway
 

--- a/homeassistant/components/aurora/config_flow.py
+++ b/homeassistant/components/aurora/config_flow.py
@@ -10,12 +10,7 @@ from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
-from .const import (  # pylint: disable=unused-import
-    CONF_THRESHOLD,
-    DEFAULT_NAME,
-    DEFAULT_THRESHOLD,
-    DOMAIN,
-)
+from .const import CONF_THRESHOLD, DEFAULT_NAME, DEFAULT_THRESHOLD, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/automation/trace.py
+++ b/homeassistant/components/automation/trace.py
@@ -44,7 +44,7 @@ def trace_automation(hass, automation_id, config, context):
 
     try:
         yield trace
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception as ex:
         if automation_id:
             trace.set_error(ex)
         raise ex

--- a/homeassistant/components/azure_devops/config_flow.py
+++ b/homeassistant/components/azure_devops/config_flow.py
@@ -4,7 +4,7 @@ import aiohttp
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.azure_devops.const import (  # pylint:disable=unused-import
+from homeassistant.components.azure_devops.const import (
     CONF_ORG,
     CONF_PAT,
     CONF_PROJECT,

--- a/homeassistant/components/bmw_connected_drive/config_flow.py
+++ b/homeassistant/components/bmw_connected_drive/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_REGION, CONF_SOURCE, CONF_USERNAME
 from homeassistant.core import callback
 
-from . import DOMAIN  # pylint: disable=unused-import
+from . import DOMAIN
 from .const import CONF_ALLOWED_REGIONS, CONF_READ_ONLY, CONF_USE_LOCATION
 
 DATA_SCHEMA = vol.Schema(

--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 from .utils import BondHub
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -17,12 +17,7 @@ from homeassistant.components.dhcp import IP_ADDRESS, MAC_ADDRESS
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_TIMEOUT, CONF_TYPE
 from homeassistant.helpers import config_validation as cv
 
-from .const import (  # pylint: disable=unused-import
-    DEFAULT_PORT,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-    DOMAINS_AND_TYPES,
-)
+from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN, DOMAINS_AND_TYPES
 from .helpers import format_mac
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_HOST, CONF_TYPE
 
-from .const import DOMAIN, PRINTER_TYPES  # pylint:disable=unused-import
+from .const import DOMAIN, PRINTER_TYPES
 from .utils import get_snmp_engine
 
 DATA_SCHEMA = vol.Schema(

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -12,11 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNA
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import (  # pylint:disable=unused-import
-    CONF_DEVICE_IDENT,
-    CONF_PASSKEY,
-    DOMAIN,
-)
+from .const import CONF_DEVICE_IDENT, CONF_PASSKEY, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/canary/config_flow.py
+++ b/homeassistant/components/canary/config_flow.py
@@ -13,8 +13,12 @@ from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import CONF_FFMPEG_ARGUMENTS, DEFAULT_FFMPEG_ARGUMENTS, DEFAULT_TIMEOUT
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import (
+    CONF_FFMPEG_ARGUMENTS,
+    DEFAULT_FFMPEG_ARGUMENTS,
+    DEFAULT_TIMEOUT,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/cert_expiry/config_flow.py
+++ b/homeassistant/components/cert_expiry/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-from .const import DEFAULT_PORT, DOMAIN  # pylint: disable=unused-import
+from .const import DEFAULT_PORT, DOMAIN
 from .errors import (
     ConnectionRefused,
     ConnectionTimeout,

--- a/homeassistant/components/climacell/config_flow.py
+++ b/homeassistant/components/climacell/config_flow.py
@@ -20,8 +20,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import CONF_TIMESTEP, DEFAULT_NAME, DEFAULT_TIMESTEP
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_TIMESTEP, DEFAULT_NAME, DEFAULT_TIMESTEP, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/cloudflare/config_flow.py
+++ b/homeassistant/components/cloudflare/config_flow.py
@@ -19,8 +19,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_RECORDS
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_RECORDS, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/control4/config_flow.py
+++ b/homeassistant/components/control4/config_flow.py
@@ -19,8 +19,12 @@ from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
-from .const import CONF_CONTROLLER_UNIQUE_ID, DEFAULT_SCAN_INTERVAL, MIN_SCAN_INTERVAL
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import (
+    CONF_CONTROLLER_UNIQUE_ID,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    MIN_SCAN_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/coolmaster/config_flow.py
+++ b/homeassistant/components/coolmaster/config_flow.py
@@ -6,7 +6,6 @@ import voluptuous as vol
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-# pylint: disable=unused-import
 from .const import AVAILABLE_MODES, CONF_SUPPORTED_MODES, DEFAULT_PORT, DOMAIN
 
 MODES_SCHEMA = {vol.Required(mode, default=True): bool for mode in AVAILABLE_MODES}

--- a/homeassistant/components/coronavirus/config_flow.py
+++ b/homeassistant/components/coronavirus/config_flow.py
@@ -4,7 +4,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 
 from . import get_coordinator
-from .const import DOMAIN, OPTION_WORLDWIDE  # pylint:disable=unused-import
+from .const import DOMAIN, OPTION_WORLDWIDE
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/demo/config_flow.py
+++ b/homeassistant/components/demo/config_flow.py
@@ -5,7 +5,6 @@ from homeassistant import config_entries
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
-# pylint: disable=unused-import
 from . import DOMAIN
 
 CONF_STRING = "string"

--- a/homeassistant/components/devolo_home_control/config_flow.py
+++ b/homeassistant/components/devolo_home_control/config_flow.py
@@ -8,11 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import (  # pylint:disable=unused-import
-    CONF_MYDEVOLO,
-    DEFAULT_MYDEVOLO,
-    DOMAIN,
-)
+from .const import CONF_MYDEVOLO, DEFAULT_MYDEVOLO, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/dexcom/config_flow.py
+++ b/homeassistant/components/dexcom/config_flow.py
@@ -6,14 +6,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_UNIT_OF_MEASUREMENT, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import (  # pylint:disable=unused-import
-    CONF_SERVER,
-    DOMAIN,
-    MG_DL,
-    MMOL_L,
-    SERVER_OUS,
-    SERVER_US,
-)
+from .const import CONF_SERVER, DOMAIN, MG_DL, MMOL_L, SERVER_OUS, SERVER_US
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/directv/config_flow.py
+++ b/homeassistant/components/directv/config_flow.py
@@ -18,8 +18,7 @@ from homeassistant.helpers.typing import (
     HomeAssistantType,
 )
 
-from .const import CONF_RECEIVER_ID
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_RECEIVER_ID, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/doorbird/config_flow.py
+++ b/homeassistant/components/doorbird/config_flow.py
@@ -17,8 +17,7 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.util.network import is_link_local
 
-from .const import CONF_EVENTS, DOORBIRD_OUI
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_EVENTS, DOMAIN, DOORBIRD_OUI
 from .util import get_mac_address_from_doorstation_info
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 
-from .const import (  # pylint:disable=unused-import
+from .const import (
     CONF_DSMR_VERSION,
     CONF_SERIAL_ID,
     CONF_SERIAL_ID_GAS,

--- a/homeassistant/components/dunehd/config_flow.py
+++ b/homeassistant/components/dunehd/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_HOST
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/eafm/config_flow.py
+++ b/homeassistant/components/eafm/config_flow.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-# pylint: disable=unused-import
 from .const import DOMAIN
 
 

--- a/homeassistant/components/econet/config_flow.py
+++ b/homeassistant/components/econet/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class EcoNetFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/elgato/config_flow.py
+++ b/homeassistant/components/elgato/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_SERIAL_NUMBER, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_SERIAL_NUMBER, DOMAIN
 
 
 class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/elkm1/config_flow.py
+++ b/homeassistant/components/elkm1/config_flow.py
@@ -21,8 +21,7 @@ from homeassistant.const import (
 from homeassistant.util import slugify
 
 from . import async_wait_for_elk_to_sync
-from .const import CONF_AUTO_CONFIGURE
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_AUTO_CONFIGURE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/enocean/config_flow.py
+++ b/homeassistant/components/enocean/config_flow.py
@@ -7,8 +7,7 @@ from homeassistant.config_entries import CONN_CLASS_ASSUMED
 from homeassistant.const import CONF_DEVICE
 
 from . import dongle
-from .const import DOMAIN  # pylint:disable=unused-import
-from .const import ERROR_INVALID_DONGLE_PATH, LOGGER
+from .const import DOMAIN, ERROR_INVALID_DONGLE_PATH, LOGGER
 
 
 class EnOceanFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/faa_delays/config_flow.py
+++ b/homeassistant/components/faa_delays/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_ID
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/firmata/config_flow.py
+++ b/homeassistant/components/firmata/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 
 from .board import get_board
-from .const import CONF_SERIAL_PORT, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_SERIAL_PORT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flick_electric/config_flow.py
+++ b/homeassistant/components/flick_electric/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flo/config_flow.py
+++ b/homeassistant/components/flo/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, LOGGER  # pylint:disable=unused-import
+from .const import DOMAIN, LOGGER
 
 DATA_SCHEMA = vol.Schema({"username": str, "password": str})
 

--- a/homeassistant/components/flume/config_flow.py
+++ b/homeassistant/components/flume/config_flow.py
@@ -14,8 +14,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 
-from .const import BASE_TOKEN_FILENAME
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import BASE_TOKEN_FILENAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/flunearyou/config_flow.py
+++ b/homeassistant/components/flunearyou/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
+from .const import DOMAIN, LOGGER
 
 
 class FluNearYouFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/forked_daapd/config_flow.py
+++ b/homeassistant/components/forked_daapd/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import (  # pylint:disable=unused-import
+from .const import (
     CONF_LIBRESPOT_JAVA_PORT,
     CONF_MAX_PLAYLISTS,
     CONF_TTS_PAUSE_TIME,

--- a/homeassistant/components/freebox/config_flow.py
+++ b/homeassistant/components/freebox/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_PORT
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 from .router import get_api
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/fritzbox_callmonitor/config_flow.py
+++ b/homeassistant/components/fritzbox_callmonitor/config_flow.py
@@ -16,8 +16,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 
 from .base import FritzBoxPhonebook
-
-# pylint:disable=unused-import
 from .const import (
     CONF_PHONEBOOK,
     CONF_PREFIXES,

--- a/homeassistant/components/garmin_connect/config_flow.py
+++ b/homeassistant/components/garmin_connect/config_flow.py
@@ -12,7 +12,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/gdacs/config_flow.py
+++ b/homeassistant/components/gdacs/config_flow.py
@@ -12,12 +12,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 
-from .const import (  # pylint: disable=unused-import
-    CONF_CATEGORIES,
-    DEFAULT_RADIUS,
-    DEFAULT_SCAN_INTERVAL,
-    DOMAIN,
-)
+from .const import CONF_CATEGORIES, DEFAULT_RADIUS, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 DATA_SCHEMA = vol.Schema(
     {vol.Optional(CONF_RADIUS, default=DEFAULT_RADIUS): cv.positive_int}

--- a/homeassistant/components/geonetnz_quakes/config_flow.py
+++ b/homeassistant/components/geonetnz_quakes/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import config_validation as cv
 
-from .const import (  # pylint: disable=unused-import
+from .const import (
     CONF_MINIMUM_MAGNITUDE,
     CONF_MMI,
     DEFAULT_MINIMUM_MAGNITUDE,

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_STATION_ID, DEFAULT_NAME, DOMAIN  # pylint:disable=unused-import
+from .const import CONF_STATION_ID, DEFAULT_NAME, DOMAIN
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/goalzero/config_flow.py
+++ b/homeassistant/components/goalzero/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DEFAULT_NAME, DOMAIN  # pylint:disable=unused-import
+from .const import DEFAULT_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/gogogate2/config_flow.py
+++ b/homeassistant/components/gogogate2/config_flow.py
@@ -16,8 +16,7 @@ from homeassistant.const import (
 )
 
 from .common import get_api
-from .const import DEVICE_TYPE_GOGOGATE2, DEVICE_TYPE_ISMARTGATE
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DEVICE_TYPE_GOGOGATE2, DEVICE_TYPE_ISMARTGATE, DOMAIN
 
 
 class Gogogate2FlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/guardian/config_flow.py
+++ b/homeassistant/components/guardian/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries, core
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
 from homeassistant.core import callback
 
-from .const import CONF_UID, DOMAIN, LOGGER  # pylint:disable=unused-import
+from .const import CONF_UID, DOMAIN, LOGGER
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_IP_ADDRESS): str, vol.Required(CONF_PORT, default=7777): int}

--- a/homeassistant/components/habitica/config_flow.py
+++ b/homeassistant/components/habitica/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_API_KEY, CONF_NAME, CONF_URL
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_API_USER, DEFAULT_URL, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_API_USER, DEFAULT_URL, DOMAIN
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/hive/config_flow.py
+++ b/homeassistant/components/hive/config_flow.py
@@ -13,11 +13,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import (  # pylint:disable=unused-import
-    CONF_CODE,
-    CONFIG_ENTRY_VERSION,
-    DOMAIN,
-)
+from .const import CONF_CODE, CONFIG_ENTRY_VERSION, DOMAIN
 
 
 class HiveFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -31,10 +31,12 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
-from .const import CONNECTION_TIMEOUT, DEFAULT_DEVICE_NAME, DEFAULT_NOTIFY_SERVICE_NAME
-
-# see https://github.com/PyCQA/pylint/issues/3202 about the DOMAIN's pylint issue
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import (
+    CONNECTION_TIMEOUT,
+    DEFAULT_DEVICE_NAME,
+    DEFAULT_NOTIFY_SERVICE_NAME,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
 from .bridge import authenticate_bridge
-from .const import (  # pylint: disable=unused-import
+from .const import (
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
     DEFAULT_ALLOW_HUE_GROUPS,

--- a/homeassistant/components/huisbaasje/config_flow.py
+++ b/homeassistant/components/huisbaasje/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import AbortFlow
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hunterdouglas_powerview/config_flow.py
+++ b/homeassistant/components/hunterdouglas_powerview/config_flow.py
@@ -10,8 +10,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import async_get_device_info
-from .const import DEVICE_NAME, DEVICE_SERIAL_NUMBER, HUB_EXCEPTIONS
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DEVICE_NAME, DEVICE_SERIAL_NUMBER, DOMAIN, HUB_EXCEPTIONS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -31,8 +31,6 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from . import create_hyperion_client
-
-# pylint: disable=unused-import
 from .const import (
     CONF_AUTH_ID,
     CONF_CREATE_TOKEN,

--- a/homeassistant/components/insteon/config_flow.py
+++ b/homeassistant/components/insteon/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-# pylint: disable=unused-import
 from .const import (
     CONF_HOUSECODE,
     CONF_HUB_VERSION,

--- a/homeassistant/components/ipp/config_flow.py
+++ b/homeassistant/components/ipp/config_flow.py
@@ -26,8 +26,7 @@ from homeassistant.const import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import CONF_BASE_PATH, CONF_SERIAL, CONF_UUID
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_BASE_PATH, CONF_SERIAL, CONF_UUID, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/iqvia/config_flow.py
+++ b/homeassistant/components/iqvia/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_ZIP_CODE, DOMAIN  # pylint:disable=unused-import
+from .const import CONF_ZIP_CODE, DOMAIN
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/islamic_prayer_times/config_flow.py
+++ b/homeassistant/components/islamic_prayer_times/config_flow.py
@@ -4,7 +4,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
-# pylint: disable=unused-import
 from .const import CALC_METHODS, CONF_CALC_METHOD, DEFAULT_CALC_METHOD, DOMAIN, NAME
 
 

--- a/homeassistant/components/isy994/config_flow.py
+++ b/homeassistant/components/isy994/config_flow.py
@@ -22,10 +22,10 @@ from .const import (
     DEFAULT_SENSOR_STRING,
     DEFAULT_TLS_VERSION,
     DEFAULT_VAR_SENSOR_STRING,
+    DOMAIN,
     ISY_URL_POSTFIX,
     UDN_UUID_PREFIX,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/juicenet/config_flow.py
+++ b/homeassistant/components/juicenet/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/kmtronic/config_flow.py
+++ b/homeassistant/components/kmtronic/config_flow.py
@@ -11,8 +11,7 @@ from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
-from .const import CONF_REVERSE
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_REVERSE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/kodi/config_flow.py
+++ b/homeassistant/components/kodi/config_flow.py
@@ -24,8 +24,8 @@ from .const import (
     DEFAULT_SSL,
     DEFAULT_TIMEOUT,
     DEFAULT_WS_PORT,
+    DOMAIN,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/litterrobot/config_flow.py
+++ b/homeassistant/components/litterrobot/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 from .hub import LitterRobotHub
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/lutron_caseta/config_flow.py
+++ b/homeassistant/components/lutron_caseta/config_flow.py
@@ -21,10 +21,10 @@ from .const import (
     CONF_CA_CERTS,
     CONF_CERTFILE,
     CONF_KEYFILE,
+    DOMAIN,
     ERROR_CANNOT_CONNECT,
     STEP_IMPORT_FAILED,
 )
-from .const import DOMAIN  # pylint: disable=unused-import
 
 HOSTNAME = "hostname"
 

--- a/homeassistant/components/mazda/config_flow.py
+++ b/homeassistant/components/mazda/config_flow.py
@@ -13,9 +13,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_REGION
 from homeassistant.helpers import aiohttp_client
 
-# https://github.com/PyCQA/pylint/issues/3202
-from .const import DOMAIN  # pylint: disable=unused-import
-from .const import MAZDA_REGIONS
+from .const import DOMAIN, MAZDA_REGIONS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/melcloud/config_flow.py
+++ b/homeassistant/components/melcloud/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     HTTP_UNAUTHORIZED,
 )
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/meteo_france/config_flow.py
+++ b/homeassistant/components/meteo_france/config_flow.py
@@ -9,8 +9,7 @@ from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
 from homeassistant.core import callback
 
-from .const import CONF_CITY, FORECAST_MODE, FORECAST_MODE_DAILY
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_CITY, DOMAIN, FORECAST_MODE, FORECAST_MODE_DAILY
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/metoffice/config_flow.py
+++ b/homeassistant/components/metoffice/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.helpers import config_validation as cv
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 from .data import MetOfficeData
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/mill/config_flow.py
+++ b/homeassistant/components/mill/config_flow.py
@@ -6,7 +6,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}

--- a/homeassistant/components/minecraft_server/config_flow.py
+++ b/homeassistant/components/minecraft_server/config_flow.py
@@ -11,12 +11,7 @@ from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 
 from . import MinecraftServer, helpers
-from .const import (  # pylint: disable=unused-import
-    DEFAULT_HOST,
-    DEFAULT_NAME,
-    DEFAULT_PORT,
-    DOMAIN,
-)
+from .const import DEFAULT_HOST, DEFAULT_NAME, DEFAULT_PORT, DOMAIN
 
 
 class MinecraftServerConfigFlow(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/monoprice/config_flow.py
+++ b/homeassistant/components/monoprice/config_flow.py
@@ -16,8 +16,8 @@ from .const import (
     CONF_SOURCE_5,
     CONF_SOURCE_6,
     CONF_SOURCES,
+    DOMAIN,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/motion_blinds/config_flow.py
+++ b/homeassistant/components/motion_blinds/config_flow.py
@@ -5,7 +5,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 
-# pylint: disable=unused-import
 from .const import DEFAULT_GATEWAY_NAME, DOMAIN
 from .gateway import ConnectMotionGateway
 

--- a/homeassistant/components/myq/config_flow.py
+++ b/homeassistant/components/myq/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nexia/config_flow.py
+++ b/homeassistant/components/nexia/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 from .util import is_invalid_auth_code
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/nightscout/config_flow.py
+++ b/homeassistant/components/nightscout/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_API_KEY, CONF_URL
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 from .utils import hash_from_url
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/notion/config_flow.py
+++ b/homeassistant/components/notion/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class NotionFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/nuheat/config_flow.py
+++ b/homeassistant/components/nuheat/config_flow.py
@@ -13,8 +13,7 @@ from homeassistant.const import (
     HTTP_INTERNAL_SERVER_ERROR,
 )
 
-from .const import CONF_SERIAL_NUMBER
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_SERIAL_NUMBER, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nuki/config_flow.py
+++ b/homeassistant/components/nuki/config_flow.py
@@ -10,11 +10,7 @@ from homeassistant import config_entries, exceptions
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 
-from .const import (  # pylint: disable=unused-import
-    DEFAULT_PORT,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-)
+from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nut/config_flow.py
+++ b/homeassistant/components/nut/config_flow.py
@@ -22,12 +22,12 @@ from .const import (
     DEFAULT_HOST,
     DEFAULT_PORT,
     DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
     KEY_STATUS,
     KEY_STATUS_DISPLAY,
     SENSOR_NAME,
     SENSOR_TYPES,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nws/config_flow.py
+++ b/homeassistant/components/nws/config_flow.py
@@ -11,7 +11,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from . import base_unique_id
-from .const import CONF_STATION, DOMAIN  # pylint:disable=unused-import
+from .const import CONF_STATION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/nzbget/config_flow.py
+++ b/homeassistant/components/nzbget/config_flow.py
@@ -26,8 +26,8 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SSL,
     DEFAULT_VERIFY_SSL,
+    DOMAIN,
 )
-from .const import DOMAIN  # pylint: disable=unused-import
 from .coordinator import NZBGetAPI, NZBGetAPIException
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/onvif/config_flow.py
+++ b/homeassistant/components/onvif/config_flow.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 
-# pylint: disable=unused-import
 from .const import (
     CONF_DEVICE_ID,
     CONF_RTSP_TRANSPORT,

--- a/homeassistant/components/openuv/config_flow.py
+++ b/homeassistant/components/openuv/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/openweathermap/config_flow.py
+++ b/homeassistant/components/openweathermap/config_flow.py
@@ -20,10 +20,10 @@ from .const import (
     DEFAULT_FORECAST_MODE,
     DEFAULT_LANGUAGE,
     DEFAULT_NAME,
+    DOMAIN,
     FORECAST_MODES,
     LANGUAGES,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 
 class OpenWeatherMapConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/ovo_energy/config_flow.py
+++ b/homeassistant/components/ovo_energy/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 USER_SCHEMA = vol.Schema(

--- a/homeassistant/components/owntracks/config_flow.py
+++ b/homeassistant/components/owntracks/config_flow.py
@@ -4,7 +4,7 @@ import secrets
 from homeassistant import config_entries
 from homeassistant.const import CONF_WEBHOOK_ID
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 from .helper import supports_encryption
 
 CONF_SECRET = "secret"

--- a/homeassistant/components/panasonic_viera/config_flow.py
+++ b/homeassistant/components/panasonic_viera/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PIN, CONF_PORT
 
-from .const import (  # pylint: disable=unused-import
+from .const import (
     ATTR_DEVICE_INFO,
     ATTR_FRIENDLY_NAME,
     ATTR_UDN,

--- a/homeassistant/components/philips_js/config_flow.py
+++ b/homeassistant/components/philips_js/config_flow.py
@@ -17,12 +17,7 @@ from homeassistant.const import (
 )
 
 from . import LOGGER
-from .const import (  # pylint:disable=unused-import
-    CONF_SYSTEM,
-    CONST_APP_ID,
-    CONST_APP_NAME,
-    DOMAIN,
-)
+from .const import CONF_SYSTEM, CONST_APP_ID, CONST_APP_NAME, DOMAIN
 
 
 async def validate_input(

--- a/homeassistant/components/pi_hole/config_flow.py
+++ b/homeassistant/components/pi_hole/config_flow.py
@@ -6,7 +6,7 @@ from hole.exceptions import HoleError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.components.pi_hole.const import (  # pylint: disable=unused-import
+from homeassistant.components.pi_hole.const import (
     CONF_LOCATION,
     CONF_STATISTICS_ONLY,
     DEFAULT_LOCATION,

--- a/homeassistant/components/plaato/config_flow.py
+++ b/homeassistant/components/plaato/config_flow.py
@@ -17,12 +17,12 @@ from .const import (
     CONF_USE_WEBHOOK,
     DEFAULT_SCAN_INTERVAL,
     DOCS_URL,
+    DOMAIN,
     PLACEHOLDER_DEVICE_NAME,
     PLACEHOLDER_DEVICE_TYPE,
     PLACEHOLDER_DOCS_URL,
     PLACEHOLDER_WEBHOOK_URL,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 from .utils import load_plum
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/poolsense/config_flow.py
+++ b/homeassistant/components/poolsense/config_flow.py
@@ -8,7 +8,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/powerwall/config_flow.py
+++ b/homeassistant/components/powerwall/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.components.dhcp import IP_ADDRESS
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD
 from homeassistant.core import callback
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/profiler/config_flow.py
+++ b/homeassistant/components/profiler/config_flow.py
@@ -3,8 +3,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 
-from .const import DEFAULT_NAME
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DEFAULT_NAME, DOMAIN
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/rachio/config_flow.py
+++ b/homeassistant/components/rachio/config_flow.py
@@ -12,11 +12,11 @@ from homeassistant.core import callback
 from .const import (
     CONF_MANUAL_RUN_MINS,
     DEFAULT_MANUAL_RUN_MINS,
+    DOMAIN,
     KEY_ID,
     KEY_STATUS,
     KEY_USERNAME,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rainmachine/config_flow.py
+++ b/homeassistant/components/rainmachine/config_flow.py
@@ -8,12 +8,7 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, CONF_
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-from .const import (  # pylint: disable=unused-import
-    CONF_ZONE_RUN_TIME,
-    DEFAULT_PORT,
-    DEFAULT_ZONE_RUN,
-    DOMAIN,
-)
+from .const import CONF_ZONE_RUN_TIME, DEFAULT_PORT, DEFAULT_ZONE_RUN, DOMAIN
 
 DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/recollect_waste/config_flow.py
+++ b/homeassistant/components/recollect_waste/config_flow.py
@@ -10,12 +10,7 @@ from homeassistant.const import CONF_FRIENDLY_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
-from .const import (  # pylint:disable=unused-import
-    CONF_PLACE_ID,
-    CONF_SERVICE_ID,
-    DOMAIN,
-    LOGGER,
-)
+from .const import CONF_PLACE_ID, CONF_SERVICE_ID, DOMAIN, LOGGER
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_PLACE_ID): str, vol.Required(CONF_SERVICE_ID): str}

--- a/homeassistant/components/ring/config_flow.py
+++ b/homeassistant/components/ring/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries, const, core, exceptions
 
-from . import DOMAIN  # pylint: disable=unused-import
+from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/risco/config_flow.py
+++ b/homeassistant/components/risco/config_flow.py
@@ -23,9 +23,9 @@ from .const import (
     CONF_HA_STATES_TO_RISCO,
     CONF_RISCO_STATES_TO_HA,
     DEFAULT_OPTIONS,
+    DOMAIN,
     RISCO_STATES,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import ACCOUNT_HASH, DOMAIN  # pylint:disable=unused-import
+from .const import ACCOUNT_HASH, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/roku/config_flow.py
+++ b/homeassistant/components/roku/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import HomeAssistantType
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str})
 

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -18,9 +18,9 @@ from .const import (
     CONF_CONTINUOUS,
     DEFAULT_CONTINUOUS,
     DEFAULT_DELAY,
+    DOMAIN,
     ROOMBA_SESSION,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 ROOMBA_DISCOVERY_LOCK = "roomba_discovery_lock"
 

--- a/homeassistant/components/roon/config_flow.py
+++ b/homeassistant/components/roon/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_API_KEY, CONF_HOST
 
-from .const import (  # pylint: disable=unused-import
+from .const import (
     AUTHENTICATE_TIMEOUT,
     CONF_ROON_ID,
     DEFAULT_NAME,

--- a/homeassistant/components/ruckus_unleashed/config_flow.py
+++ b/homeassistant/components/ruckus_unleashed/config_flow.py
@@ -8,11 +8,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 
-from .const import (  # pylint:disable=unused-import
-    API_SERIAL,
-    API_SYSTEM_OVERVIEW,
-    DOMAIN,
-)
+from .const import API_SERIAL, API_SYSTEM_OVERVIEW, DOMAIN
 
 _LOGGER = logging.getLogger(__package__)
 

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 
-# pylint:disable=unused-import
 from .bridge import SamsungTVBridge
 from .const import (
     CONF_MANUFACTURER,

--- a/homeassistant/components/screenlogic/config_flow.py
+++ b/homeassistant/components/screenlogic/config_flow.py
@@ -13,8 +13,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import format_mac
 
-from .const import DEFAULT_SCAN_INTERVAL, MIN_SCAN_INTERVAL
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, MIN_SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/script/trace.py
+++ b/homeassistant/components/script/trace.py
@@ -30,7 +30,7 @@ def trace_script(hass, item_id, config, context):
 
     try:
         yield trace
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception as ex:
         if item_id:
             trace.set_error(ex)
         raise ex

--- a/homeassistant/components/sense/config_flow.py
+++ b/homeassistant/components/sense/config_flow.py
@@ -8,8 +8,7 @@ from homeassistant import config_entries, core
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TIMEOUT
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import ACTIVE_UPDATE_RATE, DEFAULT_TIMEOUT, SENSE_TIMEOUT_EXCEPTIONS
-from .const import DOMAIN  # pylint:disable=unused-import; pylint:disable=unused-import
+from .const import ACTIVE_UPDATE_RATE, DEFAULT_TIMEOUT, DOMAIN, SENSE_TIMEOUT_EXCEPTIONS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import callback
 
-from .const import (  # pylint: disable=unused-import
+from .const import (
     CONF_DSN,
     CONF_ENVIRONMENT,
     CONF_EVENT_CUSTOM_COMPONENTS,

--- a/homeassistant/components/sharkiq/config_flow.py
+++ b/homeassistant/components/sharkiq/config_flow.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import _LOGGER, DOMAIN  # pylint:disable=unused-import
+from .const import _LOGGER, DOMAIN
 
 SHARKIQ_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}

--- a/homeassistant/components/shelly/config_flow.py
+++ b/homeassistant/components/shelly/config_flow.py
@@ -16,8 +16,7 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import aiohttp_client
 
-from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import AIOSHELLY_DEVICE_TIMEOUT_SEC, DOMAIN
 from .utils import get_coap_context, get_device_sleep_period
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
 from . import async_get_client_id
-from .const import DOMAIN, LOGGER  # pylint: disable=unused-import
+from .const import DOMAIN, LOGGER
 
 FULL_DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/smart_meter_texas/config_flow.py
+++ b/homeassistant/components/smart_meter_texas/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/smarthab/config_flow.py
+++ b/homeassistant/components/smarthab/config_flow.py
@@ -7,7 +7,6 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
-# pylint: disable=unused-import
 from . import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/smartthings/config_flow.py
+++ b/homeassistant/components/smartthings/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-# pylint: disable=unused-import
 from .const import (
     APP_OAUTH_CLIENT_NAME,
     APP_OAUTH_SCOPES,

--- a/homeassistant/components/smarttub/config_flow.py
+++ b/homeassistant/components/smarttub/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 from .controller import SmartTubController
 
 DATA_SCHEMA = vol.Schema(

--- a/homeassistant/components/sms/config_flow.py
+++ b/homeassistant/components/sms/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_DEVICE
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 from .gateway import create_sms_gateway
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/sonarr/config_flow.py
+++ b/homeassistant/components/sonarr/config_flow.py
@@ -29,8 +29,8 @@ from .const import (
     DEFAULT_UPCOMING_DAYS,
     DEFAULT_VERIFY_SSL,
     DEFAULT_WANTED_MAX_ITEMS,
+    DOMAIN,
 )
-from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/songpal/config_flow.py
+++ b/homeassistant/components/songpal/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import callback
 
-from .const import CONF_ENDPOINT, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_ENDPOINT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/squeezebox/config_flow.py
+++ b/homeassistant/components/squeezebox/config_flow.py
@@ -15,7 +15,6 @@ from homeassistant.const import (
 )
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-# pylint: disable=unused-import
 from .const import DEFAULT_PORT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/srp_energy/config_flow.py
+++ b/homeassistant/components/srp_energy/config_flow.py
@@ -7,11 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_PASSWORD, CONF_USERNAME
 
-from .const import (  # pylint:disable=unused-import
-    CONF_IS_TOU,
-    DEFAULT_NAME,
-    SRP_ENERGY_DOMAIN,
-)
+from .const import CONF_IS_TOU, DEFAULT_NAME, SRP_ENERGY_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/starline/config_flow.py
+++ b/homeassistant/components/starline/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import (  # pylint: disable=unused-import
+from .const import (
     _LOGGER,
     CONF_APP_ID,
     CONF_APP_SECRET,

--- a/homeassistant/components/subaru/config_flow.py
+++ b/homeassistant/components/subaru/config_flow.py
@@ -16,7 +16,6 @@ from homeassistant.const import CONF_DEVICE_ID, CONF_PASSWORD, CONF_PIN, CONF_US
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client, config_validation as cv
 
-# pylint: disable=unused-import
 from .const import CONF_COUNTRY, CONF_UPDATE_ENABLED, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/syncthru/config_flow.py
+++ b/homeassistant/components/syncthru/config_flow.py
@@ -12,7 +12,6 @@ from homeassistant.components import ssdp
 from homeassistant.const import CONF_NAME, CONF_URL
 from homeassistant.helpers import aiohttp_client
 
-# pylint: disable=unused-import # for DOMAIN https://github.com/PyCQA/pylint/issues/3202
 from .const import DEFAULT_MODEL, DEFAULT_NAME_TEMPLATE, DOMAIN
 
 

--- a/homeassistant/components/synology_dsm/config_flow.py
+++ b/homeassistant/components/synology_dsm/config_flow.py
@@ -39,8 +39,8 @@ from .const import (
     DEFAULT_TIMEOUT,
     DEFAULT_USE_SSL,
     DEFAULT_VERIFY_SSL,
+    DOMAIN,
 )
-from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tado/config_flow.py
+++ b/homeassistant/components/tado/config_flow.py
@@ -9,8 +9,7 @@ from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
-from .const import CONF_FALLBACK, UNIQUE_ID
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import CONF_FALLBACK, DOMAIN, UNIQUE_ID
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tesla/config_flow.py
+++ b/homeassistant/components/tesla/config_flow.py
@@ -20,9 +20,9 @@ from .const import (
     CONF_WAKE_ON_START,
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_WAKE_ON_START,
+    DOMAIN,
     MIN_SCAN_INTERVAL,
 )
-from .const import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/tibber/config_flow.py
+++ b/homeassistant/components/tibber/config_flow.py
@@ -9,7 +9,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_ACCESS_TOKEN): str})
 

--- a/homeassistant/components/tile/config_flow.py
+++ b/homeassistant/components/tile/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import aiohttp_client
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class TileFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/totalconnect/config_flow.py
+++ b/homeassistant/components/totalconnect/config_flow.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import CONF_USERCODES, DOMAIN  # pylint: disable=unused-import
+from .const import CONF_USERCODES, DOMAIN
 
 CONF_LOCATION = "location"
 

--- a/homeassistant/components/twentemilieu/config_flow.py
+++ b/homeassistant/components/twentemilieu/config_flow.py
@@ -15,8 +15,7 @@ from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_ID
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CONF_HOUSE_LETTER, CONF_HOUSE_NUMBER, CONF_POST_CODE
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_HOUSE_LETTER, CONF_HOUSE_NUMBER, CONF_POST_CODE, DOMAIN
 
 
 class TwenteMilieuFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/twinkly/config_flow.py
+++ b/homeassistant/components/twinkly/config_flow.py
@@ -18,10 +18,8 @@ from .const import (
     DEV_ID,
     DEV_MODEL,
     DEV_NAME,
+    DOMAIN,
 )
-
-# https://github.com/PyCQA/pylint/issues/3202
-from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/upb/config_flow.py
+++ b/homeassistant/components/upb/config_flow.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant import config_entries, exceptions
 from homeassistant.const import CONF_ADDRESS, CONF_FILE_PATH, CONF_HOST, CONF_PROTOCOL
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 PROTOCOL_MAP = {"TCP": "tcp://", "Serial port": "serial://"}

--- a/homeassistant/components/upcloud/config_flow.py
+++ b/homeassistant/components/upcloud/config_flow.py
@@ -10,7 +10,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
 from homeassistant.core import callback
 
-# pylint: disable=unused-import # for DOMAIN https://github.com/PyCQA/pylint/issues/3202
 from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
 
-from .const import (  # pylint:disable=unused-import
+from .const import (
     CONF_GIID,
     CONF_LOCK_CODE_DIGITS,
     CONF_LOCK_DEFAULT_CODE,

--- a/homeassistant/components/vicare/__init__.py
+++ b/homeassistant/components/vicare/__init__.py
@@ -33,7 +33,6 @@ DEFAULT_HEATING_TYPE = "generic"
 
 
 class HeatingType(enum.Enum):
-    # pylint: disable=invalid-name
     """Possible options for heating type."""
 
     generic = "generic"

--- a/homeassistant/components/vilfo/config_flow.py
+++ b/homeassistant/components/vilfo/config_flow.py
@@ -13,8 +13,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_ID, CONF_MAC
 
-from .const import DOMAIN  # pylint:disable=unused-import
-from .const import ROUTER_DEFAULT_HOST
+from .const import DOMAIN, ROUTER_DEFAULT_HOST
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/volumio/config_flow.py
+++ b/homeassistant/components/volumio/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/wiffi/config_flow.py
+++ b/homeassistant/components/wiffi/config_flow.py
@@ -11,11 +11,7 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_PORT, CONF_TIMEOUT
 from homeassistant.core import callback
 
-from .const import (  # pylint: disable=unused-import
-    DEFAULT_PORT,
-    DEFAULT_TIMEOUT,
-    DOMAIN,
-)
+from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN
 
 
 class WiffiFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/wilight/config_flow.py
+++ b/homeassistant/components/wilight/config_flow.py
@@ -7,7 +7,7 @@ from homeassistant.components import ssdp
 from homeassistant.config_entries import CONN_CLASS_LOCAL_PUSH, ConfigFlow
 from homeassistant.const import CONF_HOST
 
-from . import DOMAIN  # pylint: disable=unused-import
+from . import DOMAIN
 
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_MODEL_NAME = "model_name"

--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/wolflink/config_flow.py
+++ b/homeassistant/components/wolflink/config_flow.py
@@ -9,12 +9,7 @@ from wolf_smartset.wolf_client import WolfClient
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
-from .const import (  # pylint:disable=unused-import
-    DEVICE_GATEWAY,
-    DEVICE_ID,
-    DEVICE_NAME,
-    DOMAIN,
-)
+from .const import DEVICE_GATEWAY, DEVICE_ID, DEVICE_NAME, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/xiaomi_aqara/config_flow.py
+++ b/homeassistant/components/xiaomi_aqara/config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_PORT, CONF_
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 
-# pylint: disable=unused-import
 from .const import (
     CONF_INTERFACE,
     CONF_KEY,

--- a/homeassistant/components/xiaomi_miio/config_flow.py
+++ b/homeassistant/components/xiaomi_miio/config_flow.py
@@ -8,7 +8,6 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.helpers.device_registry import format_mac
 
-# pylint: disable=unused-import
 from .const import (
     CONF_DEVICE,
     CONF_FLOW_TYPE,

--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -16,10 +16,10 @@ from . import (
     CONF_NIGHTLIGHT_SWITCH_TYPE,
     CONF_SAVE_ON_CHANGE,
     CONF_TRANSITION,
+    DOMAIN,
     NIGHTLIGHT_SWITCH_TYPE_LIGHT,
     _async_unique_name,
 )
-from . import DOMAIN  # pylint:disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -10,7 +10,7 @@ from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries
 
-from .core.const import (  # pylint:disable=unused-import
+from .core.const import (
     CONF_BAUDRATE,
     CONF_FLOWCONTROL,
     CONF_RADIO_TYPE,

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -178,7 +178,6 @@ PRESET_COMPLEX = "complex"
 
 
 class RadioType(enum.Enum):
-    # pylint: disable=invalid-name
     """Possible options for radio type."""
 
     znp = (

--- a/homeassistant/components/zone/config_flow.py
+++ b/homeassistant/components/zone/config_flow.py
@@ -6,7 +6,7 @@ migrated to the storage collection.
 """
 from homeassistant import config_entries
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 
 class ZoneConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .addon import AddonError, AddonManager, get_addon_manager
-from .const import (  # pylint:disable=unused-import
+from .const import (
     CONF_ADDON_DEVICE,
     CONF_ADDON_NETWORK_KEY,
     CONF_INTEGRATION_CREATED_ADDON,

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -150,7 +150,6 @@ def is_callback(func: Callable[..., Any]) -> bool:
 
 @enum.unique
 class HassJobType(enum.Enum):
-    # pylint: disable=invalid-name
     """Represent a job type."""
 
     Coroutinefunction = 1
@@ -196,7 +195,6 @@ def _get_callable_job_type(target: Callable) -> HassJobType:
 
 
 class CoreState(enum.Enum):
-    # pylint: disable=invalid-name
     """Represent the current state of Home Assistant."""
 
     not_running = "NOT_RUNNING"
@@ -586,7 +584,6 @@ class Context:
 
 
 class EventOrigin(enum.Enum):
-    # pylint: disable=invalid-name
     """Represent the origin of an event."""
 
     local = "LOCAL"

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -103,7 +103,7 @@ def trace_condition(variables: TemplateVarsType) -> Generator:
     trace_stack_push(trace_stack_cv, trace_element)
     try:
         yield trace_element
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception as ex:
         trace_element.set_error(ex)
         raise ex
     finally:

--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -43,7 +43,7 @@ class HassHttpXAsyncClient(httpx.AsyncClient):
         """Prevent an integration from reopen of the client via context manager."""
         return self
 
-    async def __aexit__(self, *args: Any) -> None:  # pylint: disable=signature-differs
+    async def __aexit__(self, *args: Any) -> None:
         """Prevent an integration from close of the client via context manager."""
 
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -187,7 +187,7 @@ async def trace_action(hass, script_run, stop, variables):
 
     try:
         yield trace_element
-    except Exception as ex:  # pylint: disable=broad-except
+    except Exception as ex:
         trace_element.set_error(ex)
         raise ex
     finally:

--- a/homeassistant/helpers/selector.py
+++ b/homeassistant/helpers/selector.py
@@ -70,9 +70,7 @@ class DeviceSelector(Selector):
             # Model of device
             vol.Optional("model"): str,
             # Device has to contain entities matching this selector
-            vol.Optional(
-                "entity"
-            ): EntitySelector.CONFIG_SCHEMA,  # pylint: disable=no-member
+            vol.Optional("entity"): EntitySelector.CONFIG_SCHEMA,
         }
     )
 

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -20,7 +20,6 @@ QueryType = Any
 
 
 class UndefinedType(Enum):
-    # pylint: disable=invalid-name
     """Singleton type for use with not set sentinel values."""
 
     _singleton = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ extension-pkg-whitelist = [
 ]
 
 [tool.pylint.BASIC]
+class-const-naming-style = "any"
 good-names = [
     "_",
     "ev",

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,8 +10,8 @@ jsonpickle==1.4.1
 mock-open==1.4.0
 mypy==0.812
 pre-commit==2.11.1
-pylint==2.7.2
-astroid==2.5.1
+pylint==2.7.3
+astroid==2.5.2
 pipdeptree==1.0.0
 pylint-strict-informational==0.1
 pytest-aiohttp==0.3.0

--- a/script/scaffold/templates/config_flow/integration/config_flow.py
+++ b/script/scaffold/templates/config_flow/integration/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Proposed change
Changelog: http://pylint.pycqa.org/en/latest/whatsnew/changelog.html#what-s-new-in-pylint-2-7-3
Full diff: https://github.com/PyCQA/pylint/compare/pylint-2.7.2...pylint-2.7.3

**Note-worthy changes**
- Custom name preset for class constants (which include Enums): https://github.com/PyCQA/pylint/pull/4185
- Fix for false-positive `unused-import`: https://github.com/PyCQA/pylint/pull/4207
It's no longer necessary to use `pylint: disable=unused-import` in `**/config_flow.py`. This removes a lot of disables.
- Fix for false-positive `no-member` for typed annotations without default value: https://github.com/PyCQA/pylint/pull/4194
@frenck If I remember correctly, you complained about this one quite a bit ;)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
https://github.com/home-assistant/developers.home-assistant/pull/871

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
