### PR TITLE
Include script script_execution in script and automation traces

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -57,6 +57,7 @@ from homeassistant.helpers.script_variables import ScriptVariables
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.trace import (
     TraceElement,
+    script_execution_set,
     trace_append_element,
     trace_get,
     trace_path,
@@ -471,6 +472,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
                     "Conditions not met, aborting automation. Condition summary: %s",
                     trace_get(clear=False),
                 )
+                script_execution_set("failed_conditions")
                 return
 
             self.async_set_context(trigger_context)

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -8,6 +8,7 @@ from typing import Any, Deque
 from homeassistant.core import Context
 from homeassistant.helpers.trace import (
     TraceElement,
+    stop_reason_get,
     trace_id_get,
     trace_id_set,
     trace_set_child_id,
@@ -55,6 +56,7 @@ class ActionTrace:
         self.context: Context = context
         self._error: Exception | None = None
         self._state: str = "running"
+        self._stop_reason: str | None = None
         self.run_id: str = str(next(self._run_ids))
         self._timestamp_finish: dt.datetime | None = None
         self._timestamp_start: dt.datetime = dt_util.utcnow()
@@ -75,6 +77,7 @@ class ActionTrace:
         """Set finish time."""
         self._timestamp_finish = dt_util.utcnow()
         self._state = "stopped"
+        self._stop_reason = stop_reason_get()
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this ActionTrace."""
@@ -109,6 +112,7 @@ class ActionTrace:
             "last_step": last_step,
             "run_id": self.run_id,
             "state": self._state,
+            "stop_reason": self._stop_reason,
             "timestamp": {
                 "start": self._timestamp_start,
                 "finish": self._timestamp_finish,

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, Deque
 from homeassistant.core import Context
 from homeassistant.helpers.trace import (
     TraceElement,
-    stop_reason_get,
+    script_execution_get,
     trace_id_get,
     trace_id_set,
     trace_set_child_id,
@@ -56,7 +56,7 @@ class ActionTrace:
         self.context: Context = context
         self._error: Exception | None = None
         self._state: str = "running"
-        self._stop_reason: str | None = None
+        self._script_execution: str | None = None
         self.run_id: str = str(next(self._run_ids))
         self._timestamp_finish: dt.datetime | None = None
         self._timestamp_start: dt.datetime = dt_util.utcnow()
@@ -77,7 +77,7 @@ class ActionTrace:
         """Set finish time."""
         self._timestamp_finish = dt_util.utcnow()
         self._state = "stopped"
-        self._stop_reason = stop_reason_get()
+        self._script_execution = script_execution_get()
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this ActionTrace."""
@@ -112,7 +112,7 @@ class ActionTrace:
             "last_step": last_step,
             "run_id": self.run_id,
             "state": self._state,
-            "stop_reason": self._stop_reason,
+            "script_execution": self._script_execution,
             "timestamp": {
                 "start": self._timestamp_start,
                 "finish": self._timestamp_finish,

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -333,15 +333,14 @@ class _ScriptRun:
     async def async_run(self) -> None:
         """Run script."""
         try:
-            if self._stop.is_set():
-                stop_reason_set("cancelled")
-                return
             self._log("Running %s", self._script.running_description)
             for self._step, self._action in enumerate(self._script.sequence):
                 if self._stop.is_set():
+                    stop_reason_set("cancelled")
                     break
                 await self._async_step(log_exceptions=False)
-            stop_reason_set("finished")
+            else:
+                stop_reason_set("finished")
         except _StopScript:
             stop_reason_set("aborted")
         except Exception:

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -63,6 +63,7 @@ from homeassistant.helpers.dispatcher import (
 )
 from homeassistant.helpers.event import async_call_later, async_track_template
 from homeassistant.helpers.script_variables import ScriptVariables
+from homeassistant.helpers.trace import stop_reason_set
 from homeassistant.helpers.trigger import (
     async_initialize_triggers,
     async_validate_trigger_config,
@@ -333,14 +334,19 @@ class _ScriptRun:
         """Run script."""
         try:
             if self._stop.is_set():
+                stop_reason_set("cancelled")
                 return
             self._log("Running %s", self._script.running_description)
             for self._step, self._action in enumerate(self._script.sequence):
                 if self._stop.is_set():
                     break
                 await self._async_step(log_exceptions=False)
+            stop_reason_set("finished")
         except _StopScript:
-            pass
+            stop_reason_set("aborted")
+        except Exception:
+            stop_reason_set("error")
+            raise
         finally:
             self._finish()
 

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -88,6 +88,10 @@ variables_cv: ContextVar[Any | None] = ContextVar("variables_cv", default=None)
 trace_id_cv: ContextVar[tuple[str, str] | None] = ContextVar(
     "trace_id_cv", default=None
 )
+# Reason for stopped script execution
+stop_reason_cv: ContextVar[StopReason | None] = ContextVar(
+    "stop_reason_cv", default=None
+)
 
 
 def trace_id_set(trace_id: tuple[str, str]) -> None:
@@ -172,6 +176,7 @@ def trace_clear() -> None:
     trace_stack_cv.set(None)
     trace_path_stack_cv.set(None)
     variables_cv.set(None)
+    stop_reason_cv.set(StopReason())
 
 
 def trace_set_child_id(child_key: tuple[str, str], child_run_id: str) -> None:
@@ -185,6 +190,28 @@ def trace_set_result(**kwargs: Any) -> None:
     """Set the result of TraceElement at the top of the stack."""
     node = cast(TraceElement, trace_stack_top(trace_stack_cv))
     node.set_result(**kwargs)
+
+
+class StopReason:
+    """Mutable container class for stop_reason."""
+
+    stop_reason: str | None = None
+
+
+def stop_reason_set(reason: str) -> None:
+    """Set stop reason."""
+    data = stop_reason_cv.get()
+    if data is None:
+        return
+    data.stop_reason = reason
+
+
+def stop_reason_get() -> str | None:
+    """Return the current trace."""
+    data = stop_reason_cv.get()
+    if data is None:
+        return None
+    return data.stop_reason
 
 
 @contextmanager

--- a/homeassistant/helpers/trace.py
+++ b/homeassistant/helpers/trace.py
@@ -89,8 +89,8 @@ trace_id_cv: ContextVar[tuple[str, str] | None] = ContextVar(
     "trace_id_cv", default=None
 )
 # Reason for stopped script execution
-stop_reason_cv: ContextVar[StopReason | None] = ContextVar(
-    "stop_reason_cv", default=None
+script_execution_cv: ContextVar[StopReason | None] = ContextVar(
+    "script_execution_cv", default=None
 )
 
 
@@ -176,7 +176,7 @@ def trace_clear() -> None:
     trace_stack_cv.set(None)
     trace_path_stack_cv.set(None)
     variables_cv.set(None)
-    stop_reason_cv.set(StopReason())
+    script_execution_cv.set(StopReason())
 
 
 def trace_set_child_id(child_key: tuple[str, str], child_run_id: str) -> None:
@@ -193,25 +193,25 @@ def trace_set_result(**kwargs: Any) -> None:
 
 
 class StopReason:
-    """Mutable container class for stop_reason."""
+    """Mutable container class for script_execution."""
 
-    stop_reason: str | None = None
+    script_execution: str | None = None
 
 
-def stop_reason_set(reason: str) -> None:
+def script_execution_set(reason: str) -> None:
     """Set stop reason."""
-    data = stop_reason_cv.get()
+    data = script_execution_cv.get()
     if data is None:
         return
-    data.stop_reason = reason
+    data.script_execution = reason
 
 
-def stop_reason_get() -> str | None:
+def script_execution_get() -> str | None:
     """Return the current trace."""
-    data = stop_reason_cv.get()
+    data = script_execution_cv.get()
     if data is None:
         return None
-    return data.stop_reason
+    return data.script_execution
 
 
 @contextmanager

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -86,9 +86,10 @@ def assert_element(trace_element, expected_element, path):
         assert not trace_element._variables
 
 
-def assert_action_trace(expected):
+def assert_action_trace(expected, expected_stop_reason="finished"):
     """Assert a trace condition sequence is as expected."""
     action_trace = trace.trace_get(clear=False)
+    stop_reason = trace.stop_reason_get()
     trace.trace_clear()
     expected_trace_keys = list(expected.keys())
     assert list(action_trace.keys()) == expected_trace_keys
@@ -97,6 +98,8 @@ def assert_action_trace(expected):
         for index, element in enumerate(expected[key]):
             path = f"[{trace_key_index}][{index}]"
             assert_element(action_trace[key][index], element, path)
+
+    assert stop_reason == expected_stop_reason
 
 
 def async_watch_for_action(script_obj, message):
@@ -620,7 +623,8 @@ async def test_delay_template_invalid(hass, caplog):
         {
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [{"error_type": script._StopScript}],
-        }
+        },
+        expected_stop_reason="aborted",
     )
 
 
@@ -680,7 +684,8 @@ async def test_delay_template_complex_invalid(hass, caplog):
         {
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [{"error_type": script._StopScript}],
-        }
+        },
+        expected_stop_reason="aborted",
     )
 
 
@@ -1131,6 +1136,7 @@ async def test_wait_continue_on_timeout(
     if continue_on_timeout is False:
         expected_trace["0"][0]["result"]["timeout"] = True
         expected_trace["0"][0]["error_type"] = script._StopScript
+        expected_stop_reason = "aborted"
     else:
         expected_trace["1"] = [
             {
@@ -1138,7 +1144,8 @@ async def test_wait_continue_on_timeout(
                 "variables": variable_wait,
             }
         ]
-    assert_action_trace(expected_trace)
+        expected_stop_reason = "finished"
+    assert_action_trace(expected_trace, expected_stop_reason)
 
 
 async def test_wait_template_variables_in(hass):
@@ -1404,7 +1411,8 @@ async def test_condition_warning(hass, caplog):
             "1": [{"error_type": script._StopScript, "result": {"result": False}}],
             "1/condition": [{"error_type": ConditionError}],
             "1/condition/entity_id/0": [{"error_type": ConditionError}],
-        }
+        },
+        expected_stop_reason="aborted",
     )
 
 
@@ -1456,7 +1464,8 @@ async def test_condition_basic(hass, caplog):
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [{"error_type": script._StopScript, "result": {"result": False}}],
             "1/condition": [{"result": {"result": False}}],
-        }
+        },
+        expected_stop_reason="aborted",
     )
 
 
@@ -2141,7 +2150,7 @@ async def test_propagate_error_service_not_found(hass):
             }
         ],
     }
-    assert_action_trace(expected_trace)
+    assert_action_trace(expected_trace, expected_stop_reason="error")
 
 
 async def test_propagate_error_invalid_service_data(hass):
@@ -2178,7 +2187,7 @@ async def test_propagate_error_invalid_service_data(hass):
             }
         ],
     }
-    assert_action_trace(expected_trace)
+    assert_action_trace(expected_trace, expected_stop_reason="error")
 
 
 async def test_propagate_error_service_exception(hass):
@@ -2219,7 +2228,7 @@ async def test_propagate_error_service_exception(hass):
             }
         ],
     }
-    assert_action_trace(expected_trace)
+    assert_action_trace(expected_trace, expected_stop_reason="error")
 
 
 async def test_referenced_entities(hass):

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -86,10 +86,10 @@ def assert_element(trace_element, expected_element, path):
         assert not trace_element._variables
 
 
-def assert_action_trace(expected, expected_stop_reason="finished"):
+def assert_action_trace(expected, expected_script_execution="finished"):
     """Assert a trace condition sequence is as expected."""
     action_trace = trace.trace_get(clear=False)
-    stop_reason = trace.stop_reason_get()
+    script_execution = trace.script_execution_get()
     trace.trace_clear()
     expected_trace_keys = list(expected.keys())
     assert list(action_trace.keys()) == expected_trace_keys
@@ -99,7 +99,7 @@ def assert_action_trace(expected, expected_stop_reason="finished"):
             path = f"[{trace_key_index}][{index}]"
             assert_element(action_trace[key][index], element, path)
 
-    assert stop_reason == expected_stop_reason
+    assert script_execution == expected_script_execution
 
 
 def async_watch_for_action(script_obj, message):
@@ -624,7 +624,7 @@ async def test_delay_template_invalid(hass, caplog):
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [{"error_type": script._StopScript}],
         },
-        expected_stop_reason="aborted",
+        expected_script_execution="aborted",
     )
 
 
@@ -685,7 +685,7 @@ async def test_delay_template_complex_invalid(hass, caplog):
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
             "1": [{"error_type": script._StopScript}],
         },
-        expected_stop_reason="aborted",
+        expected_script_execution="aborted",
     )
 
 
@@ -1136,7 +1136,7 @@ async def test_wait_continue_on_timeout(
     if continue_on_timeout is False:
         expected_trace["0"][0]["result"]["timeout"] = True
         expected_trace["0"][0]["error_type"] = script._StopScript
-        expected_stop_reason = "aborted"
+        expected_script_execution = "aborted"
     else:
         expected_trace["1"] = [
             {
@@ -1144,8 +1144,8 @@ async def test_wait_continue_on_timeout(
                 "variables": variable_wait,
             }
         ]
-        expected_stop_reason = "finished"
-    assert_action_trace(expected_trace, expected_stop_reason)
+        expected_script_execution = "finished"
+    assert_action_trace(expected_trace, expected_script_execution)
 
 
 async def test_wait_template_variables_in(hass):
@@ -1412,7 +1412,7 @@ async def test_condition_warning(hass, caplog):
             "1/condition": [{"error_type": ConditionError}],
             "1/condition/entity_id/0": [{"error_type": ConditionError}],
         },
-        expected_stop_reason="aborted",
+        expected_script_execution="aborted",
     )
 
 
@@ -1465,7 +1465,7 @@ async def test_condition_basic(hass, caplog):
             "1": [{"error_type": script._StopScript, "result": {"result": False}}],
             "1/condition": [{"result": {"result": False}}],
         },
-        expected_stop_reason="aborted",
+        expected_script_execution="aborted",
     )
 
 
@@ -2150,7 +2150,7 @@ async def test_propagate_error_service_not_found(hass):
             }
         ],
     }
-    assert_action_trace(expected_trace, expected_stop_reason="error")
+    assert_action_trace(expected_trace, expected_script_execution="error")
 
 
 async def test_propagate_error_invalid_service_data(hass):
@@ -2187,7 +2187,7 @@ async def test_propagate_error_invalid_service_data(hass):
             }
         ],
     }
-    assert_action_trace(expected_trace, expected_stop_reason="error")
+    assert_action_trace(expected_trace, expected_script_execution="error")
 
 
 async def test_propagate_error_service_exception(hass):
@@ -2228,7 +2228,7 @@ async def test_propagate_error_service_exception(hass):
             }
         ],
     }
-    assert_action_trace(expected_trace, expected_stop_reason="error")
+    assert_action_trace(expected_trace, expected_script_execution="error")
 
 
 async def test_referenced_entities(hass):

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -722,7 +722,8 @@ async def test_cancel_delay(hass):
     assert_action_trace(
         {
             "0": [{"result": {"delay": 5.0, "done": False}}],
-        }
+        },
+        expected_script_execution="cancelled",
     )
 
 
@@ -974,13 +975,15 @@ async def test_cancel_wait(hass, action_type):
         assert_action_trace(
             {
                 "0": [{"result": {"wait": {"completed": False, "remaining": None}}}],
-            }
+            },
+            expected_script_execution="cancelled",
         )
     else:
         assert_action_trace(
             {
                 "0": [{"result": {"wait": {"trigger": None, "remaining": None}}}],
-            }
+            },
+            expected_script_execution="cancelled",
         )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Include script script_execution in script and automation traces

`script_execution` is set according to:
- The script was not executed because the automation's condition failed
  -  `script_execution = failed_condition`
- The script was not executed because the run mode is `single`
  -  `script_execution = failed_single`
- The script was not executed because max parallel runs would be exceeded
  -  `script_execution = failed_max_runs`
- All script steps finished:
  - `script_execution = "finished"`
- Script execution stopped by the script itself because a condition fails, wait_for_trigger timeouts etc:
  - `script_execution = "aborted"`
  - Details about failing condition, timeout etc. is in the last element of the trace
- Script execution stops because of an unexpected exception:
  - `script_execution = "error"`
  - The exception is in the trace itself or in the last element of the trace
- Script execution stopped by `async_stop` called on the script run because home assistant is shutting down, script mode is `SCRIPT_MODE_RESTART` etc:
  - `script_execution  = "cancelled"`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
