### PR TITLE
New overrides in universal media player

### DIFF
--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -561,12 +561,12 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     async def async_media_seek(self, position):
         """Send seek command."""
         data = {ATTR_MEDIA_SEEK_POSITION: position}
-        await self._async_call_service(SERVICE_MEDIA_SEEK, data)
+        await self._async_call_service(SERVICE_MEDIA_SEEK, data, allow_override=True)
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""
         data = {ATTR_MEDIA_CONTENT_TYPE: media_type, ATTR_MEDIA_CONTENT_ID: media_id}
-        await self._async_call_service(SERVICE_PLAY_MEDIA, data)
+        await self._async_call_service(SERVICE_PLAY_MEDIA, data, allow_override=True)
 
     async def async_volume_up(self):
         """Turn volume up for media player."""
@@ -608,7 +608,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
     async def async_toggle(self):
         """Toggle the power on the media player."""
-        await self._async_call_service(SERVICE_TOGGLE)
+        await self._async_call_service(SERVICE_TOGGLE, allow_override=True)
 
     async def async_update(self):
         """Update state in HA."""

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -46,6 +46,7 @@ from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
+    SUPPORT_PLAY_MEDIA,
     SUPPORT_PREVIOUS_TRACK,
     SUPPORT_REPEAT_SET,
     SUPPORT_SELECT_SOUND_MODE,
@@ -485,6 +486,9 @@ class UniversalMediaPlayer(MediaPlayerEntity):
         ):
             flags |= SUPPORT_SELECT_SOURCE
 
+        if SERVICE_PLAY_MEDIA in self._cmds:
+            flags |= SUPPORT_PLAY_MEDIA
+
         if SERVICE_CLEAR_PLAYLIST in self._cmds:
             flags |= SUPPORT_CLEAR_PLAYLIST
 
@@ -561,7 +565,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
     async def async_media_seek(self, position):
         """Send seek command."""
         data = {ATTR_MEDIA_SEEK_POSITION: position}
-        await self._async_call_service(SERVICE_MEDIA_SEEK, data, allow_override=True)
+        await self._async_call_service(SERVICE_MEDIA_SEEK, data)
 
     async def async_play_media(self, media_type, media_id, **kwargs):
         """Play a piece of media."""

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -538,23 +538,23 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
     async def async_media_play(self):
         """Send play command."""
-        await self._async_call_service(SERVICE_MEDIA_PLAY)
+        await self._async_call_service(SERVICE_MEDIA_PLAY, allow_override=True)
 
     async def async_media_pause(self):
         """Send pause command."""
-        await self._async_call_service(SERVICE_MEDIA_PAUSE)
+        await self._async_call_service(SERVICE_MEDIA_PAUSE, allow_override=True)
 
     async def async_media_stop(self):
         """Send stop command."""
-        await self._async_call_service(SERVICE_MEDIA_STOP)
+        await self._async_call_service(SERVICE_MEDIA_STOP, allow_override=True)
 
     async def async_media_previous_track(self):
         """Send previous track command."""
-        await self._async_call_service(SERVICE_MEDIA_PREVIOUS_TRACK)
+        await self._async_call_service(SERVICE_MEDIA_PREVIOUS_TRACK, allow_override=True)
 
     async def async_media_next_track(self):
         """Send next track command."""
-        await self._async_call_service(SERVICE_MEDIA_NEXT_TRACK)
+        await self._async_call_service(SERVICE_MEDIA_NEXT_TRACK, allow_override=True)
 
     async def async_media_seek(self, position):
         """Send seek command."""
@@ -576,7 +576,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
     async def async_media_play_pause(self):
         """Play or pause the media player."""
-        await self._async_call_service(SERVICE_MEDIA_PLAY_PAUSE)
+        await self._async_call_service(SERVICE_MEDIA_PLAY_PAUSE, allow_override=True)
 
     async def async_select_sound_mode(self, sound_mode):
         """Select sound mode."""
@@ -592,7 +592,7 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
     async def async_clear_playlist(self):
         """Clear players playlist."""
-        await self._async_call_service(SERVICE_CLEAR_PLAYLIST)
+        await self._async_call_service(SERVICE_CLEAR_PLAYLIST, allow_override=True)
 
     async def async_set_shuffle(self, shuffle):
         """Enable/disable shuffling."""

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -550,7 +550,9 @@ class UniversalMediaPlayer(MediaPlayerEntity):
 
     async def async_media_previous_track(self):
         """Send previous track command."""
-        await self._async_call_service(SERVICE_MEDIA_PREVIOUS_TRACK, allow_override=True)
+        await self._async_call_service(
+            SERVICE_MEDIA_PREVIOUS_TRACK, allow_override=True
+        )
 
     async def async_media_next_track(self):
         """Send next track command."""

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -681,6 +681,184 @@ class TestMediaPlayer(unittest.TestCase):
 
         assert check_flags == ump.supported_features
 
+    async def test_overrides(self):
+        """Test overrides."""
+        config = copy(self.config_children_and_attr)
+        await async_setup_component(self.hass, "media_player", config)
+        excmd = {"service": "media_player.test", "data": {"entity_id": "test"}}
+        config["commands"] = {
+            "turn_on": excmd,
+            "turn_off": excmd,
+            "volume_up": excmd,
+            "volume_down": excmd,
+            "volume_mute": excmd,
+            "volume_set": excmd,
+            "select_sound_mode": excmd,
+            "select_source": excmd,
+            "repeat_set": excmd,
+            "shuffle_set": excmd,
+            "media_play": excmd,
+            "media_play_pause": excmd,
+            "media_pause": excmd,
+            "media_stop": excmd,
+            "media_next_track": excmd,
+            "media_previous_track": excmd,
+            "toggle": excmd,
+            "clear_playlist": excmd,
+            "media_seek": excmd,
+            "play_media": excmd,
+            "toggle": excmd,
+        }
+
+        service = mock_service(self.hass, "media_player", "test")
+        self.hass.services.call(
+            "media_player",
+            "turn_on",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 1
+        self.hass.services.call(
+            "media_player",
+            "turn_off",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 2
+        self.hass.services.call(
+            "media_player",
+            "volume_up",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 3
+        self.hass.services.call(
+            "media_player",
+            "volume_down",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 4
+        self.hass.services.call(
+            "media_player",
+            "volume_mute",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 5
+        self.hass.services.call(
+            "media_player",
+            "volume_set",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 6
+        self.hass.services.call(
+            "media_player",
+            "select_sound_mode",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 7
+        self.hass.services.call(
+            "media_player",
+            "select_source",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 8
+        self.hass.services.call(
+            "media_player",
+            "repeat_set",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 9
+        self.hass.services.call(
+            "media_player",
+            "shuffle_set",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 10
+        self.hass.services.call(
+            "media_player",
+            "media_play",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 11
+        self.hass.services.call(
+            "media_player",
+            "media_pause",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 12
+        self.hass.services.call(
+            "media_player",
+            "media_stop",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 13
+        self.hass.services.call(
+            "media_player",
+            "media_next_track",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 14
+        self.hass.services.call(
+            "media_player",
+            "media_previous_track",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 15
+        self.hass.services.call(
+            "media_player",
+            "toggle",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 16
+        self.hass.services.call(
+            "media_player",
+            "clear_playlist",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 17
+        self.hass.services.call(
+            "media_player",
+            "media_play_pause",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 18
+        self.hass.services.call(
+            "media_player",
+            "play_media",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 19
+        self.hass.services.call(
+            "media_player",
+            "media_seek",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 20
+        self.hass.services.call(
+            "media_player",
+            "toggle",
+            service_data={"entity_id": "media_player.test"},
+            blocking=True,
+        )
+        assert len(service) == 21
+
     def test_supported_features_play_pause(self):
         """Test supported media commands with play_pause function."""
         config = copy(self.config_children_and_attr)

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -711,147 +711,147 @@ class TestMediaPlayer(unittest.TestCase):
         }
 
         service = mock_service(self.hass, "media_player", "test")
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "turn_on",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 1
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "turn_off",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 2
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "volume_up",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 3
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "volume_down",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 4
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "volume_mute",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 5
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "volume_set",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 6
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "select_sound_mode",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 7
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "select_source",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 8
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "repeat_set",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 9
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "shuffle_set",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 10
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_play",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 11
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_pause",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 12
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_stop",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 13
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_next_track",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 14
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_previous_track",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 15
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "toggle",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 16
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "clear_playlist",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 17
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_play_pause",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 18
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "play_media",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 19
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "media_seek",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 20
-        self.hass.services.call(
+        await self.hass.services.async_call(
             "media_player",
             "toggle",
             service_data={"entity_id": "media_player.test"},

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, callback
-from homeassistant.setup import async_setup_component
+from homeassistant.setup import async_setup_component, setup_component
 
 from tests.common import get_test_home_assistant, mock_service
 
@@ -681,7 +681,7 @@ class TestMediaPlayer(unittest.TestCase):
 
         assert check_flags == ump.supported_features
 
-    async def test_overrides(self):
+    def test_overrides(self):
         """Test overrides."""
         config = copy(self.config_children_and_attr)
         excmd = {"service": "media_player.test", "data": {"entity_id": "media_player.overridden"}}
@@ -708,150 +708,150 @@ class TestMediaPlayer(unittest.TestCase):
             "play_media": excmd,
             "toggle": excmd,
         }
-        await async_setup_component(self.hass, "media_player", config)
+        setup_component(self.hass, "media_player", config)
 
         service = mock_service(self.hass, "media_player", "test")
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "turn_on",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 1
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "turn_off",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 2
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "volume_up",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 3
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "volume_down",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 4
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "volume_mute",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 5
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "volume_set",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 6
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "select_sound_mode",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 7
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "select_source",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 8
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "repeat_set",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 9
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "shuffle_set",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 10
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_play",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 11
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_pause",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 12
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_stop",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 13
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_next_track",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 14
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_previous_track",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 15
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "toggle",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 16
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "clear_playlist",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 17
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_play_pause",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 18
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "play_media",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 19
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "media_seek",
             service_data={"entity_id": "media_player.test"},
             blocking=True,
         )
         assert len(service) == 20
-        await self.hass.services.async_call(
+        self.hass.services.call(
             "media_player",
             "toggle",
             service_data={"entity_id": "media_player.test"},

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -713,7 +713,7 @@ class TestMediaPlayer(unittest.TestCase):
         }
         setup_component(self.hass, "media_player", config)
 
-        service = mock_service(self.hass, "media_player", "test")
+        service = mock_service(self.hass, "media_player", "overridden")
         self.hass.services.call(
             "media_player",
             "turn_on",

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -685,7 +685,7 @@ class TestMediaPlayer(unittest.TestCase):
         """Test overrides."""
         config = copy(self.config_children_and_attr)
         await async_setup_component(self.hass, "media_player", config)
-        excmd = {"service": "media_player.test", "data": {"entity_id": "test"}}
+        excmd = {"service": "media_player.test", "data": {"entity_id": "media_player.overridden"}}
         config["commands"] = {
             "turn_on": excmd,
             "turn_off": excmd,

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -630,7 +630,7 @@ class TestMediaPlayer(unittest.TestCase):
     def test_supported_features_children_and_cmds(self):
         """Test supported media commands with children and attrs."""
         config = copy(self.config_children_and_attr)
-        excmd = {"service": "media_player.test", "data": {"entity_id": "test"}}
+        excmd = {"service": "media_player.test", "data": {}}
         config["commands"] = {
             "turn_on": excmd,
             "turn_off": excmd,
@@ -648,6 +648,7 @@ class TestMediaPlayer(unittest.TestCase):
             "media_next_track": excmd,
             "media_previous_track": excmd,
             "toggle": excmd,
+            "play_media": excmd,
             "clear_playlist": excmd,
         }
         config = validate_config(config)
@@ -676,6 +677,7 @@ class TestMediaPlayer(unittest.TestCase):
             | universal.SUPPORT_STOP
             | universal.SUPPORT_NEXT_TRACK
             | universal.SUPPORT_PREVIOUS_TRACK
+            | universal.SUPPORT_PLAY_MEDIA
             | universal.SUPPORT_CLEAR_PLAYLIST
         )
 
@@ -684,10 +686,8 @@ class TestMediaPlayer(unittest.TestCase):
     def test_overrides(self):
         """Test overrides."""
         config = copy(self.config_children_and_attr)
-        excmd = {
-            "service": "media_player.test",
-            "data": {"entity_id": "media_player.overridden"},
-        }
+        excmd = {"service": "test.override", "data": {}}
+        config["name"] = "overridden"
         config["commands"] = {
             "turn_on": excmd,
             "turn_off": excmd,
@@ -705,162 +705,156 @@ class TestMediaPlayer(unittest.TestCase):
             "media_stop": excmd,
             "media_next_track": excmd,
             "media_previous_track": excmd,
-            "toggle": excmd,
             "clear_playlist": excmd,
-            "media_seek": excmd,
             "play_media": excmd,
             "toggle": excmd,
         }
-        setup_component(self.hass, "media_player", config)
+        setup_component(self.hass, "media_player", {"media_player": config})
 
-        service = mock_service(self.hass, "media_player", "overridden")
+        service = mock_service(self.hass, "test", "override")
         self.hass.services.call(
             "media_player",
             "turn_on",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 1
         self.hass.services.call(
             "media_player",
             "turn_off",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 2
         self.hass.services.call(
             "media_player",
             "volume_up",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 3
         self.hass.services.call(
             "media_player",
             "volume_down",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 4
         self.hass.services.call(
             "media_player",
             "volume_mute",
-            service_data={"entity_id": "media_player.test"},
+            service_data={
+                "entity_id": "media_player.overridden",
+                "is_volume_muted": True,
+            },
             blocking=True,
         )
         assert len(service) == 5
         self.hass.services.call(
             "media_player",
             "volume_set",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden", "volume_level": 1},
             blocking=True,
         )
         assert len(service) == 6
         self.hass.services.call(
             "media_player",
             "select_sound_mode",
-            service_data={"entity_id": "media_player.test"},
+            service_data={
+                "entity_id": "media_player.overridden",
+                "sound_mode": "music",
+            },
             blocking=True,
         )
         assert len(service) == 7
         self.hass.services.call(
             "media_player",
             "select_source",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden", "source": "video1"},
             blocking=True,
         )
         assert len(service) == 8
         self.hass.services.call(
             "media_player",
             "repeat_set",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden", "repeat": "all"},
             blocking=True,
         )
         assert len(service) == 9
         self.hass.services.call(
             "media_player",
             "shuffle_set",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden", "shuffle": True},
             blocking=True,
         )
         assert len(service) == 10
         self.hass.services.call(
             "media_player",
             "media_play",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 11
         self.hass.services.call(
             "media_player",
             "media_pause",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 12
         self.hass.services.call(
             "media_player",
             "media_stop",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 13
         self.hass.services.call(
             "media_player",
             "media_next_track",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 14
         self.hass.services.call(
             "media_player",
             "media_previous_track",
-            service_data={"entity_id": "media_player.test"},
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 15
         self.hass.services.call(
             "media_player",
-            "toggle",
-            service_data={"entity_id": "media_player.test"},
+            "clear_playlist",
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 16
         self.hass.services.call(
             "media_player",
-            "clear_playlist",
-            service_data={"entity_id": "media_player.test"},
+            "media_play_pause",
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 17
         self.hass.services.call(
             "media_player",
-            "media_play_pause",
-            service_data={"entity_id": "media_player.test"},
+            "play_media",
+            service_data={
+                "entity_id": "media_player.overridden",
+                "media_content_id": 1,
+                "media_content_type": "channel",
+            },
             blocking=True,
         )
         assert len(service) == 18
         self.hass.services.call(
             "media_player",
-            "play_media",
-            service_data={"entity_id": "media_player.test"},
+            "toggle",
+            service_data={"entity_id": "media_player.overridden"},
             blocking=True,
         )
         assert len(service) == 19
-        self.hass.services.call(
-            "media_player",
-            "media_seek",
-            service_data={"entity_id": "media_player.test"},
-            blocking=True,
-        )
-        assert len(service) == 20
-        self.hass.services.call(
-            "media_player",
-            "toggle",
-            service_data={"entity_id": "media_player.test"},
-            blocking=True,
-        )
-        assert len(service) == 21
 
     def test_supported_features_play_pause(self):
         """Test supported media commands with play_pause function."""

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -684,7 +684,6 @@ class TestMediaPlayer(unittest.TestCase):
     async def test_overrides(self):
         """Test overrides."""
         config = copy(self.config_children_and_attr)
-        await async_setup_component(self.hass, "media_player", config)
         excmd = {"service": "media_player.test", "data": {"entity_id": "media_player.overridden"}}
         config["commands"] = {
             "turn_on": excmd,
@@ -709,6 +708,7 @@ class TestMediaPlayer(unittest.TestCase):
             "play_media": excmd,
             "toggle": excmd,
         }
+        await async_setup_component(self.hass, "media_player", config)
 
         service = mock_service(self.hass, "media_player", "test")
         await self.hass.services.async_call(

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -684,7 +684,10 @@ class TestMediaPlayer(unittest.TestCase):
     def test_overrides(self):
         """Test overrides."""
         config = copy(self.config_children_and_attr)
-        excmd = {"service": "media_player.test", "data": {"entity_id": "media_player.overridden"}}
+        excmd = {
+            "service": "media_player.test",
+            "data": {"entity_id": "media_player.overridden"},
+        }
         config["commands"] = {
             "turn_on": excmd,
             "turn_off": excmd,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow override some commands in the Universal Media Player:

- media_play
- media_pause
- media_play_pause
- media_stop
- media_previous_track
- media_next_track
- play_media
- clear_playlist

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
- platform: universal
  name: "Sony TV"
  device_class: tv
  children:
    - media_player.sony_tv_cast
    - media_player.sony_tv_adb
    - media_player.sony_tv_psk
  commands:
    media_previous_track:
      service: braviatv_psk.bravia_command
      data:
        entity_id: media_player.sony_tv_psk
        command_id: Prev
    media_next_track:
      service: braviatv_psk.bravia_command
      data:
        entity_id: media_player.sony_tv_psk
        command_id: Next
    media_play:
      service: braviatv_psk.bravia_command
      data:
        entity_id: media_player.sony_tv_psk
        command_id: Play   
    media_pause:
      service: braviatv_psk.bravia_command
      data:
        entity_id: media_player.sony_tv_psk
        command_id: Pause
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48608
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io/pull/17548

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
