### PR TITLE
Replace http startup logic with async_when_setup_or_start

### DIFF
--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -10,7 +10,11 @@ from typing import Awaitable, Callable, Generator, Iterable
 
 from homeassistant import config as conf_util, core, loader, requirements
 from homeassistant.config import async_notify_setup_error
-from homeassistant.const import EVENT_COMPONENT_LOADED, PLATFORM_FORMAT
+from homeassistant.const import (
+    EVENT_COMPONENT_LOADED,
+    EVENT_HOMEASSISTANT_START,
+    PLATFORM_FORMAT,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import dt as dt_util, ensure_unique_string
@@ -378,6 +382,27 @@ def async_when_setup(
     when_setup_cb: Callable[[core.HomeAssistant, str], Awaitable[None]],
 ) -> None:
     """Call a method when a component is setup."""
+    _async_when_setup(hass, component, when_setup_cb, False)
+
+
+@core.callback
+def async_when_setup_or_start(
+    hass: core.HomeAssistant,
+    component: str,
+    when_setup_cb: Callable[[core.HomeAssistant, str], Awaitable[None]],
+) -> None:
+    """Call a method when a component is setup or state is fired."""
+    _async_when_setup(hass, component, when_setup_cb, True)
+
+
+@core.callback
+def _async_when_setup(
+    hass: core.HomeAssistant,
+    component: str,
+    when_setup_cb: Callable[[core.HomeAssistant, str], Awaitable[None]],
+    start_event: bool,
+) -> None:
+    """Call a method when a component is setup or the start event fires."""
 
     async def when_setup() -> None:
         """Call the callback."""
@@ -386,22 +411,28 @@ def async_when_setup(
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Error handling when_setup callback for %s", component)
 
-    # Running it in a new task so that it always runs after
     if component in hass.config.components:
         hass.async_create_task(when_setup())
         return
 
-    unsub = None
+    listeners: list[Callable] = []
 
-    async def loaded_event(event: core.Event) -> None:
-        """Call the callback."""
-        if event.data[ATTR_COMPONENT] != component:
-            return
-
-        unsub()  # type: ignore
+    async def _matched_event(event: core.Event) -> None:
+        """Call the callback when we matched an event."""
+        for listener in listeners:
+            listener()
         await when_setup()
 
-    unsub = hass.bus.async_listen(EVENT_COMPONENT_LOADED, loaded_event)
+    async def _loaded_event(event: core.Event) -> None:
+        """Call the callback if we loaded the expected component."""
+        if event.data[ATTR_COMPONENT] == component:
+            await _matched_event(event)
+
+    listeners.append(hass.bus.async_listen(EVENT_COMPONENT_LOADED, _loaded_event))
+    if start_event:
+        listeners.append(
+            hass.bus.async_listen(EVENT_HOMEASSISTANT_START, _matched_event)
+        )
 
 
 @core.callback


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I built this for https://github.com/home-assistant/core/pull/48704 but turned out not to need it, but since its less code in `http`, I figured its still worth merging.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
