### PR TITLE
Apply ConfigEntryNotReady improvements to PlatformNotReady

### DIFF
--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -6,8 +6,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from homeassistant.const import PERCENTAGE
-from homeassistant.core import callback
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, PERCENTAGE
+from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
 from homeassistant.helpers import (
     device_registry as dr,
@@ -592,6 +592,52 @@ async def test_setup_entry_platform_not_ready(hass, caplog):
     assert len(mock_call_later.mock_calls) == 1
 
 
+async def test_setup_entry_platform_not_ready_with_message(hass, caplog):
+    """Test when an entry is not ready yet that includes a message."""
+    async_setup_entry = Mock(side_effect=PlatformNotReady("lp0 on fire"))
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry()
+    ent_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    with patch.object(entity_platform, "async_call_later") as mock_call_later:
+        assert not await ent_platform.async_setup_entry(config_entry)
+
+    full_name = f"{ent_platform.domain}.{config_entry.domain}"
+    assert full_name not in hass.config.components
+    assert len(async_setup_entry.mock_calls) == 1
+
+    assert "Platform test not ready yet" in caplog.text
+    assert "lp0 on fire" in caplog.text
+    assert len(mock_call_later.mock_calls) == 1
+
+
+async def test_setup_entry_platform_not_ready_from_exception(hass, caplog):
+    """Test when an entry is not ready yet that includes the causing exception string."""
+    original_exception = HomeAssistantError("The device dropped the connection")
+    platform_exception = PlatformNotReady()
+    platform_exception.__cause__ = original_exception
+
+    async_setup_entry = Mock(side_effect=platform_exception)
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry()
+    ent_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    with patch.object(entity_platform, "async_call_later") as mock_call_later:
+        assert not await ent_platform.async_setup_entry(config_entry)
+
+    full_name = f"{ent_platform.domain}.{config_entry.domain}"
+    assert full_name not in hass.config.components
+    assert len(async_setup_entry.mock_calls) == 1
+
+    assert "Platform test not ready yet" in caplog.text
+    assert "The device dropped the connection" in caplog.text
+    assert len(mock_call_later.mock_calls) == 1
+
+
 async def test_reset_cancels_retry_setup(hass):
     """Test that resetting a platform will cancel scheduled a setup retry."""
     async_setup_entry = Mock(side_effect=PlatformNotReady)
@@ -611,6 +657,31 @@ async def test_reset_cancels_retry_setup(hass):
     await ent_platform.async_reset()
 
     assert len(mock_call_later.return_value.mock_calls) == 1
+    assert ent_platform._async_cancel_retry_setup is None
+
+
+async def test_reset_cancels_retry_setup_when_not_started(hass):
+    """Test that resetting a platform will cancel scheduled a setup retry when not yet started."""
+    hass.state = CoreState.starting
+    async_setup_entry = Mock(side_effect=PlatformNotReady)
+    initial_listeners = hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED]
+
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry()
+    ent_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    assert not await ent_platform.async_setup_entry(config_entry)
+    await hass.async_block_till_done()
+    assert (
+        hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED] == initial_listeners + 1
+    )
+    assert ent_platform._async_cancel_retry_setup is not None
+
+    await ent_platform.async_reset()
+    await hass.async_block_till_done()
+    assert hass.bus.async_listeners()[EVENT_HOMEASSISTANT_STARTED] == initial_listeners
     assert ent_platform._async_cancel_retry_setup is None
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Apply ConfigEntryNotReady improvements to PlatformNotReady

- Limit log spam #47201
- Log exception reason #48449
- Prevent startup blockage #48660


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
