### PR TITLE
Revert "Add URL input for Prowl"

### DIFF
--- a/homeassistant/components/prowl/notify.py
+++ b/homeassistant/components/prowl/notify.py
@@ -48,8 +48,6 @@ class ProwlNotificationService(BaseNotificationService):
             "description": message,
             "priority": data["priority"] if data and "priority" in data else 0,
         }
-        if data.get("url"):
-            payload["url"] = data["url"]
 
         _LOGGER.debug("Attempting call Prowl service at %s", url)
         session = async_get_clientsession(self._hass)


### PR DESCRIPTION
Reverts home-assistant/core#46427

I think the changes suggested have failed and this has caused the prowl integration to fail ... "data:" is not a required field, and the change assumed it would be there? Apologies, I should have fully tested it again.

"    if data.get("url"):
AttributeError: 'NoneType' object has no attribute 'get'"

I know my initial worked, not sure what the emergency fix methodology is for this .. 

This worked fine and checked whether or not it was set.
        if data.get("url") is not None:
            payload["url"] = data.get("url")

It's not an important change, and I'd pull it asap to make sure the functionality runs for users. I presume I will need to start the process of integration again from the start?


fixes #48864