### PR TITLE
Improve warnings on undefined template errors

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1341,14 +1341,14 @@ class LoggingUndefined(jinja2.Undefined):
     def _fail_with_undefined_error(self, *args, **kwargs):
         try:
             return super()._fail_with_undefined_error(*args, **kwargs)
-        except self._undefined_exception as e:
+        except self._undefined_exception as ex:
             template = template_cv.get() or ""
             _LOGGER.error(
                 "Template variable error when rendering '%s': %s",
                 template,
                 self._undefined_message,
             )
-            raise e
+            raise ex
 
     def __str__(self):
         """Log undefined __str___."""

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -6,6 +6,7 @@ import asyncio
 import base64
 import collections.abc
 from contextlib import suppress
+from contextvars import ContextVar
 from datetime import datetime, timedelta
 from functools import partial, wraps
 import json
@@ -78,6 +79,8 @@ _COLLECTABLE_STATE_ATTRIBUTES = {
 
 ALL_STATES_RATE_LIMIT = timedelta(minutes=1)
 DOMAIN_STATES_RATE_LIMIT = timedelta(seconds=1)
+
+template_cv: ContextVar[str | None] = ContextVar("template_cv", default=None)
 
 
 @bind_hass
@@ -299,7 +302,7 @@ class Template:
 
         self.template: str = template.strip()
         self._compiled_code = None
-        self._compiled: Template | None = None
+        self._compiled: jinja2.Template | None = None
         self.hass = hass
         self.is_static = not is_template_string(template)
         self._limited = None
@@ -370,7 +373,7 @@ class Template:
             kwargs.update(variables)
 
         try:
-            render_result = compiled.render(kwargs)
+            render_result = _render_with_context(self.template, compiled, **kwargs)
         except Exception as err:
             raise TemplateError(err) from err
 
@@ -442,7 +445,7 @@ class Template:
 
         def _render_template() -> None:
             try:
-                compiled.render(kwargs)
+                _render_with_context(self.template, compiled, **kwargs)
             except TimeoutError:
                 pass
             finally:
@@ -524,7 +527,9 @@ class Template:
             variables["value_json"] = json.loads(value)
 
         try:
-            return self._compiled.render(variables).strip()
+            return _render_with_context(
+                self.template, self._compiled, **variables
+            ).strip()
         except jinja2.TemplateError as ex:
             if error_value is _SENTINEL:
                 _LOGGER.error(
@@ -535,7 +540,7 @@ class Template:
                 )
             return value if error_value is _SENTINEL else error_value
 
-    def _ensure_compiled(self, limited: bool = False) -> Template:
+    def _ensure_compiled(self, limited: bool = False) -> jinja2.Template:
         """Bind a template to a specific hass instance."""
         self.ensure_valid()
 
@@ -548,7 +553,7 @@ class Template:
         env = self._env
 
         self._compiled = cast(
-            Template,
+            jinja2.Template,
             jinja2.Template.from_code(env, self._compiled_code, env.globals, None),
         )
 
@@ -1314,12 +1319,59 @@ def urlencode(value):
     return urllib_urlencode(value).encode("utf-8")
 
 
+def _render_with_context(
+    template_str: str, template: jinja2.Template, **kwargs: Any
+) -> str:
+    """Store template being rendered in a ContextVar to aid error handling."""
+    template_cv.set(template_str)
+    return template.render(**kwargs)
+
+
+class LoggingUndefined(jinja2.Undefined):
+    """Log on undefined variables."""
+
+    def _log_message(self):
+        template = template_cv.get() or ""
+        _LOGGER.warning(
+            "Template variable warning when rendering '%s': %s",
+            template,
+            self._undefined_message,
+        )
+
+    def _fail_with_undefined_error(self, *args, **kwargs):
+        try:
+            return super()._fail_with_undefined_error(*args, **kwargs)
+        except self._undefined_exception as e:
+            template = template_cv.get() or ""
+            _LOGGER.error(
+                "Template variable error when rendering '%s': %s",
+                template,
+                self._undefined_message,
+            )
+            raise e
+
+    def __str__(self):
+        """Log undefined __str___."""
+        self._log_message()
+        return super().__str__()
+
+    def __iter__(self):
+        """Log undefined __iter___."""
+        self._log_message()
+        return super().__iter__()
+
+    def __bool__(self):
+        """Log undefined __bool___."""
+        self._log_message()
+        return super().__bool__()
+
+
 class TemplateEnvironment(ImmutableSandboxedEnvironment):
     """The Home Assistant template environment."""
 
     def __init__(self, hass, limited=False):
         """Initialise template environment."""
-        super().__init__(undefined=jinja2.make_logging_undefined(logger=_LOGGER))
+        super().__init__(undefined=LoggingUndefined)
         self.hass = hass
         self.template_cache = weakref.WeakValueDictionary()
         self.filters["round"] = forgiving_round

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1333,9 +1333,9 @@ class LoggingUndefined(jinja2.Undefined):
     def _log_message(self):
         template = template_cv.get() or ""
         _LOGGER.warning(
-            "Template variable warning when rendering '%s': %s",
-            template,
+            "Template variable warning: %s when rendering '%s'",
             self._undefined_message,
+            template,
         )
 
     def _fail_with_undefined_error(self, *args, **kwargs):
@@ -1344,9 +1344,9 @@ class LoggingUndefined(jinja2.Undefined):
         except self._undefined_exception as ex:
             template = template_cv.get() or ""
             _LOGGER.error(
-                "Template variable error when rendering '%s': %s",
-                template,
+                "Template variable error: %s when rendering '%s'",
                 self._undefined_message,
+                template,
             )
             raise ex
 

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2503,4 +2503,7 @@ async def test_undefined_variable(hass, caplog):
     """Test a warning is logged on undefined variables."""
     tpl = template.Template("{{ no_such_variable }}", hass)
     assert tpl.async_render() == ""
-    assert "Template variable warning: no_such_variable is undefined" in caplog.text
+    assert (
+        "Template variable warning when rendering '{{ no_such_variable }}': 'no_such_variable' is undefined"
+        in caplog.text
+    )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -2504,6 +2504,6 @@ async def test_undefined_variable(hass, caplog):
     tpl = template.Template("{{ no_such_variable }}", hass)
     assert tpl.async_render() == ""
     assert (
-        "Template variable warning when rendering '{{ no_such_variable }}': 'no_such_variable' is undefined"
+        "Template variable warning: 'no_such_variable' is undefined when rendering '{{ no_such_variable }}'"
         in caplog.text
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve warnings for undefined variables in templates introduced in #48140

Example: rendering template `"{{ no_such_variable }}"` will result in this error message:
```
"Template variable warning when rendering '{{ no_such_variable }}': 'no_such_variable' is undefined"
```

Also fix some incorrect type annotations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48616 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
