### PR TITLE
Apply Precision/Scale/Offset to struct in modbus sensor

### DIFF
--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -319,7 +319,19 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
             # If unpack() returns a tuple greater than 1, don't try to process the value.
             # Instead, return the values of unpack(...) separated by commas.
             if len(val) > 1:
-                self._value = ",".join(map(str, val))
+                # Apply scale and precision to floats and ints
+                v_result = []
+                for entry in val:
+                    v_temp = self._scale * entry + self._offset
+
+                    # We could convert int to float, and the code would still work; however
+                    # we lose some precision, and unit tests will fail. Therefore, we do
+                    # the conversion only when it's absolutely necessary.
+                    if isinstance(v_temp, int) and self._precision == 0:
+                        v_result.append(str(v_temp))
+                    else:
+                        v_result.append(f"{float(v_temp):.{self._precision}f}")
+                self._value = ",".join(map(str, v_result))
             else:
                 val = val[0]
 

--- a/tests/components/modbus/test_modbus_sensor.py
+++ b/tests/components/modbus/test_modbus_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.modbus.const import (
     CONF_REGISTERS,
     CONF_REVERSE_ORDER,
     CONF_SCALE,
+    DATA_TYPE_CUSTOM,
     DATA_TYPE_FLOAT,
     DATA_TYPE_INT,
     DATA_TYPE_STRING,
@@ -26,6 +27,7 @@ from homeassistant.const import (
     CONF_OFFSET,
     CONF_SENSORS,
     CONF_SLAVE,
+    CONF_STRUCTURE,
 )
 
 from .conftest import base_config_test, base_test
@@ -338,6 +340,7 @@ async def test_config_sensor(hass, do_discovery, do_config):
 )
 async def test_all_sensor(hass, cfg, regs, expected):
     """Run test for sensor."""
+
     sensor_name = "modbus_test_sensor"
     state = await base_test(
         hass,
@@ -349,6 +352,44 @@ async def test_all_sensor(hass, cfg, regs, expected):
         regs,
         expected,
         method_discovery=True,
+        scan_interval=5,
+    )
+    assert state == expected
+
+
+async def test_struct_sensor(hass):
+    """Run test for sensor struct."""
+
+    sensor_name = "modbus_test_sensor"
+    # floats: 7.931250095367432, 10.600000381469727,
+    #         1.000879611487865e-28, 10.566553115844727
+    expected = "7.93,10.60,0.00,10.57"
+    state = await base_test(
+        hass,
+        {
+            CONF_NAME: sensor_name,
+            CONF_REGISTER: 1234,
+            CONF_COUNT: 8,
+            CONF_PRECISION: 2,
+            CONF_DATA_TYPE: DATA_TYPE_CUSTOM,
+            CONF_STRUCTURE: ">4f",
+        },
+        sensor_name,
+        SENSOR_DOMAIN,
+        CONF_SENSORS,
+        CONF_REGISTERS,
+        [
+            0x40FD,
+            0xCCCD,
+            0x4129,
+            0x999A,
+            0x10FD,
+            0xC0CD,
+            0x4129,
+            0x109A,
+        ],
+        expected,
+        method_discovery=False,
         scan_interval=5,
     )
     assert state == expected


### PR DESCRIPTION
The single values in struct are corrected with presicion, scale and offset,
just as it is done with single values.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
the struct configuration e.g.
```yaml
sensors:
  - name test1
  - data_type = custom
  - count = 8
  - struct = ">4f"
```
Could result in very long strings being delivered back, due to many decimal digits.
```yaml
sensors:
  - name test1
  - data_type: custom
  - scale: 1
  - offset: 0
  - precision: 2
  - count: 8
  - struct: ">4f"
```
will cut the decimals to 2.





## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44254 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
