### PR TITLE
Allow templatable service target to support scripts

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -916,7 +916,7 @@ SERVICE_SCHEMA = vol.All(
             vol.Optional("data"): vol.All(dict, template_complex),
             vol.Optional("data_template"): vol.All(dict, template_complex),
             vol.Optional(CONF_ENTITY_ID): comp_entity_ids,
-            vol.Optional(CONF_TARGET): ENTITY_SERVICE_FIELDS,
+            vol.Optional(CONF_TARGET): vol.Any(ENTITY_SERVICE_FIELDS, dynamic_template),
         }
     ),
     has_at_least_one_key(CONF_SERVICE, CONF_SERVICE_TEMPLATE),

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -204,10 +204,15 @@ def async_prepare_call_from_config(
 
     target = {}
     if CONF_TARGET in config:
-        conf = config.get(CONF_TARGET)
+        conf = config[CONF_TARGET]
         try:
-            template.attach(hass, conf)
-            target.update(template.render_complex(conf, variables))
+            if isinstance(conf, template.Template):
+                conf.hass = hass
+                target.update(conf.async_render(variables))
+            else:
+                template.attach(hass, conf)
+                target.update(template.render_complex(conf, variables))
+
             if CONF_ENTITY_ID in target:
                 target[CONF_ENTITY_ID] = cv.comp_entity_ids(target[CONF_ENTITY_ID])
         except TemplateError as ex:

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -213,6 +213,30 @@ class TestServiceHelpers(unittest.TestCase):
             "entity_id": ["light.static", "light.dynamic"],
         }
 
+        config = {
+            "service": "{{ 'test_domain.test_service' }}",
+            "target": "{{ var_target }}",
+        }
+
+        service.call_from_config(
+            self.hass,
+            config,
+            variables={
+                "var_target": {
+                    "entity_id": "light.static",
+                    "area_id": ["area-42", "area-51"],
+                },
+            },
+        )
+
+        service.call_from_config(self.hass, config)
+        self.hass.block_till_done()
+
+        assert dict(self.calls[2].data) == {
+            "area_id": ["area-42", "area-51"],
+            "entity_id": ["light.static"],
+        }
+
     def test_service_template_service_call(self):
         """Test legacy service_template call with templating."""
         config = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With #48469 we added support for the use of Selectors in script fields.
This includes the `target` selector, however, since scripts do not have `!input` capabilities, it has to rely on templates.

Currently, this doesn't work:

```py
- service: light.turn_on
  target: "{{ my_script_var_field }}"
```

This PR adjusts that oversight and ensures selectors for scripts in 2021.4.0 work as expected.


⚠️  This is a new feature, but also a bug fix for 2021.4... A bit in the middle 🤷‍♂️  Right now it can cause unexpected behavior (as I already learned on Discord today, hence this PR).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
