### PR TITLE
Add missing function in modbus

### DIFF
--- a/tests/components/modbus/test_modbus.py
+++ b/tests/components/modbus/test_modbus.py
@@ -11,6 +11,7 @@ from homeassistant.components.modbus.const import (
     DEFAULT_HUB,
     MODBUS_DOMAIN as DOMAIN,
 )
+from homeassistant.components.modbus.modbus import ModbusHub
 from homeassistant.const import (
     CONF_DELAY,
     CONF_HOST,
@@ -138,7 +139,7 @@ async def test_config_modbus(hass, do_config):
         assert DOMAIN in hass.data
 
         # the "if" should really be in the do_config above, but
-        # there are no easy way to have vol add default.
+        # there are no easy way to have vol add default in a test setup
         if CONF_NAME not in do_config[DOMAIN][0]:
             do_config[DOMAIN][0][CONF_NAME] = DEFAULT_HUB
         assert do_config[DOMAIN][0][CONF_NAME] in hass.data[DOMAIN]
@@ -234,11 +235,49 @@ async def test_multiple_config_modbus(hass, do_config):
         assert do_config[DOMAIN][1][CONF_NAME] in hass.data[DOMAIN]
 
 
-async def test_pymodbus_read(hass):
+@pytest.mark.parametrize(
+    "do_read_type",
+    [
+        "read_coils",
+        "read_discrete_inputs",
+        "read_input_registers",
+        "read_holding_registers",
+    ],
+)
+async def test_pymodbus_read(hass, do_read_type):
     """Run test for modbus."""
 
+    # dummy config
+    config_hub = {
+        CONF_NAME: DEFAULT_HUB,
+        CONF_TYPE: "tcp",
+        CONF_HOST: "modbusTest",
+        CONF_PORT: 5001,
+        CONF_DELAY: 1,
+        CONF_TIMEOUT: 1,
+    }
 
-async def test_pymodbus_write(hass):
+    mock_sync = mock.MagicMock()
+    with mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusTcpClient", return_value=mock_sync
+    ), mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusSerialClient",
+        return_value=mock_sync,
+    ), mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusUdpClient", return_value=mock_sync
+    ):
+        # mocking is needed to secure the pymodbus library is not called!
+        # simulate read_* functions in pymodbus library
+
+        hub = ModbusHub(config_hub)
+        print(hub)
+
+
+@pytest.mark.parametrize(
+    "do_write_type",
+    [],
+)
+async def test_pymodbus_write(hass, do_write_type):
     """Run test for modbus."""
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
the function write_coils was missing in ModbusHub. This was detected while writing the pymodbus test cases (soon
to come PR).

ModbusHub setup() contained an empty assert, which are dead code, since voluptuous secures that invalid config values are caught before entering the integration code. Dead code is removed. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
