### PR TITLE
Add trigger service to template

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -2,25 +2,76 @@
 import logging
 from typing import Optional
 
+import voluptuous as vol
+
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_START
 from homeassistant.core import CoreState, callback
 from homeassistant.helpers import (
+    config_validation as cv,
     discovery,
+    entity_component,
     trigger as trigger_helper,
     update_coordinator,
 )
 from homeassistant.helpers.reload import async_setup_reload_service
+from homeassistant.helpers.service import async_register_admin_service
 
 from .const import CONF_TRIGGER, DOMAIN, PLATFORMS
+
+ATTR_VARIABLES = "variables"
+SERVICE_TRIGGER = "trigger"
 
 
 async def async_setup(hass, config):
     """Set up the template integration."""
+    coordinators = []
+
     if DOMAIN in config:
         for conf in config[DOMAIN]:
             coordinator = TriggerUpdateCoordinator(hass, conf)
             await coordinator.async_setup(config)
+            coordinators.append(coordinator)
+
+    async def trigger_coordinator(service_call):
+        """Trigger an update coordinator."""
+        entity_id = service_call.data[ATTR_ENTITY_ID]
+
+        found = None
+
+        for coordinator in coordinators:
+            if entity_id in coordinator.entity_ids:
+                found = coordinator
+                break
+
+        if found is None:
+            if ATTR_VARIABLES in service_call.data:
+                raise vol.Invalid(
+                    "Passing variables to state machine based template entities is not allowed"
+                )
+            await entity_component.async_update_entity(hass, entity_id)
+            return
+
+        found.handle_triggered(
+            {
+                **service_call.data.get(ATTR_VARIABLES, {}),
+                "trigger": {"platform": None},
+            },
+            context=service_call.context,
+        )
+
+    async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_TRIGGER,
+        trigger_coordinator,
+        vol.Schema(
+            {
+                vol.Required(ATTR_ENTITY_ID): cv.entity_id,
+                vol.Optional(ATTR_VARIABLES): dict,
+            }
+        ),
+    )
 
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
@@ -37,6 +88,7 @@ class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
         )
         self.config = config
         self._unsub_trigger = None
+        self.entity_ids = set()
 
     @property
     def unique_id(self) -> Optional[str]:
@@ -68,7 +120,7 @@ class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
         self._unsub_trigger = await trigger_helper.async_initialize_triggers(
             self.hass,
             self.config[CONF_TRIGGER],
-            self._handle_triggered,
+            self.handle_triggered,
             DOMAIN,
             self.name,
             self.logger.log,
@@ -76,7 +128,8 @@ class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
         )
 
     @callback
-    def _handle_triggered(self, run_variables, context=None):
+    def handle_triggered(self, run_variables, context=None):
+        """Handle a trigger firing."""
         self.async_set_updated_data(
             {"run_variables": run_variables, "context": context}
         )

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -5,7 +5,7 @@ from typing import Optional
 import voluptuous as vol
 
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import EVENT_HOMEASSISTANT_START
+from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
 from homeassistant.core import CoreState, callback
 from homeassistant.helpers import (
     config_validation as cv,

--- a/homeassistant/components/template/services.yaml
+++ b/homeassistant/components/template/services.yaml
@@ -1,3 +1,16 @@
 reload:
   description: Reload all template entities.
 
+trigger:
+  name: "Trigger updating an entity"
+  description: Trigger an update of a template entity. If the entity updates based on a trigger, the whole section that configured this entity will be updated.
+  target:
+    entity:
+      integration: template
+  fields:
+    variables:
+      name: Variables
+      description: Variables to make available to the trigger-based entity.
+      required: false
+      selector:
+        object:

--- a/homeassistant/components/template/trigger_entity.py
+++ b/homeassistant/components/template/trigger_entity.py
@@ -113,6 +113,8 @@ class TriggerEntity(update_coordinator.CoordinatorEntity):
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
         template.attach(self.hass, self._config)
+        self.coordinator.entity_ids.add(self.entity_id)
+        self.async_on_remove(lambda: self.coordinator.entity_ids.remove(self.entity_id))
         await super().async_added_to_hass()
         if self.coordinator.data is not None:
             self._handle_coordinator_update()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new service to manually trigger a trigger-based template entity with ability to pass variables.

~~Also fixes a bug for trigger-based entities without a unique ID~~ Bug fix extracted to #48631

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
