### PR TITLE
Use microsecond precision for datetime values on MariaDB/MySQL

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -363,6 +363,13 @@ def _apply_update(engine, new_version, old_version):
         if engine.dialect.name == "mysql":
             _modify_columns(engine, "events", ["event_data LONGTEXT"])
             _modify_columns(engine, "states", ["attributes LONGTEXT"])
+    elif new_version == 13:
+        if engine.dialect.name == "mysql":
+            _modify_columns(engine, "events", ["time_fired DATETIME(6)"])
+            _modify_columns(engine, "events", ["created DATETIME(6)"])
+            _modify_columns(engine, "states", ["last_changed DATETIME(6)"])
+            _modify_columns(engine, "states", ["last_updated DATETIME(6)"])
+            _modify_columns(engine, "states", ["created DATETIME(6)"])
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -365,11 +365,18 @@ def _apply_update(engine, new_version, old_version):
             _modify_columns(engine, "states", ["attributes LONGTEXT"])
     elif new_version == 13:
         if engine.dialect.name == "mysql":
-            _modify_columns(engine, "events", ["time_fired DATETIME(6)"])
-            _modify_columns(engine, "events", ["created DATETIME(6)"])
-            _modify_columns(engine, "states", ["last_changed DATETIME(6)"])
-            _modify_columns(engine, "states", ["last_updated DATETIME(6)"])
-            _modify_columns(engine, "states", ["created DATETIME(6)"])
+            _modify_columns(
+                engine, "events", ["time_fired DATETIME(6)", "created DATETIME(6)"]
+            )
+            _modify_columns(
+                engine,
+                "states",
+                [
+                    "last_changed DATETIME(6)",
+                    "last_updated DATETIME(6)",
+                    "created DATETIME(6)",
+                ],
+            )
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")
 

--- a/homeassistant/components/recorder/models.py
+++ b/homeassistant/components/recorder/models.py
@@ -26,7 +26,7 @@ import homeassistant.util.dt as dt_util
 # pylint: disable=invalid-name
 Base = declarative_base()
 
-SCHEMA_VERSION = 12
+SCHEMA_VERSION = 13
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -38,6 +38,10 @@ TABLE_RECORDER_RUNS = "recorder_runs"
 TABLE_SCHEMA_CHANGES = "schema_changes"
 
 ALL_TABLES = [TABLE_STATES, TABLE_EVENTS, TABLE_RECORDER_RUNS, TABLE_SCHEMA_CHANGES]
+
+DATETIME_TYPE = DateTime(timezone=True).with_variant(
+    mysql.DATETIME(timezone=True, fsp=6), "mysql"
+)
 
 
 class Events(Base):  # type: ignore
@@ -52,8 +56,8 @@ class Events(Base):  # type: ignore
     event_type = Column(String(32))
     event_data = Column(Text().with_variant(mysql.LONGTEXT, "mysql"))
     origin = Column(String(32))
-    time_fired = Column(DateTime(timezone=True), index=True)
-    created = Column(DateTime(timezone=True), default=dt_util.utcnow)
+    time_fired = Column(DATETIME_TYPE, index=True)
+    created = Column(DATETIME_TYPE, default=dt_util.utcnow)
     context_id = Column(String(36), index=True)
     context_user_id = Column(String(36), index=True)
     context_parent_id = Column(String(36), index=True)
@@ -123,9 +127,9 @@ class States(Base):  # type: ignore
     event_id = Column(
         Integer, ForeignKey("events.event_id", ondelete="CASCADE"), index=True
     )
-    last_changed = Column(DateTime(timezone=True), default=dt_util.utcnow)
-    last_updated = Column(DateTime(timezone=True), default=dt_util.utcnow, index=True)
-    created = Column(DateTime(timezone=True), default=dt_util.utcnow)
+    last_changed = Column(DATETIME_TYPE, default=dt_util.utcnow)
+    last_updated = Column(DATETIME_TYPE, default=dt_util.utcnow, index=True)
+    created = Column(DATETIME_TYPE, default=dt_util.utcnow)
     old_state_id = Column(
         Integer, ForeignKey("states.state_id", ondelete="NO ACTION"), index=True
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use the vendor specific data type for the `mysql` backend and specify the
fractional seconds precision (fsp) to be 6 digits (microseconds). This
makes sure that events e.g. in traces are properly ordered.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
