### PR TITLE
Add flux_led RGBCW and RGBWW modes

### DIFF
--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -381,20 +381,14 @@ class FluxLight(LightEntity):
         """Return the white value of this light."""
         return self._white_value
 
-    def get_bulb_rgbww(self):
-        """Return the getRgbww value from the bulb."""
-        return self._bulb.getRgbww()
-
-    @property
     def temperature_cw(self):
         """Return the cold white temperature."""
-        rgbww = self.get_bulb_rgbww()
+        rgbww = self._bulb.getRgbww()
         return [rgbww[4], rgbww[3]]
 
-    @property
     def temperature_ww(self):
         """Return the warm white temperature."""
-        rgbww = self.get_bulb_rgbww()
+        rgbww = self._bulb.getRgbww()
         return rgbww[3]
 
     @property

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -318,7 +318,7 @@ class FluxLight(LightEntity):
             self._mode = MODE_RGB
 
         if self._mode == MODE_RGBCW:
-            white_temp = self.temperature_cw
+            white_temp = self.temperature_cw()
             self._white_value = (
                 white_temp[0] if white_temp[0] > white_temp[1] else white_temp[1]
             )

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -327,7 +327,7 @@ class FluxLight(LightEntity):
                 self._brightness = 0
 
         elif self._mode == MODE_RGBWW:
-            self._white_value = self.temperature_ww
+            self._white_value = self.temperature_ww()
 
             if self._bulb.mode == "ww":
                 self._brightness = 0

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -381,16 +381,20 @@ class FluxLight(LightEntity):
         """Return the white value of this light."""
         return self._white_value
 
+    def get_bulb_rgbww(self):
+        """Return the getRgbww value from the bulb."""
+        return self._bulb.getRgbww()
+
     @property
     def temperature_cw(self):
         """Return the cold white temperature."""
-        rgbww = self._bulb.getRgbww()
+        rgbww = self.get_bulb_rgbww()
         return [rgbww[4], rgbww[3]]
 
     @property
     def temperature_ww(self):
         """Return the warm white temperature."""
-        rgbww = self._bulb.getRgbww()
+        rgbww = self.get_bulb_rgbww()
         return rgbww[3]
 
     @property

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -317,26 +317,27 @@ class FluxLight(LightEntity):
         else:
             self._mode = MODE_RGB
 
-        white_temp = None
         if self._mode == MODE_RGBCW:
             white_temp = self.temperature_cw()
             self._white_value = (
                 white_temp[0] if white_temp[0] > white_temp[1] else white_temp[1]
             )
+
+            if white_temp[0] or white_temp[1]:
+                self._brightness = 0
+
         elif self._mode == MODE_RGBWW:
             self._white_value = self.temperature_ww
+
+            if self._bulb.mode == "ww":
+                self._brightness = 0
         else:
             self._white_value = self._get_rgbw[3]
 
-        if self._mode == MODE_WHITE:
-            self._brightness = self._white_value
-        elif self._mode == MODE_RGBCW:
-            if white_temp[0] or white_temp[1]:
-                self._brightness = 0
-        elif self._mode == MODE_RGBWW and self._bulb.mode == "ww":
-            self._brightness = 0
-        else:
-            self._brightness = self._bulb.brightness
+            if self._mode == MODE_WHITE:
+                self.brightness = self._white_value
+            else:
+                self._brightness = self._bulb.brightness
 
         self._hs_color = color_util.color_RGB_to_hs(*self._get_rgb)
 

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -64,6 +64,8 @@ SUPPORT_FLUX_LED = SUPPORT_BRIGHTNESS | SUPPORT_EFFECT | SUPPORT_COLOR
 
 MODE_RGB = "rgb"
 MODE_RGBW = "rgbw"
+MODE_RGBCW = "rgbcw"
+MODE_RGBWW = "rgbww"
 
 # This mode enables white value to be controlled by brightness.
 # RGB value is ignored when this mode is specified.
@@ -145,7 +147,7 @@ DEVICE_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_NAME): cv.string,
         vol.Optional(ATTR_MODE, default=MODE_RGBW): vol.All(
-            cv.string, vol.In([MODE_RGBW, MODE_RGB, MODE_WHITE])
+            cv.string, vol.In([MODE_RGBW, MODE_RGBWW, MODE_RGBCW, MODE_RGB, MODE_WHITE])
         ),
         vol.Optional(CONF_PROTOCOL): vol.All(cv.string, vol.In(["ledenet"])),
         vol.Optional(CONF_CUSTOM_EFFECT): CUSTOM_EFFECT_SCHEMA,
@@ -315,10 +317,24 @@ class FluxLight(LightEntity):
         else:
             self._mode = MODE_RGB
 
-        self._white_value = self._get_rgbw[3]
+        if self._mode == MODE_RGBCW:
+            white_temp = self.temperature_cw
+            self._white_value = (
+                white_temp[0] if white_temp[0] > white_temp[1] else white_temp[1]
+            )
+        elif self._mode == MODE_RGBWW:
+            self._white_value = self.temperature_ww
+        else:
+            self._white_value = self._get_rgbw[3]
 
         if self._mode == MODE_WHITE:
             self._brightness = self._white_value
+        elif self._mode == MODE_RGBCW:
+            rgbww = self.temperature_cw
+            if rgbww[0] or rgbww[1]:
+                self._brightness = 0
+        elif self._mode == MODE_RGBWW and self._bulb.mode == "ww":
+            self._brightness = 0
         else:
             self._brightness = self._bulb.brightness
 
@@ -366,11 +382,24 @@ class FluxLight(LightEntity):
         return self._white_value
 
     @property
+    def temperature_cw(self):
+        """Return the cold white temperature."""
+        rgbww = self._bulb.getRgbww()
+        return [rgbww[4], rgbww[3]]
+
+    @property
+    def temperature_ww(self):
+        """Return the warm white temperature."""
+        rgbww = self._bulb.getRgbww()
+        return rgbww[3]
+
+    @property
     def supported_features(self):
         """Return the supported features for this light."""
-        if self._mode == MODE_RGBW:
+        if self._mode == MODE_RGBW or self._mode == MODE_RGBCW:
             return SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE | SUPPORT_COLOR_TEMP
-
+        elif self._mode == MODE_RGBWW:
+            return SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE
         return SUPPORT_FLUX_LED
 
     @property
@@ -426,8 +455,40 @@ class FluxLight(LightEntity):
         white = kwargs.get(ATTR_WHITE_VALUE)
         color_temp = kwargs.get(ATTR_COLOR_TEMP)
 
-        # handle special modes
+        # Handle special modes
         if color_temp is not None:
+            if white is None:
+                white = self.white_value if self.white_value > 0 else 255
+
+            if self._mode == MODE_RGBCW:
+                # 153 - 500 color temp in mired
+
+                # Map mired range from light input to kelvin range for bulb
+                mired_min = 500
+                mired_max = 153
+                kelvin_min = 2700
+                kelvin_max = 6500
+
+                # Map mired to kelvin specifically for the setWhiteTemperature since it wants 2700~6500 kelvin and
+                # we have 153~500 mired as an input which doesn't match up the way we want
+                color_temp_kelvin = (color_temp - mired_min) / (
+                    mired_max - mired_min
+                ) * (kelvin_max - kelvin_min) + kelvin_min
+
+                color_temp_kelvin = max(color_temp_kelvin - 2700, 0)
+                warm = 255 * (1 - (color_temp_kelvin / 3800))
+                cold = min(255 * color_temp_kelvin / 3800, 255)
+                warm *= white / 255  # White controls brightness
+                cold *= white / 255
+
+                if (
+                    warm > cold
+                ):  # Warm side will activate both cold and warm leds at same rate (much brighter warm mode)
+                    cold = warm
+
+                self._bulb.setRgbw(w=warm, w2=cold)
+                return
+
             if brightness is None:
                 brightness = self.brightness
             if color_temp > COLOR_TEMP_WARM_VS_COLD_WHITE_CUT_OFF:
@@ -435,6 +496,20 @@ class FluxLight(LightEntity):
             else:
                 self._bulb.setRgbw(w2=brightness)
             return
+
+        if white is not None:
+            if self._mode == MODE_RGBCW:
+                current_temp = self.temperature_cw
+                if not current_temp[0] and not current_temp[1]:
+                    current_temp[0] = 255
+                    current_temp[1] = 255
+                current_temp[0] *= white / 255
+                current_temp[1] *= white / 255
+                self._bulb.setRgbw(w=current_temp[1], w2=current_temp[0])
+                return
+            elif self._mode == MODE_RGBWW:
+                self._bulb.setWarmWhite255(white)
+                return
 
         if effect == EFFECT_RANDOM:
             color_red = random.randint(0, 255)

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -317,6 +317,7 @@ class FluxLight(LightEntity):
         else:
             self._mode = MODE_RGB
 
+        white_temp = None
         if self._mode == MODE_RGBCW:
             white_temp = self.temperature_cw()
             self._white_value = (
@@ -330,8 +331,7 @@ class FluxLight(LightEntity):
         if self._mode == MODE_WHITE:
             self._brightness = self._white_value
         elif self._mode == MODE_RGBCW:
-            rgbww = self.temperature_cw
-            if rgbww[0] or rgbww[1]:
+            if white_temp[0] or white_temp[1]:
                 self._brightness = 0
         elif self._mode == MODE_RGBWW and self._bulb.mode == "ww":
             self._brightness = 0

--- a/homeassistant/components/flux_led/light.py
+++ b/homeassistant/components/flux_led/light.py
@@ -398,7 +398,7 @@ class FluxLight(LightEntity):
         """Return the supported features for this light."""
         if self._mode == MODE_RGBW or self._mode == MODE_RGBCW:
             return SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE | SUPPORT_COLOR_TEMP
-        elif self._mode == MODE_RGBWW:
+        if self._mode == MODE_RGBWW:
             return SUPPORT_FLUX_LED | SUPPORT_WHITE_VALUE
         return SUPPORT_FLUX_LED
 
@@ -507,7 +507,7 @@ class FluxLight(LightEntity):
                 current_temp[1] *= white / 255
                 self._bulb.setRgbw(w=current_temp[1], w2=current_temp[0])
                 return
-            elif self._mode == MODE_RGBWW:
+            if self._mode == MODE_RGBWW:
                 self._bulb.setWarmWhite255(white)
                 return
 

--- a/homeassistant/components/flux_led/services.yaml
+++ b/homeassistant/components/flux_led/services.yaml
@@ -1,10 +1,17 @@
 set_custom_effect:
   description: Set a custom light effect.
+<<<<<<< HEAD
   target:
     entity:
       integration: flux_led
       domain: light
   fields:
+=======
+  fields:
+    entity_id:
+      description: Target light entity. (Required)
+      example: 'entity_id: light.led_lights'
+>>>>>>> Add custom effect service for flux_led.
     colors:
       description: List of colors for the custom effect (RGB). (Required, Max 16 Colors)
       example: |

--- a/homeassistant/components/flux_led/services.yaml
+++ b/homeassistant/components/flux_led/services.yaml
@@ -1,17 +1,10 @@
 set_custom_effect:
   description: Set a custom light effect.
-<<<<<<< HEAD
   target:
     entity:
       integration: flux_led
       domain: light
   fields:
-=======
-  fields:
-    entity_id:
-      description: Target light entity. (Required)
-      example: 'entity_id: light.led_lights'
->>>>>>> Add custom effect service for flux_led.
     colors:
       description: List of colors for the custom effect (RGB). (Required, Max 16 Colors)
       example: |


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

This last change to the refactored flux_led integration adds RGBCW and RGBWW modes to the integration to handle newer types of MagicHome/Flux_LED strips.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
