### PR TITLE
Fix Hue service being removed on entry reload

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -3,19 +3,18 @@ import asyncio
 import logging
 
 from aiohue.util import normalize_bridge_id
+import voluptuous as vol
 
 from homeassistant import config_entries, core
 from homeassistant.components import persistent_notification
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.service import verify_domain_control
 
-from .bridge import (
+from .bridge import HueBridge
+from .const import (
     ATTR_GROUP_NAME,
     ATTR_SCENE_NAME,
-    SCENE_SCHEMA,
-    SERVICE_HUE_SCENE,
-    HueBridge,
-)
-from .const import (
+    ATTR_TRANSITION,
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
     DEFAULT_ALLOW_HUE_GROUPS,
@@ -24,46 +23,7 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass, config):
-    """Set up the Hue platform."""
-
-    async def hue_activate_scene(call, skip_reload=True):
-        """Handle activation of Hue scene."""
-        # Get parameters
-        group_name = call.data[ATTR_GROUP_NAME]
-        scene_name = call.data[ATTR_SCENE_NAME]
-
-        # Call the set scene function on each bridge
-        tasks = [
-            bridge.hue_activate_scene(
-                call, updated=skip_reload, hide_warnings=skip_reload
-            )
-            for bridge in hass.data[DOMAIN].values()
-            if isinstance(bridge, HueBridge)
-        ]
-        results = await asyncio.gather(*tasks)
-
-        # Did *any* bridge succeed? If not, refresh / retry
-        # Note that we'll get a "None" value for a successful call
-        if None not in results:
-            if skip_reload:
-                await hue_activate_scene(call, skip_reload=False)
-                return
-            _LOGGER.warning(
-                "No bridge was able to activate " "scene %s in group %s",
-                scene_name,
-                group_name,
-            )
-
-    # Register a local handler for scene activation
-    hass.services.async_register(
-        DOMAIN, SERVICE_HUE_SCENE, hue_activate_scene, schema=SCENE_SCHEMA
-    )
-
-    hass.data[DOMAIN] = {}
-    return True
+SERVICE_HUE_SCENE = "hue_activate_scene"
 
 
 async def async_setup_entry(
@@ -104,7 +64,9 @@ async def async_setup_entry(
     if not await bridge.async_setup():
         return False
 
-    hass.data[DOMAIN][entry.entry_id] = bridge
+    _register_services(hass)
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = bridge
     config = bridge.api.config
 
     # For backwards compat
@@ -172,5 +134,55 @@ async def async_setup_entry(
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
     bridge = hass.data[DOMAIN].pop(entry.entry_id)
-    hass.services.async_remove(DOMAIN, SERVICE_HUE_SCENE)
+    if len(hass.data[DOMAIN]) == 0:
+        hass.data.pop(DOMAIN)
+        hass.services.async_remove(DOMAIN, SERVICE_HUE_SCENE)
     return await bridge.async_reset()
+
+
+@core.callback
+def _register_services(hass):
+    """Register Hue services."""
+
+    async def hue_activate_scene(call, skip_reload=True):
+        """Handle activation of Hue scene."""
+        # Get parameters
+        group_name = call.data[ATTR_GROUP_NAME]
+        scene_name = call.data[ATTR_SCENE_NAME]
+
+        # Call the set scene function on each bridge
+        tasks = [
+            bridge.hue_activate_scene(
+                call.data, updated=skip_reload, hide_warnings=skip_reload
+            )
+            for bridge in hass.data[DOMAIN].values()
+            if isinstance(bridge, HueBridge)
+        ]
+        results = await asyncio.gather(*tasks)
+
+        # Did *any* bridge succeed? If not, refresh / retry
+        # Note that we'll get a "None" value for a successful call
+        if None not in results:
+            if skip_reload:
+                await hue_activate_scene(call, skip_reload=False)
+                return
+            _LOGGER.warning(
+                "No bridge was able to activate " "scene %s in group %s",
+                scene_name,
+                group_name,
+            )
+
+    if DOMAIN not in hass.data:
+        # Register a local handler for scene activation
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_HUE_SCENE,
+            verify_domain_control(hass, DOMAIN)(hue_activate_scene),
+            schema=vol.Schema(
+                {
+                    vol.Required(ATTR_GROUP_NAME): cv.string,
+                    vol.Required(ATTR_SCENE_NAME): cv.string,
+                    vol.Optional(ATTR_TRANSITION): cv.positive_int,
+                }
+            ),
+        )

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -7,14 +7,16 @@ from aiohttp import client_exceptions
 import aiohue
 import async_timeout
 import slugify as unicode_slug
-import voluptuous as vol
 
 from homeassistant import core
 from homeassistant.const import HTTP_INTERNAL_SERVER_ERROR
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client, config_validation as cv
+from homeassistant.helpers import aiohttp_client
 
 from .const import (
+    ATTR_GROUP_NAME,
+    ATTR_SCENE_NAME,
+    ATTR_TRANSITION,
     CONF_ALLOW_HUE_GROUPS,
     CONF_ALLOW_UNREACHABLE,
     DEFAULT_ALLOW_HUE_GROUPS,
@@ -25,17 +27,6 @@ from .errors import AuthenticationRequired, CannotConnect
 from .helpers import create_config_flow
 from .sensor_base import SensorManager
 
-SERVICE_HUE_SCENE = "hue_activate_scene"
-ATTR_GROUP_NAME = "group_name"
-ATTR_SCENE_NAME = "scene_name"
-ATTR_TRANSITION = "transition"
-SCENE_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_GROUP_NAME): cv.string,
-        vol.Required(ATTR_SCENE_NAME): cv.string,
-        vol.Optional(ATTR_TRANSITION): cv.positive_int,
-    }
-)
 # How long should we sleep if the hub is busy
 HUB_BUSY_SLEEP = 0.5
 _LOGGER = logging.getLogger(__name__)
@@ -202,11 +193,11 @@ class HueBridge:
         # None and True are OK
         return False not in results
 
-    async def hue_activate_scene(self, call, updated=False, hide_warnings=False):
+    async def hue_activate_scene(self, data, skip_reload=False, hide_warnings=False):
         """Service to call directly into bridge to set scenes."""
-        group_name = call.data[ATTR_GROUP_NAME]
-        scene_name = call.data[ATTR_SCENE_NAME]
-        transition = call.data.get(ATTR_TRANSITION)
+        group_name = data[ATTR_GROUP_NAME]
+        scene_name = data[ATTR_SCENE_NAME]
+        transition = data.get(ATTR_TRANSITION)
 
         group = next(
             (group for group in self.api.groups.values() if group.name == group_name),
@@ -226,10 +217,10 @@ class HueBridge:
         )
 
         # If we can't find it, fetch latest info.
-        if not updated and (group is None or scene is None):
+        if not skip_reload and (group is None or scene is None):
             await self.async_request_call(self.api.groups.update)
             await self.async_request_call(self.api.scenes.update)
-            return await self.hue_activate_scene(call, updated=True)
+            return await self.hue_activate_scene(data, skip_reload=True)
 
         if group is None:
             if not hide_warnings:

--- a/homeassistant/components/hue/const.py
+++ b/homeassistant/components/hue/const.py
@@ -18,3 +18,7 @@ GROUP_TYPE_LIGHT_GROUP = "LightGroup"
 GROUP_TYPE_ROOM = "Room"
 GROUP_TYPE_LUMINAIRE = "Luminaire"
 GROUP_TYPE_LIGHT_SOURCE = "LightSource"
+
+ATTR_GROUP_NAME = "group_name"
+ATTR_SCENE_NAME = "scene_name"
+ATTR_TRANSITION = "transition"

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -185,7 +185,7 @@ async def test_hue_activate_scene(hass, mock_api):
     call = Mock()
     call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner"}
     with patch("aiohue.Bridge", return_value=mock_api):
-        assert await hue_bridge.hue_activate_scene(call) is None
+        assert await hue_bridge.hue_activate_scene(call.data) is None
 
     assert len(mock_api.mock_requests) == 3
     assert mock_api.mock_requests[2]["json"]["scene"] == "scene_1"
@@ -220,7 +220,7 @@ async def test_hue_activate_scene_transition(hass, mock_api):
     call = Mock()
     call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner", "transition": 30}
     with patch("aiohue.Bridge", return_value=mock_api):
-        assert await hue_bridge.hue_activate_scene(call) is None
+        assert await hue_bridge.hue_activate_scene(call.data) is None
 
     assert len(mock_api.mock_requests) == 3
     assert mock_api.mock_requests[2]["json"]["scene"] == "scene_1"
@@ -255,7 +255,7 @@ async def test_hue_activate_scene_group_not_found(hass, mock_api):
     call = Mock()
     call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner"}
     with patch("aiohue.Bridge", return_value=mock_api):
-        assert await hue_bridge.hue_activate_scene(call) is False
+        assert await hue_bridge.hue_activate_scene(call.data) is False
 
 
 async def test_hue_activate_scene_scene_not_found(hass, mock_api):
@@ -285,4 +285,4 @@ async def test_hue_activate_scene_scene_not_found(hass, mock_api):
     call = Mock()
     call.data = {"group_name": "Group 1", "scene_name": "Cozy dinner"}
     with patch("aiohue.Bridge", return_value=mock_api):
-        assert await hue_bridge.hue_activate_scene(call) is False
+        assert await hue_bridge.hue_activate_scene(call.data) is False

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -27,7 +27,7 @@ async def test_setup_with_no_config(hass):
     assert len(hass.config_entries.flow.async_progress()) == 0
 
     # No configs stored
-    assert hass.data[hue.DOMAIN] == {}
+    assert hue.DOMAIN not in hass.data
 
 
 async def test_unload_entry(hass, mock_bridge_setup):
@@ -41,7 +41,7 @@ async def test_unload_entry(hass, mock_bridge_setup):
     mock_bridge_setup.async_reset = AsyncMock(return_value=True)
     assert await hue.async_unload_entry(hass, entry)
     assert len(mock_bridge_setup.async_reset.mock_calls) == 1
-    assert hass.data[hue.DOMAIN] == {}
+    assert hue.DOMAIN not in hass.data
 
 
 async def test_setting_unique_id(hass, mock_bridge_setup):

--- a/tests/components/hue/test_init_multiple_bridges.py
+++ b/tests/components/hue/test_init_multiple_bridges.py
@@ -1,6 +1,5 @@
 """Test Hue init with multiple bridges."""
-
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from aiohue.groups import Groups
 from aiohue.lights import Lights
@@ -12,6 +11,8 @@ from homeassistant import config_entries
 from homeassistant.components import hue
 from homeassistant.components.hue import sensor_base as hue_sensor_base
 from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
 
 
 async def setup_component(hass):
@@ -108,12 +109,10 @@ async def test_hue_activate_scene_zero_responds(
 
 async def setup_bridge(hass, mock_bridge, config_entry):
     """Load the Hue light platform with the provided bridge."""
-    hue._register_services(hass)
     mock_bridge.config_entry = config_entry
-    hass.data.setdefault(hue.DOMAIN, {})[config_entry.entry_id] = mock_bridge
-    await hass.config_entries.async_forward_entry_setup(config_entry, "light")
-    # To flush out the service call to update the group
-    await hass.async_block_till_done()
+    config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.hue.HueBridge", return_value=mock_bridge):
+        await hass.config_entries.async_setup(config_entry.entry_id)
 
 
 @pytest.fixture
@@ -130,14 +129,10 @@ def mock_config_entry2(hass):
 
 def create_config_entry():
     """Mock a config entry."""
-    return config_entries.ConfigEntry(
-        1,
-        hue.DOMAIN,
-        "Mock Title",
-        {"host": "mock-host"},
-        "test",
-        config_entries.CONN_CLASS_LOCAL_POLL,
-        system_options={},
+    return MockConfigEntry(
+        domain=hue.DOMAIN,
+        data={"host": "mock-host"},
+        connection_class=config_entries.CONN_CLASS_LOCAL_POLL,
     )
 
 
@@ -164,6 +159,7 @@ def create_mock_bridge(hass):
         api=Mock(),
         reset_jobs=[],
         spec=hue.HueBridge,
+        async_setup=AsyncMock(return_value=True),
     )
     bridge.sensor_manager = hue_sensor_base.SensorManager(bridge)
     bridge.mock_requests = []

--- a/tests/components/hue/test_init_multiple_bridges.py
+++ b/tests/components/hue/test_init_multiple_bridges.py
@@ -108,8 +108,9 @@ async def test_hue_activate_scene_zero_responds(
 
 async def setup_bridge(hass, mock_bridge, config_entry):
     """Load the Hue light platform with the provided bridge."""
+    hue._register_services(hass)
     mock_bridge.config_entry = config_entry
-    hass.data[hue.DOMAIN][config_entry.entry_id] = mock_bridge
+    hass.data.setdefault(hue.DOMAIN, {})[config_entry.entry_id] = mock_bridge
     await hass.config_entries.async_forward_entry_setup(config_entry, "light")
     # To flush out the service call to update the group
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix hue activate scene on hub service to be removed when reloading the config entry.

Fixes #48562

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
