### PR TITLE
Fix duplicates and unexpected failures during roomba discovery

### DIFF
--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -336,6 +336,7 @@ async def _async_discover_roombas(hass, host):
             except OSError:
                 # Socket temporarily unavailable
                 await asyncio.sleep(ROOMBA_WAKE_TIME * attempt)
+                continue
             else:
                 for device in discovered:
                     if device.ip in discovered_hosts:

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -23,7 +23,8 @@ from .const import (
 from .const import DOMAIN  # pylint:disable=unused-import
 
 ROOMBA_DISCOVERY_LOCK = "roomba_discovery_lock"
-MAX_DISCOVER_ATTEMPTS = 2
+ALL_ATTEMPTS = 3
+HOST_ATTEMPTS = 10
 ROOMBA_WAKE_TIME = 6
 
 DEFAULT_OPTIONS = {CONF_CONTINUOUS: DEFAULT_CONTINUOUS, CONF_DELAY: DEFAULT_DELAY}
@@ -321,8 +322,9 @@ async def _async_discover_roombas(hass, host):
     discovered_hosts = set()
     devices = []
     discover_lock = hass.data.setdefault(ROOMBA_DISCOVERY_LOCK, asyncio.Lock())
+    discover_attempts = HOST_ATTEMPTS if host else ALL_ATTEMPTS
 
-    for _ in range(MAX_DISCOVER_ATTEMPTS + 1):
+    for _ in range(discover_attempts + 1):
         async with discover_lock:
             try:
                 if host:

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -318,7 +318,6 @@ def _async_blid_from_hostname(hostname):
 
 
 async def _async_discover_roombas(hass, host):
-    discovery = _async_get_roomba_discovery()
     discovered_hosts = set()
     devices = []
     discover_lock = hass.data.setdefault(ROOMBA_DISCOVERY_LOCK, asyncio.Lock())
@@ -326,6 +325,7 @@ async def _async_discover_roombas(hass, host):
 
     for attempt in range(discover_attempts + 1):
         async with discover_lock:
+            discovery = _async_get_roomba_discovery()
             try:
                 if host:
                     discovered = [
@@ -343,6 +343,8 @@ async def _async_discover_roombas(hass, host):
                         continue
                     discovered_hosts.add(device.ip)
                     devices.append(device)
+            finally:
+                discovery.server_socket.close()
 
         if host and host in discovered_hosts:
             return devices

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -338,12 +338,14 @@ async def _async_discover_roombas(hass, host):
                 pass
             else:
                 for device in discovered:
-                    if device.host in discovered_hosts:
+                    if device.ip in discovered_hosts:
                         continue
-                    discovered_hosts.add(device.host)
+                    discovered_hosts.add(device.ip)
                     devices.append(device)
 
         if host and host in discovered_hosts:
             return devices
 
         await asyncio.sleep(ROOMBA_WAKE_TIME)
+
+    return devices

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -92,9 +92,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # going for a longer hostname we abort so the user
         # does not see two flows if discovery fails.
         for progress in self._async_in_progress():
-            flow_unique_id = progress["context"].get("unique_id")
-            if not flow_unique_id or flow_unique_id == self.blid:
-                continue
+            flow_unique_id = progress["context"]["unique_id"]
             if flow_unique_id.startswith(self.blid):
                 return self.async_abort(reason="short_blid")
             if self.blid.startswith(flow_unique_id):

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -44,11 +44,13 @@ async def validate_input(hass: core.HomeAssistant, data):
         address=data[CONF_HOST],
         blid=data[CONF_BLID],
         password=data[CONF_PASSWORD],
-        continuous=data[CONF_CONTINUOUS],
+        continuous=False,
         delay=data[CONF_DELAY],
     )
 
     info = await async_connect_or_timeout(hass, roomba)
+    if info:
+        await async_disconnect_or_timeout(hass, roomba)
 
     return {
         ROOMBA_SESSION: info[ROOMBA_SESSION],
@@ -229,7 +231,6 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 return self.async_abort(reason="cannot_connect")
 
-            await async_disconnect_or_timeout(self.hass, info[ROOMBA_SESSION])
             self.name = info[CONF_NAME]
 
         return self.async_create_entry(title=self.name, data=config)
@@ -251,7 +252,6 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors = {"base": "cannot_connect"}
 
             if not errors:
-                await async_disconnect_or_timeout(self.hass, info[ROOMBA_SESSION])
                 return self.async_create_entry(title=info[CONF_NAME], data=config)
 
         return self.async_show_form(

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -29,9 +29,7 @@ DEFAULT_OPTIONS = {CONF_CONTINUOUS: DEFAULT_CONTINUOUS, CONF_DELAY: DEFAULT_DELA
 MAX_NUM_DEVICES_TO_DISCOVER = 25
 
 AUTH_HELP_URL_KEY = "auth_help_url"
-AUTH_HELP_URL_VALUE = (
-    "https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials"
-)
+AUTH_HELP_URL_VALUE = "https://www.home-assistant.io/integrations/roomba/#manually-retrieving-your-credentials"
 
 
 async def validate_input(hass: core.HomeAssistant, data):
@@ -83,14 +81,25 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not dhcp_discovery[HOSTNAME].startswith(("irobot-", "roomba-")):
             return self.async_abort(reason="not_irobot_device")
 
-        blid = _async_blid_from_hostname(dhcp_discovery[HOSTNAME])
-        await self.async_set_unique_id(blid)
-        self._abort_if_unique_id_configured(
-            updates={CONF_HOST: dhcp_discovery[IP_ADDRESS]}
-        )
-
         self.host = dhcp_discovery[IP_ADDRESS]
-        self.blid = blid
+        self.blid = _async_blid_from_hostname(dhcp_discovery[HOSTNAME])
+        await self.async_set_unique_id(self.blid)
+        self._abort_if_unique_id_configured(updates={CONF_HOST: self.host})
+
+        # Because the hostname is so long some sources may
+        # truncate the hostname since it will be longer than
+        # the valid allowed length. If we already have a flow
+        # going for a longer hostname we abort so the user
+        # does not see two flows if discovery fails.
+        for progress in self._async_in_progress():
+            flow_unique_id = progress["context"].get("unique_id")
+            if not flow_unique_id or flow_unique_id == self.blid:
+                continue
+            if flow_unique_id.startswith(self.blid):
+                return self.async_abort(reason="short_blid")
+            if self.blid.startswith(flow_unique_id):
+                self.hass.config_entries.flow.async_abort(progress["flow_id"])
+
         self.context["title_placeholders"] = {"host": self.host, "name": self.blid}
         return await self.async_step_user()
 
@@ -130,13 +139,14 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 for device in devices
                 if device.blid not in already_configured
             }
-            if self.host and self.host in self.discovered_robots:
-                # From discovery
-                self.context["title_placeholders"] = {
-                    "host": self.host,
-                    "name": self.discovered_robots[self.host].robot_name,
-                }
-                return await self._async_start_link()
+
+        if self.host and self.host in self.discovered_robots:
+            # From discovery
+            self.context["title_placeholders"] = {
+                "host": self.host,
+                "name": self.discovered_robots[self.host].robot_name,
+            }
+            return await self._async_start_link()
 
         if not self.discovered_robots:
             return await self.async_step_manual()
@@ -180,7 +190,7 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_configured")
 
         self.host = user_input[CONF_HOST]
-        self.blid = user_input[CONF_BLID]
+        self.blid = user_input[CONF_BLID].upper()
         await self.async_set_unique_id(self.blid, raise_on_progress=False)
         self._abort_if_unique_id_configured()
         return await self.async_step_link()
@@ -197,10 +207,10 @@ class RoombaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 description_placeholders={CONF_NAME: self.name or self.blid},
             )
 
+        roomba_pw = RoombaPassword(self.host)
+
         try:
-            password = await self.hass.async_add_executor_job(
-                RoombaPassword(self.host).get_password
-            )
+            password = await self.hass.async_add_executor_job(roomba_pw.get_password)
         except ConnectionRefusedError:
             return await self.async_step_link_manual()
 
@@ -305,4 +315,4 @@ def _async_get_roomba_discovery():
 @callback
 def _async_blid_from_hostname(hostname):
     """Extract the blid from the hostname."""
-    return hostname.split("-")[1].split(".")[0]
+    return hostname.split("-")[1].split(".")[0].upper()

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -23,8 +23,8 @@ from .const import (
 from .const import DOMAIN  # pylint:disable=unused-import
 
 ROOMBA_DISCOVERY_LOCK = "roomba_discovery_lock"
-ALL_ATTEMPTS = 3
-HOST_ATTEMPTS = ALL_ATTEMPTS * 2
+ALL_ATTEMPTS = 2
+HOST_ATTEMPTS = 6
 ROOMBA_WAKE_TIME = 6
 
 DEFAULT_OPTIONS = {CONF_CONTINUOUS: DEFAULT_CONTINUOUS, CONF_DELAY: DEFAULT_DELAY}

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -11,7 +11,7 @@
       },
       "manual": {
         "title": "Manually connect to the device",
-        "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-`. Please follow the steps outlined in the documentation at: {auth_help_url}",
+        "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-` or `Roomba-`. Please follow the steps outlined in the documentation at: {auth_help_url}",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "blid": "BLID"
@@ -35,7 +35,8 @@
     "abort": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "not_irobot_device": "Discovered device is not an iRobot device"
+      "not_irobot_device": "Discovered device is not an iRobot device",
+      "short_blid": "The BLID was truncated"
     }    
   },
   "options": {

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -19,7 +19,7 @@
       },      
       "link": {
         "title": "Retrieve Password",
-        "description": "Press and hold the Home button on {name} until the device generates a sound (about two seconds)."
+        "description": "Press and hold the Home button on {name} until the device generates a sound (about two seconds), then submit within 30 seconds."
       },
       "link_manual": {
         "title": "Enter Password",

--- a/homeassistant/components/roomba/translations/en.json
+++ b/homeassistant/components/roomba/translations/en.json
@@ -3,7 +3,8 @@
         "abort": {
             "already_configured": "Device is already configured",
             "cannot_connect": "Failed to connect",
-            "not_irobot_device": "Discovered device is not an iRobot device"
+            "not_irobot_device": "Discovered device is not an iRobot device",
+            "short_blid": "The BLID was truncated"
         },
         "error": {
             "cannot_connect": "Failed to connect"
@@ -33,19 +34,8 @@
                     "blid": "BLID",
                     "host": "Host"
                 },
-                "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-`. Please follow the steps outlined in the documentation at: {auth_help_url}",
+                "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-` or `Roomba-`. Please follow the steps outlined in the documentation at: {auth_help_url}",
                 "title": "Manually connect to the device"
-            },
-            "user": {
-                "data": {
-                    "blid": "BLID",
-                    "continuous": "Continuous",
-                    "delay": "Delay",
-                    "host": "Host",
-                    "password": "Password"
-                },
-                "description": "Currently retrieving the BLID and password is a manual process. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
-                "title": "Connect to the device"
             }
         }
     },

--- a/homeassistant/components/roomba/translations/en.json
+++ b/homeassistant/components/roomba/translations/en.json
@@ -19,7 +19,7 @@
                 "title": "Automatically connect to the device"
             },
             "link": {
-                "description": "Press and hold the Home button on {name} until the device generates a sound (about two seconds).",
+                "description": "Press and hold the Home button on {name} until the device generates a sound (about two seconds), then submit within 30 seconds.",
                 "title": "Retrieve Password"
             },
             "link_manual": {

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.const import CONF_DELAY, CONF_HOST, CONF_PASSWORD
 from tests.common import MockConfigEntry
 
 MOCK_IP = "1.2.3.4"
-VALID_CONFIG = {CONF_HOST: MOCK_IP, CONF_BLID: "blid", CONF_PASSWORD: "password"}
+VALID_CONFIG = {CONF_HOST: MOCK_IP, CONF_BLID: "BLID", CONF_PASSWORD: "password"}
 
 DHCP_DISCOVERY_DEVICES = [
     {
@@ -58,7 +58,7 @@ def _mocked_discovery(*_):
     roomba_discovery = MagicMock()
 
     roomba = RoombaInfo(
-        hostname="irobot-blid",
+        hostname="irobot-BLID",
         robot_name="robot_name",
         ip=MOCK_IP,
         mac="mac",
@@ -145,9 +145,9 @@ async def test_form_user_discovery_and_password_fetch(hass):
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result3["title"] == "robot_name"
-    assert result3["result"].unique_id == "blid"
+    assert result3["result"].unique_id == "BLID"
     assert result3["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: MOCK_IP,
@@ -161,7 +161,7 @@ async def test_form_user_discovery_skips_known(hass):
     """Test discovery proceeds to manual if all discovered are already known."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="blid")
+    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
     entry.add_to_hass(hass)
 
     with patch(
@@ -181,7 +181,7 @@ async def test_form_user_failed_discovery_aborts_already_configured(hass):
     """Test if we manually configure an existing host we abort."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="blid")
+    entry = MockConfigEntry(domain=DOMAIN, data=VALID_CONFIG, unique_id="BLID")
     entry.add_to_hass(hass)
 
     with patch(
@@ -264,9 +264,9 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result4["title"] == "myroomba"
-    assert result4["result"].unique_id == "blid"
+    assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: MOCK_IP,
@@ -391,9 +391,9 @@ async def test_form_user_discovery_fails_and_auto_password_fetch(hass):
 
     assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result3["title"] == "myroomba"
-    assert result3["result"].unique_id == "blid"
+    assert result3["result"].unique_id == "BLID"
     assert result3["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: MOCK_IP,
@@ -460,9 +460,9 @@ async def test_form_user_discovery_fails_and_password_fetch_fails(hass):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result4["title"] == "myroomba"
-    assert result4["result"].unique_id == "blid"
+    assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: MOCK_IP,
@@ -593,9 +593,9 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(ha
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result4["title"] == "myroomba"
-    assert result4["result"].unique_id == "blid"
+    assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: MOCK_IP,
@@ -650,9 +650,9 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "robot_name"
-    assert result2["result"].unique_id == "blid"
+    assert result2["result"].unique_id == "BLID"
     assert result2["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: MOCK_IP,
@@ -723,9 +723,9 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
 
     assert result4["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result4["title"] == "myroomba"
-    assert result4["result"].unique_id == "blid"
+    assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
-        CONF_BLID: "blid",
+        CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,
         CONF_HOST: "1.1.1.1",
@@ -789,7 +789,7 @@ async def test_dhcp_discovery_already_configured_blid(hass):
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_BLID: "blid"}, unique_id="blid"
+        domain=DOMAIN, data={CONF_BLID: "BLID"}, unique_id="BLID"
     )
     config_entry.add_to_hass(hass)
 
@@ -816,7 +816,7 @@ async def test_dhcp_discovery_not_irobot(hass):
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     config_entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_BLID: "blid"}, unique_id="blid"
+        domain=DOMAIN, data={CONF_BLID: "BLID"}, unique_id="BLID"
     )
     config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Handles short hostnames (abort duplicate flows)
- Ensures all BLIDs are uppercases to avoid duplicate setups
- Retries discovery when the listen server cannot start
- Retries discovery when roomba has not yet awakened
- Limits discovery to a single ip address when we know the host from discovery
- Fix incorrect help url 
- Handle discovery failure case when Home Assistant is on another subnet

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48180
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
