### PR TITLE
Improve enter and exit criteria for zones

### DIFF
--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -63,6 +63,8 @@ class BaseTrackerEntity(Entity):
 class TrackerEntity(BaseTrackerEntity):
     """Base class for a tracked device."""
 
+    _zone_state = None
+
     @property
     def should_poll(self):
         """No polling for entities that have location pushed."""
@@ -103,15 +105,19 @@ class TrackerEntity(BaseTrackerEntity):
             return self.location_name
 
         if self.latitude is not None:
-            zone_state = zone.async_active_zone(
-                self.hass, self.latitude, self.longitude, self.location_accuracy
+            self._zone_state = zone.async_active_zone(
+                self.hass,
+                self.latitude,
+                self.longitude,
+                self.location_accuracy,
+                self._zone_state,
             )
-            if zone_state is None:
+            if self._zone_state is None:
                 state = STATE_NOT_HOME
-            elif zone_state.entity_id == zone.ENTITY_ID_HOME:
+            elif self._zone_state.entity_id == zone.ENTITY_ID_HOME:
                 state = STATE_HOME
             else:
-                state = zone_state.name
+                state = self._zone_state.name
             return state
 
         return None

--- a/homeassistant/components/device_tracker/config_entry.py
+++ b/homeassistant/components/device_tracker/config_entry.py
@@ -63,7 +63,7 @@ class BaseTrackerEntity(Entity):
 class TrackerEntity(BaseTrackerEntity):
     """Base class for a tracked device."""
 
-    _zone_state = None
+    _current_zone = None
 
     @property
     def should_poll(self):
@@ -105,19 +105,20 @@ class TrackerEntity(BaseTrackerEntity):
             return self.location_name
 
         if self.latitude is not None:
-            self._zone_state = zone.async_active_zone(
+            zone_state = zone.async_active_zone(
                 self.hass,
                 self.latitude,
                 self.longitude,
                 self.location_accuracy,
-                self._zone_state,
+                self._current_zone,
             )
-            if self._zone_state is None:
+            self._current_zone = zone_state.entity_id if zone_state else None
+            if zone_state is None:
                 state = STATE_NOT_HOME
-            elif self._zone_state.entity_id == zone.ENTITY_ID_HOME:
+            elif zone_state.entity_id == zone.ENTITY_ID_HOME:
                 state = STATE_HOME
             else:
-                state = self._zone_state.name
+                state = zone_state.name
             return state
 
         return None

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -608,6 +608,7 @@ class Device(RestoreEntity):
     battery: int = None
     attributes: dict = None
     icon: str = None
+    _zone_state = None
 
     # Track if the last update of this device was HOME.
     last_update_home = False
@@ -753,15 +754,15 @@ class Device(RestoreEntity):
         if self.location_name:
             self._state = self.location_name
         elif self.gps is not None and self.source_type == SOURCE_TYPE_GPS:
-            zone_state = zone.async_active_zone(
-                self.hass, self.gps[0], self.gps[1], self.gps_accuracy
+            self._zone_state = zone.async_active_zone(
+                self.hass, self.gps[0], self.gps[1], self.gps_accuracy, self._zone_state
             )
-            if zone_state is None:
+            if self._zone_state is None:
                 self._state = STATE_NOT_HOME
-            elif zone_state.entity_id == zone.ENTITY_ID_HOME:
+            elif self._zone_state.entity_id == zone.ENTITY_ID_HOME:
                 self._state = STATE_HOME
             else:
-                self._state = zone_state.name
+                self._state = self._zone_state.name
         elif self.stale():
             self.mark_stale()
         else:

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -608,7 +608,7 @@ class Device(RestoreEntity):
     battery: int = None
     attributes: dict = None
     icon: str = None
-    _zone_state = None
+    _current_zone = None
 
     # Track if the last update of this device was HOME.
     last_update_home = False
@@ -754,15 +754,20 @@ class Device(RestoreEntity):
         if self.location_name:
             self._state = self.location_name
         elif self.gps is not None and self.source_type == SOURCE_TYPE_GPS:
-            self._zone_state = zone.async_active_zone(
-                self.hass, self.gps[0], self.gps[1], self.gps_accuracy, self._zone_state
+            zone_state = zone.async_active_zone(
+                self.hass,
+                self.gps[0],
+                self.gps[1],
+                self.gps_accuracy,
+                self._current_zone,
             )
-            if self._zone_state is None:
+            self._current_zone = zone_state.entity_id if zone_state else None
+            if zone_state is None:
                 self._state = STATE_NOT_HOME
-            elif self._zone_state.entity_id == zone.ENTITY_ID_HOME:
+            elif zone_state.entity_id == zone.ENTITY_ID_HOME:
                 self._state = STATE_HOME
             else:
-                self._state = self._zone_state.name
+                self._state = zone_state.name
         elif self.stale():
             self.mark_stale()
         else:

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -102,6 +102,7 @@ class IcloudAccount:
         self._devices = {}
         self._retried_fetch = False
         self._config_entry = config_entry
+        self._current_zone = None
 
         self.listeners = []
 
@@ -257,8 +258,10 @@ class IcloudAccount:
                 device.location[DEVICE_LOCATION_LATITUDE],
                 device.location[DEVICE_LOCATION_LONGITUDE],
                 device.location[DEVICE_LOCATION_HORIZONTAL_ACCURACY],
+                self._current_zone,
             ).result()
 
+            self._current_zone = current_zone.entity_id if current_zone else None
             # Max interval if in zone
             if current_zone is not None:
                 continue

--- a/homeassistant/components/life360/device_tracker.py
+++ b/homeassistant/components/life360/device_tracker.py
@@ -137,6 +137,7 @@ class Life360Scanner:
         self._dev_data = {}
         self._circles_logged = set()
         self._members_logged = set()
+        self._current_zone = None
 
         _dump_filter(self._circles_filter, "Circles")
         _dump_filter(self._members_filter, "device IDs", self._dev_id)
@@ -317,8 +318,15 @@ class Life360Scanner:
         # location is not in a HA zone, then set location name accordingly.
         loc_name = None
         active_zone = run_callback_threadsafe(
-            self._hass.loop, async_active_zone, self._hass, lat, lon, gps_accuracy
+            self._hass.loop,
+            async_active_zone,
+            self._hass,
+            lat,
+            lon,
+            gps_accuracy,
+            self._current_zone,
         ).result()
+        self._current_zone = active_zone.entity_id if active_zone else None
         if not active_zone:
             if SHOW_DRIVING in self._show_as_state and driving is True:
                 loc_name = SHOW_DRIVING

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -101,7 +101,7 @@ def _set_gps_from_zone(kwargs, location, zone):
             zone.attributes[ATTR_LATITUDE],
             zone.attributes[ATTR_LONGITUDE],
         )
-        kwargs["gps_accuracy"] = zone.attributes["radius"]
+        kwargs["gps_accuracy"] = 0.0
         kwargs["location_name"] = location
     return kwargs
 

--- a/homeassistant/components/owntracks/messages.py
+++ b/homeassistant/components/owntracks/messages.py
@@ -97,6 +97,7 @@ def _set_gps_from_zone(kwargs, location, zone):
     Async friendly.
     """
     if zone is not None:
+        # Snap to the center of the zone, with perfect accuracy
         kwargs["gps"] = (
             zone.attributes[ATTR_LATITUDE],
             zone.attributes[ATTR_LONGITUDE],

--- a/homeassistant/components/traccar/__init__.py
+++ b/homeassistant/components/traccar/__init__.py
@@ -28,7 +28,7 @@ from .const import (
 TRACKER_UPDATE = f"{DOMAIN}_tracker_update"
 
 
-DEFAULT_ACCURACY = HTTP_OK
+DEFAULT_ACCURACY = 200
 DEFAULT_BATTERY = -1
 
 

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -127,7 +127,7 @@ def async_active_zone(
         )
         if zone_dist is not None:
             # Still within zone if zone and location circles intersect
-            within_zone = zone_dist <= current_zone.attributes[ATTR_RADIUS] + radius
+            within_zone = zone_dist < current_zone.attributes[ATTR_RADIUS] + radius
 
             if within_zone:
                 min_dist = zone_dist
@@ -148,7 +148,7 @@ def async_active_zone(
             continue
 
         # Within zone if location circle is inside zone
-        within_zone = zone_dist + radius <= zone.attributes[ATTR_RADIUS]
+        within_zone = zone_dist + radius < zone.attributes[ATTR_RADIUS]
         closer_zone = closest is None or zone_dist < min_dist  # type: ignore
         smaller_zone = (
             zone_dist == min_dist

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -198,7 +198,8 @@ def in_zone(zone: State, latitude: float, longitude: float, radius: float = 0) -
 
     if zone_dist is None or zone.attributes[ATTR_RADIUS] is None:
         return False
-    return zone_dist - radius < cast(float, zone.attributes[ATTR_RADIUS])
+    # Within zone if location circle is inside zone
+    return zone_dist + radius < cast(float, zone.attributes[ATTR_RADIUS])
 
 
 class ZoneStorageCollection(collection.StorageCollection):

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -110,6 +110,10 @@ def async_active_zone(
     min_dist = None
     closest = None
 
+    # Update state of current_zone
+    if current_zone:
+        current_zone = hass.states.get(current_zone.entity_id)
+
     if (
         current_zone
         and current_zone.state != STATE_UNAVAILABLE
@@ -122,7 +126,8 @@ def async_active_zone(
             current_zone.attributes[ATTR_LONGITUDE],
         )
         if zone_dist is not None:
-            within_zone = zone_dist < current_zone.attributes[ATTR_RADIUS] + radius
+            # Still within zone if zone and location circles intersect
+            within_zone = zone_dist <= current_zone.attributes[ATTR_RADIUS] + radius
 
             if within_zone:
                 min_dist = zone_dist
@@ -142,7 +147,8 @@ def async_active_zone(
         if zone_dist is None:
             continue
 
-        within_zone = zone_dist + radius < zone.attributes[ATTR_RADIUS]
+        # Within zone if location circle is inside zone
+        within_zone = zone_dist + radius <= zone.attributes[ATTR_RADIUS]
         closer_zone = closest is None or zone_dist < min_dist  # type: ignore
         smaller_zone = (
             zone_dist == min_dist

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -95,7 +95,7 @@ def async_active_zone(
     latitude: float,
     longitude: float,
     radius: int = 0,
-    current_zone: State | None = None,
+    current_zone: str | None = None,
 ) -> State | None:
     """Find the active zone for given latitude, longitude.
 
@@ -115,31 +115,32 @@ def async_active_zone(
         latitude,
         longitude,
         radius,
-        current_zone.entity_id if current_zone else None,
+        current_zone,
     )
 
     # Update state of current_zone
-    if current_zone:
-        current_zone = hass.states.get(current_zone.entity_id)
+    current_zone_state = hass.states.get(current_zone) if current_zone else None
 
     if (
-        current_zone
-        and current_zone.state != STATE_UNAVAILABLE
-        and not current_zone.attributes.get(ATTR_PASSIVE)
+        current_zone_state
+        and current_zone_state.state != STATE_UNAVAILABLE
+        and not current_zone_state.attributes.get(ATTR_PASSIVE)
     ):
         zone_dist = distance(
             latitude,
             longitude,
-            current_zone.attributes[ATTR_LATITUDE],
-            current_zone.attributes[ATTR_LONGITUDE],
+            current_zone_state.attributes[ATTR_LATITUDE],
+            current_zone_state.attributes[ATTR_LONGITUDE],
         )
         if zone_dist is not None:
             # Still within zone if zone and location circles intersect
-            within_zone = zone_dist < current_zone.attributes[ATTR_RADIUS] + radius
+            within_zone = (
+                zone_dist < current_zone_state.attributes[ATTR_RADIUS] + radius
+            )
 
             if within_zone:
                 min_dist = zone_dist
-                closest = current_zone
+                closest = current_zone_state
 
     for zone in zones:
         if zone.state == STATE_UNAVAILABLE or zone.attributes.get(ATTR_PASSIVE):

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -110,6 +110,14 @@ def async_active_zone(
     min_dist = None
     closest = None
 
+    _LOGGER.debug(
+        "location: %s:%s/%s, current_zone: %s",
+        latitude,
+        longitude,
+        radius,
+        current_zone.entity_id if current_zone else None,
+    )
+
     # Update state of current_zone
     if current_zone:
         current_zone = hass.states.get(current_zone.entity_id)
@@ -143,6 +151,14 @@ def async_active_zone(
             zone.attributes[ATTR_LATITUDE],
             zone.attributes[ATTR_LONGITUDE],
         )
+        _LOGGER.debug(
+            "zone %s: %s:%s/%s, distance: %s",
+            zone.entity_id,
+            zone.attributes[ATTR_LATITUDE],
+            zone.attributes[ATTR_LONGITUDE],
+            zone.attributes[ATTR_RADIUS],
+            zone_dist,
+        )
 
         if zone_dist is None:
             continue
@@ -160,6 +176,7 @@ def async_active_zone(
             min_dist = zone_dist
             closest = zone
 
+    _LOGGER.debug("closest zone: %s", closest.entity_id if closest else None)
     return closest
 
 

--- a/tests/components/gpslogger/test_init.py
+++ b/tests/components/gpslogger/test_init.py
@@ -110,7 +110,12 @@ async def test_enter_and_exit(hass, gpslogger_client, webhook_id):
     """Test when there is a known zone."""
     url = f"/api/webhook/{webhook_id}"
 
-    data = {"latitude": HOME_LATITUDE, "longitude": HOME_LONGITUDE, "device": "123"}
+    data = {
+        "latitude": HOME_LATITUDE,
+        "longitude": HOME_LONGITUDE,
+        "device": "123",
+        "accuracy": 99,
+    }
 
     # Enter the Home
     req = await gpslogger_client.post(url, data=data)
@@ -177,7 +182,7 @@ async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
         "latitude": HOME_LATITUDE,
         "longitude": HOME_LONGITUDE,
         "device": "123",
-        "accuracy": 123,
+        "accuracy": 99,
         "battery": 23,
         "speed": 23,
         "direction": 123,
@@ -191,7 +196,7 @@ async def test_enter_with_attrs(hass, gpslogger_client, webhook_id):
     assert req.status == HTTP_OK
     state = hass.states.get(f"{DEVICE_TRACKER_DOMAIN}.{data['device']}")
     assert state.state == STATE_HOME
-    assert state.attributes["gps_accuracy"] == 123
+    assert state.attributes["gps_accuracy"] == 99
     assert state.attributes["battery_level"] == 23
     assert state.attributes["speed"] == 23
     assert state.attributes["direction"] == 123

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -37,7 +37,7 @@ CONF_REGION_MAPPING = owntracks.CONF_REGION_MAPPING
 
 TEST_ZONE_LAT = 45.0
 TEST_ZONE_LON = 90.0
-TEST_ZONE_DEG_PER_M = 0.0000010
+TEST_ZONE_DEG_PER_M = 0.0000127
 FIVE_M = TEST_ZONE_DEG_PER_M * 5.0
 
 
@@ -69,7 +69,7 @@ DEFAULT_LOCATION_MESSAGE = {
     "_type": "location",
     "lon": OUTER_ZONE["longitude"],
     "lat": OUTER_ZONE["latitude"],
-    "acc": 10,
+    "acc": 40,
     "tid": "user",
     "t": "u",
     "batt": 92,
@@ -89,7 +89,7 @@ DEFAULT_TRANSITION_MESSAGE = {
     "t": "c",
     "lon": INNER_ZONE["longitude"],
     "lat": INNER_ZONE["latitude"] - ZONE_EDGE,
-    "acc": 10,
+    "acc": 40,
     "event": "enter",
     "tid": "user",
     "desc": "inner",
@@ -622,9 +622,10 @@ async def test_event_gps_entry_exit_wrong_order(hass, context):
 async def test_event_gps_entry_unknown_zone(hass, context):
     """Test the event for unknown zone."""
     # Just treat as location update
-    message = build_message({"desc": "unknown"}, REGION_GPS_ENTER_MESSAGE)
+    lat = INNER_ZONE["latitude"]
+    message = build_message({"desc": "unknown", "lat": lat}, REGION_GPS_ENTER_MESSAGE)
     await send_message(hass, EVENT_TOPIC, message)
-    assert_location_latitude(hass, REGION_GPS_ENTER_MESSAGE["lat"])
+    assert_location_latitude(hass, lat)
     assert_location_state(hass, "inner")
 
 

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -37,7 +37,7 @@ CONF_REGION_MAPPING = owntracks.CONF_REGION_MAPPING
 
 TEST_ZONE_LAT = 45.0
 TEST_ZONE_LON = 90.0
-TEST_ZONE_DEG_PER_M = 0.0000127
+TEST_ZONE_DEG_PER_M = 0.0000010
 FIVE_M = TEST_ZONE_DEG_PER_M * 5.0
 
 
@@ -69,7 +69,7 @@ DEFAULT_LOCATION_MESSAGE = {
     "_type": "location",
     "lon": OUTER_ZONE["longitude"],
     "lat": OUTER_ZONE["latitude"],
-    "acc": 60,
+    "acc": 10,
     "tid": "user",
     "t": "u",
     "batt": 92,
@@ -89,7 +89,7 @@ DEFAULT_TRANSITION_MESSAGE = {
     "t": "c",
     "lon": INNER_ZONE["longitude"],
     "lat": INNER_ZONE["latitude"] - ZONE_EDGE,
-    "acc": 60,
+    "acc": 10,
     "event": "enter",
     "tid": "user",
     "desc": "inner",

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -461,7 +461,7 @@ async def test_event_gps_entry_exit(hass, context):
 
     # Enter uses the zone's gps co-ords
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -472,7 +472,7 @@ async def test_event_gps_entry_exit(hass, context):
     #  received a transition message though so I'm still
     #  associated with the inner zone regardless of GPS.
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     await send_message(hass, EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE)
@@ -514,7 +514,7 @@ async def test_event_gps_entry_inaccurate(hass, context):
 
     # I enter the zone even though the message GPS was inaccurate.
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
 
@@ -524,14 +524,14 @@ async def test_event_gps_entry_exit_inaccurate(hass, context):
 
     # Enter uses the zone's gps co-ords
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     await send_message(hass, EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE_INACCURATE)
 
     # Exit doesn't use inaccurate gps
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     # But does exit region correctly
@@ -544,14 +544,14 @@ async def test_event_gps_entry_exit_zero_accuracy(hass, context):
 
     # Enter uses the zone's gps co-ords
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     await send_message(hass, EVENT_TOPIC, REGION_GPS_LEAVE_MESSAGE_ZERO)
 
     # Exit doesn't use zero gps
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     # But does exit region correctly
@@ -725,7 +725,7 @@ async def test_event_region_entry_exit(hass, context):
 
     # Enter uses the zone's gps co-ords
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     await send_message(hass, LOCATION_TOPIC, LOCATION_MESSAGE)
@@ -736,7 +736,7 @@ async def test_event_region_entry_exit(hass, context):
     #  received a transition message though so I'm still
     #  associated with the inner zone regardless of GPS.
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     await send_message(hass, EVENT_TOPIC, REGION_BEACON_LEAVE_MESSAGE)
@@ -745,7 +745,7 @@ async def test_event_region_entry_exit(hass, context):
     # so I am still located at the center of the inner region
     # until I receive a location update.
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
     # Left clean zone state
@@ -797,7 +797,7 @@ async def test_event_region_entry_exit_right_order(hass, context):
     # coordinates are set to the center of the last region I
     # entered which puts me in the inner zone.
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner")
 
 
@@ -824,7 +824,7 @@ async def test_event_region_entry_exit_wrong_order(hass, context):
     # coordinates are set to the center of the last region I
     # entered which puts me in the inner_2 zone.
     assert_location_latitude(hass, INNER_ZONE["latitude"])
-    assert_location_accuracy(hass, INNER_ZONE["radius"])
+    assert_location_accuracy(hass, 0.0)
     assert_location_state(hass, "inner_2")
 
 

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -1116,10 +1116,7 @@ async def test_complex_movement_sticky_keys_beacon(hass, context):
 
     # gps to inner location and event, as actually happens with OwnTracks
     location_message = build_message(
-        {
-            "lat": REGION_GPS_ENTER_MESSAGE["lat"],
-            "lon": REGION_GPS_ENTER_MESSAGE["lon"],
-        },
+        {"acc": 40, "lat": INNER_ZONE["latitude"], "lon": INNER_ZONE["longitude"]},
         LOCATION_MESSAGE,
     )
     await send_message(hass, LOCATION_TOPIC, location_message)
@@ -1130,6 +1127,7 @@ async def test_complex_movement_sticky_keys_beacon(hass, context):
     # see keys mobile beacon and location message as actually happens
     location_message = build_message(
         {
+            "acc": 40,
             "lat": location_message["lat"] + FIVE_M,
             "lon": location_message["lon"] + FIVE_M,
         },
@@ -1146,6 +1144,7 @@ async def test_complex_movement_sticky_keys_beacon(hass, context):
     # with OwnTracks
     location_message = build_message(
         {
+            "acc": 40,
             "lat": location_message["lat"] + FIVE_M,
             "lon": location_message["lon"] + FIVE_M,
         },

--- a/tests/components/owntracks/test_device_tracker.py
+++ b/tests/components/owntracks/test_device_tracker.py
@@ -69,7 +69,7 @@ DEFAULT_LOCATION_MESSAGE = {
     "_type": "location",
     "lon": OUTER_ZONE["longitude"],
     "lat": OUTER_ZONE["latitude"],
-    "acc": 40,
+    "acc": 60,
     "tid": "user",
     "t": "u",
     "batt": 92,
@@ -89,7 +89,7 @@ DEFAULT_TRANSITION_MESSAGE = {
     "t": "c",
     "lon": INNER_ZONE["longitude"],
     "lat": INNER_ZONE["latitude"] - ZONE_EDGE,
-    "acc": 40,
+    "acc": 60,
     "event": "enter",
     "tid": "user",
     "desc": "inner",
@@ -623,7 +623,9 @@ async def test_event_gps_entry_unknown_zone(hass, context):
     """Test the event for unknown zone."""
     # Just treat as location update
     lat = INNER_ZONE["latitude"]
-    message = build_message({"desc": "unknown", "lat": lat}, REGION_GPS_ENTER_MESSAGE)
+    message = build_message(
+        {"desc": "unknown", "lat": lat, "acc": 40}, REGION_GPS_ENTER_MESSAGE
+    )
     await send_message(hass, EVENT_TOPIC, message)
     assert_location_latitude(hass, lat)
     assert_location_state(hass, "inner")

--- a/tests/components/traccar/test_init.py
+++ b/tests/components/traccar/test_init.py
@@ -51,7 +51,7 @@ async def setup_zones(loop, hass):
                 "name": "Home",
                 "latitude": HOME_LATITUDE,
                 "longitude": HOME_LONGITUDE,
-                "radius": 100,
+                "radius": traccar.DEFAULT_ACCURACY + 1,
             }
         },
     )

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -802,3 +802,28 @@ async def test_unavailable_zone(hass):
     assert zone.async_active_zone(hass, 0.0, 0.01) is None
 
     assert zone.in_zone(hass.states.get("zone.bla"), 0, 0) is False
+
+
+async def test_leave_unavailable_zone(hass):
+    """Test we leave a zone which becomes unavailable."""
+    attributes = {"latitude": 0.0, "longitude": 0.01, "radius": 100}
+    assert await setup.async_setup_component(hass, DOMAIN, {"zone": {}})
+    hass.states.async_set("zone.bla", "", attributes)
+    active = zone.async_active_zone(hass, 0.0, 0.01, 0, "zone.bla")
+    assert active.entity_id == "zone.bla"
+
+    hass.states.async_set("zone.bla", "unavailable", attributes)
+    assert zone.async_active_zone(hass, 0.0, 0.01, 0, active.entity_id) is None
+
+
+async def test_leave_passive_zone(hass):
+    """Test we leave a zone which becomes passive."""
+    attributes = {"latitude": 0.0, "longitude": 0.01, "radius": 100}
+    assert await setup.async_setup_component(hass, DOMAIN, {"zone": {}})
+    hass.states.async_set("zone.bla", "", attributes)
+    active = zone.async_active_zone(hass, 0.0, 0.01, 0, "zone.bla")
+    assert active.entity_id == "zone.bla"
+
+    attributes["passive"] = True
+    hass.states.async_set("zone.bla", "", attributes)
+    assert zone.async_active_zone(hass, 0.0, 0.01, 0, active.entity_id) is None

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -210,6 +210,11 @@ def calculate_postion_from_distance(position, distance):
     return (lat, lon)
 
 
+def current_zone_entity_id(active):
+    """Return entity_id of active, or None if active is None."""
+    return active.entity_id if active else None
+
+
 async def test_setup_no_zones_still_adds_home_zone(hass):
     """Test if no config is passed in we still get the home zone."""
     assert await setup.async_setup_component(hass, zone.DOMAIN, {"zone": None})
@@ -377,11 +382,13 @@ async def test_zone_smaller_than_accuracy(hass):
     assert active is None
 
     # Should enter zone, accuracy is good enough
-    active = zone.async_active_zone(hass, latitude, longitude, 49, active)
+    current_zone = current_zone_entity_id(active)
+    active = zone.async_active_zone(hass, latitude, longitude, 49, current_zone)
     assert active.entity_id == "zone.smallest_zone"
 
     # Should remain in zone
-    active = zone.async_active_zone(hass, latitude, longitude, 51, active)
+    current_zone = current_zone_entity_id(active)
+    active = zone.async_active_zone(hass, latitude, longitude, 51, current_zone)
     assert active.entity_id == "zone.smallest_zone"
 
 
@@ -485,7 +492,8 @@ async def test_zone_criteria(hass, zone_settings, locations, expected_zones):
         distance, radius = location
         # Calculate new location
         lat, lon = calculate_postion_from_distance(origin, distance)
-        active = zone.async_active_zone(hass, lat, lon, radius, active)
+        current_zone = current_zone_entity_id(active)
+        active = zone.async_active_zone(hass, lat, lon, radius, current_zone)
         expected_zone = expected_zones[idx]
         assert_zone(active, expected_zone, idx)
 

--- a/tests/components/zone/test_init.py
+++ b/tests/components/zone/test_init.py
@@ -199,6 +199,38 @@ async def test_active_zone_prefers_smaller_zone_if_same_distance_2(hass):
     assert active.entity_id == "zone.smallest_zone"
 
 
+async def test_zone_smaller_than_accuracy(hass):
+    """Test zone size preferences."""
+    latitude = 32.880600
+    longitude = -117.237561
+    assert await setup.async_setup_component(
+        hass,
+        zone.DOMAIN,
+        {
+            "zone": [
+                {
+                    "name": "Smallest Zone",
+                    "latitude": latitude,
+                    "longitude": longitude,
+                    "radius": 50,
+                }
+            ]
+        },
+    )
+
+    # Should not enter zone, accuracy is poor
+    active = zone.async_active_zone(hass, latitude, longitude, 51)
+    assert active is None
+
+    # Should enter zone, accuracy is good enough
+    active = zone.async_active_zone(hass, latitude, longitude, 49, active)
+    assert active.entity_id == "zone.smallest_zone"
+
+    # Should remain in zone
+    active = zone.async_active_zone(hass, latitude, longitude, 51, active)
+    assert active.entity_id == "zone.smallest_zone"
+
+
 async def test_in_zone_works_for_passive_zones(hass):
     """Test working in passive zones."""
     latitude = 32.880600


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Enter and exit criteria for zones is changed:
 - Enter a zone only if the circle defined by the location and its accuracy is within the zone
 - Leave a zone if the circle defined by the location and its accuracy and the zone no longer intersect

It may be necessary to adjust radii of zones according to the new criteria.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve enter and exit criteria for zones:
 - Enter a zone only if the circle defined by the location and its accuracy is within the zone
 - Leave a zone if the circle defined by the location and its accuracy and the zone no longer intersect

### Background
Location updates from device trackers have a center location and an accuracy.
The true location of the device can be anywhere within the circle centered at location, with radius accuracy.

Likewise, zones are circular defined by a center location and a radius.

The old criteria for zones  would at every location update find the zone nearest to the center of the location update where the circles defined by the location update and the zone were overlapping, no matter how big the circle defined by the location update was.
This criteria meant it was possible to jump in to a very small zone based on a highly inaccurate location update.

To illustrate further, @justus502 made an illustration:
<img src="https://user-images.githubusercontent.com/14281572/115867224-165ab080-a43b-11eb-9deb-68d0763e321e.png" width="500" height="500">

The brown circles are the GPS-coordinates in the center and the (in)accuracy sent by the device.
The green circles are zones and their center in the middle.
The red circle is the actual location of the device.

The old code would consider the device to be within all three zones (the green circles), and would pick the one to the upper left.
The newer code will no longer enter a zone unless the location (the brown circle) is entirely within the green circle, this means none of the three zones in the illustration would be entered.
Once a zone has been entered however, less accurate location updates (a larger brown circle) are allowed, and the zone won't be exited unless the location (brown circle) is no longer overlapping the zone (the green circle).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
