### PR TITLE
Fix caldav TZ interpretation of all day events

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -310,7 +310,9 @@ class WebDavCalendarData:
                 # represent same time regardless of which time zone is currently being observed
                 return obj.replace(tzinfo=dt.DEFAULT_TIME_ZONE)
             return obj
-        return dt.as_local(dt.dt.datetime.combine(obj, dt.dt.time.min))
+        return dt.dt.datetime.combine(obj, dt.dt.time.min).replace(
+            tzinfo=dt.DEFAULT_TIME_ZONE
+        )
 
     @staticmethod
     def get_attr_value(obj, attribute):

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -222,6 +222,39 @@ CALDAV_CONFIG = {
     "custom_calendars": [],
 }
 
+ORIG_TZ = dt.DEFAULT_TIME_ZONE
+
+
+@pytest.fixture(autouse=True)
+def reset_tz():
+    """Restore the default TZ after test runs."""
+    yield
+    dt.DEFAULT_TIME_ZONE = ORIG_TZ
+
+
+@pytest.fixture
+def set_tz(request):
+    """Set the default TZ to the one requested."""
+    return request.getfixturevalue(request.param)
+
+
+@pytest.fixture
+def utc():
+    """Set the default TZ to UTC."""
+    dt.set_default_time_zone(dt.get_time_zone("UTC"))
+
+
+@pytest.fixture
+def new_york():
+    """Set the default TZ to America/New_York."""
+    dt.set_default_time_zone(dt.get_time_zone("America/New_York"))
+
+
+@pytest.fixture
+def baghdad():
+    """Set the default TZ to Asia/Baghdad."""
+    dt.set_default_time_zone(dt.get_time_zone("Asia/Baghdad"))
+
 
 @pytest.fixture(autouse=True)
 def mock_http(hass):
@@ -526,30 +559,72 @@ async def test_no_result_with_filtering(mock_now, hass, calendar):
     assert state.state == "off"
 
 
-@patch("homeassistant.util.dt.now", return_value=_local_datetime(17, 30))
-async def test_all_day_event_returned(mock_now, hass, calendar):
-    """Test that the event lasting the whole day is returned."""
+async def _day_event_returned(hass, calendar, config, date_time):
+    with patch("homeassistant.util.dt.now", return_value=date_time):
+        assert await async_setup_component(hass, "calendar", {"calendar": config})
+        await hass.async_block_till_done()
+
+        state = hass.states.get("calendar.private_private")
+        assert state.name == calendar.name
+        assert state.state == STATE_ON
+        assert dict(state.attributes) == {
+            "friendly_name": "Private",
+            "message": "This is an all day event",
+            "all_day": True,
+            "offset_reached": False,
+            "start_time": "2017-11-27 00:00:00",
+            "end_time": "2017-11-28 00:00:00",
+            "location": "Hamburg",
+            "description": "What a beautiful day",
+        }
+
+
+@pytest.mark.parametrize("set_tz", ["utc", "new_york", "baghdad"], indirect=True)
+async def test_all_day_event_returned_early(hass, calendar, set_tz):
+    """Test that the event lasting the whole day is returned, if it's early in the local day."""
     config = dict(CALDAV_CONFIG)
     config["custom_calendars"] = [
         {"name": "Private", "calendar": "Private", "search": ".*"}
     ]
 
-    assert await async_setup_component(hass, "calendar", {"calendar": config})
-    await hass.async_block_till_done()
+    await _day_event_returned(
+        hass,
+        calendar,
+        config,
+        datetime.datetime(2017, 11, 27, 0, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+    )
 
-    state = hass.states.get("calendar.private_private")
-    assert state.name == calendar.name
-    assert state.state == STATE_ON
-    assert dict(state.attributes) == {
-        "friendly_name": "Private",
-        "message": "This is an all day event",
-        "all_day": True,
-        "offset_reached": False,
-        "start_time": "2017-11-27 00:00:00",
-        "end_time": "2017-11-28 00:00:00",
-        "location": "Hamburg",
-        "description": "What a beautiful day",
-    }
+
+@pytest.mark.parametrize("set_tz", ["utc", "new_york", "baghdad"], indirect=True)
+async def test_all_day_event_returned_mid(hass, calendar, set_tz):
+    """Test that the event lasting the whole day is returned, if it's in the middle of the local day."""
+    config = dict(CALDAV_CONFIG)
+    config["custom_calendars"] = [
+        {"name": "Private", "calendar": "Private", "search": ".*"}
+    ]
+
+    await _day_event_returned(
+        hass,
+        calendar,
+        config,
+        datetime.datetime(2017, 11, 27, 12, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+    )
+
+
+@pytest.mark.parametrize("set_tz", ["utc", "new_york", "baghdad"], indirect=True)
+async def test_all_day_event_returned_late(hass, calendar, set_tz):
+    """Test that the event lasting the whole day is returned, if it's late in the local day."""
+    config = dict(CALDAV_CONFIG)
+    config["custom_calendars"] = [
+        {"name": "Private", "calendar": "Private", "search": ".*"}
+    ]
+
+    await _day_event_returned(
+        hass,
+        calendar,
+        config,
+        datetime.datetime(2017, 11, 27, 23, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+    )
 
 
 @patch("homeassistant.util.dt.now", return_value=_local_datetime(21, 45))
@@ -657,33 +732,72 @@ async def test_event_rrule_endless(mock_now, hass, calendar):
     }
 
 
-@patch(
-    "homeassistant.util.dt.now",
-    return_value=dt.as_local(datetime.datetime(2016, 12, 1, 17, 30)),
-)
-async def test_event_rrule_all_day(mock_now, hass, calendar):
-    """Test that the recurring all day event is returned."""
+async def _event_rrule_all_day(hass, calendar, config, date_time):
+    with patch("homeassistant.util.dt.now", return_value=date_time):
+        assert await async_setup_component(hass, "calendar", {"calendar": config})
+        await hass.async_block_till_done()
+
+        state = hass.states.get("calendar.private_private")
+        assert state.name == calendar.name
+        assert state.state == STATE_ON
+        assert dict(state.attributes) == {
+            "friendly_name": "Private",
+            "message": "This is a recurring all day event",
+            "all_day": True,
+            "offset_reached": False,
+            "start_time": "2016-12-01 00:00:00",
+            "end_time": "2016-12-02 00:00:00",
+            "location": "Hamburg",
+            "description": "Groundhog Day",
+        }
+
+
+@pytest.mark.parametrize("set_tz", ["utc", "new_york", "baghdad"], indirect=True)
+async def test_event_rrule_all_day_early(hass, calendar, set_tz):
+    """Test that the recurring all day event is returned early in the local day, and not on the first occurrence."""
     config = dict(CALDAV_CONFIG)
     config["custom_calendars"] = [
         {"name": "Private", "calendar": "Private", "search": ".*"}
     ]
 
-    assert await async_setup_component(hass, "calendar", {"calendar": config})
-    await hass.async_block_till_done()
+    await _event_rrule_all_day(
+        hass,
+        calendar,
+        config,
+        datetime.datetime(2016, 12, 1, 0, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+    )
 
-    state = hass.states.get("calendar.private_private")
-    assert state.name == calendar.name
-    assert state.state == STATE_ON
-    assert dict(state.attributes) == {
-        "friendly_name": "Private",
-        "message": "This is a recurring all day event",
-        "all_day": True,
-        "offset_reached": False,
-        "start_time": "2016-12-01 00:00:00",
-        "end_time": "2016-12-02 00:00:00",
-        "location": "Hamburg",
-        "description": "Groundhog Day",
-    }
+
+@pytest.mark.parametrize("set_tz", ["utc", "new_york", "baghdad"], indirect=True)
+async def test_event_rrule_all_day_mid(hass, calendar, set_tz):
+    """Test that the recurring all day event is returned in the middle of the local day, and not on the first occurrence."""
+    config = dict(CALDAV_CONFIG)
+    config["custom_calendars"] = [
+        {"name": "Private", "calendar": "Private", "search": ".*"}
+    ]
+
+    await _event_rrule_all_day(
+        hass,
+        calendar,
+        config,
+        datetime.datetime(2016, 12, 1, 17, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+    )
+
+
+@pytest.mark.parametrize("set_tz", ["utc", "new_york", "baghdad"], indirect=True)
+async def test_event_rrule_all_day_late(hass, calendar, set_tz):
+    """Test that the recurring all day event is returned late in the local day, and not on the first occurrence."""
+    config = dict(CALDAV_CONFIG)
+    config["custom_calendars"] = [
+        {"name": "Private", "calendar": "Private", "search": ".*"}
+    ]
+
+    await _event_rrule_all_day(
+        hass,
+        calendar,
+        config,
+        datetime.datetime(2016, 12, 1, 23, 30).replace(tzinfo=dt.DEFAULT_TIME_ZONE),
+    )
 
 
 @patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In the caldav component, all-day events are treated as if they are from 00:00 to 00:00 in UTC, instead of in the local timezone.  This code fixes the logic which interprets date-only events as being that date in UTC to being that date in local time.  This is similar to how datetimes without a timezone are treated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #25814
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

Note: There's already a test for this change, but it was passing because the tests set the timezone to UTC and there's no good way to change it on a per-test basis (changing the global DEFAULT_TIME_ZONE is a bad idea since the tests aren't synchronous, and the patch decorator doesn't work because await is used for the component setup which references DEFAULT_TIME_ZONE and causes failure).  Several tests fail (before and after this PR) if the tests are forced to run in another timezone (by modifying homeassistant/util/dt.py).  However, the all-day tests will pass when the timezone is not UTC (after this PR).

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
