### PR TITLE
Bump libhdate dependency

### DIFF
--- a/homeassistant/components/jewish_calendar/manifest.json
+++ b/homeassistant/components/jewish_calendar/manifest.json
@@ -2,6 +2,6 @@
   "domain": "jewish_calendar",
   "name": "Jewish Calendar",
   "documentation": "https://www.home-assistant.io/integrations/jewish_calendar",
-  "requirements": ["hdate==0.9.12"],
+  "requirements": ["hdate==0.10.2"],
   "codeowners": ["@tsvi"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ hass_splunk==0.1.1
 hatasmota==0.2.9
 
 # homeassistant.components.jewish_calendar
-hdate==0.9.12
+hdate==0.10.2
 
 # homeassistant.components.heatmiser
 heatmiserV3==1.1.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -408,7 +408,7 @@ hass-nabucasa==0.42.0
 hatasmota==0.2.9
 
 # homeassistant.components.jewish_calendar
-hdate==0.9.12
+hdate==0.10.2
 
 # homeassistant.components.here_travel_time
 herepy==2.0.0

--- a/tests/components/jewish_calendar/test_binary_sensor.py
+++ b/tests/components/jewish_calendar/test_binary_sensor.py
@@ -248,10 +248,10 @@ async def test_issur_melacha_sensor(
     ],
     [
         make_nyc_test_params(
-            dt(2020, 10, 23, 17, 46, 59, 999999), [STATE_OFF, STATE_ON]
+            dt(2020, 10, 23, 17, 44, 59, 999999), [STATE_OFF, STATE_ON]
         ),
         make_nyc_test_params(
-            dt(2020, 10, 24, 18, 44, 59, 999999), [STATE_ON, STATE_OFF]
+            dt(2020, 10, 24, 18, 42, 59, 999999), [STATE_ON, STATE_OFF]
         ),
     ],
     ids=["before_candle_lighting", "before_havdalah"],

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -77,7 +77,7 @@ TEST_PARAMS = [
         "hebrew",
         "t_set_hakochavim",
         True,
-        dt(2018, 9, 8, 19, 48),
+        dt(2018, 9, 8, 19, 45),
     ),
     (
         dt(2018, 9, 8),
@@ -87,7 +87,7 @@ TEST_PARAMS = [
         "hebrew",
         "t_set_hakochavim",
         False,
-        dt(2018, 9, 8, 19, 21),
+        dt(2018, 9, 8, 19, 19),
     ),
     (
         dt(2018, 10, 14),
@@ -204,10 +204,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 1, 16, 0),
         {
-            "english_upcoming_candle_lighting": dt(2018, 8, 31, 19, 15),
-            "english_upcoming_havdalah": dt(2018, 9, 1, 20, 14),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 8, 31, 19, 15),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 1, 20, 14),
+            "english_upcoming_candle_lighting": dt(2018, 8, 31, 19, 12),
+            "english_upcoming_havdalah": dt(2018, 9, 1, 20, 10),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 8, 31, 19, 12),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 1, 20, 10),
             "english_parshat_hashavua": "Ki Tavo",
             "hebrew_parshat_hashavua": "כי תבוא",
         },
@@ -215,10 +215,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 1, 16, 0),
         {
-            "english_upcoming_candle_lighting": dt(2018, 8, 31, 19, 15),
-            "english_upcoming_havdalah": dt(2018, 9, 1, 20, 22),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 8, 31, 19, 15),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 1, 20, 22),
+            "english_upcoming_candle_lighting": dt(2018, 8, 31, 19, 12),
+            "english_upcoming_havdalah": dt(2018, 9, 1, 20, 18),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 8, 31, 19, 12),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 1, 20, 18),
             "english_parshat_hashavua": "Ki Tavo",
             "hebrew_parshat_hashavua": "כי תבוא",
         },
@@ -227,10 +227,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 1, 20, 0),
         {
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 8, 31, 19, 15),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 1, 20, 14),
-            "english_upcoming_candle_lighting": dt(2018, 8, 31, 19, 15),
-            "english_upcoming_havdalah": dt(2018, 9, 1, 20, 14),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 8, 31, 19, 12),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 1, 20, 10),
+            "english_upcoming_candle_lighting": dt(2018, 8, 31, 19, 12),
+            "english_upcoming_havdalah": dt(2018, 9, 1, 20, 10),
             "english_parshat_hashavua": "Ki Tavo",
             "hebrew_parshat_hashavua": "כי תבוא",
         },
@@ -238,10 +238,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 1, 20, 21),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 7, 19, 4),
-            "english_upcoming_havdalah": dt(2018, 9, 8, 20, 2),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 7, 19, 4),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 8, 20, 2),
+            "english_upcoming_candle_lighting": dt(2018, 9, 7, 19),
+            "english_upcoming_havdalah": dt(2018, 9, 8, 19, 58),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 7, 19),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 8, 19, 58),
             "english_parshat_hashavua": "Nitzavim",
             "hebrew_parshat_hashavua": "נצבים",
         },
@@ -249,10 +249,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 7, 13, 1),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 7, 19, 4),
-            "english_upcoming_havdalah": dt(2018, 9, 8, 20, 2),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 7, 19, 4),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 8, 20, 2),
+            "english_upcoming_candle_lighting": dt(2018, 9, 7, 19),
+            "english_upcoming_havdalah": dt(2018, 9, 8, 19, 58),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 7, 19),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 8, 19, 58),
             "english_parshat_hashavua": "Nitzavim",
             "hebrew_parshat_hashavua": "נצבים",
         },
@@ -260,10 +260,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 8, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 9, 19, 1),
-            "english_upcoming_havdalah": dt(2018, 9, 11, 19, 57),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 14, 18, 52),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 15, 19, 50),
+            "english_upcoming_candle_lighting": dt(2018, 9, 9, 18, 57),
+            "english_upcoming_havdalah": dt(2018, 9, 11, 19, 53),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 14, 18, 48),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 15, 19, 46),
             "english_parshat_hashavua": "Vayeilech",
             "hebrew_parshat_hashavua": "וילך",
             "english_holiday": "Erev Rosh Hashana",
@@ -273,10 +273,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 9, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 9, 19, 1),
-            "english_upcoming_havdalah": dt(2018, 9, 11, 19, 57),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 14, 18, 52),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 15, 19, 50),
+            "english_upcoming_candle_lighting": dt(2018, 9, 9, 18, 57),
+            "english_upcoming_havdalah": dt(2018, 9, 11, 19, 53),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 14, 18, 48),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 15, 19, 46),
             "english_parshat_hashavua": "Vayeilech",
             "hebrew_parshat_hashavua": "וילך",
             "english_holiday": "Rosh Hashana I",
@@ -286,10 +286,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 10, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 9, 19, 1),
-            "english_upcoming_havdalah": dt(2018, 9, 11, 19, 57),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 14, 18, 52),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 15, 19, 50),
+            "english_upcoming_candle_lighting": dt(2018, 9, 9, 18, 57),
+            "english_upcoming_havdalah": dt(2018, 9, 11, 19, 53),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 14, 18, 48),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 15, 19, 46),
             "english_parshat_hashavua": "Vayeilech",
             "hebrew_parshat_hashavua": "וילך",
             "english_holiday": "Rosh Hashana II",
@@ -299,10 +299,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 28, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 28, 18, 28),
-            "english_upcoming_havdalah": dt(2018, 9, 29, 19, 25),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 28, 18, 28),
-            "english_upcoming_shabbat_havdalah": dt(2018, 9, 29, 19, 25),
+            "english_upcoming_candle_lighting": dt(2018, 9, 28, 18, 25),
+            "english_upcoming_havdalah": dt(2018, 9, 29, 19, 22),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 9, 28, 18, 25),
+            "english_upcoming_shabbat_havdalah": dt(2018, 9, 29, 19, 22),
             "english_parshat_hashavua": "none",
             "hebrew_parshat_hashavua": "none",
         },
@@ -310,10 +310,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 29, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 25),
-            "english_upcoming_havdalah": dt(2018, 10, 2, 19, 20),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 17),
-            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 19, 13),
+            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 22),
+            "english_upcoming_havdalah": dt(2018, 10, 2, 19, 17),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 13),
+            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 19, 11),
             "english_parshat_hashavua": "Bereshit",
             "hebrew_parshat_hashavua": "בראשית",
             "english_holiday": "Hoshana Raba",
@@ -323,10 +323,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 9, 30, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 25),
-            "english_upcoming_havdalah": dt(2018, 10, 2, 19, 20),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 17),
-            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 19, 13),
+            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 22),
+            "english_upcoming_havdalah": dt(2018, 10, 2, 19, 17),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 13),
+            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 19, 11),
             "english_parshat_hashavua": "Bereshit",
             "hebrew_parshat_hashavua": "בראשית",
             "english_holiday": "Shmini Atzeret",
@@ -336,10 +336,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2018, 10, 1, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 25),
-            "english_upcoming_havdalah": dt(2018, 10, 2, 19, 20),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 17),
-            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 19, 13),
+            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 22),
+            "english_upcoming_havdalah": dt(2018, 10, 2, 19, 17),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 13),
+            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 19, 11),
             "english_parshat_hashavua": "Bereshit",
             "hebrew_parshat_hashavua": "בראשית",
             "english_holiday": "Simchat Torah",
@@ -349,10 +349,10 @@ SHABBAT_PARAMS = [
     make_jerusalem_test_params(
         dt(2018, 9, 29, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 10),
-            "english_upcoming_havdalah": dt(2018, 10, 1, 19, 2),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 3),
-            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 18, 56),
+            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 7),
+            "english_upcoming_havdalah": dt(2018, 10, 1, 19, 1),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 1),
+            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 18, 54),
             "english_parshat_hashavua": "Bereshit",
             "hebrew_parshat_hashavua": "בראשית",
             "english_holiday": "Hoshana Raba",
@@ -362,10 +362,10 @@ SHABBAT_PARAMS = [
     make_jerusalem_test_params(
         dt(2018, 9, 30, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 10),
-            "english_upcoming_havdalah": dt(2018, 10, 1, 19, 2),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 3),
-            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 18, 56),
+            "english_upcoming_candle_lighting": dt(2018, 9, 30, 18, 7),
+            "english_upcoming_havdalah": dt(2018, 10, 1, 19, 1),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 1),
+            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 18, 54),
             "english_parshat_hashavua": "Bereshit",
             "hebrew_parshat_hashavua": "בראשית",
             "english_holiday": "Shmini Atzeret",
@@ -375,10 +375,10 @@ SHABBAT_PARAMS = [
     make_jerusalem_test_params(
         dt(2018, 10, 1, 21, 25),
         {
-            "english_upcoming_candle_lighting": dt(2018, 10, 5, 18, 3),
-            "english_upcoming_havdalah": dt(2018, 10, 6, 18, 56),
-            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 3),
-            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 18, 56),
+            "english_upcoming_candle_lighting": dt(2018, 10, 5, 18, 1),
+            "english_upcoming_havdalah": dt(2018, 10, 6, 18, 54),
+            "english_upcoming_shabbat_candle_lighting": dt(2018, 10, 5, 18, 1),
+            "english_upcoming_shabbat_havdalah": dt(2018, 10, 6, 18, 54),
             "english_parshat_hashavua": "Bereshit",
             "hebrew_parshat_hashavua": "בראשית",
         },
@@ -386,9 +386,9 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2016, 6, 11, 8, 25),
         {
-            "english_upcoming_candle_lighting": dt(2016, 6, 10, 20, 7),
-            "english_upcoming_havdalah": dt(2016, 6, 13, 21, 17),
-            "english_upcoming_shabbat_candle_lighting": dt(2016, 6, 10, 20, 7),
+            "english_upcoming_candle_lighting": dt(2016, 6, 10, 20, 9),
+            "english_upcoming_havdalah": dt(2016, 6, 13, 21, 19),
+            "english_upcoming_shabbat_candle_lighting": dt(2016, 6, 10, 20, 9),
             "english_upcoming_shabbat_havdalah": "unknown",
             "english_parshat_hashavua": "Bamidbar",
             "hebrew_parshat_hashavua": "במדבר",
@@ -399,10 +399,10 @@ SHABBAT_PARAMS = [
     make_nyc_test_params(
         dt(2016, 6, 12, 8, 25),
         {
-            "english_upcoming_candle_lighting": dt(2016, 6, 10, 20, 7),
-            "english_upcoming_havdalah": dt(2016, 6, 13, 21, 17),
-            "english_upcoming_shabbat_candle_lighting": dt(2016, 6, 17, 20, 10),
-            "english_upcoming_shabbat_havdalah": dt(2016, 6, 18, 21, 19),
+            "english_upcoming_candle_lighting": dt(2016, 6, 10, 20, 9),
+            "english_upcoming_havdalah": dt(2016, 6, 13, 21, 19),
+            "english_upcoming_shabbat_candle_lighting": dt(2016, 6, 17, 20, 12),
+            "english_upcoming_shabbat_havdalah": dt(2016, 6, 18, 21, 21),
             "english_parshat_hashavua": "Nasso",
             "hebrew_parshat_hashavua": "נשא",
             "english_holiday": "Shavuot",
@@ -412,10 +412,10 @@ SHABBAT_PARAMS = [
     make_jerusalem_test_params(
         dt(2017, 9, 21, 8, 25),
         {
-            "english_upcoming_candle_lighting": dt(2017, 9, 20, 18, 23),
-            "english_upcoming_havdalah": dt(2017, 9, 23, 19, 13),
-            "english_upcoming_shabbat_candle_lighting": dt(2017, 9, 22, 19, 14),
-            "english_upcoming_shabbat_havdalah": dt(2017, 9, 23, 19, 13),
+            "english_upcoming_candle_lighting": dt(2017, 9, 20, 18, 20),
+            "english_upcoming_havdalah": dt(2017, 9, 23, 19, 11),
+            "english_upcoming_shabbat_candle_lighting": dt(2017, 9, 22, 19, 12),
+            "english_upcoming_shabbat_havdalah": dt(2017, 9, 23, 19, 11),
             "english_parshat_hashavua": "Ha'Azinu",
             "hebrew_parshat_hashavua": "האזינו",
             "english_holiday": "Rosh Hashana I",
@@ -425,10 +425,10 @@ SHABBAT_PARAMS = [
     make_jerusalem_test_params(
         dt(2017, 9, 22, 8, 25),
         {
-            "english_upcoming_candle_lighting": dt(2017, 9, 20, 18, 23),
-            "english_upcoming_havdalah": dt(2017, 9, 23, 19, 13),
-            "english_upcoming_shabbat_candle_lighting": dt(2017, 9, 22, 19, 14),
-            "english_upcoming_shabbat_havdalah": dt(2017, 9, 23, 19, 13),
+            "english_upcoming_candle_lighting": dt(2017, 9, 20, 18, 20),
+            "english_upcoming_havdalah": dt(2017, 9, 23, 19, 11),
+            "english_upcoming_shabbat_candle_lighting": dt(2017, 9, 22, 19, 12),
+            "english_upcoming_shabbat_havdalah": dt(2017, 9, 23, 19, 11),
             "english_parshat_hashavua": "Ha'Azinu",
             "hebrew_parshat_hashavua": "האזינו",
             "english_holiday": "Rosh Hashana II",
@@ -438,10 +438,10 @@ SHABBAT_PARAMS = [
     make_jerusalem_test_params(
         dt(2017, 9, 23, 8, 25),
         {
-            "english_upcoming_candle_lighting": dt(2017, 9, 20, 18, 23),
-            "english_upcoming_havdalah": dt(2017, 9, 23, 19, 13),
-            "english_upcoming_shabbat_candle_lighting": dt(2017, 9, 22, 19, 14),
-            "english_upcoming_shabbat_havdalah": dt(2017, 9, 23, 19, 13),
+            "english_upcoming_candle_lighting": dt(2017, 9, 20, 18, 20),
+            "english_upcoming_havdalah": dt(2017, 9, 23, 19, 11),
+            "english_upcoming_shabbat_candle_lighting": dt(2017, 9, 22, 19, 12),
+            "english_upcoming_shabbat_havdalah": dt(2017, 9, 23, 19, 11),
             "english_parshat_hashavua": "Ha'Azinu",
             "hebrew_parshat_hashavua": "האזינו",
             "english_holiday": "",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update libhdate to newest version. 
This version depends on Astral 2.2, which is now part of HA (https://github.com/home-assistant/core/pull/48573).
There is single commit in the new version of the library:
https://github.com/py-libhdate/py-libhdate/commit/e015993bc45b646ab04069f166abf0ae959dae3f 
This change replaces the time calculation logic to use Astral 2.2 library, instead of doing the math internally.
(There are a few more commits in the repository between version 0.9.12, which is the current version in HA, and the newest version 0.10.2. However, all of them are only for the dev environment of the library, and there is no changes to the library itself.)


Release notes:
- <https://github.com/py-libhdate/py-libhdate/releases/tag/v0.10.0>
- <https://github.com/py-libhdate/py-libhdate/releases/tag/v0.10.1>
- <https://github.com/py-libhdate/py-libhdate/releases/tag/v0.10.2>

Git compare: <https://github.com/py-libhdate/py-libhdate/compare/v0.9.12...v0.10.2>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
