### PR TITLE
Add hive boost off functionality

### DIFF
--- a/homeassistant/components/hive/climate.py
+++ b/homeassistant/components/hive/climate.py
@@ -227,7 +227,7 @@ class HiveClimateEntity(HiveEntity, ClimateEntity):
     async def async_heating_boost(self, time_period, temperature):
         """Handle boost heating service call."""
         _LOGGER.warning(
-            "Hive Service heating_boost will be deprecated in 2021.6.0 Please update to heating_boost_on"
+            "Hive Service heating_boost will be removed in 2021.7.0, please update to heating_boost_on"
         )
         await self.async_heating_boost_on(time_period, temperature)
 

--- a/homeassistant/components/hive/const.py
+++ b/homeassistant/components/hive/const.py
@@ -16,5 +16,6 @@ PLATFORM_LOOKUP = {
     "water_heater": "water_heater",
 }
 SERVICE_BOOST_HOT_WATER = "boost_hot_water"
-SERVICE_BOOST_HEATING = "boost_heating"
+SERVICE_BOOST_HEATING_ON = "boost_heating_on"
+SERVICE_BOOST_HEATING_OFF = "boost_heating_off"
 WATER_HEATER_MODES = ["on", "off"]

--- a/homeassistant/components/hive/services.yaml
+++ b/homeassistant/components/hive/services.yaml
@@ -1,5 +1,5 @@
 boost_heating:
-  name: Boost Heating On (To be deprecated)
+  name: Boost Heating (To be deprecated)
   description: To be deprecated please use boost_heating_on.
   fields:
     entity_id:

--- a/homeassistant/components/hive/services.yaml
+++ b/homeassistant/components/hive/services.yaml
@@ -1,3 +1,22 @@
+boost_heating:
+  name: Boost Heating On (To be deprecated)
+  description: To be deprecated please use boost_heating_on.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Select entity_id to boost.
+      required: true
+      example: climate.heating
+    time_period:
+      name: Time Period
+      description: Set the time period for the boost.
+      required: true
+      example: 01:30:00
+    temperature:
+      name: Temperature
+      description: Set the target temperature for the boost period.
+      required: true
+      example: 20.5
 boost_heating_on:
   name: Boost Heating On
   description: Set the boost mode ON defining the period of time and the desired target temperature for the boost.

--- a/homeassistant/components/hive/services.yaml
+++ b/homeassistant/components/hive/services.yaml
@@ -1,5 +1,5 @@
-boost_heating:
-  name: Boost Heating
+boost_heating_on:
+  name: Boost Heating On
   description: Set the boost mode ON defining the period of time and the desired target temperature for the boost.
   fields:
     entity_id:
@@ -30,6 +30,19 @@ boost_heating:
           step: 0.5
           unit_of_measurement: degrees
           mode: slider
+boost_heating_off:
+  name: Boost Heating Off
+  description: Set the boost mode OFF.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Select entity_id to turn boost off.
+      required: true
+      example: climate.heating
+      selector:
+        entity:
+          integration: hive
+          domain: climate
 boost_hot_water:
   name: Boost Hotwater
   description: Set the boost mode ON or OFF defining the period of time for the boost.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The existing Hive service `heating_boost` will be deprecated in Home Assistant release 2021.0.6 and a new service to replace it has been created called`heating_boost_on`.

If you use the `heating_boost` Hive service please update your configuration to the new service. A deprecation warning will be printed to the logs when the deprecated service is used.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add boost off service to the Hive integration. Allowing users to cancel the current boost and return the thermostat to the previous state as per the Hive app. This change creates a new boost on service with a view of deprecating the old one in release 2021.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17293

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
