### PR TITLE
Remove if/else from modbus test cases

### DIFF
--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -5,25 +5,30 @@ import voluptuous as vol
 from homeassistant.components.modbus import number
 
 
-async def test_number_validator():
+@pytest.mark.parametrize(
+    "value,value_type",
+    [
+        (15, int),
+        (15.1, float),
+        ("15", int),
+        ("15.1", float),
+        (-15, int),
+        (-15.1, float),
+        ("-15", int),
+        ("-15.1", float),
+    ],
+)
+async def test_number_validator(value, value_type):
     """Test number validator."""
 
-    # positive tests
-    value = number(15)
-    assert isinstance(value, int)
+    assert isinstance(number(value), value_type)
 
-    value = number(15.1)
-    assert isinstance(value, float)
 
-    value = number("15")
-    assert isinstance(value, int)
+async def test_number_exception():
+    """Test number exception."""
 
-    value = number("15.1")
-    assert isinstance(value, float)
-
-    # exception test
     try:
-        value = number("x15.1")
+        number("x15.1")
     except (vol.Invalid):
         return
 

--- a/tests/components/modbus/test_modbus.py
+++ b/tests/components/modbus/test_modbus.py
@@ -55,9 +55,11 @@ from .conftest import base_config_test
 async def test_config_modbus(hass, do_discovery, do_options, do_config):
     """Run test for modbus."""
     config = {
-        DOMAIN: do_config,
+        DOMAIN: {
+            **do_config,
+            **do_options,
+        }
     }
-    config.update(do_options)
     await base_config_test(
         hass,
         None,

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -22,7 +22,17 @@ from .conftest import base_config_test, base_test
 
 
 @pytest.mark.parametrize("do_discovery", [False, True])
-@pytest.mark.parametrize("do_options", [False, True])
+@pytest.mark.parametrize(
+    "do_options",
+    [
+        {},
+        {
+            CONF_SLAVE: 10,
+            CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+            CONF_DEVICE_CLASS: "door",
+        },
+    ],
+)
 async def test_config_binary_sensor(hass, do_discovery, do_options):
     """Run test for binary sensor."""
     sensor_name = "test_sensor"
@@ -31,13 +41,7 @@ async def test_config_binary_sensor(hass, do_discovery, do_options):
         CONF_ADDRESS: 51,
     }
     if do_options:
-        config_sensor.update(
-            {
-                CONF_SLAVE: 10,
-                CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
-                CONF_DEVICE_CLASS: "door",
-            }
-        )
+        config_sensor.update()
     await base_config_test(
         hass,
         config_sensor,

--- a/tests/components/modbus/test_modbus_binary_sensor.py
+++ b/tests/components/modbus/test_modbus_binary_sensor.py
@@ -39,9 +39,8 @@ async def test_config_binary_sensor(hass, do_discovery, do_options):
     config_sensor = {
         CONF_NAME: sensor_name,
         CONF_ADDRESS: 51,
+        **do_options,
     }
-    if do_options:
-        config_sensor.update()
     await base_config_test(
         hass,
         config_sensor,

--- a/tests/components/modbus/test_modbus_climate.py
+++ b/tests/components/modbus/test_modbus_climate.py
@@ -13,7 +13,16 @@ from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_SLAVE
 from .conftest import base_config_test, base_test
 
 
-@pytest.mark.parametrize("do_options", [False, True])
+@pytest.mark.parametrize(
+    "do_options",
+    [
+        {},
+        {
+            CONF_SCAN_INTERVAL: 20,
+            CONF_DATA_COUNT: 2,
+        },
+    ],
+)
 async def test_config_climate(hass, do_options):
     """Run test for climate."""
     device_name = "test_climate"
@@ -23,13 +32,7 @@ async def test_config_climate(hass, do_options):
         CONF_CURRENT_TEMP: 117,
         CONF_SLAVE: 10,
     }
-    if do_options:
-        device_config.update(
-            {
-                CONF_SCAN_INTERVAL: 20,
-                CONF_DATA_COUNT: 2,
-            }
-        )
+    device_config.update(do_options)
     await base_config_test(
         hass,
         device_config,

--- a/tests/components/modbus/test_modbus_climate.py
+++ b/tests/components/modbus/test_modbus_climate.py
@@ -31,8 +31,8 @@ async def test_config_climate(hass, do_options):
         CONF_TARGET_TEMP: 117,
         CONF_CURRENT_TEMP: 117,
         CONF_SLAVE: 10,
+        **do_options,
     }
-    device_config.update(do_options)
     await base_config_test(
         hass,
         device_config,

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -15,7 +15,16 @@ from homeassistant.const import (
 from .conftest import base_config_test, base_test
 
 
-@pytest.mark.parametrize("do_options", [False, True])
+@pytest.mark.parametrize(
+    "do_options",
+    [
+        {},
+        {
+            CONF_SLAVE: 10,
+            CONF_SCAN_INTERVAL: 20,
+        },
+    ],
+)
 @pytest.mark.parametrize("read_type", [CALL_TYPE_COIL, CONF_REGISTER])
 async def test_config_cover(hass, do_options, read_type):
     """Run test for cover."""
@@ -24,13 +33,7 @@ async def test_config_cover(hass, do_options, read_type):
         CONF_NAME: device_name,
         read_type: 1234,
     }
-    if do_options:
-        device_config.update(
-            {
-                CONF_SLAVE: 10,
-                CONF_SCAN_INTERVAL: 20,
-            }
-        )
+    device_config.update(do_options)
     await base_config_test(
         hass,
         device_config,

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -32,8 +32,8 @@ async def test_config_cover(hass, do_options, read_type):
     device_config = {
         CONF_NAME: device_name,
         read_type: 1234,
+        **do_options,
     }
-    device_config.update(do_options)
     await base_config_test(
         hass,
         device_config,

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -113,8 +113,8 @@ async def test_config_sensor(hass, do_discovery, do_config):
     sensor_name = "test_sensor"
     config_sensor = {
         CONF_NAME: sensor_name,
+        **do_config,
     }
-    config_sensor.update(do_config)
     await base_config_test(
         hass,
         config_sensor,

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -31,21 +31,19 @@ from homeassistant.const import (
 from .conftest import base_config_test, base_test
 
 
-@pytest.mark.parametrize("do_discovery", [False, True])
-@pytest.mark.parametrize("do_options", [False, True])
 @pytest.mark.parametrize(
-    "do_type", [CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]
-)
-async def test_config_sensor(hass, do_discovery, do_options, do_type):
-    """Run test for sensor."""
-    sensor_name = "test_sensor"
-    config_sensor = {
-        CONF_NAME: sensor_name,
-        CONF_ADDRESS: 51,
-    }
-    if do_options:
-        config_sensor.update(
+    "do_discovery, do_config",
+    [
+        (
+            False,
             {
+                CONF_REGISTER: 51,
+            },
+        ),
+        (
+            False,
+            {
+                CONF_REGISTER: 51,
                 CONF_SLAVE: 10,
                 CONF_COUNT: 1,
                 CONF_DATA_TYPE: "int",
@@ -53,17 +51,70 @@ async def test_config_sensor(hass, do_discovery, do_options, do_type):
                 CONF_SCALE: 1,
                 CONF_REVERSE_ORDER: False,
                 CONF_OFFSET: 0,
-                CONF_INPUT_TYPE: do_type,
+                CONF_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
                 CONF_DEVICE_CLASS: "battery",
-            }
-        )
-    if not do_discovery:
-        # bridge difference in configuration
-        config_sensor[CONF_REGISTER] = config_sensor[CONF_ADDRESS]
-        del config_sensor[CONF_ADDRESS]
-        if do_options:
-            config_sensor[CONF_REGISTER_TYPE] = config_sensor[CONF_INPUT_TYPE]
-            del config_sensor[CONF_INPUT_TYPE]
+            },
+        ),
+        (
+            False,
+            {
+                CONF_REGISTER: 51,
+                CONF_SLAVE: 10,
+                CONF_COUNT: 1,
+                CONF_DATA_TYPE: "int",
+                CONF_PRECISION: 0,
+                CONF_SCALE: 1,
+                CONF_REVERSE_ORDER: False,
+                CONF_OFFSET: 0,
+                CONF_REGISTER_TYPE: CALL_TYPE_REGISTER_INPUT,
+                CONF_DEVICE_CLASS: "battery",
+            },
+        ),
+        (
+            True,
+            {
+                CONF_ADDRESS: 51,
+            },
+        ),
+        (
+            True,
+            {
+                CONF_ADDRESS: 51,
+                CONF_SLAVE: 10,
+                CONF_COUNT: 1,
+                CONF_DATA_TYPE: "int",
+                CONF_PRECISION: 0,
+                CONF_SCALE: 1,
+                CONF_REVERSE_ORDER: False,
+                CONF_OFFSET: 0,
+                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                CONF_DEVICE_CLASS: "battery",
+            },
+        ),
+        (
+            True,
+            {
+                CONF_ADDRESS: 51,
+                CONF_SLAVE: 10,
+                CONF_COUNT: 1,
+                CONF_DATA_TYPE: "int",
+                CONF_PRECISION: 0,
+                CONF_SCALE: 1,
+                CONF_REVERSE_ORDER: False,
+                CONF_OFFSET: 0,
+                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
+                CONF_DEVICE_CLASS: "battery",
+            },
+        ),
+    ],
+)
+async def test_config_sensor(hass, do_discovery, do_config):
+    """Run test for sensor."""
+    sensor_name = "test_sensor"
+    config_sensor = {
+        CONF_NAME: sensor_name,
+    }
+    config_sensor.update(do_config)
     await base_config_test(
         hass,
         config_sensor,

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -161,8 +161,8 @@ async def test_config_switch(hass, array_type, do_config):
 
     device_config = {
         CONF_NAME: device_name,
+        **do_config,
     }
-    device_config.update(do_config)
 
     await base_config_test(
         hass,

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -31,57 +31,138 @@ from homeassistant.const import (
 from .conftest import base_config_test, base_test
 
 
-@pytest.mark.parametrize("do_discovery", [False, True])
-@pytest.mark.parametrize("do_options", [False, True])
 @pytest.mark.parametrize(
-    "read_type", [CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT, CALL_TYPE_COIL]
+    "array_type, do_config",
+    [
+        (
+            None,
+            {
+                CONF_ADDRESS: 1234,
+            },
+        ),
+        (
+            None,
+            {
+                CONF_ADDRESS: 1234,
+            },
+        ),
+        (
+            None,
+            {
+                CONF_ADDRESS: 1234,
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+            },
+        ),
+        (
+            None,
+            {
+                CONF_ADDRESS: 1234,
+                CONF_SLAVE: 1,
+                CONF_STATE_OFF: 0,
+                CONF_STATE_ON: 1,
+                CONF_VERIFY_REGISTER: 1235,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+                CONF_DEVICE_CLASS: "switch",
+                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            },
+        ),
+        (
+            None,
+            {
+                CONF_ADDRESS: 1234,
+                CONF_SLAVE: 1,
+                CONF_STATE_OFF: 0,
+                CONF_STATE_ON: 1,
+                CONF_VERIFY_REGISTER: 1235,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+                CONF_DEVICE_CLASS: "switch",
+                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
+            },
+        ),
+        (
+            None,
+            {
+                CONF_ADDRESS: 1234,
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+                CONF_SLAVE: 1,
+                CONF_DEVICE_CLASS: "switch",
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+            },
+        ),
+        (
+            CONF_REGISTERS,
+            {
+                CONF_REGISTER: 1234,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+            },
+        ),
+        (
+            CONF_REGISTERS,
+            {
+                CONF_REGISTER: 1234,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+            },
+        ),
+        (
+            CONF_COILS,
+            {
+                CALL_TYPE_COIL: 1234,
+                CONF_SLAVE: 1,
+            },
+        ),
+        (
+            CONF_REGISTERS,
+            {
+                CONF_REGISTER: 1234,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+                CONF_SLAVE: 1,
+                CONF_STATE_OFF: 0,
+                CONF_STATE_ON: 1,
+                CONF_VERIFY_REGISTER: 1235,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+                CONF_VERIFY_STATE: True,
+                CONF_REGISTER_TYPE: CALL_TYPE_REGISTER_INPUT,
+            },
+        ),
+        (
+            CONF_REGISTERS,
+            {
+                CONF_REGISTER: 1234,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+                CONF_SLAVE: 1,
+                CONF_STATE_OFF: 0,
+                CONF_STATE_ON: 1,
+                CONF_VERIFY_REGISTER: 1235,
+                CONF_COMMAND_OFF: 0x00,
+                CONF_COMMAND_ON: 0x01,
+                CONF_VERIFY_STATE: True,
+                CONF_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
+            },
+        ),
+        (
+            CONF_COILS,
+            {
+                CALL_TYPE_COIL: 1234,
+                CONF_SLAVE: 1,
+            },
+        ),
+    ],
 )
-async def test_config_switch(hass, do_discovery, do_options, read_type):
+async def test_config_switch(hass, array_type, do_config):
     """Run test for switch."""
     device_name = "test_switch"
 
     device_config = {
         CONF_NAME: device_name,
     }
-    if not do_discovery:
-        if read_type == CALL_TYPE_COIL:
-            array_type = CONF_COILS
-            device_config[CALL_TYPE_COIL] = 1234
-            device_config[CONF_SLAVE] = 1
-        else:
-            array_type = CONF_REGISTERS
-            device_config[CONF_REGISTER] = 1234
-            device_config[CONF_COMMAND_OFF] = 0x00
-            device_config[CONF_COMMAND_ON] = 0x01
-    else:
-        array_type = None
-        device_config[CONF_ADDRESS] = 1234
-        if read_type == CALL_TYPE_COIL:
-            device_config[CONF_INPUT_TYPE] = CALL_TYPE_COIL
-
-    if do_options:
-        device_config[CONF_SLAVE] = 1
-        if read_type != CALL_TYPE_COIL:
-            device_config.update(
-                {
-                    CONF_STATE_OFF: 0,
-                    CONF_STATE_ON: 1,
-                    CONF_VERIFY_REGISTER: 1235,
-                    CONF_COMMAND_OFF: 0x00,
-                    CONF_COMMAND_ON: 0x01,
-                }
-            )
-        if do_discovery:
-            device_config.update(
-                {
-                    CONF_DEVICE_CLASS: "switch",
-                    CONF_INPUT_TYPE: read_type,
-                }
-            )
-        else:
-            if read_type != CALL_TYPE_COIL:
-                device_config[CONF_VERIFY_STATE] = True
-                device_config[CONF_REGISTER_TYPE] = read_type
+    device_config.update(do_config)
 
     await base_config_test(
         hass,
@@ -90,7 +171,7 @@ async def test_config_switch(hass, do_discovery, do_options, read_type):
         SWITCH_DOMAIN,
         CONF_SWITCHES,
         array_type,
-        method_discovery=do_discovery,
+        method_discovery=(array_type is None),
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We should avoid if/else in the test cases when combined with parametrisation. This PR updates all modbus test cases.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
