### PR TITLE
Add yaml key to Shelly to allow CoAP port customization

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -59,10 +59,8 @@ async def async_setup(hass: HomeAssistant, config: dict):
     hass.data[DOMAIN] = {DATA_CONFIG_ENTRY: {}}
 
     conf = config.get(DOMAIN)
-    if conf is None:
-        conf = COAP_SCHEMA({})
-
-    hass.data[DOMAIN][CONF_COAP_PORT] = conf[CONF_COAP_PORT]
+    if conf is not None:
+        hass.data[DOMAIN][CONF_COAP_PORT] = conf[CONF_COAP_PORT]
 
     return True
 

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -5,6 +5,7 @@ import logging
 
 import aioshelly
 import async_timeout
+import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -17,6 +18,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client, device_registry, update_coordinator
+import homeassistant.helpers.config_validation as cv
 
 from .const import (
     AIOSHELLY_DEVICE_TIMEOUT_SEC,
@@ -25,7 +27,9 @@ from .const import (
     ATTR_DEVICE,
     BATTERY_DEVICES_WITH_PERMANENT_CONNECTION,
     COAP,
+    CONF_COAP_PORT,
     DATA_CONFIG_ENTRY,
+    DEFAULT_COAP_PORT,
     DEVICE,
     DOMAIN,
     EVENT_SHELLY_CLICK,
@@ -42,10 +46,24 @@ PLATFORMS = ["binary_sensor", "cover", "light", "sensor", "switch"]
 SLEEPING_PLATFORMS = ["binary_sensor", "sensor"]
 _LOGGER = logging.getLogger(__name__)
 
+COAP_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_COAP_PORT, default=DEFAULT_COAP_PORT): cv.port,
+    }
+)
+CONFIG_SCHEMA = vol.Schema({DOMAIN: COAP_SCHEMA}, extra=vol.ALLOW_EXTRA)
+
 
 async def async_setup(hass: HomeAssistant, config: dict):
     """Set up the Shelly component."""
     hass.data[DOMAIN] = {DATA_CONFIG_ENTRY: {}}
+
+    conf = config.get(DOMAIN)
+    if conf is None:
+        conf = COAP_SCHEMA({})
+
+    hass.data[DOMAIN][CONF_COAP_PORT] = conf[CONF_COAP_PORT]
+
     return True
 
 

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -45,7 +45,6 @@ EVENT_SHELLY_CLICK = "shelly.click"
 ATTR_CLICK_TYPE = "click_type"
 ATTR_CHANNEL = "channel"
 ATTR_DEVICE = "device"
-
 CONF_SUBTYPE = "subtype"
 
 BASIC_INPUTS_EVENTS_TYPES = {

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -6,6 +6,9 @@ DEVICE = "device"
 DOMAIN = "shelly"
 REST = "rest"
 
+CONF_COAP_PORT = "coap_port"
+DEFAULT_COAP_PORT = 5683
+
 # Used in "_async_update_data" as timeout for polling data from devices.
 POLLING_TIMEOUT_SEC = 18
 
@@ -42,9 +45,8 @@ EVENT_SHELLY_CLICK = "shelly.click"
 ATTR_CLICK_TYPE = "click_type"
 ATTR_CHANNEL = "channel"
 ATTR_DEVICE = "device"
-CONF_COAP_PORT = "coap_port"
+
 CONF_SUBTYPE = "subtype"
-DEFAULT_COAP_PORT = 5683
 
 BASIC_INPUTS_EVENTS_TYPES = {
     "single",

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -42,7 +42,9 @@ EVENT_SHELLY_CLICK = "shelly.click"
 ATTR_CLICK_TYPE = "click_type"
 ATTR_CHANNEL = "channel"
 ATTR_DEVICE = "device"
+CONF_COAP_PORT = "coap_port"
 CONF_SUBTYPE = "subtype"
+DEFAULT_COAP_PORT = 5683
 
 BASIC_INPUTS_EVENTS_TYPES = {
     "single",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -191,7 +191,9 @@ def get_device_wrapper(hass: HomeAssistant, device_id: str):
 async def get_coap_context(hass):
     """Get CoAP context to be used in all Shelly devices."""
     context = aioshelly.COAP()
-    port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
+    port = DEFAULT_COAP_PORT
+    if DOMAIN in hass.data:
+        port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
     _LOGGER.info("Starting CoAP context with UDP port %s", port)
     await context.initialize(port)
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -16,6 +16,7 @@ from .const import (
     COAP,
     CONF_COAP_PORT,
     DATA_CONFIG_ENTRY,
+    DEFAULT_COAP_PORT,
     DOMAIN,
     SHBTN_1_INPUTS_EVENTS_TYPES,
     SHIX3_1_INPUTS_EVENTS_TYPES,
@@ -190,8 +191,11 @@ def get_device_wrapper(hass: HomeAssistant, device_id: str):
 async def get_coap_context(hass):
     """Get CoAP context to be used in all Shelly devices."""
     context = aioshelly.COAP()
-    port = hass.data[DOMAIN][CONF_COAP_PORT]
-    _LOGGER.debug("Starting CoAP context with UDP port %s", port)
+    if DOMAIN in hass.data:
+        port = hass.data[DOMAIN][CONF_COAP_PORT]
+    else:
+        port = DEFAULT_COAP_PORT
+    _LOGGER.info("Starting CoAP context with UDP port %s", port)
     await context.initialize(port)
 
     @callback

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -191,10 +191,7 @@ def get_device_wrapper(hass: HomeAssistant, device_id: str):
 async def get_coap_context(hass):
     """Get CoAP context to be used in all Shelly devices."""
     context = aioshelly.COAP()
-    if DOMAIN in hass.data:
-        port = hass.data[DOMAIN][CONF_COAP_PORT]
-    else:
-        port = DEFAULT_COAP_PORT
+    port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
     _LOGGER.info("Starting CoAP context with UDP port %s", port)
     await context.initialize(port)
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -194,6 +194,8 @@ async def get_coap_context(hass):
     port = DEFAULT_COAP_PORT
     if DOMAIN in hass.data:
         port = hass.data[DOMAIN].get(CONF_COAP_PORT, DEFAULT_COAP_PORT)
+    else:
+        port = DEFAULT_COAP_PORT
     _LOGGER.info("Starting CoAP context with UDP port %s", port)
     await context.initialize(port)
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -16,7 +16,6 @@ from .const import (
     COAP,
     CONF_COAP_PORT,
     DATA_CONFIG_ENTRY,
-    DEFAULT_COAP_PORT,
     DOMAIN,
     SHBTN_1_INPUTS_EVENTS_TYPES,
     SHIX3_1_INPUTS_EVENTS_TYPES,
@@ -191,11 +190,7 @@ def get_device_wrapper(hass: HomeAssistant, device_id: str):
 async def get_coap_context(hass):
     """Get CoAP context to be used in all Shelly devices."""
     context = aioshelly.COAP()
-    port = (
-        hass.data[DOMAIN][CONF_COAP_PORT]
-        if hass.data.get(DOMAIN)
-        else DEFAULT_COAP_PORT
-    )
+    port = hass.data[DOMAIN][CONF_COAP_PORT]
     _LOGGER.debug("Starting CoAP context with UDP port %s", port)
     await context.initialize(port)
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -16,6 +16,7 @@ from .const import (
     COAP,
     CONF_COAP_PORT,
     DATA_CONFIG_ENTRY,
+    DEFAULT_COAP_PORT,
     DOMAIN,
     SHBTN_1_INPUTS_EVENTS_TYPES,
     SHIX3_1_INPUTS_EVENTS_TYPES,
@@ -190,7 +191,11 @@ def get_device_wrapper(hass: HomeAssistant, device_id: str):
 async def get_coap_context(hass):
     """Get CoAP context to be used in all Shelly devices."""
     context = aioshelly.COAP()
-    port = hass.data[DOMAIN][CONF_COAP_PORT]
+    port = (
+        hass.data[DOMAIN][CONF_COAP_PORT]
+        if hass.data.get(DOMAIN)
+        else DEFAULT_COAP_PORT
+    )
     _LOGGER.debug("Starting CoAP context with UDP port %s", port)
     await context.initialize(port)
 

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -14,6 +14,7 @@ from homeassistant.util.dt import parse_datetime, utcnow
 from .const import (
     BASIC_INPUTS_EVENTS_TYPES,
     COAP,
+    CONF_COAP_PORT,
     DATA_CONFIG_ENTRY,
     DOMAIN,
     SHBTN_1_INPUTS_EVENTS_TYPES,
@@ -189,7 +190,9 @@ def get_device_wrapper(hass: HomeAssistant, device_id: str):
 async def get_coap_context(hass):
     """Get CoAP context to be used in all Shelly devices."""
     context = aioshelly.COAP()
-    await context.initialize()
+    port = hass.data[DOMAIN][CONF_COAP_PORT]
+    _LOGGER.debug("Starting CoAP context with UDP port %s", port)
+    await context.initialize(port)
 
     @callback
     def shutdown_listener(ev):

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -28,9 +28,6 @@ async def test_form(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -73,9 +70,6 @@ async def test_form(hass):
 async def test_title_without_name(hass):
     """Test we set the title to the hostname when the device doesn't have a name."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -122,9 +116,6 @@ async def test_title_without_name(hass):
 
 async def test_form_auth(hass):
     """Test manual configuration if auth is required."""
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -253,9 +244,6 @@ async def test_form_already_configured(hass):
 async def test_user_setup_ignored_device(hass):
     """Test user can successfully setup an ignored device."""
 
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
-
     await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(
         domain="shelly",
@@ -331,9 +319,6 @@ async def test_form_firmware_unsupported(hass):
 async def test_form_auth_errors_test_connection(hass, error):
     """Test we handle errors in authenticated devices."""
 
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
-
     exc, base_error = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -360,9 +345,6 @@ async def test_form_auth_errors_test_connection(hass, error):
 async def test_zeroconf(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",
@@ -415,9 +397,6 @@ async def test_zeroconf(hass):
 async def test_zeroconf_sleeping_device(hass):
     """Test sleeping device configuration via zeroconf."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",
@@ -490,9 +469,6 @@ async def test_zeroconf_sleeping_device_error(hass, error):
     """Test sleeping device configuration via zeroconf with error."""
     exc = error
     await setup.async_setup_component(hass, "persistent_notification", {})
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",
@@ -567,9 +543,6 @@ async def test_zeroconf_cannot_connect(hass):
 async def test_zeroconf_require_auth(hass):
     """Test zeroconf if auth is required."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -7,7 +7,6 @@ import aioshelly
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.shelly import async_setup
 from homeassistant.components.shelly.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -21,13 +20,11 @@ DISCOVERY_INFO = {
     "name": "shelly1pm-12345",
     "properties": {"id": "shelly1pm-12345"},
 }
-MOCK_CONFIG = {"domain": "Shelly", "coap_port": 1234}
 
 
 async def test_form(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -70,7 +67,6 @@ async def test_form(hass):
 async def test_title_without_name(hass):
     """Test we set the title to the hostname when the device doesn't have a name."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -116,7 +112,6 @@ async def test_title_without_name(hass):
 
 async def test_form_auth(hass):
     """Test manual configuration if auth is required."""
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -192,10 +187,6 @@ async def test_form_errors_get_info(hass, error):
 )
 async def test_form_errors_test_connection(hass, error):
     """Test we handle errors."""
-
-    config = MOCK_CONFIG.copy()
-    await async_setup(hass, config)
-
     exc, base_error = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -243,7 +234,6 @@ async def test_form_already_configured(hass):
 
 async def test_user_setup_ignored_device(hass):
     """Test user can successfully setup an ignored device."""
-
     await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(
         domain="shelly",
@@ -318,7 +308,6 @@ async def test_form_firmware_unsupported(hass):
 )
 async def test_form_auth_errors_test_connection(hass, error):
     """Test we handle errors in authenticated devices."""
-
     exc, base_error = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/shelly/test_config_flow.py
+++ b/tests/components/shelly/test_config_flow.py
@@ -7,6 +7,7 @@ import aioshelly
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.shelly import async_setup
 from homeassistant.components.shelly.const import DOMAIN
 
 from tests.common import MockConfigEntry
@@ -20,11 +21,16 @@ DISCOVERY_INFO = {
     "name": "shelly1pm-12345",
     "properties": {"id": "shelly1pm-12345"},
 }
+MOCK_CONFIG = {"domain": "Shelly", "coap_port": 1234}
 
 
 async def test_form(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -67,6 +73,10 @@ async def test_form(hass):
 async def test_title_without_name(hass):
     """Test we set the title to the hostname when the device doesn't have a name."""
     await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -112,6 +122,10 @@ async def test_title_without_name(hass):
 
 async def test_form_auth(hass):
     """Test manual configuration if auth is required."""
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
+
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -187,6 +201,10 @@ async def test_form_errors_get_info(hass, error):
 )
 async def test_form_errors_test_connection(hass, error):
     """Test we handle errors."""
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
+
     exc, base_error = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -234,6 +252,10 @@ async def test_form_already_configured(hass):
 
 async def test_user_setup_ignored_device(hass):
     """Test user can successfully setup an ignored device."""
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
+
     await setup.async_setup_component(hass, "persistent_notification", {})
     entry = MockConfigEntry(
         domain="shelly",
@@ -308,6 +330,10 @@ async def test_form_firmware_unsupported(hass):
 )
 async def test_form_auth_errors_test_connection(hass, error):
     """Test we handle errors in authenticated devices."""
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
+
     exc, base_error = error
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -334,6 +360,9 @@ async def test_form_auth_errors_test_connection(hass, error):
 async def test_zeroconf(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",
@@ -386,6 +415,9 @@ async def test_zeroconf(hass):
 async def test_zeroconf_sleeping_device(hass):
     """Test sleeping device configuration via zeroconf."""
     await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",
@@ -458,6 +490,9 @@ async def test_zeroconf_sleeping_device_error(hass, error):
     """Test sleeping device configuration via zeroconf with error."""
     exc = error
     await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",
@@ -532,6 +567,9 @@ async def test_zeroconf_cannot_connect(hass):
 async def test_zeroconf_require_auth(hass):
     """Test zeroconf if auth is required."""
     await setup.async_setup_component(hass, "persistent_notification", {})
+
+    config = MOCK_CONFIG.copy()
+    await async_setup(hass, config)
 
     with patch(
         "aioshelly.get_info",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a yaml key to allow advanced users to personalize the CoAP port.

For example, this is mandatory if you have a prod and test instance on the same Docket host.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
shelly:
    coap_port: 5555
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49763
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17308

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
