### PR TITLE
Implement Ignore list for poll control configuration on Ikea devices

### DIFF
--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -424,7 +424,7 @@ class PollControl(ZigbeeChannel):
 
     @callback
     def skip_manufacturer_id(self, manufacturer_code: int) -> None:
-        """Black list a specific manufacturer id from changing default polling."""
+        """Block a specific manufacturer id from changing default polling."""
         self._IGNORED_MANUFACTURER_ID.add(manufacturer_code)
 
 

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -391,6 +391,9 @@ class PollControl(ZigbeeChannel):
     CHECKIN_INTERVAL = 55 * 60 * 4  # 55min
     CHECKIN_FAST_POLL_TIMEOUT = 2 * 4  # 2s
     LONG_POLL = 6 * 4  # 6s
+    _BLACK_LIST = {
+        4476,
+    }  # IKEA
 
     async def async_configure_channel_specific(self) -> None:
         """Configure channel: set check-in interval."""
@@ -416,7 +419,13 @@ class PollControl(ZigbeeChannel):
     async def check_in_response(self, tsn: int) -> None:
         """Respond to checkin command."""
         await self.checkin_response(True, self.CHECKIN_FAST_POLL_TIMEOUT, tsn=tsn)
-        await self.set_long_poll_interval(self.LONG_POLL)
+        if self._ch_pool.manufacturer_code not in self._BLACK_LIST:
+            await self.set_long_poll_interval(self.LONG_POLL)
+
+    @callback
+    def black_list_manufacturer(self, manufacturer_code: int) -> None:
+        """Black list a specific manufacturer id from changing default polling."""
+        self._BLACK_LIST.add(manufacturer_code)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.PowerConfiguration.cluster_id)

--- a/homeassistant/components/zha/core/channels/general.py
+++ b/homeassistant/components/zha/core/channels/general.py
@@ -391,7 +391,7 @@ class PollControl(ZigbeeChannel):
     CHECKIN_INTERVAL = 55 * 60 * 4  # 55min
     CHECKIN_FAST_POLL_TIMEOUT = 2 * 4  # 2s
     LONG_POLL = 6 * 4  # 6s
-    _BLACK_LIST = {
+    _IGNORED_MANUFACTURER_ID = {
         4476,
     }  # IKEA
 
@@ -419,13 +419,13 @@ class PollControl(ZigbeeChannel):
     async def check_in_response(self, tsn: int) -> None:
         """Respond to checkin command."""
         await self.checkin_response(True, self.CHECKIN_FAST_POLL_TIMEOUT, tsn=tsn)
-        if self._ch_pool.manufacturer_code not in self._BLACK_LIST:
+        if self._ch_pool.manufacturer_code not in self._IGNORED_MANUFACTURER_ID:
             await self.set_long_poll_interval(self.LONG_POLL)
 
     @callback
-    def black_list_manufacturer(self, manufacturer_code: int) -> None:
+    def skip_manufacturer_id(self, manufacturer_code: int) -> None:
         """Black list a specific manufacturer id from changing default polling."""
-        self._BLACK_LIST.add(manufacturer_code)
+        self._IGNORED_MANUFACTURER_ID.add(manufacturer_code)
 
 
 @registries.ZIGBEE_CHANNEL_REGISTRY.register(general.PowerConfiguration.cluster_id)

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -492,6 +492,38 @@ async def test_poll_control_cluster_command(hass, poll_control_device):
     assert data["device_id"] == poll_control_device.device_id
 
 
+async def test_poll_control_blacklist(hass, poll_control_device):
+    """Test poll control channel blacklisting."""
+    set_long_poll_mock = AsyncMock()
+    poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
+    cluster = poll_control_ch.cluster
+
+    with mock.patch.object(cluster, "set_long_poll_interval", set_long_poll_mock):
+        await poll_control_ch.check_in_response(33)
+
+    assert set_long_poll_mock.call_count == 1
+
+    set_long_poll_mock.reset_mock()
+    poll_control_ch.black_list_manufacturer(4151)
+    with mock.patch.object(cluster, "set_long_poll_interval", set_long_poll_mock):
+        await poll_control_ch.check_in_response(33)
+
+    assert set_long_poll_mock.call_count == 0
+
+
+async def test_poll_control_ikea(hass, poll_control_device):
+    """Test poll control channel blacklisting for ikea."""
+    set_long_poll_mock = AsyncMock()
+    poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
+    cluster = poll_control_ch.cluster
+
+    poll_control_device.device.node_desc.manufacturer_code = 4476
+    with mock.patch.object(cluster, "set_long_poll_interval", set_long_poll_mock):
+        await poll_control_ch.check_in_response(33)
+
+    assert set_long_poll_mock.call_count == 0
+
+
 @pytest.fixture
 def zigpy_zll_device(zigpy_device_mock):
     """ZLL device fixture."""

--- a/tests/components/zha/test_channels.py
+++ b/tests/components/zha/test_channels.py
@@ -492,8 +492,8 @@ async def test_poll_control_cluster_command(hass, poll_control_device):
     assert data["device_id"] == poll_control_device.device_id
 
 
-async def test_poll_control_blacklist(hass, poll_control_device):
-    """Test poll control channel blacklisting."""
+async def test_poll_control_ignore_list(hass, poll_control_device):
+    """Test poll control channel ignore list."""
     set_long_poll_mock = AsyncMock()
     poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
     cluster = poll_control_ch.cluster
@@ -504,7 +504,7 @@ async def test_poll_control_blacklist(hass, poll_control_device):
     assert set_long_poll_mock.call_count == 1
 
     set_long_poll_mock.reset_mock()
-    poll_control_ch.black_list_manufacturer(4151)
+    poll_control_ch.skip_manufacturer_id(4151)
     with mock.patch.object(cluster, "set_long_poll_interval", set_long_poll_mock):
         await poll_control_ch.check_in_response(33)
 
@@ -512,7 +512,7 @@ async def test_poll_control_blacklist(hass, poll_control_device):
 
 
 async def test_poll_control_ikea(hass, poll_control_device):
-    """Test poll control channel blacklisting for ikea."""
+    """Test poll control channel ignore list for ikea."""
     set_long_poll_mock = AsyncMock()
     poll_control_ch = poll_control_device.channels.pools[0].all_channels["1:0x0020"]
     cluster = poll_control_ch.cluster


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
No

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't configure "long_poll_interval" for Ikea devices, as it may cause battery drain.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

n/a

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #43969
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
