### PR TITLE
Include blueprint input in automation trace

### DIFF
--- a/homeassistant/components/automation/trace.py
+++ b/homeassistant/components/automation/trace.py
@@ -18,11 +18,12 @@ class AutomationTrace(ActionTrace):
         self,
         item_id: str,
         config: dict[str, Any],
+        blueprint_inputs: dict[str, Any],
         context: Context,
     ):
         """Container for automation trace."""
         key = ("automation", item_id)
-        super().__init__(key, config, context)
+        super().__init__(key, config, blueprint_inputs, context)
         self._trigger_description: str | None = None
 
     def set_trigger_description(self, trigger: str) -> None:
@@ -37,9 +38,9 @@ class AutomationTrace(ActionTrace):
 
 
 @contextmanager
-def trace_automation(hass, automation_id, config, context):
+def trace_automation(hass, automation_id, config, blueprint_inputs, context):
     """Trace action execution of automation with automation_id."""
-    trace = AutomationTrace(automation_id, config, context)
+    trace = AutomationTrace(automation_id, config, blueprint_inputs, context)
     async_store_trace(hass, trace)
 
     try:

--- a/homeassistant/components/script/trace.py
+++ b/homeassistant/components/script/trace.py
@@ -19,7 +19,7 @@ class ScriptTrace(ActionTrace):
     ):
         """Container for automation trace."""
         key = ("script", item_id)
-        super().__init__(key, config, context)
+        super().__init__(key, config, None, context)
 
 
 @contextmanager

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -48,11 +48,13 @@ class ActionTrace:
         self,
         key: tuple[str, str],
         config: dict[str, Any],
+        blueprint_inputs: dict[str, Any],
         context: Context,
     ):
         """Container for script trace."""
         self._trace: dict[str, Deque[TraceElement]] | None = None
         self._config: dict[str, Any] = config
+        self._blueprint_inputs: dict[str, Any] = blueprint_inputs
         self.context: Context = context
         self._error: Exception | None = None
         self._state: str = "running"
@@ -93,6 +95,7 @@ class ActionTrace:
             {
                 "trace": traces,
                 "config": self._config,
+                "blueprint_inputs": self._blueprint_inputs,
                 "context": self.context,
             }
         )

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -169,6 +169,7 @@ async def test_get_trace(
     assert trace["trace"][f"{prefix}/0"][0]["error"]
     assert trace["trace"][f"{prefix}/0"][0]["result"] == sun_action
     _assert_raw_config(domain, sun_config, trace)
+    assert trace["blueprint_inputs"] is None
     assert trace["context"]
     assert trace["error"] == "Unable to find service test.automation"
     assert trace["state"] == "stopped"
@@ -210,6 +211,7 @@ async def test_get_trace(
     assert "error" not in trace["trace"][f"{prefix}/0"][0]
     assert trace["trace"][f"{prefix}/0"][0]["result"] == moon_action
     _assert_raw_config(domain, moon_config, trace)
+    assert trace["blueprint_inputs"] is None
     assert trace["context"]
     assert "error" not in trace
     assert trace["state"] == "stopped"
@@ -1162,3 +1164,71 @@ async def test_script_mode_2(hass, hass_ws_client, script_mode, script_execution
     trace = _find_traces(response["result"], "script", "script1")[1]
     assert trace["state"] == "stopped"
     assert trace["script_execution"] == "finished"
+
+
+async def test_trace_blueprint_automation(hass, hass_ws_client):
+    """Test trace of blueprint automation."""
+    id = 1
+
+    def next_id():
+        nonlocal id
+        id += 1
+        return id
+
+    domain = "automation"
+    sun_config = {
+        "id": "sun",
+        "use_blueprint": {
+            "path": "test_event_service.yaml",
+            "input": {
+                "trigger_event": "blueprint_event",
+                "service_to_call": "test.automation",
+            },
+        },
+    }
+    sun_action = {
+        "limit": 10,
+        "params": {
+            "domain": "test",
+            "service": "automation",
+            "service_data": {},
+            "target": {"entity_id": ["light.kitchen"]},
+        },
+        "running_script": False,
+    }
+    assert await async_setup_component(hass, "automation", {"automation": sun_config})
+    client = await hass_ws_client()
+    hass.bus.async_fire("blueprint_event")
+    await hass.async_block_till_done()
+
+    # List traces
+    await client.send_json({"id": next_id(), "type": "trace/list", "domain": domain})
+    response = await client.receive_json()
+    assert response["success"]
+    run_id = _find_run_id(response["result"], domain, "sun")
+
+    # Get trace
+    await client.send_json(
+        {
+            "id": next_id(),
+            "type": "trace/get",
+            "domain": domain,
+            "item_id": "sun",
+            "run_id": run_id,
+        }
+    )
+    response = await client.receive_json()
+    assert response["success"]
+    trace = response["result"]
+    assert set(trace["trace"]) == {"trigger/0", "action/0"}
+    assert len(trace["trace"]["action/0"]) == 1
+    assert trace["trace"]["action/0"][0]["error"]
+    assert trace["trace"]["action/0"][0]["result"] == sun_action
+    assert trace["config"]["id"] == "sun"
+    assert trace["blueprint_inputs"] == sun_config
+    assert trace["context"]
+    assert trace["error"] == "Unable to find service test.automation"
+    assert trace["state"] == "stopped"
+    assert trace["script_execution"] == "error"
+    assert trace["item_id"] == "sun"
+    assert trace.get("trigger", UNDEFINED) == "event 'blueprint_event'"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Include automation config before blueprint substitution in automation trace.

The automation's config before blueprint substitution is available in key `blueprint_inputs` in the trace.

### Example:

Automation config:
```yaml
id: sun
use_blueprint:
  path: test_event_service.yaml
  input:
    trigger_event: blueprint_event
    service_to_call: test.automation
```

Blueprint:
```yaml
blueprint:
  name: "Call service based on event"
  domain: automation
  input:
    trigger_event:
    service_to_call:
trigger:
  platform: event
  event_type: !input trigger_event
action:
  service: !input service_to_call
  entity_id: light.kitchen
```

trace["blueprint_input"]:
```yaml
id: sun
use_blueprint:
  path: test_event_service.yaml
  input:
    trigger_event: blueprint_event
    service_to_call: test.automation
```

trace["config"]:
```yaml
id: sun
action:
  entity_id: light.kitchen
  service: test.automation
trigger:
  event_type: blueprint_event
  platform: event
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
