### PR TITLE
Bump async_upnp_client to 0.16.0

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -2,6 +2,6 @@
   "domain": "dlna_dmr",
   "name": "DLNA Digital Media Renderer",
   "documentation": "https://www.home-assistant.io/integrations/dlna_dmr",
-  "requirements": ["async-upnp-client==0.14.13"],
+  "requirements": ["async-upnp-client==0.16.0"],
   "codeowners": []
 }

--- a/homeassistant/components/dlna_dmr/media_player.py
+++ b/homeassistant/components/dlna_dmr/media_player.py
@@ -14,14 +14,6 @@ import voluptuous as vol
 
 from homeassistant.components.media_player import PLATFORM_SCHEMA, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
-    MEDIA_TYPE_CHANNEL,
-    MEDIA_TYPE_EPISODE,
-    MEDIA_TYPE_IMAGE,
-    MEDIA_TYPE_MOVIE,
-    MEDIA_TYPE_MUSIC,
-    MEDIA_TYPE_PLAYLIST,
-    MEDIA_TYPE_TVSHOW,
-    MEDIA_TYPE_VIDEO,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
@@ -69,28 +61,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_CALLBACK_URL_OVERRIDE): cv.url,
     }
 )
-
-HOME_ASSISTANT_UPNP_CLASS_MAPPING = {
-    MEDIA_TYPE_MUSIC: "object.item.audioItem",
-    MEDIA_TYPE_TVSHOW: "object.item.videoItem",
-    MEDIA_TYPE_MOVIE: "object.item.videoItem",
-    MEDIA_TYPE_VIDEO: "object.item.videoItem",
-    MEDIA_TYPE_EPISODE: "object.item.videoItem",
-    MEDIA_TYPE_CHANNEL: "object.item.videoItem",
-    MEDIA_TYPE_IMAGE: "object.item.imageItem",
-    MEDIA_TYPE_PLAYLIST: "object.item.playlistItem",
-}
-UPNP_CLASS_DEFAULT = "object.item"
-HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING = {
-    MEDIA_TYPE_MUSIC: "audio/*",
-    MEDIA_TYPE_TVSHOW: "video/*",
-    MEDIA_TYPE_MOVIE: "video/*",
-    MEDIA_TYPE_VIDEO: "video/*",
-    MEDIA_TYPE_EPISODE: "video/*",
-    MEDIA_TYPE_CHANNEL: "video/*",
-    MEDIA_TYPE_IMAGE: "image/*",
-    MEDIA_TYPE_PLAYLIST: "playlist/*",
-}
 
 
 def catch_request_errors():
@@ -342,20 +312,15 @@ class DlnaDmrDevice(MediaPlayerEntity):
     @catch_request_errors()
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
+        _LOGGER.debug("Playing media: %s, %s, %s", media_type, media_id, kwargs)
         title = "Home Assistant"
-        mime_type = HOME_ASSISTANT_UPNP_MIME_TYPE_MAPPING.get(media_type, media_type)
-        upnp_class = HOME_ASSISTANT_UPNP_CLASS_MAPPING.get(
-            media_type, UPNP_CLASS_DEFAULT
-        )
 
         # Stop current playing media
         if self._device.can_stop:
             await self.async_media_stop()
 
         # Queue media
-        await self._device.async_set_transport_uri(
-            media_id, title, mime_type, upnp_class
-        )
+        await self._device.async_set_transport_uri(media_id, title)
         await self._device.async_wait_for_can_play()
 
         # If already playing, no need to call Play

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ssdp",
   "name": "Simple Service Discovery Protocol (SSDP)",
   "documentation": "https://www.home-assistant.io/integrations/ssdp",
-  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.2", "async-upnp-client==0.14.13"],
+  "requirements": ["defusedxml==0.6.0", "netdisco==2.8.2", "async-upnp-client==0.16.0"],
   "after_dependencies": ["zeroconf"],
   "codeowners": []
 }

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -3,7 +3,7 @@
   "name": "UPnP",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
-  "requirements": ["async-upnp-client==0.14.13"],
+  "requirements": ["async-upnp-client==0.16.0"],
   "codeowners": ["@StevenLooman"],
   "ssdp": [
     {

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -4,7 +4,7 @@ aiodiscover==1.3.2
 aiohttp==3.7.4.post0
 aiohttp_cors==0.7.0
 astral==1.10.1
-async-upnp-client==0.14.13
+async-upnp-client==0.16.0
 async_timeout==3.0.1
 attrs==20.3.0
 awesomeversion==21.2.3

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -289,7 +289,7 @@ asterisk_mbox==0.5.0
 # homeassistant.components.dlna_dmr
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
-async-upnp-client==0.14.13
+async-upnp-client==0.16.0
 
 # homeassistant.components.supla
 asyncpysupla==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -178,7 +178,7 @@ arcam-fmj==0.5.3
 # homeassistant.components.dlna_dmr
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
-async-upnp-client==0.14.13
+async-upnp-client==0.16.0
 
 # homeassistant.components.aurora
 auroranoaa==0.0.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `async_upnp_client` to `0.16.0` from `0.14.3`, containing some fixes.

Note that this PR invalidates PR #47885.

Also note that this change to async_upnp_client providers IPv6 support which impacts SSDP-advertisement behavior. Testing this (by others, not being me) should be done.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
  - #46822 (preparation for fix)
  - https://github.com/B5r1oJ0A9G/teufel_raumfeld/issues/7
  - Several in https://github.com/StevenLooman/async_upnp_client
- Link to documentation pull request: 
- Additional information, from PR #47885:
  - This PR fixes the dependency issue of the Teufel Raumfeld integration: B5r1oJ0A9G/teufel_raumfeld#7. Teufel Raumfeld depends on HTTP header support and retention of XML values implemented with release 0.15.0 of async-upnp-client.
  - Changelog release 0.15.0/0.16.0 of async-upnp-client: https://github.com/StevenLooman/async_upnp_client/blob/development/CHANGES.rst
  - Comparing changes release 0.16.0 to 0.14.13: https://github.com/StevenLooman/async_upnp_client/compare/0.14.13...0.15.0


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
