### PR TITLE
Log an error if modbus Cover is not initialized correctly

### DIFF
--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+import logging
 from typing import Any
 
 from pymodbus.exceptions import ConnectionException, ModbusException
@@ -35,6 +36,8 @@ from .const import (
 )
 from .modbus import ModbusHub
 
+_LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -44,6 +47,11 @@ async def async_setup_platform(
 ):
     """Read configuration and create Modbus cover."""
     if discovery_info is None:
+        _LOGGER.error(
+            "You're trying to init Modbus Cover in an unsupported way."
+            " Check https://www.home-assistant.io/integrations/modbus/#configuring-platform-cover"
+            " and fix your configuration"
+        )
         return
 
     covers = []

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -47,7 +47,7 @@ async def async_setup_platform(
 ):
     """Read configuration and create Modbus cover."""
     if discovery_info is None:
-        _LOGGER.error(
+        _LOGGER.warning(
             "You're trying to init Modbus Cover in an unsupported way."
             " Check https://www.home-assistant.io/integrations/modbus/#configuring-platform-cover"
             " and fix your configuration"

--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -44,6 +44,7 @@ async def base_test(
     check_config_only=False,
     config_modbus=None,
     scan_interval=None,
+    expect_init_to_fail=False,
 ):
     """Run test on device for given config."""
 
@@ -107,7 +108,10 @@ async def base_test(
         if config_device is not None:
             entity_id = f"{entity_domain}.{device_name}"
             device = hass.states.get(entity_id)
-            if device is None:
+
+            if expect_init_to_fail:
+                assert device is None
+            elif device is None:
                 pytest.fail("CONFIG failed, see output")
         if check_config_only:
             return
@@ -132,6 +136,7 @@ async def base_config_test(
     array_name_old_config,
     method_discovery=False,
     config_modbus=None,
+    expect_init_to_fail=False,
 ):
     """Check config of device for given config."""
 
@@ -147,4 +152,5 @@ async def base_config_test(
         method_discovery=method_discovery,
         check_config_only=True,
         config_modbus=config_modbus,
+        expect_init_to_fail=expect_init_to_fail,
     )

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -1,8 +1,12 @@
 """The tests for the Modbus cover component."""
+from unittest import mock
+
 import pytest
 
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.modbus import cover
 from homeassistant.components.modbus.const import CALL_TYPE_COIL, CONF_REGISTER
+from homeassistant.components.modbus.cover import async_setup_platform
 from homeassistant.const import (
     CONF_COVERS,
     CONF_NAME,
@@ -117,7 +121,7 @@ async def test_coil_cover(hass, regs, expected):
         ),
     ],
 )
-async def test_register_COVER(hass, regs, expected):
+async def test_register_cover(hass, regs, expected):
     """Run test for given config."""
     cover_name = "modbus_test_cover"
     state = await base_test(
@@ -137,3 +141,11 @@ async def test_register_COVER(hass, regs, expected):
         scan_interval=5,
     )
     assert state == expected
+
+
+async def test_unsupported_config(hass):
+    """When user tries to run this component without discovery_info, print an error."""
+    with mock.patch.object(cover, "_LOGGER") as mock_logger:
+        await async_setup_platform(hass, {}, None, None)
+        await hass.async_block_till_done()
+        assert mock_logger.error.called

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -1,10 +1,9 @@
 """The tests for the Modbus cover component."""
-from unittest import mock
+import logging
 
 import pytest
 
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
-from homeassistant.components.modbus import cover
 from homeassistant.components.modbus.const import CALL_TYPE_COIL, CONF_REGISTER
 from homeassistant.components.modbus.cover import async_setup_platform
 from homeassistant.const import (
@@ -143,9 +142,13 @@ async def test_register_cover(hass, regs, expected):
     assert state == expected
 
 
-async def test_unsupported_config(hass):
+async def test_unsupported_config(hass, caplog):
     """When user tries to run this component without discovery_info, print an error."""
-    with mock.patch.object(cover, "_LOGGER") as mock_logger:
-        await async_setup_platform(hass, {}, None, None)
-        await hass.async_block_till_done()
-        assert mock_logger.error.called
+    caplog.set_level(logging.WARNING)
+    caplog.clear()
+
+    await async_setup_platform(hass, {}, None, None)
+    await hass.async_block_till_done()
+
+    assert len(caplog.records) == 1
+    assert caplog.records[0].levelname == "WARNING"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds an error message to the log, if user tries to initialize `Cover`
in an unsupported way, i.e., the `discovery_info` dictionary is `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
