### PR TITLE
Make sonos event asyncio

### DIFF
--- a/homeassistant/components/sonos/manifest.json
+++ b/homeassistant/components/sonos/manifest.json
@@ -3,7 +3,7 @@
   "name": "Sonos",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/sonos",
-  "requirements": ["pysonos==0.0.40"],
+  "requirements": ["pysonos==0.0.41"],
   "after_dependencies": ["plex"],
   "ssdp": [
     {

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -513,7 +513,7 @@ class SonosEntity(MediaPlayerEntity):
     async def async_seen(self, player):
         """Record that this player was seen right now."""
         was_available = self.available
-        _LOGGER.warning("Async seen: %s, was_available: %s", player, was_available)
+        _LOGGER.debug("Async seen: %s, was_available: %s", player, was_available)
 
         self._player = player
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -225,6 +225,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
                 interval=DISCOVERY_INTERVAL,
                 interface_addr=config.get(CONF_INTERFACE_ADDR),
             )
+            hass.data[DATA_SONOS].discovery_thread.name = "Sonos-Discovery"
 
     _LOGGER.debug("Adding discovery job")
     hass.async_add_executor_job(_discovery)

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -588,30 +588,24 @@ class SonosEntity(MediaPlayerEntity):
 
             player = self.soco
 
-            _LOGGER.warning(
-                "Attach Player: %s, existing subscriptions: %s",
-                player,
-                self._subscriptions,
-            )
+            if self._subscriptions:
+                raise RuntimeError(
+                    f"Attempted to attach subscriptions to player: {player} "
+                    f"when existing subscriptions exist: {self._subscriptions}"
+                )
 
-            await self._async_subscribe(player.avTransport, self.async_update_media)
-            await self._async_subscribe(
-                player.renderingControl, self.async_update_volume
-            )
-            await self._async_subscribe(
-                player.zoneGroupTopology, self.async_update_groups
-            )
-            await self._async_subscribe(
-                player.contentDirectory, self.async_update_content
-            )
+            await self._subscribe(player.avTransport, self.async_update_media)
+            await self._subscribe(player.renderingControl, self.async_update_volume)
+            await self._subscribe(player.zoneGroupTopology, self.async_update_groups)
+            await self._subscribe(player.contentDirectory, self.async_update_content)
             return True
         except SoCoException as ex:
             _LOGGER.warning("Could not connect %s: %s", self.entity_id, ex)
             return False
 
-    async def _async_subscribe(self, player_prop, sub_callback):
+    async def _subscribe(self, target, sub_callback):
         """Create a sonos subscription."""
-        subscription = await player_prop.subscribe(auto_renew=True)
+        subscription = await target.subscribe(auto_renew=True)
         subscription.callback = sub_callback
         self._subscriptions.append(subscription)
 

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -9,7 +9,7 @@ import urllib.parse
 
 import async_timeout
 import pysonos
-from pysonos import alarms
+from pysonos import alarms, events_asyncio
 from pysonos.core import (
     MUSIC_SRC_LINE_IN,
     MUSIC_SRC_RADIO,
@@ -162,6 +162,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     config = hass.data[SONOS_DOMAIN].get("media_player", {})
     _LOGGER.debug("Reached async_setup_entry, config=%s", config)
+    pysonos.config.EVENTS_MODULE = events_asyncio
 
     advertise_addr = config.get(CONF_ADVERTISE_ADDR)
     if advertise_addr:
@@ -446,12 +447,9 @@ class SonosEntity(MediaPlayerEntity):
 
         self.hass.data[DATA_SONOS].entities.append(self)
 
-        def _rebuild_groups():
-            """Build the current group topology."""
-            for entity in self.hass.data[DATA_SONOS].entities:
-                entity.update_groups()
-
-        self.hass.async_add_executor_job(_rebuild_groups)
+        """Build the current group topology."""
+        for entity in self.hass.data[DATA_SONOS].entities:
+            await entity.async_update_groups_coro()
 
     @property
     def unique_id(self):
@@ -515,6 +513,7 @@ class SonosEntity(MediaPlayerEntity):
     async def async_seen(self, player):
         """Record that this player was seen right now."""
         was_available = self.available
+        _LOGGER.warning("Async seen: %s, was_available: %s", player, was_available)
 
         self._player = player
 
@@ -532,15 +531,14 @@ class SonosEntity(MediaPlayerEntity):
             self.update, datetime.timedelta(seconds=SCAN_INTERVAL)
         )
 
-        done = await self.hass.async_add_executor_job(self._attach_player)
+        done = await self._async_attach_player()
         if not done:
             self._seen_timer()
-            self.async_unseen()
+            await self.async_unseen()
 
         self.async_write_ha_state()
 
-    @callback
-    def async_unseen(self, now=None):
+    async def async_unseen(self, now=None):
         """Make this player unavailable when it was not seen recently."""
         self._seen_timer = None
 
@@ -548,11 +546,8 @@ class SonosEntity(MediaPlayerEntity):
             self._poll_timer()
             self._poll_timer = None
 
-        def _unsub(subscriptions):
-            for subscription in subscriptions:
-                subscription.unsubscribe()
-
-        self.hass.async_add_executor_job(_unsub, self._subscriptions)
+        for subscription in self._subscriptions:
+            await subscription.unsubscribe()
 
         self._subscriptions = []
 
@@ -571,6 +566,7 @@ class SonosEntity(MediaPlayerEntity):
     def _set_favorites(self):
         """Set available favorites."""
         self._favorites = []
+        # TODO: run in executor
         for fav in self.soco.music_library.get_sonos_favorites():
             try:
                 # Exclude non-playable favorites with no linked resources
@@ -582,23 +578,38 @@ class SonosEntity(MediaPlayerEntity):
 
     def _attach_player(self):
         """Get basic information and add event subscriptions."""
+        self._play_mode = self.soco.play_mode
+        self.update_volume()
+        self._set_favorites()
+
+    async def _async_attach_player(self):
+        """Get basic information and add event subscriptions."""
         try:
-            self._play_mode = self.soco.play_mode
-            self.update_volume()
-            self._set_favorites()
+            await self.hass.async_add_executor_job(self._attach_player)
 
             player = self.soco
 
-            def subscribe(sonos_service, action):
-                """Add a subscription to a pysonos service."""
-                queue = _ProcessSonosEventQueue(action)
-                sub = sonos_service.subscribe(auto_renew=True, event_queue=queue)
-                self._subscriptions.append(sub)
+            _LOGGER.warning(
+                "Attach Player: %s, existing subscriptions: %s",
+                player,
+                self._subscriptions,
+            )
 
-            subscribe(player.avTransport, self.update_media)
-            subscribe(player.renderingControl, self.update_volume)
-            subscribe(player.zoneGroupTopology, self.update_groups)
-            subscribe(player.contentDirectory, self.update_content)
+            subscription = await player.avTransport.subscribe(auto_renew=True)
+            subscription.callback = self.async_update_media
+            self._subscriptions.append(subscription)
+
+            subscription = await player.renderingControl.subscribe(auto_renew=True)
+            subscription.callback = self.async_update_volume
+            self._subscriptions.append(subscription)
+
+            subscription = await player.zoneGroupTopology.subscribe(auto_renew=True)
+            subscription.callback = self.async_update_groups
+            self._subscriptions.append(subscription)
+
+            subscription = await player.contentDirectory.subscribe(auto_renew=True)
+            subscription.callback == self.async_update_content
+            self._subscriptions.append(subscription)
             return True
         except SoCoException as ex:
             _LOGGER.warning("Could not connect %s: %s", self.entity_id, ex)
@@ -618,6 +629,11 @@ class SonosEntity(MediaPlayerEntity):
                 self.update_media()
         except SoCoException:
             pass
+
+    @callback
+    def async_update_media(self, event=None):
+        """Update information about currently playing media."""
+        self.hass.async_add_job(self.update_media, event)
 
     def update_media(self, event=None):
         """Update information about currently playing media."""
@@ -716,6 +732,7 @@ class SonosEntity(MediaPlayerEntity):
         except (TypeError, KeyError, AttributeError):
             pass
 
+        # TODO: run in executor if needed
         media_info = self.soco.get_current_media_info()
 
         self._media_channel = media_info["channel"]
@@ -759,31 +776,46 @@ class SonosEntity(MediaPlayerEntity):
         if playlist_position > 0:
             self._queue_position = playlist_position - 1
 
-    def update_volume(self, event=None):
+    @callback
+    def async_update_volume(self, event=None):
         """Update information about currently volume settings."""
-        if event:
-            variables = event.variables
+        variables = event.variables
 
-            if "volume" in variables:
-                self._player_volume = int(variables["volume"]["Master"])
+        if "volume" in variables:
+            self._player_volume = int(variables["volume"]["Master"])
 
-            if "mute" in variables:
-                self._player_muted = variables["mute"]["Master"] == "1"
+        if "mute" in variables:
+            self._player_muted = variables["mute"]["Master"] == "1"
 
-            if "night_mode" in variables:
-                self._night_sound = variables["night_mode"] == "1"
+        if "night_mode" in variables:
+            self._night_sound = variables["night_mode"] == "1"
 
-            if "dialog_level" in variables:
-                self._speech_enhance = variables["dialog_level"] == "1"
+        if "dialog_level" in variables:
+            self._speech_enhance = variables["dialog_level"] == "1"
 
-            self.schedule_update_ha_state()
-        else:
-            self._player_volume = self.soco.volume
-            self._player_muted = self.soco.mute
-            self._night_sound = self.soco.night_mode
-            self._speech_enhance = self.soco.dialog_mode
+        self.async_write_ha_state()
+
+    def update_volume(self):
+        """Update information about currently volume settings."""
+        self._player_volume = self.soco.volume
+        self._player_muted = self.soco.mute
+        self._night_sound = self.soco.night_mode
+        self._speech_enhance = self.soco.dialog_mode
 
     def update_groups(self, event=None):
+        """Handle callback for topology change event."""
+        coro = self.async_update_groups_coro(event)
+        if coro:
+            self.hass.add_job(coro)
+
+    @callback
+    def async_update_groups(self, event=None):
+        """Handle callback for topology change event."""
+        coro = self.async_update_groups_coro(event)
+        if coro:
+            self.hass.async_add_job(coro)
+
+    def async_update_groups_coro(self, event=None):
         """Handle callback for topology change event."""
 
         def _get_soco_group():
@@ -849,13 +881,13 @@ class SonosEntity(MediaPlayerEntity):
         if event and not hasattr(event, "zone_player_uui_ds_in_group"):
             return
 
-        self.hass.add_job(_async_handle_group_event(event))
+        return _async_handle_group_event(event)
 
-    def update_content(self, event=None):
+    def async_update_content(self, event=None):
         """Update information about available content."""
         if event and "favorites_update_id" in event.variables:
-            self._set_favorites()
-            self.schedule_update_ha_state()
+            self.hass.async_add_job(self._set_favorites)
+            self.async_write_ha_state()
 
     @property
     def volume_level(self):

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -565,7 +565,6 @@ class SonosEntity(MediaPlayerEntity):
     def _set_favorites(self):
         """Set available favorites."""
         self._favorites = []
-        # TODO: run in executor
         for fav in self.soco.music_library.get_sonos_favorites():
             try:
                 # Exclude non-playable favorites with no linked resources

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -609,10 +609,10 @@ class SonosEntity(MediaPlayerEntity):
             _LOGGER.warning("Could not connect %s: %s", self.entity_id, ex)
             return False
 
-    async def _async_subscribe(self, player_prop, callback):
+    async def _async_subscribe(self, player_prop, sub_callback):
         """Create a sonos subscription."""
         subscription = await player_prop.subscribe(auto_renew=True)
-        subscription.callback = callback
+        subscription.callback = sub_callback
         self._subscriptions.append(subscription)
 
     @property

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -447,7 +447,6 @@ class SonosEntity(MediaPlayerEntity):
 
         self.hass.data[DATA_SONOS].entities.append(self)
 
-        """Build the current group topology."""
         for entity in self.hass.data[DATA_SONOS].entities:
             await entity.async_update_groups_coro()
 
@@ -595,25 +594,26 @@ class SonosEntity(MediaPlayerEntity):
                 self._subscriptions,
             )
 
-            subscription = await player.avTransport.subscribe(auto_renew=True)
-            subscription.callback = self.async_update_media
-            self._subscriptions.append(subscription)
-
-            subscription = await player.renderingControl.subscribe(auto_renew=True)
-            subscription.callback = self.async_update_volume
-            self._subscriptions.append(subscription)
-
-            subscription = await player.zoneGroupTopology.subscribe(auto_renew=True)
-            subscription.callback = self.async_update_groups
-            self._subscriptions.append(subscription)
-
-            subscription = await player.contentDirectory.subscribe(auto_renew=True)
-            subscription.callback == self.async_update_content
-            self._subscriptions.append(subscription)
+            await self._async_subscribe(player.avTransport, self.async_update_media)
+            await self._async_subscribe(
+                player.renderingControl, self.async_update_volume
+            )
+            await self._async_subscribe(
+                player.zoneGroupTopology, self.async_update_groups
+            )
+            await self._async_subscribe(
+                player.contentDirectory, self.async_update_content
+            )
             return True
         except SoCoException as ex:
             _LOGGER.warning("Could not connect %s: %s", self.entity_id, ex)
             return False
+
+    async def _async_subscribe(self, player_prop, callback):
+        """Create a sonos subscription."""
+        subscription = await player_prop.subscribe(auto_renew=True)
+        subscription.callback = callback
+        self._subscriptions.append(subscription)
 
     @property
     def should_poll(self):
@@ -732,7 +732,6 @@ class SonosEntity(MediaPlayerEntity):
         except (TypeError, KeyError, AttributeError):
             pass
 
-        # TODO: run in executor if needed
         media_info = self.soco.get_current_media_info()
 
         self._media_channel = media_info["channel"]

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -776,7 +776,7 @@ class SonosEntity(MediaPlayerEntity):
             self._queue_position = playlist_position - 1
 
     @callback
-    def async_update_volume(self, event=None):
+    def async_update_volume(self, event):
         """Update information about currently volume settings."""
         variables = event.variables
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1717,7 +1717,7 @@ pysnmp==4.4.12
 pysoma==0.0.10
 
 # homeassistant.components.sonos
-pysonos==0.0.40
+pysonos==0.0.41
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -926,7 +926,7 @@ pysmartthings==0.7.6
 pysoma==0.0.10
 
 # homeassistant.components.sonos
-pysonos==0.0.40
+pysonos==0.0.41
 
 # homeassistant.components.spc
 pyspcwebgw==0.4.0

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -1,5 +1,5 @@
 """Configuration for Sonos tests."""
-from unittest.mock import Mock, patch as patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch as patch
 
 import pytest
 
@@ -41,6 +41,7 @@ def discover_fixture(soco):
 
     def do_callback(callback, **kwargs):
         callback(soco)
+        return MagicMock()
 
     with patch("pysonos.discover_thread", side_effect=do_callback) as mock:
         yield mock
@@ -56,7 +57,7 @@ def config_fixture():
 def dummy_soco_service_fixture():
     """Create dummy_soco_service fixture."""
     service = Mock()
-    service.subscribe = Mock()
+    service.subscribe = AsyncMock()
     return service
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make sonos event asyncio

pysonos changelog: https://github.com/amelchio/pysonos/compare/v0.0.40...v0.0.41

Verified the port skip logic still works by running two containers on the same system.
```
2021-04-03 21:57:35 WARNING (MainThread) [pysonos.events_asyncio] [Errno 98] Address in use
2021-04-03 21:57:35 WARNING (MainThread) [pysonos.events_asyncio] Trying next port (1401)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48598
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io


