### PR TITLE
Add alarm control panel support to deCONZ integration

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -1,0 +1,61 @@
+"""Support for deCONZ climate devices."""
+from __future__ import annotations
+
+from pydeconz.sensor import AncillaryControl
+
+from homeassistant.components.alarm_control_panel import DOMAIN, AlarmControlPanelEntity
+from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+
+from .const import NEW_SENSOR
+from .deconz_device import DeconzDevice
+from .gateway import get_gateway_from_config_entry
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the deCONZ alarm control panel devices.
+
+    Alarm control panels are based on the same device class as sensors in deCONZ.
+    """
+    gateway = get_gateway_from_config_entry(hass, config_entry)
+    gateway.entities[DOMAIN] = set()
+
+    @callback
+    def async_add_alarm_control_panel(sensors=gateway.api.sensors.values()):
+        """Add alarm control panel devices from deCONZ."""
+        entities = []
+
+        for sensor in sensors:
+
+            if (
+                sensor.type in AncillaryControl.ZHATYPE
+                and sensor.uniqueid not in gateway.entities[DOMAIN]
+            ):
+                entities.append(DeconzAlarmControlPanel(sensor, gateway))
+
+        if entities:
+            async_add_entities(entities)
+
+    gateway.listeners.append(
+        async_dispatcher_connect(
+            hass,
+            gateway.async_signal_new_device(NEW_SENSOR),
+            async_add_alarm_control_panel,
+        )
+    )
+
+    async_add_alarm_control_panel()
+
+
+class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
+    """Representation of a deCONZ alarm control panel."""
+
+    TYPE = DOMAIN
+
+    def __init__(self, device, gateway):
+        """Set up alarm control panel device."""
+        super().__init__(device, gateway)
+
+    @property
+    def supported_features(self) -> int:
+        """Return the list of supported features."""

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -5,7 +5,14 @@ from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY,
+    ANCILLARY_CONTROL_ARMING_AWAY,
+    ANCILLARY_CONTROL_ARMING_NIGHT,
+    ANCILLARY_CONTROL_ARMING_STAY,
     ANCILLARY_CONTROL_DISARMED,
+    ANCILLARY_CONTROL_ENTRY_DELAY,
+    ANCILLARY_CONTROL_EXIT_DELAY,
+    ANCILLARY_CONTROL_IN_ALARM,
+    ANCILLARY_CONTROL_NOT_READY,
     AncillaryControl,
 )
 
@@ -20,24 +27,43 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
+    STATE_ALARM_PENDING,
+    STATE_ALARM_TRIGGERED,
 )
 from homeassistant.core import callback
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
+SERVICE_ALARM_TRIGGERED = "alarm_triggered"
+SERVICE_ALARM_ARMING_AWAY = "arming_away"
+SERVICE_ALARM_ARMING_HOME = "arming_home"
+SERVICE_ALARM_ARMING_NIGHT = "arming_night"
+SERVICE_ALARM_ENTRY_DELAY = "entry_delay"
+SERVICE_ALARM_EXIT_DELAY = "exit_delay"
+SERVICE_ALARM_NOT_READY = "not_ready"
+
 DECONZ_TO_ALARM_STATE = {
     ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY: STATE_ALARM_ARMED_HOME,
     ANCILLARY_CONTROL_DISARMED: STATE_ALARM_DISARMED,
+    ANCILLARY_CONTROL_ARMING_AWAY: STATE_ALARM_ARMING,
+    ANCILLARY_CONTROL_ARMING_NIGHT: STATE_ALARM_ARMING,
+    ANCILLARY_CONTROL_ARMING_STAY: STATE_ALARM_ARMING,
+    ANCILLARY_CONTROL_ENTRY_DELAY: STATE_ALARM_PENDING,
+    ANCILLARY_CONTROL_EXIT_DELAY: STATE_ALARM_PENDING,
+    ANCILLARY_CONTROL_IN_ALARM: STATE_ALARM_TRIGGERED,
+    ANCILLARY_CONTROL_NOT_READY: STATE_ALARM_PENDING,  # ???
 }
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """Set up the deCONZ alarm control panel devices.
 
     Alarm control panels are based on the same device class as sensors in deCONZ.
@@ -46,7 +72,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     gateway.entities[DOMAIN] = set()
 
     @callback
-    def async_add_alarm_control_panel(sensors=gateway.api.sensors.values()):
+    def async_add_alarm_control_panel(sensors=gateway.api.sensors.values()) -> None:
         """Add alarm control panel devices from deCONZ."""
         entities = []
 
@@ -71,13 +97,45 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     async_add_alarm_control_panel()
 
+    # Custom services
+
+    platform = entity_platform.current_platform.get()
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_ARMING_AWAY, {}, "async_alarm_arming_away"
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_ARMING_HOME, {}, "async_alarm_arming_home"
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_ARMING_NIGHT, {}, "async_alarm_arming_night"
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_ENTRY_DELAY, {}, "async_alarm_entry_delay"
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_EXIT_DELAY, {}, "async_alarm_exit_delay"
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_NOT_READY, {}, "async_alarm_not_ready"
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_ALARM_TRIGGERED, {}, "async_alarm_triggered"
+    )
+
 
 class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     """Representation of a deCONZ alarm control panel."""
 
     TYPE = DOMAIN
 
-    def __init__(self, device, gateway):
+    def __init__(self, device, gateway) -> None:
         """Set up alarm control panel device."""
         super().__init__(device, gateway)
 
@@ -91,22 +149,69 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
         return self._features
 
     @property
+    def code_arm_required(self) -> bool:
+        """Code is not required for arm actions."""
+        return False
+
+    @property
+    def code_format(self) -> None:
+        """Code is not supported."""
+        return None
+
+    @callback
+    def async_update_callback(self, force_update: bool = False) -> None:
+        """Update the control panels state."""
+        keys = {"panel", "reachable"}
+        if force_update or self._device.changed_keys.intersection(keys):
+            super().async_update_callback(force_update=force_update)
+
+    @property
     def state(self) -> str:
         """Return the state of the sensor."""
         return DECONZ_TO_ALARM_STATE.get(self._device.panel)
 
-    async def async_alarm_arm_away(self, code=None) -> None:
+    async def async_alarm_arm_away(self, code: None = None) -> None:
         """Send arm away command."""
         await self._device.arm_away()
 
-    async def async_alarm_arm_home(self, code=None) -> None:
+    async def async_alarm_arm_home(self, code: None = None) -> None:
         """Send arm home command."""
         await self._device.arm_stay()
 
-    async def async_alarm_arm_night(self, code=None) -> None:
+    async def async_alarm_arm_night(self, code: None = None) -> None:
         """Send arm night command."""
         await self._device.arm_night()
 
-    async def async_alarm_disarm(self, code=None) -> None:
+    async def async_alarm_disarm(self, code: None = None) -> None:
         """Send disarm command."""
         await self._device.disarm()
+
+    # Custom services
+
+    async def async_alarm_arming_away(self) -> None:
+        """Send arming away command."""
+        await self._device.arming_away()
+
+    async def async_alarm_arming_home(self) -> None:
+        """Send arming home command."""
+        await self._device.arming_stay()
+
+    async def async_alarm_arming_night(self) -> None:
+        """Send arming night command."""
+        await self._device.arming_night()
+
+    async def async_alarm_entry_delay(self) -> None:
+        """Send entry delay command."""
+        await self._device.entry_delay()
+
+    async def async_alarm_exit_delay(self) -> None:
+        """Send exit delay command."""
+        await self._device.exit_delay()
+
+    async def async_alarm_not_ready(self) -> None:
+        """Send not ready command."""
+        await self._device.not_ready()
+
+    async def async_alarm_triggered(self) -> None:
+        """Send in alarm command."""
+        await self._device.in_alarm()

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -1,15 +1,40 @@
 """Support for deCONZ climate devices."""
 from __future__ import annotations
 
-from pydeconz.sensor import AncillaryControl
+from pydeconz.sensor import (
+    ANCILLARY_CONTROL_ARMED_AWAY,
+    ANCILLARY_CONTROL_ARMED_NIGHT,
+    ANCILLARY_CONTROL_ARMED_STAY,
+    ANCILLARY_CONTROL_DISARMED,
+    AncillaryControl,
+)
 
-from homeassistant.components.alarm_control_panel import DOMAIN, AlarmControlPanelEntity
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN,
+    SUPPORT_ALARM_ARM_AWAY,
+    SUPPORT_ALARM_ARM_HOME,
+    SUPPORT_ALARM_ARM_NIGHT,
+    AlarmControlPanelEntity,
+)
+from homeassistant.const import (
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_DISARMED,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
+
+DECONZ_TO_ALARM_STATE = {
+    ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
+    ANCILLARY_CONTROL_ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
+    ANCILLARY_CONTROL_ARMED_STAY: STATE_ALARM_ARMED_HOME,
+    ANCILLARY_CONTROL_DISARMED: STATE_ALARM_DISARMED,
+}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -56,6 +81,32 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
         """Set up alarm control panel device."""
         super().__init__(device, gateway)
 
+        self._features = SUPPORT_ALARM_ARM_AWAY
+        self._features |= SUPPORT_ALARM_ARM_HOME
+        self._features |= SUPPORT_ALARM_ARM_NIGHT
+
     @property
     def supported_features(self) -> int:
         """Return the list of supported features."""
+        return self._features
+
+    @property
+    def state(self) -> str:
+        """Return the state of the sensor."""
+        return DECONZ_TO_ALARM_STATE.get(self._device.panel)
+
+    async def async_alarm_arm_away(self, code=None) -> None:
+        """Send arm away command."""
+        await self._device.arm_away()
+
+    async def async_alarm_arm_home(self, code=None) -> None:
+        """Send arm home command."""
+        await self._device.arm_stay()
+
+    async def async_alarm_arm_night(self, code=None) -> None:
+        """Send arm night command."""
+        await self._device.arm_night()
+
+    async def async_alarm_disarm(self, code=None) -> None:
+        """Send disarm command."""
+        await self._device.disarm()

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -5,70 +5,36 @@ from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY,
-    ANCILLARY_CONTROL_ARMING_AWAY,
-    ANCILLARY_CONTROL_ARMING_NIGHT,
-    ANCILLARY_CONTROL_ARMING_STAY,
     ANCILLARY_CONTROL_DISARMED,
-    ANCILLARY_CONTROL_ENTRY_DELAY,
-    ANCILLARY_CONTROL_EXIT_DELAY,
-    ANCILLARY_CONTROL_IN_ALARM,
-    ANCILLARY_CONTROL_NOT_READY,
     AncillaryControl,
 )
-import voluptuous as vol
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN,
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
     SUPPORT_ALARM_ARM_NIGHT,
-    SUPPORT_ALARM_TRIGGER,
     AlarmControlPanelEntity,
 )
 from homeassistant.const import (
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
-    STATE_ALARM_PENDING,
-    STATE_ALARM_TRIGGERED,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import entity_platform
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from .const import NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
-SERVICE_ALARM_ACTION = "alarm_custom_action"
-CONF_ALARM_ACTION = "alarm_action"
-SERVICE_ALARM_ACTION_SCHEMA = {
-    vol.Required(CONF_ALARM_ACTION): vol.In(
-        {
-            ANCILLARY_CONTROL_ARMING_AWAY: "Arming away",
-            ANCILLARY_CONTROL_ARMING_STAY: "Arming home",
-            ANCILLARY_CONTROL_ARMING_NIGHT: "Arming night",
-            ANCILLARY_CONTROL_ENTRY_DELAY: "Entry delay",
-            ANCILLARY_CONTROL_EXIT_DELAY: "Exit delay",
-            ANCILLARY_CONTROL_NOT_READY: "Alarm not ready",
-        }
-    )
-}
-
 DECONZ_TO_ALARM_STATE = {
     ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY: STATE_ALARM_ARMED_HOME,
     ANCILLARY_CONTROL_DISARMED: STATE_ALARM_DISARMED,
-    ANCILLARY_CONTROL_ARMING_AWAY: STATE_ALARM_ARMING,
-    ANCILLARY_CONTROL_ARMING_NIGHT: STATE_ALARM_ARMING,
-    ANCILLARY_CONTROL_ARMING_STAY: STATE_ALARM_ARMING,
-    ANCILLARY_CONTROL_ENTRY_DELAY: STATE_ALARM_PENDING,
-    ANCILLARY_CONTROL_EXIT_DELAY: STATE_ALARM_PENDING,
-    ANCILLARY_CONTROL_IN_ALARM: STATE_ALARM_TRIGGERED,
-    ANCILLARY_CONTROL_NOT_READY: STATE_ALARM_PENDING,  # ???
 }
 
 
@@ -79,8 +45,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
     """
     gateway = get_gateway_from_config_entry(hass, config_entry)
     gateway.entities[DOMAIN] = set()
-
-    platform = entity_platform.current_platform.get()
 
     @callback
     def async_add_alarm_control_panel(sensors=gateway.api.sensors.values()) -> None:
@@ -96,9 +60,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
                 entities.append(DeconzAlarmControlPanel(sensor, gateway))
 
         if entities:
-            platform.async_register_entity_service(
-                SERVICE_ALARM_ACTION, SERVICE_ALARM_ACTION_SCHEMA, "async_alarm_action"
-            )
             async_add_entities(entities)
 
     gateway.listeners.append(
@@ -124,7 +85,6 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
         self._features = SUPPORT_ALARM_ARM_AWAY
         self._features |= SUPPORT_ALARM_ARM_HOME
         self._features |= SUPPORT_ALARM_ARM_NIGHT
-        self._features |= SUPPORT_ALARM_TRIGGER
 
     @property
     def supported_features(self) -> int:
@@ -144,14 +104,17 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @callback
     def async_update_callback(self, force_update: bool = False) -> None:
         """Update the control panels state."""
-        keys = {"panel", "reachable"}
-        if force_update or self._device.changed_keys.intersection(keys):
+        keys = {"armed", "reachable"}
+        if force_update or (
+            self._device.changed_keys.intersection(keys)
+            and self._device.state in DECONZ_TO_ALARM_STATE
+        ):
             super().async_update_callback(force_update=force_update)
 
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        return DECONZ_TO_ALARM_STATE.get(self._device.state)
+        return DECONZ_TO_ALARM_STATE.get(self._device.state, STATE_UNKNOWN)
 
     async def async_alarm_arm_away(self, code: None = None) -> None:
         """Send arm away command."""
@@ -168,11 +131,3 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     async def async_alarm_disarm(self, code: None = None) -> None:
         """Send disarm command."""
         await self._device.disarm()
-
-    async def async_alarm_trigger(self, code: None = None) -> None:
-        """Send in alarm command."""
-        await self._device.in_alarm()
-
-    async def async_alarm_action(self, alarm_action: str) -> None:
-        """Send alarm_action command."""
-        await getattr(self._device, alarm_action)()

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -40,13 +40,13 @@ from .const import NEW_SENSOR
 from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
+SERVICE_ALARM_ARMING_AWAY = "alarm_arming_away"
+SERVICE_ALARM_ARMING_HOME = "alarm_arming_home"
+SERVICE_ALARM_ARMING_NIGHT = "alarm_arming_night"
+SERVICE_ALARM_ENTRY_DELAY = "alarm_entry_delay"
+SERVICE_ALARM_EXIT_DELAY = "alarm_exit_delay"
+SERVICE_ALARM_NOT_READY = "alarm_not_ready"
 SERVICE_ALARM_TRIGGERED = "alarm_triggered"
-SERVICE_ALARM_ARMING_AWAY = "arming_away"
-SERVICE_ALARM_ARMING_HOME = "arming_home"
-SERVICE_ALARM_ARMING_NIGHT = "arming_night"
-SERVICE_ALARM_ENTRY_DELAY = "entry_delay"
-SERVICE_ALARM_EXIT_DELAY = "exit_delay"
-SERVICE_ALARM_NOT_READY = "not_ready"
 
 DECONZ_TO_ALARM_STATE = {
     ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -113,7 +113,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
 
     @property
     def state(self) -> str:
-        """Return the state of the sensor."""
+        """Return the state of the control panel."""
         return DECONZ_TO_ALARM_STATE.get(self._device.state, STATE_UNKNOWN)
 
     async def async_alarm_arm_away(self, code: None = None) -> None:

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -21,6 +21,7 @@ from homeassistant.components.alarm_control_panel import (
     SUPPORT_ALARM_ARM_AWAY,
     SUPPORT_ALARM_ARM_HOME,
     SUPPORT_ALARM_ARM_NIGHT,
+    SUPPORT_ALARM_TRIGGER,
     AlarmControlPanelEntity,
 )
 from homeassistant.const import (
@@ -46,7 +47,6 @@ SERVICE_ALARM_ARMING_NIGHT = "alarm_arming_night"
 SERVICE_ALARM_ENTRY_DELAY = "alarm_entry_delay"
 SERVICE_ALARM_EXIT_DELAY = "alarm_exit_delay"
 SERVICE_ALARM_NOT_READY = "alarm_not_ready"
-SERVICE_ALARM_TRIGGERED = "alarm_triggered"
 
 DECONZ_TO_ALARM_STATE = {
     ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
@@ -125,10 +125,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities) -> None:
         SERVICE_ALARM_NOT_READY, {}, "async_alarm_not_ready"
     )
 
-    platform.async_register_entity_service(
-        SERVICE_ALARM_TRIGGERED, {}, "async_alarm_triggered"
-    )
-
 
 class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     """Representation of a deCONZ alarm control panel."""
@@ -142,6 +138,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
         self._features = SUPPORT_ALARM_ARM_AWAY
         self._features |= SUPPORT_ALARM_ARM_HOME
         self._features |= SUPPORT_ALARM_ARM_NIGHT
+        self._features |= SUPPORT_ALARM_TRIGGER
 
     @property
     def supported_features(self) -> int:
@@ -168,7 +165,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str:
         """Return the state of the sensor."""
-        return DECONZ_TO_ALARM_STATE.get(self._device.panel)
+        return DECONZ_TO_ALARM_STATE.get(self._device.state)
 
     async def async_alarm_arm_away(self, code: None = None) -> None:
         """Send arm away command."""
@@ -185,6 +182,10 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     async def async_alarm_disarm(self, code: None = None) -> None:
         """Send disarm command."""
         await self._device.disarm()
+
+    async def async_alarm_trigger(self, code: None = None) -> None:
+        """Send in alarm command."""
+        await self._device.in_alarm()
 
     # Custom services
 
@@ -211,7 +212,3 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     async def async_alarm_not_ready(self) -> None:
         """Send not ready command."""
         await self._device.not_ready()
-
-    async def async_alarm_triggered(self) -> None:
-        """Send in alarm command."""
-        await self._device.in_alarm()

--- a/homeassistant/components/deconz/const.py
+++ b/homeassistant/components/deconz/const.py
@@ -1,6 +1,9 @@
 """Constants for the deCONZ component."""
 import logging
 
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
@@ -29,6 +32,7 @@ CONF_ALLOW_NEW_DEVICES = "allow_new_devices"
 CONF_MASTER_GATEWAY = "master"
 
 PLATFORMS = [
+    ALARM_CONTROL_PANEL_DOMAIN,
     BINARY_SENSOR_DOMAIN,
     CLIMATE_DOMAIN,
     COVER_DOMAIN,

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -1,7 +1,26 @@
 """Representation of a deCONZ remote."""
-from pydeconz.sensor import Switch
 
-from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
+from pydeconz.sensor import (
+    ANCILLARY_CONTROL_ARMED_AWAY,
+    ANCILLARY_CONTROL_ARMED_NIGHT,
+    ANCILLARY_CONTROL_ARMED_STAY,
+    ANCILLARY_CONTROL_DISARMED,
+    AncillaryControl,
+    Switch,
+)
+
+from homeassistant.const import (
+    CONF_CODE,
+    CONF_DEVICE_ID,
+    CONF_EVENT,
+    CONF_ID,
+    CONF_UNIQUE_ID,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_DISARMED,
+    STATE_UNKNOWN,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.util import slugify
@@ -10,6 +29,14 @@ from .const import CONF_ANGLE, CONF_GESTURE, CONF_XY, LOGGER, NEW_SENSOR
 from .deconz_device import DeconzBase
 
 CONF_DECONZ_EVENT = "deconz_event"
+CONF_DECONZ_ALARM_EVENT = "deconz_alarm_event"
+
+DECONZ_TO_ALARM_STATE = {
+    ANCILLARY_CONTROL_ARMED_AWAY: STATE_ALARM_ARMED_AWAY,
+    ANCILLARY_CONTROL_ARMED_NIGHT: STATE_ALARM_ARMED_NIGHT,
+    ANCILLARY_CONTROL_ARMED_STAY: STATE_ALARM_ARMED_HOME,
+    ANCILLARY_CONTROL_DISARMED: STATE_ALARM_DISARMED,
+}
 
 
 async def async_setup_events(gateway) -> None:
@@ -23,12 +50,18 @@ async def async_setup_events(gateway) -> None:
             if not gateway.option_allow_clip_sensor and sensor.type.startswith("CLIP"):
                 continue
 
-            if sensor.type not in Switch.ZHATYPE or sensor.uniqueid in {
-                event.unique_id for event in gateway.events
-            }:
+            if (
+                sensor.type not in Switch.ZHATYPE + AncillaryControl.ZHATYPE
+                or sensor.uniqueid in {event.unique_id for event in gateway.events}
+            ):
                 continue
 
-            new_event = DeconzEvent(sensor, gateway)
+            if sensor.type in Switch.ZHATYPE:
+                new_event = DeconzEvent(sensor, gateway)
+
+            elif sensor.type in AncillaryControl.ZHATYPE:
+                new_event = DeconzAlarmEvent(sensor, gateway)
+
             gateway.hass.async_create_task(new_event.async_update_device_registry())
             gateway.events.append(new_event)
 
@@ -119,3 +152,28 @@ class DeconzEvent(DeconzBase):
             config_entry_id=self.gateway.config_entry.entry_id, **self.device_info
         )
         self.device_id = entry.id
+
+
+class DeconzAlarmEvent(DeconzEvent):
+    """Alarm control panel companion event when user inputs a code."""
+
+    @callback
+    def async_update_callback(self, force_update=False):
+        """Fire the event if reason is that state is updated."""
+        if (
+            self.gateway.ignore_state_updates
+            or "action" not in self._device.changed_keys
+        ):
+            return
+
+        state, code, _area = self._device.action.split(",")
+
+        data = {
+            CONF_ID: self.event_id,
+            CONF_UNIQUE_ID: self.serial,
+            CONF_DEVICE_ID: self.device_id,
+            CONF_EVENT: DECONZ_TO_ALARM_STATE.get(state, STATE_UNKNOWN),
+            CONF_CODE: code,
+        }
+
+        self.gateway.hass.bus.async_fire(CONF_DECONZ_ALARM_EVENT, data)

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -1,4 +1,4 @@
-"""Representation of a deCONZ remote."""
+"""Representation of a deCONZ remote or keypad."""
 
 from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -163,8 +163,8 @@ class DeconzAlarmEvent(DeconzEvent):
         if (
             self.gateway.ignore_state_updates
             or "action" not in self._device.changed_keys
+            or self._device.action == ""
         ):
-            self.panel_state = self._device.panel
             return
 
         state, code, _area = self._device.action.split(",")

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -164,6 +164,7 @@ class DeconzAlarmEvent(DeconzEvent):
             self.gateway.ignore_state_updates
             or "action" not in self._device.changed_keys
         ):
+            self.panel_state = self._device.panel
             return
 
         state, code, _area = self._device.action.split(",")

--- a/homeassistant/components/deconz/manifest.json
+++ b/homeassistant/components/deconz/manifest.json
@@ -3,7 +3,7 @@
   "name": "deCONZ",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/deconz",
-  "requirements": ["pydeconz==78"],
+  "requirements": ["pydeconz==79"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics"

--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -1,5 +1,6 @@
 """Support for deCONZ sensors."""
 from pydeconz.sensor import (
+    AncillaryControl,
     Battery,
     Consumption,
     Daylight,
@@ -104,7 +105,8 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
             if (
                 not sensor.BINARY
                 and sensor.type
-                not in Battery.ZHATYPE
+                not in AncillaryControl.ZHATYPE
+                + Battery.ZHATYPE
                 + DoorLock.ZHATYPE
                 + Switch.ZHATYPE
                 + Thermostat.ZHATYPE

--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -64,3 +64,31 @@ remove_orphaned_entries:
         It can be found as part of the integration name.
         Useful if you run multiple deCONZ integrations.
       example: "00212EFFFF012345"
+
+alarm_arming_away:
+  name: Arming away
+  description: Make keypad signal it is arming to away state.
+
+alarm_arming_home:
+  name: Arming home
+  description: Make keypad signal it is arming to home state.
+
+alarm_arming_night:
+  name: Arming night
+  description: Make keypad signal it is arming to night state.
+
+alarm_entry_delay:
+  name: Entry delay
+  description: Make keypad signal it is in entry delay state.
+
+alarm_exit_delay:
+  name: Exit delay
+  description: Make keypad signal it is in exit delay state.
+
+alarm_not_ready:
+  name: Not ready
+  description: Make keypad signal it is not ready.
+
+alarm_triggered:
+  name: Alarm triggered
+  description: Make keypad signal that alarm is triggered.

--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -64,25 +64,3 @@ remove_orphaned_entries:
         It can be found as part of the integration name.
         Useful if you run multiple deCONZ integrations.
       example: "00212EFFFF012345"
-
-alarm_custom_action:
-  name: Custom alarm action
-  description: Put keypad in an intermediate state.
-  target:
-    entity:
-      integration: deconz
-      domain: alarm_control_panel
-  fields:
-    alarm_action:
-      name: Intermediate state
-      description: Communicate that a transition between primary states is happening.
-      required: true
-      selector:
-        select:
-          options:
-            - "Arming away"
-            - "Arming home"
-            - "Arming night"
-            - "Entry delay"
-            - "Exit delay"
-            - "Alarm not ready"

--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -68,27 +68,74 @@ remove_orphaned_entries:
 alarm_arming_away:
   name: Arming away
   description: Make keypad signal it is arming to away state.
+  target:
 
 alarm_arming_home:
   name: Arming home
   description: Make keypad signal it is arming to home state.
+  fields:
+    entity_id:
+      name: Entity ID
+      required: true
+      description: Name of alarm control panel to set state.
+      example: "alarm_control_panel.keypad"
+      selector:
+        entity:
+          integration: deconz
+          domain: alarm_control_panel
 
 alarm_arming_night:
   name: Arming night
   description: Make keypad signal it is arming to night state.
+  fields:
+    entity_id:
+      name: Entity ID
+      required: true
+      description: Name of alarm control panel to set state.
+      example: "alarm_control_panel.keypad"
+      selector:
+        entity:
+          integration: deconz
+          domain: alarm_control_panel
 
 alarm_entry_delay:
   name: Entry delay
   description: Make keypad signal it is in entry delay state.
+  fields:
+    entity_id:
+      name: Entity ID
+      required: true
+      description: Name of alarm control panel to set state.
+      example: "alarm_control_panel.keypad"
+      selector:
+        entity:
+          integration: deconz
+          domain: alarm_control_panel
 
 alarm_exit_delay:
   name: Exit delay
   description: Make keypad signal it is in exit delay state.
+  fields:
+    entity_id:
+      name: Entity ID
+      required: true
+      description: Name of alarm control panel to set state.
+      example: "alarm_control_panel.keypad"
+      selector:
+        entity:
+          integration: deconz
+          domain: alarm_control_panel
 
 alarm_not_ready:
-  name: Not ready
+  name: Alarm not ready
   description: Make keypad signal it is not ready.
-
-alarm_triggered:
-  name: Alarm triggered
-  description: Make keypad signal that alarm is triggered.
+  fields:
+    entity_id:
+      name: Entity ID
+      required: true
+      description: Name of alarm control panel to set state.
+      example: "alarm_control_panel.keypad"
+      selector:
+        entity:
+          integration: deconz
+          domain: alarm_control_panel

--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -65,77 +65,24 @@ remove_orphaned_entries:
         Useful if you run multiple deCONZ integrations.
       example: "00212EFFFF012345"
 
-alarm_arming_away:
-  name: Arming away
-  description: Make keypad signal it is arming to away state.
+alarm_custom_action:
+  name: Custom alarm action
+  description: Put keypad in an intermediate state.
   target:
-
-alarm_arming_home:
-  name: Arming home
-  description: Make keypad signal it is arming to home state.
+    entity:
+      integration: deconz
+      domain: alarm_control_panel
   fields:
-    entity_id:
-      name: Entity ID
+    alarm_action:
+      name: Intermediate state
+      description: Communicate that a transition between primary states is happening.
       required: true
-      description: Name of alarm control panel to set state.
-      example: "alarm_control_panel.keypad"
       selector:
-        entity:
-          integration: deconz
-          domain: alarm_control_panel
-
-alarm_arming_night:
-  name: Arming night
-  description: Make keypad signal it is arming to night state.
-  fields:
-    entity_id:
-      name: Entity ID
-      required: true
-      description: Name of alarm control panel to set state.
-      example: "alarm_control_panel.keypad"
-      selector:
-        entity:
-          integration: deconz
-          domain: alarm_control_panel
-
-alarm_entry_delay:
-  name: Entry delay
-  description: Make keypad signal it is in entry delay state.
-  fields:
-    entity_id:
-      name: Entity ID
-      required: true
-      description: Name of alarm control panel to set state.
-      example: "alarm_control_panel.keypad"
-      selector:
-        entity:
-          integration: deconz
-          domain: alarm_control_panel
-
-alarm_exit_delay:
-  name: Exit delay
-  description: Make keypad signal it is in exit delay state.
-  fields:
-    entity_id:
-      name: Entity ID
-      required: true
-      description: Name of alarm control panel to set state.
-      example: "alarm_control_panel.keypad"
-      selector:
-        entity:
-          integration: deconz
-          domain: alarm_control_panel
-
-alarm_not_ready:
-  name: Alarm not ready
-  description: Make keypad signal it is not ready.
-  fields:
-    entity_id:
-      name: Entity ID
-      required: true
-      description: Name of alarm control panel to set state.
-      example: "alarm_control_panel.keypad"
-      selector:
-        entity:
-          integration: deconz
-          domain: alarm_control_panel
+        select:
+          options:
+            - "Arming away"
+            - "Arming home"
+            - "Arming night"
+            - "Entry delay"
+            - "Exit delay"
+            - "Alarm not ready"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1343,7 +1343,7 @@ pydaikin==2.4.1
 pydanfossair==0.1.0
 
 # homeassistant.components.deconz
-pydeconz==78
+pydeconz==79
 
 # homeassistant.components.delijn
 pydelijn==0.6.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -723,7 +723,7 @@ pycoolmasternet-async==0.1.2
 pydaikin==2.4.1
 
 # homeassistant.components.deconz
-pydeconz==78
+pydeconz==79
 
 # homeassistant.components.dexcom
 pydexcom==0.2.0

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -6,38 +6,22 @@ from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY,
-    ANCILLARY_CONTROL_ARMING_AWAY,
-    ANCILLARY_CONTROL_ARMING_NIGHT,
-    ANCILLARY_CONTROL_ARMING_STAY,
     ANCILLARY_CONTROL_DISARMED,
-    ANCILLARY_CONTROL_ENTRY_DELAY,
-    ANCILLARY_CONTROL_EXIT_DELAY,
-    ANCILLARY_CONTROL_IN_ALARM,
-    ANCILLARY_CONTROL_NOT_READY,
 )
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
-from homeassistant.components.deconz.alarm_control_panel import (
-    CONF_ALARM_ACTION,
-    SERVICE_ALARM_ACTION,
-)
-from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_ALARM_ARM_AWAY,
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
     SERVICE_ALARM_DISARM,
-    SERVICE_ALARM_TRIGGER,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
-    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
-    STATE_ALARM_PENDING,
-    STATE_ALARM_TRIGGERED,
     STATE_UNAVAILABLE,
 )
 
@@ -63,6 +47,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
                     "armed": "disarmed",
                     "enrolled": 0,
                     "on": True,
+                    "panel": "disarmed",
                     "pending": [],
                     "reachable": True,
                 },
@@ -76,7 +61,6 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
                     "action": "armed_away,1111,55",
                     "lastupdated": "2021-04-02T13:08:18.937",
                     "lowbattery": False,
-                    "panel": "disarmed",
                     "tampered": True,
                 },
                 "type": "ZHAAncillaryControl",
@@ -97,7 +81,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_AWAY},
+        "config": {"armed": ANCILLARY_CONTROL_ARMED_AWAY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -111,7 +95,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_NIGHT},
+        "config": {"armed": ANCILLARY_CONTROL_ARMED_NIGHT},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -127,7 +111,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_STAY},
+        "config": {"armed": ANCILLARY_CONTROL_ARMED_STAY},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -141,7 +125,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMED_NIGHT},
+        "config": {"armed": ANCILLARY_CONTROL_ARMED_NIGHT},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
@@ -157,102 +141,12 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_DISARMED},
+        "config": {"armed": ANCILLARY_CONTROL_DISARMED},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()
 
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_DISARMED
-
-    # Event signals alarm control panel arming
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMING_AWAY},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMING_NIGHT},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ARMING_STAY},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
-
-    # Event signals alarm control panel pending
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_ENTRY_DELAY},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_EXIT_DELAY},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_NOT_READY},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
-
-    # Event signals alarm control panel triggered
-
-    event_changed_sensor = {
-        "t": "event",
-        "e": "changed",
-        "r": "sensors",
-        "id": "0",
-        "state": {"panel": ANCILLARY_CONTROL_IN_ALARM},
-    }
-    await mock_deconz_websocket(data=event_changed_sensor)
-    await hass.async_block_till_done()
-
-    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_TRIGGERED
 
     # Verify service calls
 
@@ -297,96 +191,6 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         blocking=True,
     )
     assert aioclient_mock.mock_calls[4][2] == {"armed": ANCILLARY_CONTROL_DISARMED}
-
-    # Service set alarm to triggered
-
-    await hass.services.async_call(
-        ALARM_CONTROL_PANEL_DOMAIN,
-        SERVICE_ALARM_TRIGGER,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[5][2] == {"armed": ANCILLARY_CONTROL_IN_ALARM}
-
-    # Verify entity service calls
-
-    # Service set alarm to arming away
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_ACTION,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
-            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ARMING_AWAY,
-        },
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[6][2] == {"armed": ANCILLARY_CONTROL_ARMING_AWAY}
-
-    # Service set alarm to arming home
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_ACTION,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
-            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ARMING_STAY,
-        },
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[7][2] == {"armed": ANCILLARY_CONTROL_ARMING_STAY}
-
-    # Service set alarm to arming night
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_ACTION,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
-            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ARMING_NIGHT,
-        },
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[8][2] == {"armed": ANCILLARY_CONTROL_ARMING_NIGHT}
-
-    # Service set alarm to entry delay
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_ACTION,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
-            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ENTRY_DELAY,
-        },
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[9][2] == {"armed": ANCILLARY_CONTROL_ENTRY_DELAY}
-
-    # Service set alarm to exit delay
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_ACTION,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
-            CONF_ALARM_ACTION: ANCILLARY_CONTROL_EXIT_DELAY,
-        },
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[10][2] == {"armed": ANCILLARY_CONTROL_EXIT_DELAY}
-
-    # Service set alarm to not ready
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_ACTION,
-        {
-            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
-            CONF_ALARM_ACTION: ANCILLARY_CONTROL_NOT_READY,
-        },
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[11][2] == {"armed": ANCILLARY_CONTROL_NOT_READY}
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -160,7 +160,10 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[1][2] == {"armed": ANCILLARY_CONTROL_ARMED_AWAY}
+    assert aioclient_mock.mock_calls[1][2] == {
+        "armed": ANCILLARY_CONTROL_ARMED_AWAY,
+        "panel": ANCILLARY_CONTROL_ARMED_AWAY,
+    }
 
     # Service set alarm to home mode
 
@@ -170,7 +173,10 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[2][2] == {"armed": ANCILLARY_CONTROL_ARMED_STAY}
+    assert aioclient_mock.mock_calls[2][2] == {
+        "armed": ANCILLARY_CONTROL_ARMED_STAY,
+        "panel": ANCILLARY_CONTROL_ARMED_STAY,
+    }
 
     # Service set alarm to night mode
 
@@ -180,7 +186,10 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[3][2] == {"armed": ANCILLARY_CONTROL_ARMED_NIGHT}
+    assert aioclient_mock.mock_calls[3][2] == {
+        "armed": ANCILLARY_CONTROL_ARMED_NIGHT,
+        "panel": ANCILLARY_CONTROL_ARMED_NIGHT,
+    }
 
     # Service set alarm to disarmed
 
@@ -190,7 +199,10 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[4][2] == {"armed": ANCILLARY_CONTROL_DISARMED}
+    assert aioclient_mock.mock_calls[4][2] == {
+        "armed": ANCILLARY_CONTROL_DISARMED,
+        "panel": ANCILLARY_CONTROL_DISARMED,
+    }
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -1,0 +1,61 @@
+"""deCONZ alarm control panel platform tests."""
+
+from unittest.mock import patch
+
+from homeassistant.const import STATE_UNAVAILABLE
+
+from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
+
+
+async def test_no_sensors(hass, aioclient_mock):
+    """Test that no sensors in deconz results in no climate entities."""
+    await setup_deconz_integration(hass, aioclient_mock)
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
+    """Test successful creation of alarm control panel entities."""
+    data = {
+        "sensors": {
+            "0": {
+                "config": {
+                    "armed": "disarmed",
+                    "enrolled": 0,
+                    "on": True,
+                    "pending": [],
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "3c4008d74035dfaa1f0bb30d24468b12",
+                "lastseen": "2021-04-02T13:07Z",
+                "manufacturername": "Universal Electronics Inc",
+                "modelid": "URC4450BC0-X-R",
+                "name": "Keypad",
+                "state": {
+                    "action": "armed_away,1111,55",
+                    "lastupdated": "2021-04-02T13:08:18.937",
+                    "lowbattery": False,
+                    "panel": "disarmed",
+                    "tampered": True,
+                },
+                "type": "ZHAAncillaryControlSensor",
+                "uniqueid": "00:0d:6f:00:13:4f:61:39-01-0501",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    assert len(hass.states.async_all()) == 1
+    assert hass.states.get("alarm_control_panel.keypad")
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    states = hass.states.async_all()
+    assert len(states) == 1
+    for state in states:
+        assert state.state == STATE_UNAVAILABLE
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 0

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -20,12 +20,8 @@ from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
 from homeassistant.components.deconz.alarm_control_panel import (
-    SERVICE_ALARM_ARMING_AWAY,
-    SERVICE_ALARM_ARMING_HOME,
-    SERVICE_ALARM_ARMING_NIGHT,
-    SERVICE_ALARM_ENTRY_DELAY,
-    SERVICE_ALARM_EXIT_DELAY,
-    SERVICE_ALARM_NOT_READY,
+    CONF_ALARM_ACTION,
+    SERVICE_ALARM_ACTION,
 )
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.const import (
@@ -312,14 +308,17 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
     )
     assert aioclient_mock.mock_calls[5][2] == {"armed": ANCILLARY_CONTROL_IN_ALARM}
 
-    # Custom services
+    # Verify entity service calls
 
     # Service set alarm to arming away
 
     await hass.services.async_call(
         DECONZ_DOMAIN,
-        SERVICE_ALARM_ARMING_AWAY,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        SERVICE_ALARM_ACTION,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ARMING_AWAY,
+        },
         blocking=True,
     )
     assert aioclient_mock.mock_calls[6][2] == {"armed": ANCILLARY_CONTROL_ARMING_AWAY}
@@ -328,8 +327,11 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
 
     await hass.services.async_call(
         DECONZ_DOMAIN,
-        SERVICE_ALARM_ARMING_HOME,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        SERVICE_ALARM_ACTION,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ARMING_STAY,
+        },
         blocking=True,
     )
     assert aioclient_mock.mock_calls[7][2] == {"armed": ANCILLARY_CONTROL_ARMING_STAY}
@@ -338,8 +340,11 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
 
     await hass.services.async_call(
         DECONZ_DOMAIN,
-        SERVICE_ALARM_ARMING_NIGHT,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        SERVICE_ALARM_ACTION,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ARMING_NIGHT,
+        },
         blocking=True,
     )
     assert aioclient_mock.mock_calls[8][2] == {"armed": ANCILLARY_CONTROL_ARMING_NIGHT}
@@ -348,8 +353,11 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
 
     await hass.services.async_call(
         DECONZ_DOMAIN,
-        SERVICE_ALARM_ENTRY_DELAY,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        SERVICE_ALARM_ACTION,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_ACTION: ANCILLARY_CONTROL_ENTRY_DELAY,
+        },
         blocking=True,
     )
     assert aioclient_mock.mock_calls[9][2] == {"armed": ANCILLARY_CONTROL_ENTRY_DELAY}
@@ -358,8 +366,11 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
 
     await hass.services.async_call(
         DECONZ_DOMAIN,
-        SERVICE_ALARM_EXIT_DELAY,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        SERVICE_ALARM_ACTION,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_ACTION: ANCILLARY_CONTROL_EXIT_DELAY,
+        },
         blocking=True,
     )
     assert aioclient_mock.mock_calls[10][2] == {"armed": ANCILLARY_CONTROL_EXIT_DELAY}
@@ -368,8 +379,11 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
 
     await hass.services.async_call(
         DECONZ_DOMAIN,
-        SERVICE_ALARM_NOT_READY,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        SERVICE_ALARM_ACTION,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_ACTION: ANCILLARY_CONTROL_NOT_READY,
+        },
         blocking=True,
     )
     assert aioclient_mock.mock_calls[11][2] == {"armed": ANCILLARY_CONTROL_NOT_READY}

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -26,7 +26,6 @@ from homeassistant.components.deconz.alarm_control_panel import (
     SERVICE_ALARM_ENTRY_DELAY,
     SERVICE_ALARM_EXIT_DELAY,
     SERVICE_ALARM_NOT_READY,
-    SERVICE_ALARM_TRIGGERED,
 )
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.const import (
@@ -35,7 +34,14 @@ from homeassistant.const import (
     SERVICE_ALARM_ARM_HOME,
     SERVICE_ALARM_ARM_NIGHT,
     SERVICE_ALARM_DISARM,
+    SERVICE_ALARM_TRIGGER,
+    STATE_ALARM_ARMED_AWAY,
+    STATE_ALARM_ARMED_HOME,
+    STATE_ALARM_ARMED_NIGHT,
+    STATE_ALARM_ARMING,
     STATE_ALARM_DISARMED,
+    STATE_ALARM_PENDING,
+    STATE_ALARM_TRIGGERED,
     STATE_UNAVAILABLE,
 )
 
@@ -88,6 +94,170 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
     assert len(hass.states.async_all()) == 1
     assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_DISARMED
 
+    # Event signals alarm control panel armed away
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMED_AWAY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_AWAY
+
+    # Event signals alarm control panel armed night
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMED_NIGHT},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_NIGHT
+    )
+
+    # Event signals alarm control panel armed home
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMED_STAY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_HOME
+
+    # Event signals alarm control panel armed night
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMED_NIGHT},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMED_NIGHT
+    )
+
+    # Event signals alarm control panel disarmed
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_DISARMED},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_DISARMED
+
+    # Event signals alarm control panel arming
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMING_AWAY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMING_NIGHT},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ARMING_STAY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_ARMING
+
+    # Event signals alarm control panel pending
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_ENTRY_DELAY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_EXIT_DELAY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_NOT_READY},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_PENDING
+
+    # Event signals alarm control panel triggered
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "0",
+        "state": {"panel": ANCILLARY_CONTROL_IN_ALARM},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("alarm_control_panel.keypad").state == STATE_ALARM_TRIGGERED
+
     # Verify service calls
 
     mock_deconz_put_request(aioclient_mock, config_entry.data, "/sensors/0/config")
@@ -132,6 +302,16 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
     )
     assert aioclient_mock.mock_calls[4][2] == {"armed": ANCILLARY_CONTROL_DISARMED}
 
+    # Service set alarm to triggered
+
+    await hass.services.async_call(
+        ALARM_CONTROL_PANEL_DOMAIN,
+        SERVICE_ALARM_TRIGGER,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[5][2] == {"armed": ANCILLARY_CONTROL_IN_ALARM}
+
     # Custom services
 
     # Service set alarm to arming away
@@ -142,7 +322,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[5][2] == {"armed": ANCILLARY_CONTROL_ARMING_AWAY}
+    assert aioclient_mock.mock_calls[6][2] == {"armed": ANCILLARY_CONTROL_ARMING_AWAY}
 
     # Service set alarm to arming home
 
@@ -152,7 +332,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[6][2] == {"armed": ANCILLARY_CONTROL_ARMING_STAY}
+    assert aioclient_mock.mock_calls[7][2] == {"armed": ANCILLARY_CONTROL_ARMING_STAY}
 
     # Service set alarm to arming night
 
@@ -162,7 +342,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[7][2] == {"armed": ANCILLARY_CONTROL_ARMING_NIGHT}
+    assert aioclient_mock.mock_calls[8][2] == {"armed": ANCILLARY_CONTROL_ARMING_NIGHT}
 
     # Service set alarm to entry delay
 
@@ -172,7 +352,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[8][2] == {"armed": ANCILLARY_CONTROL_ENTRY_DELAY}
+    assert aioclient_mock.mock_calls[9][2] == {"armed": ANCILLARY_CONTROL_ENTRY_DELAY}
 
     # Service set alarm to exit delay
 
@@ -182,7 +362,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[9][2] == {"armed": ANCILLARY_CONTROL_EXIT_DELAY}
+    assert aioclient_mock.mock_calls[10][2] == {"armed": ANCILLARY_CONTROL_EXIT_DELAY}
 
     # Service set alarm to not ready
 
@@ -192,17 +372,7 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
         blocking=True,
     )
-    assert aioclient_mock.mock_calls[10][2] == {"armed": ANCILLARY_CONTROL_NOT_READY}
-
-    # Service set alarm to triggered
-
-    await hass.services.async_call(
-        DECONZ_DOMAIN,
-        SERVICE_ALARM_TRIGGERED,
-        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
-        blocking=True,
-    )
-    assert aioclient_mock.mock_calls[11][2] == {"armed": ANCILLARY_CONTROL_IN_ALARM}
+    assert aioclient_mock.mock_calls[11][2] == {"armed": ANCILLARY_CONTROL_NOT_READY}
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -6,12 +6,29 @@ from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY,
+    ANCILLARY_CONTROL_ARMING_AWAY,
+    ANCILLARY_CONTROL_ARMING_NIGHT,
+    ANCILLARY_CONTROL_ARMING_STAY,
     ANCILLARY_CONTROL_DISARMED,
+    ANCILLARY_CONTROL_ENTRY_DELAY,
+    ANCILLARY_CONTROL_EXIT_DELAY,
+    ANCILLARY_CONTROL_IN_ALARM,
+    ANCILLARY_CONTROL_NOT_READY,
 )
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
+from homeassistant.components.deconz.alarm_control_panel import (
+    SERVICE_ALARM_ARMING_AWAY,
+    SERVICE_ALARM_ARMING_HOME,
+    SERVICE_ALARM_ARMING_NIGHT,
+    SERVICE_ALARM_ENTRY_DELAY,
+    SERVICE_ALARM_EXIT_DELAY,
+    SERVICE_ALARM_NOT_READY,
+    SERVICE_ALARM_TRIGGERED,
+)
+from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_ALARM_ARM_AWAY,
@@ -114,6 +131,78 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
         blocking=True,
     )
     assert aioclient_mock.mock_calls[4][2] == {"armed": ANCILLARY_CONTROL_DISARMED}
+
+    # Custom services
+
+    # Service set alarm to arming away
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_ARMING_AWAY,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[5][2] == {"armed": ANCILLARY_CONTROL_ARMING_AWAY}
+
+    # Service set alarm to arming home
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_ARMING_HOME,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[6][2] == {"armed": ANCILLARY_CONTROL_ARMING_STAY}
+
+    # Service set alarm to arming night
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_ARMING_NIGHT,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[7][2] == {"armed": ANCILLARY_CONTROL_ARMING_NIGHT}
+
+    # Service set alarm to entry delay
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_ENTRY_DELAY,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[8][2] == {"armed": ANCILLARY_CONTROL_ENTRY_DELAY}
+
+    # Service set alarm to exit delay
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_EXIT_DELAY,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[9][2] == {"armed": ANCILLARY_CONTROL_EXIT_DELAY}
+
+    # Service set alarm to not ready
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_NOT_READY,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[10][2] == {"armed": ANCILLARY_CONTROL_NOT_READY}
+
+    # Service set alarm to triggered
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_TRIGGERED,
+        {ATTR_ENTITY_ID: "alarm_control_panel.keypad"},
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[11][2] == {"armed": ANCILLARY_CONTROL_IN_ALARM}
 
     await hass.config_entries.async_unload(config_entry.entry_id)
 

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -3,8 +3,18 @@
 from unittest.mock import patch
 
 from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
-from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.components.deconz.deconz_event import (
+    CONF_DECONZ_ALARM_EVENT,
+    CONF_DECONZ_EVENT,
+)
+from homeassistant.const import (
+    CONF_CODE,
+    CONF_DEVICE_ID,
+    CONF_EVENT,
+    CONF_ID,
+    CONF_UNIQUE_ID,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.helpers.device_registry import async_entries_for_config_entry
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
@@ -161,10 +171,118 @@ async def test_deconz_events(hass, aioclient_mock, mock_deconz_websocket):
         "device_id": device.id,
     }
 
+    # Unsupported event
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "name": "other name",
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert len(captured_events) == 4
+
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
     assert len(hass.states.async_all()) == 3
+    for state in states:
+        assert state.state == STATE_UNAVAILABLE
+
+    await hass.config_entries.async_remove(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_all()) == 0
+
+
+async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
+    """Test successful creation of deconz alarm events."""
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "armed": "disarmed",
+                    "enrolled": 0,
+                    "on": True,
+                    "pending": [],
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "3c4008d74035dfaa1f0bb30d24468b12",
+                "lastseen": "2021-04-02T13:07Z",
+                "manufacturername": "Universal Electronics Inc",
+                "modelid": "URC4450BC0-X-R",
+                "name": "Keypad",
+                "state": {
+                    "action": "armed_away,1111,55",
+                    "lastupdated": "2021-04-02T13:08:18.937",
+                    "lowbattery": False,
+                    "panel": "disarmed",
+                    "tampered": True,
+                },
+                "type": "ZHAAncillaryControl",
+                "uniqueid": "00:00:00:00:00:00:00:01-01-0501",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        config_entry = await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+
+    assert len(hass.states.async_all()) == 1
+    # 1 alarm control device + 2 additional devices for deconz service and host
+    assert (
+        len(async_entries_for_config_entry(device_registry, config_entry.entry_id)) == 3
+    )
+
+    captured_events = async_capture_events(hass, CONF_DECONZ_ALARM_EVENT)
+
+    # Armed away event
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"action": "armed_away,1234,1"},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, "00:00:00:00:00:00:00:01")}
+    )
+
+    assert len(captured_events) == 1
+    assert captured_events[0].data == {
+        CONF_ID: "keypad",
+        CONF_UNIQUE_ID: "00:00:00:00:00:00:00:01",
+        CONF_DEVICE_ID: device.id,
+        CONF_EVENT: "armed_away",
+        CONF_CODE: "1234",
+    }
+
+    # Unsupported event
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"panel": "armed_away"},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert len(captured_events) == 1
+
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+    states = hass.states.async_all()
+    assert len(hass.states.async_all()) == 1
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -206,6 +206,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
                     "armed": "disarmed",
                     "enrolled": 0,
                     "on": True,
+                    "panel": "disarmed",
                     "pending": [],
                     "reachable": True,
                 },
@@ -219,7 +220,6 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
                     "action": "armed_away,1111,55",
                     "lastupdated": "2021-04-02T13:08:18.937",
                     "lowbattery": False,
-                    "panel": "disarmed",
                     "tampered": True,
                 },
                 "type": "ZHAAncillaryControl",
@@ -272,7 +272,7 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         "e": "changed",
         "r": "sensors",
         "id": "1",
-        "state": {"panel": "armed_away"},
+        "config": {"panel": "armed_away"},
     }
     await mock_deconz_websocket(data=event_changed_sensor)
     await hass.async_block_till_done()

--- a/tests/components/deconz/test_gateway.py
+++ b/tests/components/deconz/test_gateway.py
@@ -7,6 +7,9 @@ import pydeconz
 from pydeconz.websocket import STATE_RETRYING, STATE_RUNNING
 import pytest
 
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
@@ -148,16 +151,20 @@ async def test_gateway_setup(hass, aioclient_mock):
 
         assert forward_entry_setup.mock_calls[0][1] == (
             config_entry,
+            ALARM_CONTROL_PANEL_DOMAIN,
+        )
+        assert forward_entry_setup.mock_calls[1][1] == (
+            config_entry,
             BINARY_SENSOR_DOMAIN,
         )
-        assert forward_entry_setup.mock_calls[1][1] == (config_entry, CLIMATE_DOMAIN)
-        assert forward_entry_setup.mock_calls[2][1] == (config_entry, COVER_DOMAIN)
-        assert forward_entry_setup.mock_calls[3][1] == (config_entry, FAN_DOMAIN)
-        assert forward_entry_setup.mock_calls[4][1] == (config_entry, LIGHT_DOMAIN)
-        assert forward_entry_setup.mock_calls[5][1] == (config_entry, LOCK_DOMAIN)
-        assert forward_entry_setup.mock_calls[6][1] == (config_entry, SCENE_DOMAIN)
-        assert forward_entry_setup.mock_calls[7][1] == (config_entry, SENSOR_DOMAIN)
-        assert forward_entry_setup.mock_calls[8][1] == (config_entry, SWITCH_DOMAIN)
+        assert forward_entry_setup.mock_calls[2][1] == (config_entry, CLIMATE_DOMAIN)
+        assert forward_entry_setup.mock_calls[3][1] == (config_entry, COVER_DOMAIN)
+        assert forward_entry_setup.mock_calls[4][1] == (config_entry, FAN_DOMAIN)
+        assert forward_entry_setup.mock_calls[5][1] == (config_entry, LIGHT_DOMAIN)
+        assert forward_entry_setup.mock_calls[6][1] == (config_entry, LOCK_DOMAIN)
+        assert forward_entry_setup.mock_calls[7][1] == (config_entry, SCENE_DOMAIN)
+        assert forward_entry_setup.mock_calls[8][1] == (config_entry, SENSOR_DOMAIN)
+        assert forward_entry_setup.mock_calls[9][1] == (config_entry, SWITCH_DOMAIN)
 
 
 async def test_gateway_retry(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
pydeconz PR: https://github.com/Kane610/deconz/pull/102
deCONZ PR: https://github.com/dresden-elektronik/deconz-rest-plugin/issues/4560

Add support for alarm control panel with keypads in deCONZ.
Also add support for alarm event from keypad when user sets code and arming mode.
In a later PR I will add support for custom states with entity services as well

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17529

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
