### PR TITLE
Fix sonos volume always showing 0

### DIFF
--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -885,9 +885,9 @@ class SonosEntity(MediaPlayerEntity):
             self.async_write_ha_state()
 
     @property
-    def volume_level(self) -> int | None:
+    def volume_level(self) -> float | None:
         """Volume level of the media player (0..1)."""
-        return self._player_volume and int(self._player_volume / 100)
+        return self._player_volume and self._player_volume / 100
 
     @property
     def is_volume_muted(self) -> bool | None:

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -31,6 +31,10 @@ def soco_fixture(music_library, speaker_info, dummy_soco_service):
         mock_soco.renderingControl = dummy_soco_service
         mock_soco.zoneGroupTopology = dummy_soco_service
         mock_soco.contentDirectory = dummy_soco_service
+        mock_soco.mute = False
+        mock_soco.night_mode = True
+        mock_soco.dialog_mode = True
+        mock_soco.volume = 19
 
         yield mock_soco
 

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -63,7 +63,7 @@ async def test_device_registry(hass, config_entry, config, soco):
 
 
 async def test_entity_basic(hass, config_entry, discover):
-    """Test discovery setup."""
+    """Test basic state and attributes."""
     await setup_platform(hass, config_entry, {})
 
     state = hass.states.get("media_player.zone_a")

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -72,5 +72,5 @@ async def test_entity_basic(hass, config_entry, discover):
     assert attributes["friendly_name"] == "Zone A"
     assert attributes["is_volume_muted"] is False
     assert attributes["night_sound"] is True
-    assert attributes["speech_enhance"] is False
+    assert attributes["speech_enhance"] is True
     assert attributes["volume_level"] == 0.19

--- a/tests/components/sonos/test_media_player.py
+++ b/tests/components/sonos/test_media_player.py
@@ -2,6 +2,7 @@
 import pytest
 
 from homeassistant.components.sonos import DOMAIN, media_player
+from homeassistant.const import STATE_IDLE
 from homeassistant.core import Context
 from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import device_registry as dr
@@ -59,3 +60,17 @@ async def test_device_registry(hass, config_entry, config, soco):
     assert reg_device.manufacturer == "Sonos"
     assert reg_device.suggested_area == "Zone A"
     assert reg_device.name == "Zone A"
+
+
+async def test_entity_basic(hass, config_entry, discover):
+    """Test discovery setup."""
+    await setup_platform(hass, config_entry, {})
+
+    state = hass.states.get("media_player.zone_a")
+    assert state.state == STATE_IDLE
+    attributes = state.attributes
+    assert attributes["friendly_name"] == "Zone A"
+    assert attributes["is_volume_muted"] is False
+    assert attributes["night_sound"] is True
+    assert attributes["speech_enhance"] is False
+    assert attributes["volume_level"] == 0.19


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Missed that volume is a float 0..1 instead of an int


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
