### PR TITLE
Fix ZHA light entities around jumping during transitions

### DIFF
--- a/homeassistant/components/zha/entity.py
+++ b/homeassistant/components/zha/entity.py
@@ -229,6 +229,7 @@ class ZhaGroupEntity(BaseZhaEntity):
         self._entity_ids: list[str] = entity_ids
         self._async_unsub_state_changed: CALLBACK_TYPE | None = None
         self._handled_group_membership = False
+        self._ignore_member_changes = False
 
     @property
     def available(self) -> bool:
@@ -269,6 +270,8 @@ class ZhaGroupEntity(BaseZhaEntity):
     @callback
     def async_state_changed_listener(self, event: Event):
         """Handle child updates."""
+        if self._ignore_member_changes:
+            return
         # Delay to ensure that we get updates from all members before updating the group
         self.hass.loop.call_later(
             UPDATE_GROUP_FROM_CHILD_DELAY,

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -452,17 +452,16 @@ class Light(BaseLight, ZhaEntity):
     async def _handle_on_off(self, operation, kwargs):
         """Perform the on or off operation."""
         transition = kwargs.get(light.ATTR_TRANSITION)
-        if transition:
-            self._transitioning = True
+        default_transition = DEFAULT_TRANSITION / 10 if DEFAULT_TRANSITION > 1 else 1
+        duration = transition + 0.5 if transition else default_transition + 0.5
+        self._transitioning = True
         await operation(**kwargs)
 
         async def do_refresh(_):
             self._transitioning = False
             await self.async_get_state()
 
-        if transition:
-            duration = transition + 0.5
-            async_call_later(self.hass, duration, do_refresh)
+        async_call_later(self.hass, duration, do_refresh)
 
     async def async_get_state(self):
         """Attempt to retrieve the state from the light."""
@@ -602,7 +601,8 @@ class LightGroup(BaseLight, ZhaGroupEntity):
         """Perform the on or off operation."""
         self._ignore_member_changes = True
         transition = kwargs.get(light.ATTR_TRANSITION)
-        duration = transition + 0.5 if transition else DEFAULT_TRANSITION + 0.5
+        default_transition = DEFAULT_TRANSITION / 10 if DEFAULT_TRANSITION > 1 else 1
+        duration = transition + 0.5 if transition else default_transition + 0.5
 
         async def refresh_members(_):
             self._ignore_member_changes = False

--- a/homeassistant/components/zha/light.py
+++ b/homeassistant/components/zha/light.py
@@ -529,8 +529,14 @@ class Light(BaseLight, ZhaEntity):
     async def _maybe_force_refresh(self, signal):
         """Force update the state if the signal contains the entity id for this entity."""
         if self.entity_id in signal["entity_ids"]:
-            await self.async_get_state()
-            self.async_write_ha_state()
+            # randomize the updating of all of the group members so we don't flood the network
+            refresh_delay = random.randint(10, 90) / 100
+
+            async def _delayed_refresh(_):
+                await self.async_get_state()
+                self.async_write_ha_state()
+
+            async_call_later(self.hass, refresh_delay, _delayed_refresh)
 
 
 @STRICT_MATCH(

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -1,5 +1,6 @@
 """Common test objects."""
 import asyncio
+from datetime import timedelta
 import time
 from unittest.mock import AsyncMock, Mock
 
@@ -14,6 +15,9 @@ import zigpy.zdo.types
 
 import homeassistant.components.zha.core.const as zha_const
 from homeassistant.util import slugify
+import homeassistant.util.dt as dt_util
+
+from tests.common import async_fire_time_changed
 
 
 class FakeEndpoint:
@@ -245,4 +249,11 @@ async def async_wait_for_updates(hass):
     await hass.async_block_till_done()
     await asyncio.sleep(0)
     await asyncio.sleep(0)
+    await hass.async_block_till_done()
+
+
+async def async_shift_time(hass):
+    """Shitf time to cause call later tasks to run."""
+    next_update = dt_util.utcnow() + timedelta(seconds=11)
+    async_fire_time_changed(hass, next_update)
     await hass.async_block_till_done()

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -273,6 +273,7 @@ async def test_light(
         await async_test_level_on_off_from_hass(
             hass, cluster_on_off, cluster_level, entity_id
         )
+        await async_shift_time(hass)
 
         # test getting a brightness change from the network
         await async_test_on_from_light(hass, cluster_on_off, entity_id)

--- a/tests/components/zha/test_light.py
+++ b/tests/components/zha/test_light.py
@@ -18,6 +18,7 @@ import homeassistant.util.dt as dt_util
 from .common import (
     async_enable_traffic,
     async_find_group_entity_id,
+    async_shift_time,
     async_test_rejoin,
     find_entity_id,
     get_zha_gateway,
@@ -390,6 +391,8 @@ async def async_test_level_on_off_from_hass(
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
 
+    await async_shift_time(hass)
+
     await hass.services.async_call(
         DOMAIN, "turn_on", {"entity_id": entity_id, "brightness": 10}, blocking=True
     )
@@ -411,6 +414,8 @@ async def async_test_level_on_off_from_hass(
     )
     on_off_cluster.request.reset_mock()
     level_cluster.request.reset_mock()
+
+    await async_shift_time(hass)
 
     await async_test_off_from_hass(hass, on_off_cluster, entity_id)
 
@@ -541,10 +546,14 @@ async def test_zha_group_light_entity(
     # test turning the lights on and off from the HA
     await async_test_on_off_from_hass(hass, group_cluster_on_off, group_entity_id)
 
+    await async_shift_time(hass)
+
     # test short flashing the lights from the HA
     await async_test_flash_from_hass(
         hass, group_cluster_identify, group_entity_id, FLASH_SHORT
     )
+
+    await async_shift_time(hass)
 
     # test turning the lights on and off from the light
     await async_test_on_off_from_light(hass, dev1_cluster_on_off, group_entity_id)
@@ -553,6 +562,8 @@ async def test_zha_group_light_entity(
     await async_test_level_on_off_from_hass(
         hass, group_cluster_on_off, group_cluster_level, group_entity_id
     )
+
+    await async_shift_time(hass)
 
     # test getting a brightness change from the network
     await async_test_on_from_light(hass, dev1_cluster_on_off, group_entity_id)
@@ -564,6 +575,8 @@ async def test_zha_group_light_entity(
     await async_test_flash_from_hass(
         hass, group_cluster_identify, group_entity_id, FLASH_LONG
     )
+
+    await async_shift_time(hass)
 
     assert len(zha_group.members) == 2
     # test some of the group logic to make sure we key off states correctly


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR corrects an issue with ZHA light group entities during on and off operations where the entity state jumps around. 

Before:

https://user-images.githubusercontent.com/1335687/113890969-a5589f00-9792-11eb-885c-e2a548cb0abd.mov

After:

https://user-images.githubusercontent.com/1335687/113891034-b2758e00-9792-11eb-8617-8664ed7f8f3b.mov

~~I still need to fix the tests for this change...~~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
