### PR TITLE
Add helper to get an entity's supported features

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -10,14 +10,9 @@ import voluptuous as vol
 import voluptuous_serialize
 
 from homeassistant.components import websocket_api
-from homeassistant.const import (
-    ATTR_SUPPORTED_FEATURES,
-    CONF_DEVICE_ID,
-    CONF_DOMAIN,
-    CONF_PLATFORM,
-)
+from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.loader import IntegrationNotFound
 from homeassistant.requirements import async_get_integration_with_requirements
@@ -183,23 +178,6 @@ async def _async_get_device_automation_capabilities(hass, automation_type, autom
         )
 
     return capabilities
-
-
-def get_supported_features(hass: HomeAssistant, entity_id: str) -> int:
-    """Get supported features for an entity.
-
-    First try the statemachine, then registry.
-    """
-    state = hass.states.get(entity_id)
-    if state:
-        return state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-
-    entity_registry = er.async_get(hass)
-    entry = entity_registry.async_get(entity_id)
-    if not entry:
-        return 0
-
-    return entry.supported_features or 0
 
 
 def handle_device_errors(func):

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -10,9 +10,14 @@ import voluptuous as vol
 import voluptuous_serialize
 
 from homeassistant.components import websocket_api
-from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_PLATFORM
+from homeassistant.const import (
+    ATTR_SUPPORTED_FEATURES,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_device
 from homeassistant.loader import IntegrationNotFound
 from homeassistant.requirements import async_get_integration_with_requirements
@@ -178,6 +183,23 @@ async def _async_get_device_automation_capabilities(hass, automation_type, autom
         )
 
     return capabilities
+
+
+def get_supported_features(hass: HomeAssistant, entity_id: str) -> int:
+    """Get supported features for an entity.
+
+    First try the statemachine, then registry.
+    """
+    state = hass.states.get(entity_id)
+    if state:
+        return state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(entity_id)
+    if not entry:
+        return 0
+
+    return entry.supported_features or 0
 
 
 def handle_device_errors(func):

--- a/homeassistant/components/light/device_action.py
+++ b/homeassistant/components/light/device_action.py
@@ -3,10 +3,7 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import (
-    get_supported_features,
-    toggle_entity,
-)
+from homeassistant.components.device_automation import toggle_entity
 from homeassistant.components.light import (
     ATTR_FLASH,
     FLASH_SHORT,
@@ -15,8 +12,9 @@ from homeassistant.components.light import (
     VALID_FLASH,
 )
 from homeassistant.const import ATTR_ENTITY_ID, CONF_DOMAIN, CONF_TYPE, SERVICE_TURN_ON
-from homeassistant.core import Context, HomeAssistant
+from homeassistant.core import Context, HomeAssistant, HomeAssistantError
 from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.entity import get_supported_features
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
 from . import ATTR_BRIGHTNESS_PCT, ATTR_BRIGHTNESS_STEP_PCT, DOMAIN, SUPPORT_BRIGHTNESS
@@ -85,7 +83,10 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
         if entry.domain != DOMAIN:
             continue
 
-        supported_features = get_supported_features(hass, entry.entity_id)
+        try:
+            supported_features = get_supported_features(hass, entry.entity_id)
+        except HomeAssistantError:
+            supported_features = 0
 
         if supported_features & SUPPORT_BRIGHTNESS:
             actions.extend(

--- a/homeassistant/components/light/device_action.py
+++ b/homeassistant/components/light/device_action.py
@@ -83,10 +83,7 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
         if entry.domain != DOMAIN:
             continue
 
-        try:
-            supported_features = get_supported_features(hass, entry.entity_id)
-        except HomeAssistantError:
-            supported_features = 0
+        supported_features = get_supported_features(hass, entry.entity_id)
 
         if supported_features & SUPPORT_BRIGHTNESS:
             actions.extend(
@@ -126,7 +123,10 @@ async def async_get_action_capabilities(hass: HomeAssistant, config: dict) -> di
     if config[CONF_TYPE] != toggle_entity.CONF_TURN_ON:
         return {}
 
-    supported_features = get_supported_features(hass, config[ATTR_ENTITY_ID])
+    try:
+        supported_features = get_supported_features(hass, config[ATTR_ENTITY_ID])
+    except HomeAssistantError:
+        supported_features = 0
 
     extra_fields = {}
 

--- a/homeassistant/components/light/device_action.py
+++ b/homeassistant/components/light/device_action.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import voluptuous as vol
 
-from homeassistant.components.device_automation import toggle_entity
+from homeassistant.components.device_automation import (
+    get_supported_features,
+    toggle_entity,
+)
 from homeassistant.components.light import (
     ATTR_FLASH,
     FLASH_SHORT,
@@ -11,13 +14,7 @@ from homeassistant.components.light import (
     VALID_BRIGHTNESS_PCT,
     VALID_FLASH,
 )
-from homeassistant.const import (
-    ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
-    CONF_DOMAIN,
-    CONF_TYPE,
-    SERVICE_TURN_ON,
-)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_DOMAIN, CONF_TYPE, SERVICE_TURN_ON
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_registry
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
@@ -88,12 +85,7 @@ async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
         if entry.domain != DOMAIN:
             continue
 
-        state = hass.states.get(entry.entity_id)
-
-        if state:
-            supported_features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        else:
-            supported_features = entry.supported_features
+        supported_features = get_supported_features(hass, entry.entity_id)
 
         if supported_features & SUPPORT_BRIGHTNESS:
             actions.extend(
@@ -133,16 +125,7 @@ async def async_get_action_capabilities(hass: HomeAssistant, config: dict) -> di
     if config[CONF_TYPE] != toggle_entity.CONF_TURN_ON:
         return {}
 
-    registry = await entity_registry.async_get_registry(hass)
-    entry = registry.async_get(config[ATTR_ENTITY_ID])
-    state = hass.states.get(config[ATTR_ENTITY_ID])
-
-    supported_features = 0
-
-    if state:
-        supported_features = state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-    elif entry:
-        supported_features = entry.supported_features
+    supported_features = get_supported_features(hass, config[ATTR_ENTITY_ID])
 
     extra_fields = {}
 

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -29,6 +29,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, NoEntitySpecifiedError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import EntityPlatform
 from homeassistant.helpers.entity_registry import RegistryEntry
 from homeassistant.helpers.event import Event, async_track_entity_registry_updated_event
@@ -84,6 +85,23 @@ def async_generate_entity_id(
         test_string = f"{preferred_string}_{tries}"
 
     return test_string
+
+
+def get_supported_features(hass: HomeAssistant, entity_id: str) -> int:
+    """Get supported features for an entity.
+
+    First try the statemachine, then entity registry.
+    """
+    state = hass.states.get(entity_id)
+    if state:
+        return state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+
+    entity_registry = er.async_get(hass)
+    entry = entity_registry.async_get(entity_id)
+    if not entry:
+        raise HomeAssistantError(f"Unknown entity {entity_id}")
+
+    return entry.supported_features or 0
 
 
 class Entity(ABC):

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -123,7 +123,87 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
         assert capabilities == {"extra_fields": []}
 
 
-async def test_get_action_capabilities_brightness(hass, device_reg, entity_reg):
+@pytest.mark.parametrize(
+    "set_state,num_actions,supported_features_reg,supported_features_state,expected_capabilities",
+    [
+        (
+            False,
+            5,
+            SUPPORT_BRIGHTNESS,
+            0,
+            {
+                "turn_on": [
+                    {
+                        "name": "brightness_pct",
+                        "optional": True,
+                        "type": "float",
+                        "valueMax": 100,
+                        "valueMin": 0,
+                    }
+                ]
+            },
+        ),
+        (
+            True,
+            5,
+            0,
+            SUPPORT_BRIGHTNESS,
+            {
+                "turn_on": [
+                    {
+                        "name": "brightness_pct",
+                        "optional": True,
+                        "type": "float",
+                        "valueMax": 100,
+                        "valueMin": 0,
+                    }
+                ]
+            },
+        ),
+        (
+            False,
+            4,
+            SUPPORT_FLASH,
+            0,
+            {
+                "turn_on": [
+                    {
+                        "name": "flash",
+                        "optional": True,
+                        "type": "select",
+                        "options": [("short", "short"), ("long", "long")],
+                    }
+                ]
+            },
+        ),
+        (
+            True,
+            4,
+            0,
+            SUPPORT_FLASH,
+            {
+                "turn_on": [
+                    {
+                        "name": "flash",
+                        "optional": True,
+                        "type": "select",
+                        "options": [("short", "short"), ("long", "long")],
+                    }
+                ]
+            },
+        ),
+    ],
+)
+async def test_get_action_capabilities_brightness(
+    hass,
+    device_reg,
+    entity_reg,
+    set_state,
+    num_actions,
+    supported_features_reg,
+    supported_features_state,
+    expected_capabilities,
+):
     """Test we get the expected capabilities from a light action."""
     config_entry = MockConfigEntry(domain="test", data={})
     config_entry.add_to_hass(hass)
@@ -131,74 +211,26 @@ async def test_get_action_capabilities_brightness(hass, device_reg, entity_reg):
         config_entry_id=config_entry.entry_id,
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_reg.async_get_or_create(
+    entity_id = entity_reg.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
         device_id=device_entry.id,
-        supported_features=SUPPORT_BRIGHTNESS,
-    )
+        supported_features=supported_features_reg,
+    ).entity_id
+    if set_state:
+        hass.states.async_set(
+            entity_id, None, {"supported_features": supported_features_state}
+        )
 
-    expected_capabilities = {
-        "extra_fields": [
-            {
-                "name": "brightness_pct",
-                "optional": True,
-                "type": "float",
-                "valueMax": 100,
-                "valueMin": 0,
-            }
-        ]
-    }
     actions = await async_get_device_automations(hass, "action", device_entry.id)
-    assert len(actions) == 5
+    assert len(actions) == num_actions
     for action in actions:
         capabilities = await async_get_device_automation_capabilities(
             hass, "action", action
         )
-        if action["type"] == "turn_on":
-            assert capabilities == expected_capabilities
-        else:
-            assert capabilities == {"extra_fields": []}
-
-
-async def test_get_action_capabilities_flash(hass, device_reg, entity_reg):
-    """Test we get the expected capabilities from a light action."""
-    config_entry = MockConfigEntry(domain="test", data={})
-    config_entry.add_to_hass(hass)
-    device_entry = device_reg.async_get_or_create(
-        config_entry_id=config_entry.entry_id,
-        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-    )
-    entity_reg.async_get_or_create(
-        DOMAIN,
-        "test",
-        "5678",
-        device_id=device_entry.id,
-        supported_features=SUPPORT_FLASH,
-    )
-
-    expected_capabilities = {
-        "extra_fields": [
-            {
-                "name": "flash",
-                "optional": True,
-                "type": "select",
-                "options": [("short", "short"), ("long", "long")],
-            }
-        ]
-    }
-
-    actions = await async_get_device_automations(hass, "action", device_entry.id)
-    assert len(actions) == 4
-    for action in actions:
-        capabilities = await async_get_device_automation_capabilities(
-            hass, "action", action
-        )
-        if action["type"] == "turn_on":
-            assert capabilities == expected_capabilities
-        else:
-            assert capabilities == {"extra_fields": []}
+        expected = {"extra_fields": expected_capabilities.get(action["type"], [])}
+        assert capabilities == expected
 
 
 async def test_action(hass, calls):
@@ -209,7 +241,7 @@ async def test_action(hass, calls):
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 
-    ent1, ent2, ent3 = platform.ENTITIES
+    ent1 = platform.ENTITIES[0]
 
     assert await async_setup_component(
         hass,

--- a/tests/components/light/test_device_action.py
+++ b/tests/components/light/test_device_action.py
@@ -107,15 +107,23 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
         config_entry_id=config_entry.entry_id,
         connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
     )
-    entity_reg.async_get_or_create(
+    # Test with entity without optional capabilities
+    entity_id = entity_reg.async_get_or_create(
         DOMAIN,
         "test",
         "5678",
         device_id=device_entry.id,
-    )
-
+    ).entity_id
     actions = await async_get_device_automations(hass, "action", device_entry.id)
     assert len(actions) == 3
+    for action in actions:
+        capabilities = await async_get_device_automation_capabilities(
+            hass, "action", action
+        )
+        assert capabilities == {"extra_fields": []}
+
+    # Test without entity
+    entity_reg.async_remove(entity_id)
     for action in actions:
         capabilities = await async_get_device_automation_capabilities(
             hass, "action", action
@@ -194,7 +202,7 @@ async def test_get_action_capabilities(hass, device_reg, entity_reg):
         ),
     ],
 )
-async def test_get_action_capabilities_brightness(
+async def test_get_action_capabilities_features(
     hass,
     device_reg,
     entity_reg,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add helper `get_supported_features` to get an entity's supported features, the helper is intended to be used for device automations.
The helper will first attempt to get supported features from the state machine, and if that fails fall back to the registry entry.

If we don't check the entity registry, automations will break if edited when the entity is not added to the state machine.
The reason for checking the state machine is a best effort attempt to handle integrations which (incorrectly) update supported features in the state machine but not the registry.

This PR doesn't affect the behavior of light device actions, but the intention is to use the same helper in other integrations which currently only check the state machine for supported features thus breaking automations edited when the entity is not added to the state machine.

Also:
 - Use the newly added helper for light device actions.
 - Improve light device action tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
