### PR TITLE
Limit log spam from rest and include reason in platform retry

### DIFF
--- a/homeassistant/components/rest/binary_sensor.py
+++ b/homeassistant/components/rest/binary_sensor.py
@@ -40,9 +40,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         conf = config
         coordinator = None
         rest = create_rest_data_from_config(hass, conf)
-        await rest.async_update()
+        await rest.async_update(log_errors=False)
 
     if rest.data is None:
+        if rest.last_exception:
+            raise PlatformNotReady from rest.last_exception
         raise PlatformNotReady
 
     name = conf.get(CONF_NAME)

--- a/homeassistant/components/rest/data.py
+++ b/homeassistant/components/rest/data.py
@@ -37,13 +37,14 @@ class RestData:
         self._verify_ssl = verify_ssl
         self._async_client = None
         self.data = None
+        self.last_exception = None
         self.headers = None
 
     def set_url(self, url):
         """Set url."""
         self._resource = url
 
-    async def async_update(self):
+    async def async_update(self, log_errors=True):
         """Get the latest data from REST service with provided method."""
         if not self._async_client:
             self._async_client = get_async_client(
@@ -64,6 +65,10 @@ class RestData:
             self.data = response.text
             self.headers = response.headers
         except httpx.RequestError as ex:
-            _LOGGER.error("Error fetching data: %s failed with %s", self._resource, ex)
+            if log_errors:
+                _LOGGER.error(
+                    "Error fetching data: %s failed with %s", self._resource, ex
+                )
+            self.last_exception = ex
             self.data = None
             self.headers = None

--- a/homeassistant/components/rest/sensor.py
+++ b/homeassistant/components/rest/sensor.py
@@ -50,9 +50,11 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
         conf = config
         coordinator = None
         rest = create_rest_data_from_config(hass, conf)
-        await rest.async_update()
+        await rest.async_update(log_errors=False)
 
     if rest.data is None:
+        if rest.last_exception:
+            raise PlatformNotReady from rest.last_exception
         raise PlatformNotReady
 
     name = conf.get(CONF_NAME)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tests will fail until this is rebased on top of #48665

- Each retry was logging the error again
- Now we set the cause of the PlatformNotReady to allow Home Assistant to log as needed



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
