### PR TITLE
Increase time out for http requests done in Axis integration 

### DIFF
--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -304,7 +304,7 @@ async def get_device(hass, host, port, username, password):
     )
 
     try:
-        with async_timeout.timeout(15):
+        with async_timeout.timeout(30):
             await device.vapix.initialize()
 
         return device
@@ -313,9 +313,9 @@ async def get_device(hass, host, port, username, password):
         LOGGER.warning("Connected to device at %s but not registered", host)
         raise AuthenticationRequired from err
 
-    except (asyncio.TimeoutError, axis.RequestError) as err:
+    except (asyncio.TimeoutError, axis.RequestError):
         LOGGER.error("Error connecting to the Axis device at %s", host)
-        raise CannotConnect from err
+        raise CannotConnect
 
     except axis.AxisException as err:
         LOGGER.exception("Unknown Axis communication error occurred")

--- a/homeassistant/components/axis/device.py
+++ b/homeassistant/components/axis/device.py
@@ -313,9 +313,9 @@ async def get_device(hass, host, port, username, password):
         LOGGER.warning("Connected to device at %s but not registered", host)
         raise AuthenticationRequired from err
 
-    except (asyncio.TimeoutError, axis.RequestError):
+    except (asyncio.TimeoutError, axis.RequestError) as err:
         LOGGER.error("Error connecting to the Axis device at %s", host)
-        raise CannotConnect
+        raise CannotConnect from err
 
     except axis.AxisException as err:
         LOGGER.exception("Unknown Axis communication error occurred")

--- a/homeassistant/components/axis/manifest.json
+++ b/homeassistant/components/axis/manifest.json
@@ -3,7 +3,7 @@
   "name": "Axis",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/axis",
-  "requirements": ["axis==43"],
+  "requirements": ["axis==44"],
   "dhcp": [
     { "hostname": "axis-00408c*", "macaddress": "00408C*" },
     { "hostname": "axis-accc8e*", "macaddress": "ACCC8E*" },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -313,7 +313,7 @@ av==8.0.3
 # avion==0.10
 
 # homeassistant.components.axis
-axis==43
+axis==44
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -187,7 +187,7 @@ auroranoaa==0.0.2
 av==8.0.3
 
 # homeassistant.components.axis
-axis==43
+axis==44
 
 # homeassistant.components.azure_event_hub
 azure-eventhub==5.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apparently the library is too aggressive to certain devices, typically on older firmware. The HTTPx library has a hidden 5 second time out per request, the library has increased this to 15 seconds. Integration default time out has been increased to 30 seconds.

https://github.com/Kane610/axis/compare/v43...v44
There is new functionality introduced with v44, but it is not yet utilized so should be harmless.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46815
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
