### PR TITLE
Remove analytics from updater

### DIFF
--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -28,8 +28,8 @@ UPDATER_URL = "https://www.home-assistant.io/version.json"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: {
-            vol.Optional(CONF_REPORTING, default=False): cv.boolean,
-            vol.Optional(CONF_COMPONENT_REPORTING, default=False): cv.boolean,
+            vol.Optional(CONF_REPORTING): cv.boolean,
+            vol.Optional(CONF_COMPONENT_REPORTING): cv.boolean,
         }
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/updater/__init__.py
+++ b/homeassistant/components/updater/__init__.py
@@ -5,7 +5,6 @@ import logging
 
 import async_timeout
 from awesomeversion import AwesomeVersion
-from distro import linux_distribution
 import voluptuous as vol
 
 from homeassistant.const import __version__ as current_version
@@ -23,12 +22,13 @@ CONF_COMPONENT_REPORTING = "include_used_components"
 
 DOMAIN = "updater"
 
-UPDATER_URL = "https://updater.home-assistant.io/"
+UPDATER_URL = "https://www.home-assistant.io/version.json"
+
 
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: {
-            vol.Optional(CONF_REPORTING, default=True): cv.boolean,
+            vol.Optional(CONF_REPORTING, default=False): cv.boolean,
             vol.Optional(CONF_COMPONENT_REPORTING, default=False): cv.boolean,
         }
     },
@@ -36,7 +36,8 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 RESPONSE_SCHEMA = vol.Schema(
-    {vol.Required("version"): cv.string, vol.Required("release-notes"): cv.url}
+    {vol.Required("current_version"): cv.string, vol.Required("release_notes"): cv.url},
+    extra=vol.REMOVE_EXTRA,
 )
 
 
@@ -52,29 +53,26 @@ class Updater:
 
 async def async_setup(hass, config):
     """Set up the updater component."""
-    if "dev" in current_version:
-        # This component only makes sense in release versions
-        _LOGGER.info("Running on 'dev', only analytics will be submitted")
-
     conf = config.get(DOMAIN, {})
-    if conf.get(CONF_REPORTING):
-        huuid = await hass.helpers.instance_id.async_get()
-    else:
-        huuid = None
 
-    include_components = conf.get(CONF_COMPONENT_REPORTING)
+    for option in (CONF_COMPONENT_REPORTING, CONF_REPORTING):
+        if option in conf:
+            _LOGGER.warning(
+                "Analytics reporting with the option '%s' "
+                "is deprecated and you should remove that from your configuration. "
+                "The analytics part of this integration has moved to the new 'analytics' integration",
+                option,
+            )
 
     async def check_new_version() -> Updater:
         """Check if a new version is available and report if one is."""
-        newest, release_notes = await get_newest_version(
-            hass, huuid, include_components
-        )
-
-        _LOGGER.debug("Fetched version %s: %s", newest, release_notes)
-
         # Skip on dev
         if "dev" in current_version:
             return Updater(False, "", "")
+
+        newest, release_notes = await get_newest_version(hass)
+
+        _LOGGER.debug("Fetched version %s: %s", newest, release_notes)
 
         # Load data from Supervisor
         if hass.components.hassio.is_hassio():
@@ -121,34 +119,12 @@ async def async_setup(hass, config):
     return True
 
 
-async def get_newest_version(hass, huuid, include_components):
+async def get_newest_version(hass):
     """Get the newest Home Assistant version."""
-    if huuid:
-        info_object = await hass.helpers.system_info.async_get_system_info()
-
-        if include_components:
-            info_object["components"] = list(hass.config.components)
-
-        linux_dist = await hass.async_add_executor_job(linux_distribution, False)
-        info_object["distribution"] = linux_dist[0]
-        info_object["os_version"] = linux_dist[1]
-
-        info_object["huuid"] = huuid
-    else:
-        info_object = {}
-
     session = async_get_clientsession(hass)
 
     with async_timeout.timeout(30):
-        req = await session.post(UPDATER_URL, json=info_object)
-
-    _LOGGER.info(
-        (
-            "Submitted analytics to Home Assistant servers. "
-            "Information submitted includes %s"
-        ),
-        info_object,
-    )
+        req = await session.get(UPDATER_URL)
 
     try:
         res = await req.json()
@@ -159,7 +135,7 @@ async def get_newest_version(hass, huuid, include_components):
 
     try:
         res = RESPONSE_SCHEMA(res)
-        return res["version"], res["release-notes"]
+        return res["current_version"], res["release_notes"]
     except vol.Invalid as err:
         raise update_coordinator.UpdateFailed(
             f"Got unexpected response: {err}"

--- a/tests/components/updater/test_init.py
+++ b/tests/components/updater/test_init.py
@@ -1,4 +1,4 @@
-"""The tests for the Updater component."""
+"""The tests for the Updater integration."""
 from unittest.mock import patch
 
 import pytest
@@ -12,8 +12,10 @@ from tests.common import mock_component
 NEW_VERSION = "10000.0"
 MOCK_VERSION = "10.0"
 MOCK_DEV_VERSION = "10.0.dev0"
-MOCK_HUUID = "abcdefg"
-MOCK_RESPONSE = {"version": "0.15", "release-notes": "https://home-assistant.io"}
+MOCK_RESPONSE = {
+    "current_version": "0.15",
+    "release_notes": "https://home-assistant.io",
+}
 MOCK_CONFIG = {updater.DOMAIN: {"reporting": True}}
 RELEASE_NOTES = "test release notes"
 
@@ -35,19 +37,8 @@ def mock_get_newest_version_fixture():
         yield mock
 
 
-@pytest.fixture(name="mock_get_uuid", autouse=True)
-def mock_get_uuid_fixture():
-    """Fixture to mock get_uuid."""
-    with patch("homeassistant.helpers.instance_id.async_get") as mock:
-        yield mock
-
-
-async def test_new_version_shows_entity_true(
-    hass, mock_get_uuid, mock_get_newest_version
-):
+async def test_new_version_shows_entity_true(hass, mock_get_newest_version):
     """Test if sensor is true if new version is available."""
-    mock_get_uuid.return_value = MOCK_HUUID
-
     assert await async_setup_component(hass, updater.DOMAIN, {updater.DOMAIN: {}})
 
     await hass.async_block_till_done()
@@ -62,11 +53,8 @@ async def test_new_version_shows_entity_true(
     )
 
 
-async def test_same_version_shows_entity_false(
-    hass, mock_get_uuid, mock_get_newest_version
-):
+async def test_same_version_shows_entity_false(hass, mock_get_newest_version):
     """Test if sensor is false if no new version is available."""
-    mock_get_uuid.return_value = MOCK_HUUID
     mock_get_newest_version.return_value = (MOCK_VERSION, "")
 
     assert await async_setup_component(hass, updater.DOMAIN, {updater.DOMAIN: {}})
@@ -81,60 +69,32 @@ async def test_same_version_shows_entity_false(
     assert "release_notes" not in hass.states.get("binary_sensor.updater").attributes
 
 
-async def test_disable_reporting(hass, mock_get_uuid, mock_get_newest_version):
+async def test_deprecated_reporting(hass, mock_get_newest_version, caplog):
     """Test we do not gather analytics when disable reporting is active."""
-    mock_get_uuid.return_value = MOCK_HUUID
     mock_get_newest_version.return_value = (MOCK_VERSION, "")
 
     assert await async_setup_component(
-        hass, updater.DOMAIN, {updater.DOMAIN: {"reporting": False}}
+        hass, updater.DOMAIN, {updater.DOMAIN: {"reporting": True}}
     )
     await hass.async_block_till_done()
 
-    assert hass.states.is_state("binary_sensor.updater", "off")
-    await updater.get_newest_version(hass, MOCK_HUUID, MOCK_CONFIG)
-    call = mock_get_newest_version.mock_calls[0][1]
-    assert call[0] is hass
-    assert call[1] is None
-
-
-async def test_get_newest_version_no_analytics_when_no_huuid(hass, aioclient_mock):
-    """Test we do not gather analytics when no huuid is passed in."""
-    aioclient_mock.post(updater.UPDATER_URL, json=MOCK_RESPONSE)
-
-    with patch(
-        "homeassistant.helpers.system_info.async_get_system_info", side_effect=Exception
-    ):
-        res = await updater.get_newest_version(hass, None, False)
-        assert res == (MOCK_RESPONSE["version"], MOCK_RESPONSE["release-notes"])
-
-
-async def test_get_newest_version_analytics_when_huuid(hass, aioclient_mock):
-    """Test we gather analytics when huuid is passed in."""
-    aioclient_mock.post(updater.UPDATER_URL, json=MOCK_RESPONSE)
-
-    with patch(
-        "homeassistant.helpers.system_info.async_get_system_info",
-        return_value={"fake": "bla"},
-    ):
-        res = await updater.get_newest_version(hass, MOCK_HUUID, False)
-        assert res == (MOCK_RESPONSE["version"], MOCK_RESPONSE["release-notes"])
+    assert "deprecated" in caplog.text
 
 
 async def test_error_fetching_new_version_bad_json(hass, aioclient_mock):
     """Test we handle json error while fetching new version."""
-    aioclient_mock.post(updater.UPDATER_URL, text="not json")
+    aioclient_mock.get(updater.UPDATER_URL, text="not json")
 
     with patch(
         "homeassistant.helpers.system_info.async_get_system_info",
         return_value={"fake": "bla"},
     ), pytest.raises(UpdateFailed):
-        await updater.get_newest_version(hass, MOCK_HUUID, False)
+        await updater.get_newest_version(hass)
 
 
 async def test_error_fetching_new_version_invalid_response(hass, aioclient_mock):
     """Test we handle response error while fetching new version."""
-    aioclient_mock.post(
+    aioclient_mock.get(
         updater.UPDATER_URL,
         json={
             "version": "0.15"
@@ -146,14 +106,13 @@ async def test_error_fetching_new_version_invalid_response(hass, aioclient_mock)
         "homeassistant.helpers.system_info.async_get_system_info",
         return_value={"fake": "bla"},
     ), pytest.raises(UpdateFailed):
-        await updater.get_newest_version(hass, MOCK_HUUID, False)
+        await updater.get_newest_version(hass)
 
 
 async def test_new_version_shows_entity_after_hour_hassio(
-    hass, mock_get_uuid, mock_get_newest_version
+    hass, mock_get_newest_version
 ):
     """Test if binary sensor gets updated if new version is available / Hass.io."""
-    mock_get_uuid.return_value = MOCK_HUUID
     mock_component(hass, "hassio")
     hass.data["hassio_core_info"] = {"version_latest": "999.0"}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The `reporting` and `include_used_components` configuration options have now been deprecated, the `updater` integration will no longer report any analytics. The analytics has moved to it's own integration. See the [`analytics` integration](/integrations/analytics) for more details on how to configure it.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Remove the `reporting` and `include_used_components` configuration options.
- Remove all analytics code.
- Change URL to get the version from `https://updater.home-assistant.io/` to `https://www.home-assistant.io/version.json`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17189

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
