### PR TITLE
Make sure weather templates work with both Metric and Imperial unit systems

### DIFF
--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -211,7 +211,9 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
             return self.hass.config.units.length(wind_speed_in_kmh, LENGTH_KILOMETERS)
         except ValueError:
             _LOGGER.warning(
-                f"Weather template '{self.entity_id}': wind_speed_template must expand to a number, but results in '{self._wind_speed}'"
+                "Weather template '%s': wind_speed_template must expand to a number, but results in '%s'",
+                self.entity_id,
+                self._wind_speed,
             )
             return None
 
@@ -241,7 +243,9 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
             )
         except ValueError:
             _LOGGER.warning(
-                f"Weather template '{self.entity_id}': visibility_template must expand to a number, but results in '{self._visibility}'"
+                "Weather template '%s': visibility_template must expand to a number, but results in '%s'",
+                self.entity_id,
+                self._visibility,
             )
             return None
 
@@ -259,7 +263,9 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
             return convert_pressure(float(self._pressure), PRESSURE_HPA, PRESSURE_INHG)
         except ValueError:
             _LOGGER.warning(
-                f"Weather template '{self.entity_id}': pressure_template must expand to a number, but results in '{self._pressure}'"
+                "Weather template '%s': pressure_template must expand to a number, but results in '%s'",
+                self.entity_id,
+                self._pressure,
             )
             return None
 

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -201,14 +201,15 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        # unit from template: m/s
+        # unit from template: km/h
 
         if self._wind_speed is None or self._wind_speed == "":
             return None
 
         try:
-            wind_speed_in_kmh = float(self._wind_speed) * 3.6
-            return self.hass.config.units.length(wind_speed_in_kmh, LENGTH_KILOMETERS)
+            return self.hass.config.units.length(
+                float(self._wind_speed), LENGTH_KILOMETERS
+            )
         except ValueError:
             _LOGGER.warning(
                 "Weather template '%s': wind_speed_template must expand to a number, but results in '%s'",

--- a/homeassistant/components/template/weather.py
+++ b/homeassistant/components/template/weather.py
@@ -20,7 +20,12 @@ from homeassistant.components.weather import (
     ENTITY_ID_FORMAT,
     WeatherEntity,
 )
-from homeassistant.const import CONF_NAME, CONF_UNIQUE_ID
+from homeassistant.const import (
+    CONF_NAME,
+    CONF_UNIQUE_ID,
+    LENGTH_KILOMETERS,
+    PRESSURE_HPA,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.config_validation import PLATFORM_SCHEMA
 from homeassistant.helpers.entity import async_generate_entity_id
@@ -183,32 +188,39 @@ class WeatherTemplate(TemplateEntity, WeatherEntity):
     @property
     def humidity(self):
         """Return the humidity."""
+        # unit from template: %
         return self._humidity
 
     @property
     def wind_speed(self):
         """Return the wind speed."""
-        return self._wind_speed
+        # unit from template: m/s
+        wind_speed_in_kmh = self._wind_speed * 3.6
+        return self.hass.config.units.length(wind_speed_in_kmh, LENGTH_KILOMETERS)
 
     @property
     def wind_bearing(self):
         """Return the wind bearing."""
+        # unit from template: °
         return self._wind_bearing
 
     @property
     def ozone(self):
         """Return the ozone level."""
+        # unit from template: ppm (parts per million)
         return self._ozone
 
     @property
     def visibility(self):
         """Return the visibility."""
-        return self._visibility
+        # unit from template: km
+        return self.hass.config.units.length(self._visibility, LENGTH_KILOMETERS)
 
     @property
     def pressure(self):
         """Return the air pressure."""
-        return self._pressure
+        # unit from template: hPa
+        return self.hass.config.units.pressure(self._pressure, PRESSURE_HPA)
 
     @property
     def forecast(self):

--- a/tests/components/template/test_weather.py
+++ b/tests/components/template/test_weather.py
@@ -68,7 +68,7 @@ async def _test_template_state_text(hass, unit_system: UnitSystem):
     await hass.async_block_till_done()
     hass.states.async_set("sensor.pressure", 1002.3)  # in hPa
     await hass.async_block_till_done()
-    hass.states.async_set("sensor.windspeed", 10)  # in m/s
+    hass.states.async_set("sensor.windspeed", 10)  # in km/h
     await hass.async_block_till_done()
     hass.states.async_set("sensor.windbearing", 180)  # in °
     await hass.async_block_till_done()
@@ -91,12 +91,12 @@ async def _test_template_state_text(hass, unit_system: UnitSystem):
     if unit_system is METRIC_SYSTEM:
         assert data.get(ATTR_WEATHER_TEMPERATURE) == approx(22.3)  # in °C
         assert data.get(ATTR_WEATHER_PRESSURE) == approx(1002.3)  # in hpa
-        assert data.get(ATTR_WEATHER_WIND_SPEED) == approx(36)  # in km/h
+        assert data.get(ATTR_WEATHER_WIND_SPEED) == approx(10)  # in km/h
         assert data.get(ATTR_WEATHER_VISIBILITY) == approx(4.6)  # in km
     else:
         assert data.get(ATTR_WEATHER_TEMPERATURE) == approx(22)  # in °F (rounded)
         assert data.get(ATTR_WEATHER_PRESSURE) == approx(29.597899)  # in inhg
-        assert data.get(ATTR_WEATHER_WIND_SPEED) == approx(22.369356)  # in mph
+        assert data.get(ATTR_WEATHER_WIND_SPEED) == approx(6.21371)  # in mph
         assert data.get(ATTR_WEATHER_VISIBILITY) == approx(2.858306)  # in mi
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The values of weather templates now have to be provided in fixed units as documented [here](https://www.home-assistant.io/integrations/weather.template/#configuration). This is to make sure that weather templates work with both Metric and Imperial unit systems. To fix your weather template, make sure that you convert the template values to the appropriate units within your template code.


## Proposed change
Weather templates currently can not be created such that they support both Metric and Imperial unit systems (see [this comment](https://github.com/home-assistant/core/pull/47736#issuecomment-798890205) for details). This PR fixes that problem by requiring certain units for the template values, and by converting them to the appropriate units in the `WeatherTemplate` class, where information on the configured unit system is available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
weather:
  - platform: template
    name: "My own weather station"
    attribution_template: "{{ 'My attribution' }}"
    condition_template: "sunny"
    temperature_template: "{{ states('sensor.temperature') | float}}"
    humidity_template: "{{ states('sensor.humidity')| float }}"
    pressure_template: "{{ states('sensor.pressure')| float }}"
    wind_speed_template: "{{ states('sensor.wind_speed')| float }}"
    wind_bearing_template: "{{ states('sensor.wind_bearing')| float }}"
    ozone_template: "{{ states('sensor.ozone')| float }}"
    visibility_template: "{{ states('sensor.visibility')| float }}"
    forecast_template: "{{ states.weather.my_region.attributes.forecast }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17241

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
