### PR TITLE
Add Rademacher HomePilot integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -431,6 +431,9 @@ omit =
     homeassistant/components/home_plus_control/api.py
     homeassistant/components/home_plus_control/helpers.py
     homeassistant/components/home_plus_control/switch.py
+    homeassistant/components/homepilot/__init__.py
+    homeassistant/components/homepilot/cover.py
+    homeassistant/components/homepilot/entity.py
     homeassistant/components/homeworks/*
     homeassistant/components/honeywell/climate.py
     homeassistant/components/horizon/media_player.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -209,6 +209,7 @@ homeassistant/components/homeassistant/* @home-assistant/core
 homeassistant/components/homekit/* @bdraco
 homeassistant/components/homekit_controller/* @Jc2k @bdraco
 homeassistant/components/homematic/* @pvizeli @danielperna84
+homeassistant/components/homepilot/* @nico0302
 homeassistant/components/http/* @home-assistant/core
 homeassistant/components/huawei_lte/* @scop @fphammerle
 homeassistant/components/huawei_router/* @abmantis

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -26,7 +26,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     session = aiohttp_client.async_create_clientsession(hass)
     auth = Auth(session, entry.data["host"], entry.data.get("password"))
 
-    if "password" in entry.data:
+    if entry.data.get("password") is not None:
         await auth.async_login()
 
     api = HomePilotAPI(auth)

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -21,7 +21,7 @@ PLATFORMS = ["cover"]
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Rademacher HomePilot component."""
-    hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
 
     return True
 

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     # Fetch initial data
-    await coordinator.async_refresh()
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
 

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -8,6 +8,7 @@ from pyhomepilot.api import HomePilotAPI
 from pyhomepilot.auth import Auth
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -24,9 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data.setdefault(DOMAIN, {})
 
     session = aiohttp_client.async_create_clientsession(hass)
-    auth = Auth(session, entry.data["host"], entry.data.get("password"))
+    auth = Auth(session, entry.data[CONF_HOST], entry.data.get(CONF_PASSWORD))
 
-    if entry.data.get("password") is not None:
+    if entry.data.get(CONF_PASSWORD) is not None:
         await auth.async_login()
 
     api = HomePilotAPI(auth)

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -19,15 +19,10 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["cover"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Rademacher HomePilot component."""
-    hass.data.setdefault(DOMAIN, {})
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Rademacher HomePilot from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+
     session = aiohttp_client.async_create_clientsession(hass)
     auth = Auth(session, entry.data["host"], entry.data.get("password"))
 

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -12,7 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import DOMAIN, SCAN_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,14 +41,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         try:
             return {device.uid: device for device in await api.async_get_all_devices()}
         except Exception as err:
-            raise UpdateFailed(f"Error communicating with API: {err}")
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     coordinator = DataUpdateCoordinator(
         hass,
         _LOGGER,
         name="homepilot",
         update_method=async_update_data,
-        update_interval=timedelta(seconds=30),
+        update_interval=timedelta(seconds=SCAN_INTERVAL),
     )
 
     # Fetch initial data

--- a/homeassistant/components/homepilot/__init__.py
+++ b/homeassistant/components/homepilot/__init__.py
@@ -1,0 +1,80 @@
+"""The Rademacher HomePilot integration."""
+
+import asyncio
+from datetime import timedelta
+import logging
+
+from pyhomepilot.api import HomePilotAPI
+from pyhomepilot.auth import Auth
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORMS = ["cover"]
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Set up the Rademacher HomePilot component."""
+    hass.data[DOMAIN] = {}
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Rademacher HomePilot from a config entry."""
+    session = aiohttp_client.async_create_clientsession(hass)
+    auth = Auth(session, entry.data["host"], entry.data.get("password"))
+
+    if "password" in entry.data:
+        await auth.async_login()
+
+    api = HomePilotAPI(auth)
+
+    async def async_update_data():
+        """Fetch data from API endpoint."""
+        try:
+            return {device.uid: device for device in await api.async_get_all_devices()}
+        except Exception as err:
+            raise UpdateFailed(f"Error communicating with API: {err}")
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="homepilot",
+        update_method=async_update_data,
+        update_interval=timedelta(seconds=30),
+    )
+
+    # Fetch initial data
+    await coordinator.async_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {"api": api, "coordinator": coordinator}
+
+    for component in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, component)
+        )
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -41,7 +41,7 @@ async def validate_input(hass: core.HomeAssistant, data):
             return {"title": name}
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class HomepilotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Rademacher HomePilot."""
 
     VERSION = 1

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -32,7 +32,7 @@ async def validate_input(hass: HomeAssistant, data):
         api = HomePilotAPI(auth)
 
         try:
-            if CONF_PASSWORD in data:
+            if data.get(CONF_PASSWORD) is not None:
                 await auth.async_login()
 
             name = await api.async_get_system_name()

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -12,24 +12,25 @@ from pyhomepilot.auth import (  # pylint:disable=redefined-builtin
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
 from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
-    {vol.Required("host"): str, vol.Optional("password"): str}
+    {vol.Required(CONF_HOST): str, vol.Optional(CONF_PASSWORD): str}
 )
 
 
 async def validate_input(hass: core.HomeAssistant, data):
     """Validate the user input allows us to connect."""
     async with aiohttp.ClientSession() as session:
-        auth = Auth(session, data["host"], data.get("password"))
+        auth = Auth(session, data[CONF_HOST], data.get(CONF_PASSWORD))
         api = HomePilotAPI(auth)
 
         try:
-            if "password" in data:
+            if CONF_PASSWORD in data:
                 await auth.async_login()
 
             name = await api.async_get_system_name()

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -1,0 +1,77 @@
+"""Config flow for Rademacher HomePilot integration."""
+
+import logging
+
+import aiohttp
+from pyhomepilot import HomePilotAPI
+from pyhomepilot.auth import Auth, AuthError, ConnectionError
+import voluptuous as vol
+
+from homeassistant import config_entries, core, exceptions
+
+from .const import DOMAIN  # pylint:disable=unused-import
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {vol.Required("host"): str, vol.Optional("password"): str}
+)
+
+
+async def validate_input(hass: core.HomeAssistant, data):
+    """Validate the user input allows us to connect."""
+    async with aiohttp.ClientSession() as session:
+        auth = Auth(session, data["host"], data.get("password"))
+        api = HomePilotAPI(auth)
+
+        try:
+            if "password" in data:
+                await auth.async_login()
+
+            name = await api.async_get_system_name()
+        except ConnectionError:
+            raise CannotConnect
+        except AuthError:
+            raise InvalidAuth
+        else:
+            return {"title": name}
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Rademacher HomePilot."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except InvalidAuth:
+            errors["base"] = "invalid_auth"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(exceptions.HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -11,8 +11,10 @@ from pyhomepilot.auth import (  # pylint:disable=redefined-builtin
 )
 import voluptuous as vol
 
-from homeassistant import config_entries, core, exceptions
+from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
 
@@ -23,7 +25,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 )
 
 
-async def validate_input(hass: core.HomeAssistant, data):
+async def validate_input(hass: HomeAssistant, data):
     """Validate the user input allows us to connect."""
     async with aiohttp.ClientSession() as session:
         auth = Auth(session, data[CONF_HOST], data.get(CONF_PASSWORD))
@@ -42,11 +44,11 @@ async def validate_input(hass: core.HomeAssistant, data):
             return {"title": name}
 
 
-class HomepilotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class HomepilotConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Rademacher HomePilot."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
+    CONNECTION_CLASS = CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
@@ -74,9 +76,9 @@ class HomepilotConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
 
-class CannotConnect(exceptions.HomeAssistantError):
+class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""
 
 
-class InvalidAuth(exceptions.HomeAssistantError):
+class InvalidAuth(HomeAssistantError):
     """Error to indicate there is invalid auth."""

--- a/homeassistant/components/homepilot/config_flow.py
+++ b/homeassistant/components/homepilot/config_flow.py
@@ -4,12 +4,16 @@ import logging
 
 import aiohttp
 from pyhomepilot import HomePilotAPI
-from pyhomepilot.auth import Auth, AuthError, ConnectionError
+from pyhomepilot.auth import (  # pylint:disable=redefined-builtin
+    Auth,
+    AuthError,
+    ConnectionError,
+)
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
 
-from .const import DOMAIN  # pylint:disable=unused-import
+from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,10 +33,10 @@ async def validate_input(hass: core.HomeAssistant, data):
                 await auth.async_login()
 
             name = await api.async_get_system_name()
-        except ConnectionError:
-            raise CannotConnect
-        except AuthError:
-            raise InvalidAuth
+        except ConnectionError as err:
+            raise CannotConnect from err
+        except AuthError as err:
+            raise InvalidAuth from err
         else:
             return {"title": name}
 

--- a/homeassistant/components/homepilot/const.py
+++ b/homeassistant/components/homepilot/const.py
@@ -1,0 +1,3 @@
+"""Constants for the Rademacher HomePilot integration."""
+
+DOMAIN = "homepilot"

--- a/homeassistant/components/homepilot/const.py
+++ b/homeassistant/components/homepilot/const.py
@@ -1,3 +1,8 @@
 """Constants for the Rademacher HomePilot integration."""
 
 DOMAIN = "homepilot"
+
+SCAN_INTERVAL = 30
+
+# HomePilot takes 1 to 4 seconds to update its state after sending a stop command
+STOP_UPDATE_DELAY = 4

--- a/homeassistant/components/homepilot/cover.py
+++ b/homeassistant/components/homepilot/cover.py
@@ -1,0 +1,88 @@
+"""Support for HomePilot Covers."""
+
+from pyhomepilot.devices import Blind
+from pyhomepilot.utils import reverse_percentage
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DEVICE_CLASS_BLIND,
+    DEVICE_CLASS_DOOR,
+    DEVICE_CLASS_GARAGE,
+    DEVICE_CLASS_SHADE,
+    DEVICE_CLASS_WINDOW,
+    CoverEntity,
+)
+
+from .const import DOMAIN
+from .entity import HomePilotEntity
+
+# supported device classes based on selected icon set
+DEVICE_CLASSES = {
+    "iconset6": DEVICE_CLASS_BLIND,
+    "iconset7": DEVICE_CLASS_SHADE,
+    "iconset8": DEVICE_CLASS_SHADE,
+    "iconset9": DEVICE_CLASS_DOOR,
+    "iconset12": DEVICE_CLASS_DOOR,
+    "iconset14": DEVICE_CLASS_DOOR,
+    "iconset15": DEVICE_CLASS_SHADE,
+    "iconset20": DEVICE_CLASS_BLIND,
+    "iconset24": DEVICE_CLASS_WINDOW,
+    "iconset30": DEVICE_CLASS_GARAGE,
+    "iconset31": DEVICE_CLASS_GARAGE,
+    "iconset34": DEVICE_CLASS_WINDOW,
+}
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up HomePilot cover platform."""
+
+    instance = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+    for uid, device in instance["coordinator"].data.items():
+        if type(device) is Blind:
+            entities.append(HomePilotCoverEntity(instance, uid))
+
+    async_add_entities(entities)
+
+
+class HomePilotCoverEntity(HomePilotEntity, CoverEntity):
+    """Class representing HomePilot cover."""
+
+    @property
+    def device_class(self):
+        """Return the class of the device."""
+        if not self._device.iconSet["k"] in DEVICE_CLASSES:
+            return None
+        return DEVICE_CLASSES[self._device.iconSet["k"]]
+
+    @property
+    def is_closed(self):
+        """Return true if cover is closed."""
+        return self._device.position == 100
+
+    @property
+    def current_cover_position(self):
+        """Return the position of the cover from 0 to 100."""
+        return reverse_percentage(self._device.position)
+
+    async def async_open_cover(self):
+        """Open the cover."""
+        await self._device.async_move_up()
+        await self.coordinator.async_refresh()
+
+    async def async_close_cover(self):
+        """Close cover."""
+        await self._device.async_move_down()
+        await self.coordinator.async_refresh()
+
+    async def async_set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        position = kwargs[ATTR_POSITION]
+        await self._device.async_goto_position(reverse_percentage(position))
+        await self.coordinator.async_refresh()
+
+    async def async_stop_cover(self, **kwargs):
+        """Stop the cover."""
+        await self._device.async_stop()
+        await self.coordinator.async_refresh()

--- a/homeassistant/components/homepilot/cover.py
+++ b/homeassistant/components/homepilot/cover.py
@@ -54,9 +54,7 @@ class HomePilotCoverEntity(HomePilotEntity, CoverEntity):
     @property
     def device_class(self):
         """Return the class of the device."""
-        if not self._device.iconSet["k"] in DEVICE_CLASSES:
-            return None
-        return DEVICE_CLASSES[self._device.iconSet["k"]]
+        return DEVICE_CLASSES.get(self._device.iconSet["k"])
 
     @property
     def is_closed(self):

--- a/homeassistant/components/homepilot/cover.py
+++ b/homeassistant/components/homepilot/cover.py
@@ -15,7 +15,7 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, STOP_UPDATE_DELAY
 from .entity import HomePilotEntity
 
 # supported device classes based on selected icon set
@@ -42,7 +42,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     entities = []
     for uid, device in instance["coordinator"].data.items():
-        if type(device) is Blind:
+        if isinstance(device, Blind):
             entities.append(HomePilotCoverEntity(instance, uid))
 
     async_add_entities(entities)
@@ -68,12 +68,12 @@ class HomePilotCoverEntity(HomePilotEntity, CoverEntity):
         """Return the position of the cover from 0 to 100."""
         return reverse_percentage(self._device.position)
 
-    async def async_open_cover(self):
+    async def async_open_cover(self, **kwargs):
         """Open the cover."""
         await self._device.async_move_up()
         await self.coordinator.async_refresh()
 
-    async def async_close_cover(self):
+    async def async_close_cover(self, **kwargs):
         """Close cover."""
         await self._device.async_move_down()
         await self.coordinator.async_refresh()
@@ -87,6 +87,5 @@ class HomePilotCoverEntity(HomePilotEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
         await self._device.async_stop()
-        # the HomePilot bridge takes 3 to 5 seconds to update its state after sending a stop command
-        await asyncio.sleep(5)
+        await asyncio.sleep(STOP_UPDATE_DELAY)
         await self.coordinator.async_refresh()

--- a/homeassistant/components/homepilot/cover.py
+++ b/homeassistant/components/homepilot/cover.py
@@ -1,5 +1,7 @@
 """Support for HomePilot Covers."""
 
+import asyncio
+
 from pyhomepilot.devices import Blind
 from pyhomepilot.utils import reverse_percentage
 
@@ -85,4 +87,6 @@ class HomePilotCoverEntity(HomePilotEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
         await self._device.async_stop()
+        # the HomePilot bridge takes 3 to 5 seconds to update its state after sending a stop command
+        await asyncio.sleep(5)
         await self.coordinator.async_refresh()

--- a/homeassistant/components/homepilot/entity.py
+++ b/homeassistant/components/homepilot/entity.py
@@ -1,0 +1,28 @@
+"""HomePilot base entity."""
+
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+
+class HomePilotEntity(CoordinatorEntity):
+    """Parent class for HomePilot entities."""
+
+    def __init__(self, instance, uid):
+        """Initialize common aspects of an HomePilot device."""
+        super().__init__(instance["coordinator"])
+        self.api = instance["api"]
+        self.uid = uid
+
+    @property
+    def _device(self):
+        """Return HomePilot device object."""
+        return self.coordinator.data[self.uid]
+
+    @property
+    def unique_id(self):
+        """Return the unique id of the device."""
+        return self._device.uid
+
+    @property
+    def name(self):
+        """Return the name of the device."""
+        return self._device.name

--- a/homeassistant/components/homepilot/manifest.json
+++ b/homeassistant/components/homepilot/manifest.json
@@ -1,0 +1,16 @@
+{
+  "domain": "homepilot",
+  "name": "Rademacher HomePilot",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/homepilot",
+  "requirements": [
+    "pyhomepilot==0.0.1"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@nico0302"
+  ]
+}

--- a/homeassistant/components/homepilot/strings.json
+++ b/homeassistant/components/homepilot/strings.json
@@ -1,0 +1,21 @@
+{
+  "title": "Rademacher HomePilot",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/homepilot/translations/en.json
+++ b/homeassistant/components/homepilot/translations/en.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid password",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password"
+                }
+            }
+        }
+    },
+    "title": "Rademacher HomePilot"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -108,6 +108,7 @@ FLOWS = [
     "homekit",
     "homekit_controller",
     "homematicip_cloud",
+    "homepilot",
     "huawei_lte",
     "hue",
     "huisbaasje",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1460,6 +1460,9 @@ pyhiveapi==0.4.2
 # homeassistant.components.homematic
 pyhomematic==0.1.72
 
+# homeassistant.components.homepilot
+pyhomepilot==0.0.1
+
 # homeassistant.components.homeworks
 pyhomeworks==0.0.6
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -807,6 +807,9 @@ pyhiveapi==0.4.2
 # homeassistant.components.homematic
 pyhomematic==0.1.72
 
+# homeassistant.components.homepilot
+pyhomepilot==0.0.1
+
 # homeassistant.components.ialarm
 pyialarm==1.5
 

--- a/tests/components/homepilot/__init__.py
+++ b/tests/components/homepilot/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Rademacher HomePilot integration."""

--- a/tests/components/homepilot/test_config_flow.py
+++ b/tests/components/homepilot/test_config_flow.py
@@ -1,7 +1,10 @@
 """Test the Rademacher HomePilot config flow."""
 from unittest.mock import patch
 
-from pyhomepilot.auth import AuthError, ConnectionError
+from pyhomepilot.auth import (  # pylint:disable=redefined-builtin
+    AuthError,
+    ConnectionError,
+)
 from pytest import raises
 
 from homeassistant import config_entries, setup

--- a/tests/components/homepilot/test_config_flow.py
+++ b/tests/components/homepilot/test_config_flow.py
@@ -14,10 +14,11 @@ from homeassistant.components.homepilot.config_flow import (
     validate_input,
 )
 from homeassistant.components.homepilot.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
 
 TEST_USER_INPUT = {
-    "host": "192.168.1.16",
-    "password": "test-password",
+    CONF_HOST: "192.168.1.16",
+    CONF_PASSWORD: "test-password",
 }
 
 
@@ -51,8 +52,6 @@ async def test_form(hass):
         "pyhomepilot.api.HomePilotAPI.async_get_system_name",
         return_value="bridge",
     ), patch(
-        "homeassistant.components.homepilot.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.homepilot.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -65,7 +64,6 @@ async def test_form(hass):
     assert result2["type"] == "create_entry"
     assert result2["title"] == "bridge"
     assert result2["data"] == TEST_USER_INPUT
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/homepilot/test_config_flow.py
+++ b/tests/components/homepilot/test_config_flow.py
@@ -1,0 +1,86 @@
+"""Test the Rademacher HomePilot config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.homepilot.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.homepilot.const import DOMAIN
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+
+    with patch("pyhomepilot.auth.Auth.async_login", return_value=True,), patch(
+        "pyhomepilot.api.HomePilotAPI.async_get_system_name",
+        return_value="bridge",
+    ), patch(
+        "homeassistant.components.homepilot.async_setup", return_value=True
+    ) as mock_setup, patch(
+        "homeassistant.components.homepilot.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "password": "test-password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == "create_entry"
+    assert result2["title"] == "bridge"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+        "password": "test-password",
+    }
+    assert len(mock_setup.mock_calls) == 1
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "pyhomepilot.auth.Auth.async_login",
+        side_effect=InvalidAuth,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "pyhomepilot.auth.Auth.async_login",
+        side_effect=CannotConnect,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+                "password": "test-password",
+            },
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "cannot_connect"}

--- a/tests/components/homepilot/test_config_flow.py
+++ b/tests/components/homepilot/test_config_flow.py
@@ -1,9 +1,39 @@
 """Test the Rademacher HomePilot config flow."""
 from unittest.mock import patch
 
+from pyhomepilot.auth import AuthError, ConnectionError
+from pytest import raises
+
 from homeassistant import config_entries, setup
-from homeassistant.components.homepilot.config_flow import CannotConnect, InvalidAuth
+from homeassistant.components.homepilot.config_flow import (
+    CannotConnect,
+    InvalidAuth,
+    validate_input,
+)
 from homeassistant.components.homepilot.const import DOMAIN
+
+TEST_USER_INPUT = {
+    "host": "192.168.1.16",
+    "password": "test-password",
+}
+
+
+async def test_validate_input_invalid_auth(hass):
+    """Test we receive an invalid auth error."""
+    with patch(
+        "pyhomepilot.auth.Auth.async_login",
+        side_effect=AuthError(None, OSError()),
+    ), raises(InvalidAuth):
+        await validate_input(hass, TEST_USER_INPUT)
+
+
+async def test_validate_input_cannot_connect(hass):
+    """Test we receive a cannot connect error."""
+    with patch(
+        "pyhomepilot.auth.Auth.async_login",
+        side_effect=ConnectionError(None, OSError()),
+    ), raises(CannotConnect):
+        await validate_input(hass, TEST_USER_INPUT)
 
 
 async def test_form(hass):
@@ -25,19 +55,13 @@ async def test_form(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "password": "test-password",
-            },
+            TEST_USER_INPUT,
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == "create_entry"
     assert result2["title"] == "bridge"
-    assert result2["data"] == {
-        "host": "1.1.1.1",
-        "password": "test-password",
-    }
+    assert result2["data"] == TEST_USER_INPUT
     assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -49,15 +73,12 @@ async def test_form_invalid_auth(hass):
     )
 
     with patch(
-        "pyhomepilot.auth.Auth.async_login",
+        "homeassistant.components.homepilot.config_flow.validate_input",
         side_effect=InvalidAuth,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "password": "test-password",
-            },
+            TEST_USER_INPUT,
         )
 
     assert result2["type"] == "form"
@@ -71,16 +92,32 @@ async def test_form_cannot_connect(hass):
     )
 
     with patch(
-        "pyhomepilot.auth.Auth.async_login",
+        "homeassistant.components.homepilot.config_flow.validate_input",
         side_effect=CannotConnect,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {
-                "host": "1.1.1.1",
-                "password": "test-password",
-            },
+            TEST_USER_INPUT,
         )
 
     assert result2["type"] == "form"
     assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_unknown_exception(hass):
+    """Test we handle unknown error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.homepilot.config_flow.validate_input",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            TEST_USER_INPUT,
+        )
+
+    assert result2["type"] == "form"
+    assert result2["errors"] == {"base": "unknown"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pull request adds a new integration supporting automatic [Rademacher HomePilot](https://www.rademacher.de/smart-home/produkte/homepilot) blinds.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17248
- Related forum thread: https://community.home-assistant.io/t/rademacher-homepilot-in-home-assistant/204935

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
