### PR TITLE
Add support for ZHADoorLock locks in deCONZ integration

### DIFF
--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -60,7 +60,7 @@ COVER_TYPES = DAMPERS + WINDOW_COVERS
 FANS = ["Fan"]
 
 # Locks
-LOCKS = ["Door Lock"]
+LOCKS = ["Door Lock", "ZHADoorLock"]
 LOCK_TYPES = LOCKS
 
 # Switches

--- a/homeassistant/components/deconz/lock.py
+++ b/homeassistant/components/deconz/lock.py
@@ -3,7 +3,7 @@ from homeassistant.components.lock import DOMAIN, LockEntity
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
-from .const import LOCKS, NEW_LIGHT
+from .const import LOCKS, NEW_LIGHT, NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
@@ -14,7 +14,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_lock(lights=gateway.api.lights.values()):
+    def async_add_lock_from_light(lights=gateway.api.lights.values()):
         """Add lock from deCONZ."""
         entities = []
 
@@ -28,11 +28,33 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     gateway.listeners.append(
         async_dispatcher_connect(
-            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_lock
+            hass, gateway.async_signal_new_device(NEW_LIGHT), async_add_lock_from_light
         )
     )
 
-    async_add_lock()
+    @callback
+    def async_add_lock_from_sensor(sensors=gateway.api.sensors.values()):
+        """Add lock from deCONZ."""
+        entities = []
+
+        for sensor in sensors:
+
+            if sensor.type in LOCKS and sensor.uniqueid not in gateway.entities[DOMAIN]:
+                entities.append(DeconzLock(sensor, gateway))
+
+        if entities:
+            async_add_entities(entities)
+
+    gateway.listeners.append(
+        async_dispatcher_connect(
+            hass,
+            gateway.async_signal_new_device(NEW_SENSOR),
+            async_add_lock_from_sensor,
+        )
+    )
+
+    async_add_lock_from_light()
+    async_add_lock_from_sensor()
 
 
 class DeconzLock(DeconzDevice, LockEntity):

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==77"],
+  "requirements": ["pydeconz==78"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -3,6 +3,7 @@ from pydeconz.sensor import (
     Battery,
     Consumption,
     Daylight,
+    DoorLock,
     Humidity,
     LightLevel,
     Power,
@@ -103,7 +104,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if (
                 not sensor.BINARY
                 and sensor.type
-                not in Battery.ZHATYPE + Switch.ZHATYPE + Thermostat.ZHATYPE
+                not in Battery.ZHATYPE
+                + DoorLock.ZHATYPE
+                + Switch.ZHATYPE
+                + Thermostat.ZHATYPE
                 and sensor.uniqueid not in gateway.entities[DOMAIN]
             ):
                 entities.append(DeconzSensor(sensor, gateway))

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1334,7 +1334,7 @@ pydaikin==2.4.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==77
+pydeconz==78
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -699,7 +699,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.4.1
 
 # homeassistant.components.deconz
-pydeconz==77
+pydeconz==78
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 from unittest.mock import Mock, patch
 
 import pydeconz
-from pydeconz.websocket import STATE_RUNNING, STATE_STARTING
+from pydeconz.websocket import STATE_RETRYING, STATE_RUNNING
 import pytest
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
@@ -199,7 +199,7 @@ async def test_connection_status_signalling(
 
     assert hass.states.get("binary_sensor.presence").state == STATE_OFF
 
-    await mock_deconz_websocket(state=STATE_STARTING)
+    await mock_deconz_websocket(state=STATE_RETRYING)
     await hass.async_block_till_done()
 
     assert hass.states.get("binary_sensor.presence").state == STATE_UNAVAILABLE

--- a/tests/components/deconz/test_lock.py
+++ b/tests/components/deconz/test_lock.py
@@ -27,8 +27,8 @@ async def test_no_locks(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 0
 
 
-async def test_locks(hass, aioclient_mock, mock_deconz_websocket):
-    """Test that all supported lock entities are created."""
+async def test_lock_from_light(hass, aioclient_mock, mock_deconz_websocket):
+    """Test that all supported lock entities based on lights are created."""
     data = {
         "lights": {
             "1": {
@@ -92,6 +92,87 @@ async def test_locks(hass, aioclient_mock, mock_deconz_websocket):
 
     states = hass.states.async_all()
     assert len(states) == 1
+    for state in states:
+        assert state.state == STATE_UNAVAILABLE
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_lock_from_sensor(hass, aioclient_mock, mock_deconz_websocket):
+    """Test that all supported lock entities based on sensors are created."""
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "battery": 100,
+                    "lock": False,
+                    "on": True,
+                    "reachable": True,
+                },
+                "ep": 11,
+                "etag": "a43862f76b7fa48b0fbb9107df123b0e",
+                "lastseen": "2021-03-06T22:25Z",
+                "manufacturername": "Onesti Products AS",
+                "modelid": "easyCodeTouch_v1",
+                "name": "Door lock",
+                "state": {
+                    "lastupdated": "2021-03-06T21:25:45.624",
+                    "lockstate": "unlocked",
+                },
+                "swversion": "20201211",
+                "type": "ZHADoorLock",
+                "uniqueid": "00:00:00:00:00:00:00:00-00",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 2
+    assert hass.states.get("lock.door_lock").state == STATE_UNLOCKED
+
+    event_changed_light = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"lockstate": "locked"},
+    }
+    await mock_deconz_websocket(data=event_changed_light)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("lock.door_lock").state == STATE_LOCKED
+
+    # Verify service calls
+
+    mock_deconz_put_request(aioclient_mock, config_entry.data, "/sensors/1/config")
+
+    # Service lock door
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_LOCK,
+        {ATTR_ENTITY_ID: "lock.door_lock"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[1][2] == {"lock": True}
+
+    # Service unlock door
+
+    await hass.services.async_call(
+        LOCK_DOMAIN,
+        SERVICE_UNLOCK,
+        {ATTR_ENTITY_ID: "lock.door_lock"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[2][2] == {"lock": False}
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    states = hass.states.async_all()
+    assert len(states) == 2
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
https://github.com/Kane610/deconz/compare/v77...v78

Add support of ZHADoorLock locks which are from the list of sensors rather than lights
Some improvement to the retry logic of the websocket to see if the situation #37372 can be improved

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
