### PR TITLE
Update xknx to version 0.17.5

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -67,7 +67,6 @@ CONF_KNX_MCAST_GRP = "multicast_group"
 CONF_KNX_MCAST_PORT = "multicast_port"
 CONF_KNX_STATE_UPDATER = "state_updater"
 CONF_KNX_RATE_LIMIT = "rate_limit"
-CONF_KNX_USE_UNIQUE_ID = "use_unique_id"
 CONF_KNX_EXPOSE = "expose"
 
 SERVICE_KNX_SEND = "send"
@@ -112,7 +111,6 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Optional(CONF_KNX_RATE_LIMIT, default=20): vol.All(
                         vol.Coerce(int), vol.Range(min=1, max=100)
                     ),
-                    vol.Optional(CONF_KNX_USE_UNIQUE_ID, default=False): cv.boolean,
                     vol.Optional(CONF_KNX_EXPOSE): vol.All(
                         cv.ensure_list, [ExposeSchema.SCHEMA]
                     ),
@@ -306,7 +304,6 @@ class KNXModule:
         self.hass = hass
         self.config = config
         self.connected = False
-        self.use_unique_id: bool = config[DOMAIN][CONF_KNX_USE_UNIQUE_ID]
         self.exposures: list[KNXExposeSensor | KNXExposeTime] = []
         self.service_exposures: dict[str, KNXExposeSensor | KNXExposeTime] = {}
 

--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -67,6 +67,7 @@ CONF_KNX_MCAST_GRP = "multicast_group"
 CONF_KNX_MCAST_PORT = "multicast_port"
 CONF_KNX_STATE_UPDATER = "state_updater"
 CONF_KNX_RATE_LIMIT = "rate_limit"
+CONF_KNX_USE_UNIQUE_ID = "use_unique_id"
 CONF_KNX_EXPOSE = "expose"
 
 SERVICE_KNX_SEND = "send"
@@ -111,6 +112,7 @@ CONFIG_SCHEMA = vol.Schema(
                     vol.Optional(CONF_KNX_RATE_LIMIT, default=20): vol.All(
                         vol.Coerce(int), vol.Range(min=1, max=100)
                     ),
+                    vol.Optional(CONF_KNX_USE_UNIQUE_ID, default=False): cv.boolean,
                     vol.Optional(CONF_KNX_EXPOSE): vol.All(
                         cv.ensure_list, [ExposeSchema.SCHEMA]
                     ),
@@ -304,6 +306,7 @@ class KNXModule:
         self.hass = hass
         self.config = config
         self.connected = False
+        self.use_unique_id: bool = config[DOMAIN][CONF_KNX_USE_UNIQUE_ID]
         self.exposures: list[KNXExposeSensor | KNXExposeTime] = []
         self.service_exposures: dict[str, KNXExposeSensor | KNXExposeTime] = {}
 

--- a/homeassistant/components/knx/knx_entity.py
+++ b/homeassistant/components/knx/knx_entity.py
@@ -36,11 +36,8 @@ class KnxEntity(Entity):
 
     @property
     def unique_id(self) -> str | None:
-        """Return the unique id of the device if enabled."""
-        if self.hass.data[DOMAIN].use_unique_id:
-            return self._device.unique_id
-
-        return None
+        """Return the unique id of the device."""
+        return self._device.unique_id
 
     async def async_update(self) -> None:
         """Request a state update from KNX bus."""

--- a/homeassistant/components/knx/knx_entity.py
+++ b/homeassistant/components/knx/knx_entity.py
@@ -1,4 +1,6 @@
 """Base class for KNX devices."""
+from __future__ import annotations
+
 from typing import cast
 
 from xknx.devices import Climate as XknxClimate, Device as XknxDevice
@@ -31,6 +33,14 @@ class KnxEntity(Entity):
     def should_poll(self) -> bool:
         """No polling needed within KNX."""
         return False
+
+    @property
+    def unique_id(self) -> str | None:
+        """Return the unique id of the device if enabled."""
+        if self.hass.data[DOMAIN].use_unique_id:
+            return self._device.unique_id
+
+        return None
 
     async def async_update(self) -> None:
         """Request a state update from KNX bus."""

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.17.4"],
+  "requirements": ["xknx==0.17.5"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2335,7 +2335,7 @@ xbox-webapi==2.0.8
 xboxapi==2.0.1
 
 # homeassistant.components.knx
-xknx==0.17.4
+xknx==0.17.5
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1208,7 +1208,7 @@ wolf_smartset==0.1.8
 xbox-webapi==2.0.8
 
 # homeassistant.components.knx
-xknx==0.17.4
+xknx==0.17.5
 
 # homeassistant.components.bluesound
 # homeassistant.components.rest


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request adds support for opt-in unique ids for KNX entities. When users enable the `use_unique_id` feature the entities will have a unique id (based on the underlying device) attached to them.

https://github.com/XKNX/xknx/compare/0.17.4...0.17.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17197

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
