### PR TITLE
2021.4.1

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -62,7 +62,7 @@ MANIFEST_JSON = {
     "screenshots": [
         {
             "src": "/static/images/screenshots/screenshot-1.png",
-            "sizes": "413×792",
+            "sizes": "413x792",
             "type": "image/png",
         }
     ],

--- a/homeassistant/components/frontend/manifest.json
+++ b/homeassistant/components/frontend/manifest.json
@@ -3,7 +3,7 @@
   "name": "Home Assistant Frontend",
   "documentation": "https://www.home-assistant.io/integrations/frontend",
   "requirements": [
-    "home-assistant-frontend==20210407.1"
+    "home-assistant-frontend==20210407.2"
   ],
   "dependencies": [
     "api",

--- a/homeassistant/components/icloud/account.py
+++ b/homeassistant/components/icloud/account.py
@@ -501,6 +501,6 @@ class IcloudDevice:
         return self._location
 
     @property
-    def exta_state_attributes(self) -> dict[str, any]:
+    def extra_state_attributes(self) -> dict[str, any]:
         """Return the attributes."""
         return self._attrs

--- a/homeassistant/components/icloud/device_tracker.py
+++ b/homeassistant/components/icloud/device_tracker.py
@@ -110,7 +110,7 @@ class IcloudTrackerEntity(TrackerEntity):
     @property
     def extra_state_attributes(self) -> dict[str, any]:
         """Return the device state attributes."""
-        return self._device.state_attributes
+        return self._device.extra_state_attributes
 
     @property
     def device_info(self) -> dict[str, any]:

--- a/homeassistant/components/icloud/sensor.py
+++ b/homeassistant/components/icloud/sensor.py
@@ -93,7 +93,7 @@ class IcloudDeviceBatterySensor(SensorEntity):
     @property
     def extra_state_attributes(self) -> dict[str, any]:
         """Return default attributes for the iCloud device entity."""
-        return self._device.state_attributes
+        return self._device.extra_state_attributes
 
     @property
     def device_info(self) -> dict[str, any]:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -73,6 +73,20 @@ VALID_COLOR_MODES = {
 COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {COLOR_MODE_ONOFF}
 COLOR_MODES_COLOR = {COLOR_MODE_HS, COLOR_MODE_RGB, COLOR_MODE_XY}
 
+
+def valid_supported_color_modes(color_modes):
+    """Validate the given color modes."""
+    color_modes = set(color_modes)
+    if (
+        not color_modes
+        or COLOR_MODE_UNKNOWN in color_modes
+        or (COLOR_MODE_BRIGHTNESS in color_modes and len(color_modes) > 1)
+        or (COLOR_MODE_ONOFF in color_modes and len(color_modes) > 1)
+    ):
+        raise vol.Error(f"Invalid supported_color_modes {sorted(color_modes)}")
+    return color_modes
+
+
 # Float that represents transition time in seconds to make change.
 ATTR_TRANSITION = "transition"
 

--- a/homeassistant/components/motion_blinds/sensor.py
+++ b/homeassistant/components/motion_blinds/sensor.py
@@ -183,10 +183,14 @@ class MotionSignalStrengthSensor(CoordinatorEntity, SensorEntity):
         if self.coordinator.data is None:
             return False
 
-        if not self.coordinator.data[KEY_GATEWAY][ATTR_AVAILABLE]:
-            return False
+        gateway_available = self.coordinator.data[KEY_GATEWAY][ATTR_AVAILABLE]
+        if self._device_type == TYPE_GATEWAY:
+            return gateway_available
 
-        return self.coordinator.data[self._device.mac][ATTR_AVAILABLE]
+        return (
+            gateway_available
+            and self.coordinator.data[self._device.mac][ATTR_AVAILABLE]
+        )
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/mqtt/light/schema_json.py
+++ b/homeassistant/components/mqtt/light/schema_json.py
@@ -35,6 +35,7 @@ from homeassistant.components.light import (
     SUPPORT_WHITE_VALUE,
     VALID_COLOR_MODES,
     LightEntity,
+    valid_supported_color_modes,
 )
 from homeassistant.const import (
     CONF_BRIGHTNESS,
@@ -130,7 +131,10 @@ PLATFORM_SCHEMA_JSON = vol.All(
             vol.Optional(CONF_RGB, default=DEFAULT_RGB): cv.boolean,
             vol.Optional(CONF_STATE_TOPIC): mqtt.valid_subscribe_topic,
             vol.Inclusive(CONF_SUPPORTED_COLOR_MODES, "color_mode"): vol.All(
-                cv.ensure_list, [vol.In(VALID_COLOR_MODES)], vol.Unique()
+                cv.ensure_list,
+                [vol.In(VALID_COLOR_MODES)],
+                vol.Unique(),
+                valid_supported_color_modes,
             ),
             vol.Optional(CONF_WHITE_VALUE, default=DEFAULT_WHITE_VALUE): cv.boolean,
             vol.Optional(CONF_XY, default=DEFAULT_XY): cv.boolean,

--- a/homeassistant/components/mysensors/cover.py
+++ b/homeassistant/components/mysensors/cover.py
@@ -70,12 +70,12 @@ class MySensorsCover(mysensors.device.MySensorsEntity, CoverEntity):
         else:
             amount = 100 if self._values.get(set_req.V_LIGHT) == STATE_ON else 0
 
+        if amount == 0:
+            return CoverState.CLOSED
         if v_up and not v_down and not v_stop:
             return CoverState.OPENING
         if not v_up and v_down and not v_stop:
             return CoverState.CLOSING
-        if not v_up and not v_down and v_stop and amount == 0:
-            return CoverState.CLOSED
         return CoverState.OPEN
 
     @property

--- a/homeassistant/components/prowl/notify.py
+++ b/homeassistant/components/prowl/notify.py
@@ -48,7 +48,7 @@ class ProwlNotificationService(BaseNotificationService):
             "description": message,
             "priority": data["priority"] if data and "priority" in data else 0,
         }
-        if data.get("url"):
+        if data and data.get("url"):
             payload["url"] = data["url"]
 
         _LOGGER.debug("Attempting call Prowl service at %s", url)

--- a/homeassistant/components/speedtestdotnet/manifest.json
+++ b/homeassistant/components/speedtestdotnet/manifest.json
@@ -3,6 +3,8 @@
   "name": "Speedtest.net",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/speedtestdotnet",
-  "requirements": ["speedtest-cli==2.1.2"],
+  "requirements": [
+    "speedtest-cli==2.1.3"
+  ],
   "codeowners": ["@rohankapoorcom", "@engrbm87"]
 }

--- a/homeassistant/components/stream/__init__.py
+++ b/homeassistant/components/stream/__init__.py
@@ -39,7 +39,12 @@ from .hls import async_setup_hls
 
 _LOGGER = logging.getLogger(__name__)
 
-STREAM_SOURCE_RE = re.compile("//(.*):(.*)@")
+STREAM_SOURCE_RE = re.compile("//.*:.*@")
+
+
+def redact_credentials(data):
+    """Redact credentials from string data."""
+    return STREAM_SOURCE_RE.sub("//****:****@", data)
 
 
 def create_stream(hass, stream_source, options=None):
@@ -176,9 +181,7 @@ class Stream:
                 target=self._run_worker,
             )
             self._thread.start()
-            _LOGGER.info(
-                "Started stream: %s", STREAM_SOURCE_RE.sub("//", str(self.source))
-            )
+            _LOGGER.info("Started stream: %s", redact_credentials(str(self.source)))
 
     def update_source(self, new_source):
         """Restart the stream with a new stream source."""
@@ -244,9 +247,7 @@ class Stream:
             self._thread_quit.set()
             self._thread.join()
             self._thread = None
-            _LOGGER.info(
-                "Stopped stream: %s", STREAM_SOURCE_RE.sub("//", str(self.source))
-            )
+            _LOGGER.info("Stopped stream: %s", redact_credentials(str(self.source)))
 
     async def async_record(self, video_path, duration=30, lookback=5):
         """Make a .mp4 recording from a provided stream."""

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -5,7 +5,7 @@ import logging
 
 import av
 
-from . import STREAM_SOURCE_RE
+from . import redact_credentials
 from .const import (
     AUDIO_CODECS,
     MAX_MISSING_DTS,
@@ -128,9 +128,7 @@ def stream_worker(source, options, segment_buffer, quit_event):
     try:
         container = av.open(source, options=options, timeout=STREAM_TIMEOUT)
     except av.AVError:
-        _LOGGER.error(
-            "Error opening stream %s", STREAM_SOURCE_RE.sub("//", str(source))
-        )
+        _LOGGER.error("Error opening stream %s", redact_credentials(str(source)))
         return
     try:
         video_stream = container.streams.video[0]

--- a/homeassistant/components/verisure/alarm_control_panel.py
+++ b/homeassistant/components/verisure/alarm_control_panel.py
@@ -112,7 +112,7 @@ class VerisureAlarm(CoordinatorEntity, AlarmControlPanelEntity):
         self._state = ALARM_STATE_TO_HA.get(
             self.coordinator.data["alarm"]["statusType"]
         )
-        self._changed_by = self.coordinator.data["alarm"]["name"]
+        self._changed_by = self.coordinator.data["alarm"].get("name")
         super()._handle_coordinator_update()
 
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -54,6 +54,7 @@ class VerisureSmartcam(CoordinatorEntity, Camera):
     ):
         """Initialize Verisure File Camera component."""
         super().__init__(coordinator)
+        Camera.__init__(self)
 
         self.serial_number = serial_number
         self._directory_path = directory_path

--- a/homeassistant/components/zwave_js/climate.py
+++ b/homeassistant/components/zwave_js/climate.py
@@ -169,11 +169,13 @@ class ZWaveClimate(ZWaveBaseEntity, ClimateEntity):
             THERMOSTAT_MODE_PROPERTY,
             CommandClass.THERMOSTAT_FAN_MODE,
             add_to_watched_value_ids=True,
+            check_all_endpoints=True,
         )
         self._fan_state = self.get_zwave_value(
             THERMOSTAT_OPERATING_STATE_PROPERTY,
             CommandClass.THERMOSTAT_FAN_STATE,
             add_to_watched_value_ids=True,
+            check_all_endpoints=True,
         )
         self._set_modes_and_presets()
         self._supported_features = 0

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 2021
 MINOR_VERSION = 4
-PATCH_VERSION = "0"
+PATCH_VERSION = "1"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 8, 0)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -16,7 +16,7 @@ defusedxml==0.6.0
 distro==1.5.0
 emoji==1.2.0
 hass-nabucasa==0.42.0
-home-assistant-frontend==20210407.1
+home-assistant-frontend==20210407.2
 httpx==0.17.1
 jinja2>=2.11.3
 netdisco==2.8.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2108,7 +2108,7 @@ sonarr==0.3.0
 speak2mary==1.4.0
 
 # homeassistant.components.speedtestdotnet
-speedtest-cli==2.1.2
+speedtest-cli==2.1.3
 
 # homeassistant.components.spider
 spiderpy==1.4.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -763,7 +763,7 @@ hole==0.5.1
 holidays==0.10.5.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20210407.1
+home-assistant-frontend==20210407.2
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -412,7 +412,7 @@ hole==0.5.1
 holidays==0.10.5.2
 
 # homeassistant.components.frontend
-home-assistant-frontend==20210407.1
+home-assistant-frontend==20210407.2
 
 # homeassistant.components.zwave
 homeassistant-pyozw==0.1.10

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1095,7 +1095,7 @@ sonarr==0.3.0
 speak2mary==1.4.0
 
 # homeassistant.components.speedtestdotnet
-speedtest-cli==2.1.2
+speedtest-cli==2.1.3
 
 # homeassistant.components.spider
 spiderpy==1.4.2

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -188,6 +188,33 @@ async def test_fail_setup_if_color_mode_deprecated(hass, mqtt_mock, deprecated):
     assert hass.states.get("light.test") is None
 
 
+@pytest.mark.parametrize(
+    "supported_color_modes", [["onoff", "rgb"], ["brightness", "rgb"], ["unknown"]]
+)
+async def test_fail_setup_if_color_modes_invalid(
+    hass, mqtt_mock, supported_color_modes
+):
+    """Test if setup fails if supported color modes is invalid."""
+    config = {
+        light.DOMAIN: {
+            "brightness": True,
+            "color_mode": True,
+            "command_topic": "test_light_rgb/set",
+            "name": "test",
+            "platform": "mqtt",
+            "schema": "json",
+            "supported_color_modes": supported_color_modes,
+        }
+    }
+    assert await async_setup_component(
+        hass,
+        light.DOMAIN,
+        config,
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get("light.test") is None
+
+
 async def test_rgb_light(hass, mqtt_mock):
     """Test RGB light flags brightness support."""
     assert await async_setup_component(

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -266,4 +266,4 @@ async def test_recorder_log(hass, caplog):
     with patch.object(hass.config, "is_allowed_path", return_value=True):
         await stream.async_record("/example/path")
     assert "https://abcd:efgh@foo.bar" not in caplog.text
-    assert "https://foo.bar" in caplog.text
+    assert "https://****:****@foo.bar" in caplog.text

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -588,4 +588,4 @@ async def test_worker_log(hass, caplog):
         )
         await hass.async_block_till_done()
     assert "https://abcd:efgh@foo.bar" not in caplog.text
-    assert "https://foo.bar" in caplog.text
+    assert "https://****:****@foo.bar" in caplog.text

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -348,7 +348,9 @@ async def test_thermostat_different_endpoints(
     """Test an entity with values on a different endpoint from the primary value."""
     state = hass.states.get(CLIMATE_RADIO_THERMOSTAT_ENTITY)
 
-    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.5
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 22.8
+    assert state.attributes[ATTR_FAN_MODE] == "Auto low"
+    assert state.attributes[ATTR_FAN_STATE] == "Idle / off"
 
 
 async def test_setpoint_thermostat(hass, client, climate_danfoss_lc_13, integration):

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -495,7 +495,7 @@ async def test_poll_value(
     assert args["valueId"] == {
         "commandClassName": "Thermostat Mode",
         "commandClass": 64,
-        "endpoint": 0,
+        "endpoint": 1,
         "property": "mode",
         "propertyName": "mode",
         "metadata": {
@@ -503,19 +503,16 @@ async def test_poll_value(
             "readable": True,
             "writeable": True,
             "min": 0,
-            "max": 31,
+            "max": 255,
             "label": "Thermostat mode",
             "states": {
                 "0": "Off",
                 "1": "Heat",
                 "2": "Cool",
-                "3": "Auto",
-                "11": "Energy heat",
-                "12": "Energy cool",
             },
         },
-        "value": 1,
-        "ccVersion": 2,
+        "value": 2,
+        "ccVersion": 0,
     }
 
     client.async_send_command.reset_mock()
@@ -531,7 +528,7 @@ async def test_poll_value(
         },
         blocking=True,
     )
-    assert len(client.async_send_command.call_args_list) == 8
+    assert len(client.async_send_command.call_args_list) == 7
 
     # Test polling against an invalid entity raises ValueError
     with pytest.raises(ValueError):

--- a/tests/fixtures/zwave_js/climate_radio_thermostat_ct100_plus_different_endpoints_state.json
+++ b/tests/fixtures/zwave_js/climate_radio_thermostat_ct100_plus_different_endpoints_state.json
@@ -1,722 +1,1087 @@
 {
-    "nodeId": 26,
-    "index": 0,
-    "installerIcon": 4608,
-    "userIcon": 4608,
-    "status": 4,
-    "ready": true,
-    "deviceClass": {
-        "basic": {"key": 4, "label":"Routing Slave"},
-        "generic": {"key": 8, "label":"Thermostat"},
-        "specific": {"key": 6, "label":"Thermostat General V2"},
-        "mandatorySupportedCCs": [],
-        "mandatoryControlCCs": []
-    },
-    "isListening": true,
-    "isFrequentListening": false,
-    "isRouting": true,
-    "maxBaudRate": 40000,
-    "isSecure": false,
-    "version": 4,
-    "isBeaming": true,
-    "manufacturerId": 152,
-    "productId": 256,
-    "productType": 25602,
-    "firmwareVersion": "10.7",
-    "zwavePlusVersion": 1,
-    "nodeType": 0,
-    "roleType": 5,
-    "deviceConfig": {
-        "manufacturerId": 152,
-        "manufacturer": "Radio Thermostat Company of America (RTC)",
-        "label": "CT100 Plus",
-        "description": "Z-Wave Thermostat",
-        "devices": [{ "productType": "0x6402", "productId": "0x0100" }],
-        "firmwareVersion": { "min": "0.0", "max": "255.255" },
-        "paramInformation": { "_map": {} }
-    },
-    "label": "CT100 Plus",
-    "neighbors": [1, 2, 3, 4, 23],
-    "endpointCountIsDynamic": false,
-    "endpointsHaveIdenticalCapabilities": false,
-    "individualEndpointCount": 2,
-    "aggregatedEndpointCount": 0,
-    "interviewAttempts": 1,
-    "endpoints": [
-        {
-            "nodeId": 26,
-            "index": 0,
-            "installerIcon": 4608,
-            "userIcon": 4608
-        },
-        { "nodeId": 26, "index": 1 },
-        {
-            "nodeId": 26,
-            "index": 2,
-            "installerIcon": 3328,
-            "userIcon": 3333
-        }
-    ],
-    "commandClasses": [],
-    "values": [
-        {
-            "commandClassName": "Manufacturer Specific",
-            "commandClass": 114,
-            "endpoint": 0,
-            "property": "manufacturerId",
-            "propertyName": "manufacturerId",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "min": 0,
-                "max": 65535,
-                "label": "Manufacturer ID"
-            },
-            "value": 152,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Manufacturer Specific",
-            "commandClass": 114,
-            "endpoint": 0,
-            "property": "productType",
-            "propertyName": "productType",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "min": 0,
-                "max": 65535,
-                "label": "Product type"
-            },
-            "value": 25602,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Manufacturer Specific",
-            "commandClass": 114,
-            "endpoint": 0,
-            "property": "productId",
-            "propertyName": "productId",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "min": 0,
-                "max": 65535,
-                "label": "Product ID"
-            },
-            "value": 256,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Thermostat Mode",
-            "commandClass": 64,
-            "endpoint": 0,
-            "property": "mode",
-            "propertyName": "mode",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "min": 0,
-                "max": 31,
-                "label": "Thermostat mode",
-                "states": {
-                    "0": "Off",
-                    "1": "Heat",
-                    "2": "Cool",
-                    "3": "Auto",
-                    "11": "Energy heat",
-                    "12": "Energy cool"
-                }
-            },
-            "value": 1,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Thermostat Mode",
-            "commandClass": 64,
-            "endpoint": 0,
-            "property": "manufacturerData",
-            "propertyName": "manufacturerData",
-            "metadata": {
-                "type": "any",
-                "readable": true,
-                "writeable": true
-            },
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Thermostat Setpoint",
-            "commandClass": 67,
-            "endpoint": 0,
-            "property": "setpoint",
-            "propertyKey": 1,
-            "propertyName": "setpoint",
-            "propertyKeyName": "Heating",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "unit": "\u00b0F",
-                "ccSpecific": { "setpointType": 1 }
-            },
-            "value": 72,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Thermostat Setpoint",
-            "commandClass": 67,
-            "endpoint": 0,
-            "property": "setpoint",
-            "propertyKey": 2,
-            "propertyName": "setpoint",
-            "propertyKeyName": "Cooling",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "unit": "\u00b0F",
-                "ccSpecific": { "setpointType": 2 }
-            },
-            "value": 73,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Thermostat Setpoint",
-            "commandClass": 67,
-            "endpoint": 0,
-            "property": "setpoint",
-            "propertyKey": 11,
-            "propertyName": "setpoint",
-            "propertyKeyName": "Energy Save Heating",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "unit": "\u00b0F",
-                "ccSpecific": { "setpointType": 11 }
-            },
-            "value": 62,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Thermostat Setpoint",
-            "commandClass": 67,
-            "endpoint": 0,
-            "property": "setpoint",
-            "propertyKey": 12,
-            "propertyName": "setpoint",
-            "propertyKeyName": "Energy Save Cooling",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "unit": "\u00b0F",
-                "ccSpecific": { "setpointType": 12 }
-            },
-            "value": 85,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Version",
-            "commandClass": 134,
-            "endpoint": 0,
-            "property": "libraryType",
-            "propertyName": "libraryType",
-            "metadata": {
-                "type": "any",
-                "readable": true,
-                "writeable": false,
-                "label": "Library type"
-            },
-            "value": 3,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Version",
-            "commandClass": 134,
-            "endpoint": 0,
-            "property": "protocolVersion",
-            "propertyName": "protocolVersion",
-            "metadata": {
-                "type": "any",
-                "readable": true,
-                "writeable": false,
-                "label": "Z-Wave protocol version"
-            },
-            "value": "4.24",
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Version",
-            "commandClass": 134,
-            "endpoint": 0,
-            "property": "firmwareVersions",
-            "propertyName": "firmwareVersions",
-            "metadata": {
-                "type": "any",
-                "readable": true,
-                "writeable": false,
-                "label": "Z-Wave chip firmware versions"
-            },
-            "value": ["10.7"],
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Version",
-            "commandClass": 134,
-            "endpoint": 0,
-            "property": "hardwareVersion",
-            "propertyName": "hardwareVersion",
-            "metadata": {
-                "type": "any",
-                "readable": true,
-                "writeable": false,
-                "label": "Z-Wave chip hardware version"
-            },
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Indicator",
-            "commandClass": 135,
-            "endpoint": 0,
-            "property": "value",
-            "propertyName": "value",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "min": 0,
-                "max": 255,
-                "label": "Indicator value",
-                "ccSpecific": { "indicatorId": 0 }
-            },
-            "value": 0,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Thermostat Operating State",
-            "commandClass": 66,
-            "endpoint": 0,
-            "property": "state",
-            "propertyName": "state",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "min": 0,
-                "max": 255,
-                "label": "Operating state",
-                "states": {
-                    "0": "Idle",
-                    "1": "Heating",
-                    "2": "Cooling",
-                    "3": "Fan Only",
-                    "4": "Pending Heat",
-                    "5": "Pending Cool",
-                    "6": "Vent/Economizer",
-                    "7": "Aux Heating",
-                    "8": "2nd Stage Heating",
-                    "9": "2nd Stage Cooling",
-                    "10": "2nd Stage Aux Heat",
-                    "11": "3rd Stage Aux Heat"
-                }
-            },
-            "value": 0,
-            "ccVersion": 2
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 1,
-            "propertyName": "Temperature Reporting Threshold",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 0,
-                "max": 4,
-                "default": 2,
-                "format": 0,
-                "allowManualEntry": false,
-                "states": {
-                    "0": "Disabled",
-                    "1": "0.5\u00b0 F",
-                    "2": "1.0\u00b0 F",
-                    "3": "1.5\u00b0 F",
-                    "4": "2.0\u00b0 F"
-                },
-                "label": "Temperature Reporting Threshold",
-                "description": "Reporting threshold for changes in the ambient temperature",
-                "isFromConfig": true
-            },
-            "value": 2,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 2,
-            "propertyName": "HVAC Settings",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "valueSize": 4,
-                "min": 0,
-                "max": 0,
-                "default": 0,
-                "format": 0,
-                "allowManualEntry": true,
-                "label": "HVAC Settings",
-                "description": "Configured HVAC settings",
-                "isFromConfig": true
-            },
-            "value": 17891329,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 4,
-            "propertyName": "Power Status",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "valueSize": 1,
-                "min": 0,
-                "max": 0,
-                "default": 0,
-                "format": 0,
-                "allowManualEntry": true,
-                "label": "Power Status",
-                "description": "C-Wire / Battery Status",
-                "isFromConfig": true
-            },
-            "value": 1,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 5,
-            "propertyName": "Humidity Reporting Threshold",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 0,
-                "max": 255,
-                "default": 0,
-                "format": 1,
-                "allowManualEntry": false,
-                "states": {
-                    "0": "Disabled",
-                    "1": "3% RH",
-                    "2": "5% RH",
-                    "3": "10% RH"
-                },
-                "label": "Humidity Reporting Threshold",
-                "description": "Reporting threshold for changes in the relative humidity",
-                "isFromConfig": true
-            },
-            "value": 2,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 6,
-            "propertyName": "Auxiliary/Emergency",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 0,
-                "max": 255,
-                "default": 0,
-                "format": 1,
-                "allowManualEntry": false,
-                "states": {
-                    "0": "Auxiliary/Emergency heat disabled",
-                    "1": "Auxiliary/Emergency heat enabled"
-                },
-                "label": "Auxiliary/Emergency",
-                "description": "Enables or disables auxiliary / emergency heating",
-                "isFromConfig": true
-            },
-            "value": 0,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 7,
-            "propertyName": "Thermostat Swing Temperature",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 1,
-                "max": 8,
-                "default": 2,
-                "format": 0,
-                "allowManualEntry": false,
-                "states": {
-                    "1": "0.5\u00b0 F",
-                    "2": "1.0\u00b0 F",
-                    "3": "1.5\u00b0 F",
-                    "4": "2.0\u00b0 F",
-                    "5": "2.5\u00b0 F",
-                    "6": "3.0\u00b0 F",
-                    "7": "3.5\u00b0 F",
-                    "8": "4.0\u00b0 F"
-                },
-                "label": "Thermostat Swing Temperature",
-                "description": "Variance allowed from setpoint to engage HVAC",
-                "isFromConfig": true
-            },
-            "value": 2,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 8,
-            "propertyName": "Thermostat Diff Temperature",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 4,
-                "max": 12,
-                "default": 4,
-                "format": 0,
-                "allowManualEntry": false,
-                "states": {
-                    "4": "2.0\u00b0 F",
-                    "8": "4.0\u00b0 F",
-                    "12": "6.0\u00b0 F"
-                },
-                "label": "Thermostat Diff Temperature",
-                "description": "Configures additional stages",
-                "isFromConfig": true
-            },
-            "value": 1028,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 9,
-            "propertyName": "Thermostat Recovery Mode",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 1,
-                "max": 2,
-                "default": 2,
-                "format": 0,
-                "allowManualEntry": false,
-                "states": {
-                    "1": "Fast recovery mode",
-                    "2": "Economy recovery mode"
-                },
-                "label": "Thermostat Recovery Mode",
-                "description": "Fast or Economy recovery mode",
-                "isFromConfig": true
-            },
-            "value": 2,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 10,
-            "propertyName": "Temperature Reporting Filter",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 4,
-                "min": 0,
-                "max": 124,
-                "default": 124,
-                "format": 0,
-                "allowManualEntry": true,
-                "label": "Temperature Reporting Filter",
-                "description": "Upper/Lower bounds for thermostat temperature reporting",
-                "isFromConfig": true
-            },
-            "value": 32000,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 11,
-            "propertyName": "Simple UI Mode",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 0,
-                "max": 1,
-                "default": 1,
-                "format": 0,
-                "allowManualEntry": false,
-                "states": {
-                    "0": "Normal mode enabled",
-                    "1": "Simple mode enabled"
-                },
-                "label": "Simple UI Mode",
-                "description": "Simple mode enable/disable",
-                "isFromConfig": true
-            },
-            "value": 1,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 12,
-            "propertyName": "Multicast",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 0,
-                "max": 1,
-                "default": 0,
-                "format": 0,
-                "allowManualEntry": false,
-                "states": {
-                    "0": "Multicast disabled",
-                    "1": "Multicast enabled"
-                },
-                "label": "Multicast",
-                "description": "Enable or disables Multicast",
-                "isFromConfig": true
-            },
-            "value": 0,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Configuration",
-            "commandClass": 112,
-            "endpoint": 0,
-            "property": 3,
-            "propertyName": "Utility Lock Enable/Disable",
-            "metadata": {
-                "type": "number",
-                "readable": false,
-                "writeable": true,
-                "valueSize": 1,
-                "min": 0,
-                "max": 255,
-                "default": 0,
-                "format": 1,
-                "allowManualEntry": false,
-                "states": {
-                    "0": "Utility lock disabled",
-                    "1": "Utility lock enabled"
-                },
-                "label": "Utility Lock Enable/Disable",
-                "description": "Prevents setpoint changes at thermostat",
-                "isFromConfig": true
-            },
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Battery",
-            "commandClass": 128,
-            "endpoint": 0,
-            "property": "level",
-            "propertyName": "level",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "min": 0,
-                "max": 100,
-                "unit": "%",
-                "label": "Battery level"
-            },
-            "value": 100,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Battery",
-            "commandClass": 128,
-            "endpoint": 0,
-            "property": "isLow",
-            "propertyName": "isLow",
-            "metadata": {
-                "type": "boolean",
-                "readable": true,
-                "writeable": false,
-                "label": "Low battery level"
-            },
-            "value": false,
-            "ccVersion": 1
-        },
-        {
-            "commandClassName": "Multilevel Sensor",
-            "commandClass": 49,
-            "endpoint": 2,
-            "property": "Air temperature",
-            "propertyName": "Air temperature",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "unit": "\u00b0F",
-                "label": "Air temperature",
-                "ccSpecific": { "sensorType": 1, "scale": 1 }
-            },
-            "value": 72.5,
-            "ccVersion": 5
-        },
-        {
-            "commandClassName": "Multilevel Sensor",
-            "commandClass": 49,
-            "endpoint": 2,
-            "property": "Humidity",
-            "propertyName": "Humidity",
-            "metadata": {
-                "type": "number",
-                "readable": true,
-                "writeable": false,
-                "unit": "%",
-                "label": "Humidity",
-                "ccSpecific": { "sensorType": 5, "scale": 0 }
-            },
-            "value": 20,
-            "ccVersion": 5
-        }
-    ]
+	"nodeId": 26,
+	"index": 0,
+	"installerIcon": 4608,
+	"userIcon": 4608,
+	"status": 4,
+	"ready": true,
+	"isListening": true,
+	"isRouting": true,
+	"isSecure": false,
+	"manufacturerId": 152,
+	"productId": 256,
+	"productType": 25602,
+	"firmwareVersion": "10.7",
+	"zwavePlusVersion": 1,
+	"deviceConfig": {
+		"filename": "/opt/node_modules/@zwave-js/config/config/devices/0x0098/ct100_plus.json",
+		"manufacturer": "Radio Thermostat Company of America (RTC)",
+		"manufacturerId": 152,
+		"label": "CT100 Plus",
+		"description": "Z-Wave Thermostat",
+		"devices": [
+			{
+				"productType": 25602,
+				"productId": 256
+			}
+		],
+		"firmwareVersion": {
+			"min": "0.0",
+			"max": "255.255"
+		},
+		"paramInformation": {
+			"_map": {}
+		}
+	},
+	"label": "CT100 Plus",
+	"neighbors": [1, 2, 29, 3, 4, 5, 6],
+	"endpointCountIsDynamic": false,
+	"endpointsHaveIdenticalCapabilities": false,
+	"individualEndpointCount": 2,
+	"aggregatedEndpointCount": 0,
+	"interviewAttempts": 0,
+	"interviewStage": 6,
+	"endpoints": [
+		{
+			"nodeId": 26,
+			"index": 0,
+			"installerIcon": 4608,
+			"userIcon": 4608,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 8,
+					"label": "Thermostat"
+				},
+				"specific": {
+					"key": 6,
+					"label": "General Thermostat V2"
+				},
+				"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+				"mandatoryControlledCCs": []
+			}
+		},
+		{
+			"nodeId": 26,
+			"index": 1,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 8,
+					"label": "Thermostat"
+				},
+				"specific": {
+					"key": 6,
+					"label": "General Thermostat V2"
+				},
+				"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+				"mandatoryControlledCCs": []
+			}
+		},
+		{
+			"nodeId": 26,
+			"index": 2,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 33,
+					"label": "Multilevel Sensor"
+				},
+				"specific": {
+					"key": 0,
+					"label": "Unused"
+				},
+				"mandatorySupportedCCs": [32, 49],
+				"mandatoryControlledCCs": []
+			}
+		}
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 5,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 73
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Humidity",
+			"propertyName": "Humidity",
+			"ccVersion": 5,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Humidity",
+				"ccSpecific": {
+					"sensorType": 5,
+					"scale": 0
+				},
+				"unit": "%"
+			},
+			"value": 36
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 66,
+			"commandClassName": "Thermostat Operating State",
+			"property": "state",
+			"propertyName": "state",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Operating state",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Idle",
+					"1": "Heating",
+					"2": "Cooling",
+					"3": "Fan Only",
+					"4": "Pending Heat",
+					"5": "Pending Cool",
+					"6": "Vent/Economizer",
+					"7": "Aux Heating",
+					"8": "2nd Stage Heating",
+					"9": "2nd Stage Cooling",
+					"10": "2nd Stage Aux Heat",
+					"11": "3rd Stage Aux Heat"
+				}
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 68,
+			"commandClassName": "Thermostat Fan Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat fan mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Auto low",
+					"1": "Low"
+				}
+			},
+            "value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 69,
+			"commandClassName": "Thermostat Fan State",
+			"property": "state",
+			"propertyName": "state",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Thermostat fan state",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Idle / off",
+					"1": "Running / running low",
+					"2": "Running high",
+					"3": "Running medium",
+					"4": "Circulation mode",
+					"5": "Humidity circulation mode",
+					"6": "Right - left circulation mode",
+					"7": "Up - down circulation mode",
+					"8": "Quiet circulation mode"
+				}
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 1,
+			"propertyName": "Temperature Reporting Threshold",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Reporting threshold for changes in the ambient temperature",
+				"label": "Temperature Reporting Threshold",
+				"default": 2,
+				"min": 0,
+				"max": 4,
+				"states": {
+					"0": "Disabled",
+					"1": "0.5\u00b0 F",
+					"2": "1.0\u00b0 F",
+					"3": "1.5\u00b0 F",
+					"4": "2.0\u00b0 F"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 2,
+			"propertyName": "HVAC Settings",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"description": "Configured HVAC settings",
+				"label": "HVAC Settings",
+				"default": 0,
+				"min": 0,
+				"max": 0,
+				"valueSize": 4,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 17891329
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 4,
+			"propertyName": "Power Status",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"description": "C-Wire / Battery Status",
+				"label": "Power Status",
+				"default": 0,
+				"min": 0,
+				"max": 0,
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 7,
+			"propertyName": "Thermostat Swing Temperature",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Variance allowed from setpoint to engage HVAC",
+				"label": "Thermostat Swing Temperature",
+				"default": 2,
+				"min": 1,
+				"max": 8,
+				"states": {
+					"1": "0.5\u00b0 F",
+					"2": "1.0\u00b0 F",
+					"3": "1.5\u00b0 F",
+					"4": "2.0\u00b0 F",
+					"5": "2.5\u00b0 F",
+					"6": "3.0\u00b0 F",
+					"7": "3.5\u00b0 F",
+					"8": "4.0\u00b0 F"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 8,
+			"propertyName": "Thermostat Diff Temperature",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Configures additional stages",
+				"label": "Thermostat Diff Temperature",
+				"default": 4,
+				"min": 4,
+				"max": 12,
+				"states": {
+					"4": "2.0\u00b0 F",
+					"8": "4.0\u00b0 F",
+					"12": "6.0\u00b0 F"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 1028
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 9,
+			"propertyName": "Thermostat Recovery Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Fast or Economy recovery mode",
+				"label": "Thermostat Recovery Mode",
+				"default": 2,
+				"min": 1,
+				"max": 2,
+				"states": {
+					"1": "Fast recovery mode",
+					"2": "Economy recovery mode"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 10,
+			"propertyName": "Temperature Reporting Filter",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Upper/Lower bounds for thermostat temperature reporting",
+				"label": "Temperature Reporting Filter",
+				"default": 124,
+				"min": 0,
+				"max": 124,
+				"valueSize": 4,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 11,
+			"propertyName": "Simple UI Mode",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Simple mode enable/disable",
+				"label": "Simple UI Mode",
+				"default": 1,
+				"min": 0,
+				"max": 1,
+				"states": {
+					"0": "Normal mode enabled",
+					"1": "Simple mode enabled"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 12,
+			"propertyName": "Multicast",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Enable or disables Multicast",
+				"label": "Multicast",
+				"default": 0,
+				"min": 0,
+				"max": 1,
+				"states": {
+					"0": "Multicast disabled",
+					"1": "Multicast enabled"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 3,
+			"propertyName": "Utility Lock Enable/Disable",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": false,
+				"writeable": true,
+				"description": "Prevents setpoint changes at thermostat",
+				"label": "Utility Lock Enable/Disable",
+				"default": 0,
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Utility lock disabled",
+					"1": "Utility lock enabled"
+				},
+				"valueSize": 1,
+				"format": 1,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 5,
+			"propertyName": "Humidity Reporting Threshold",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Reporting threshold for changes in the relative humidity",
+				"label": "Humidity Reporting Threshold",
+				"default": 0,
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Disabled",
+					"1": "3% RH",
+					"2": "5% RH",
+					"3": "10% RH"
+				},
+				"valueSize": 1,
+				"format": 1,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 6,
+			"propertyName": "Auxiliary/Emergency",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"description": "Enables or disables auxiliary / emergency heating",
+				"label": "Auxiliary/Emergency",
+				"default": 0,
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Auxiliary/Emergency heat disabled",
+					"1": "Auxiliary/Emergency heat enabled"
+				},
+				"valueSize": 1,
+				"format": 1,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 152
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 25602
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 256
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "level",
+			"propertyName": "level",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Battery level",
+				"min": 0,
+				"max": 100,
+				"unit": "%"
+			},
+			"value": 100
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 128,
+			"commandClassName": "Battery",
+			"property": "isLow",
+			"propertyName": "isLow",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Low battery level"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "4.24"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["10.7"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hardwareVersion",
+			"propertyName": "hardwareVersion",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip hardware version"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 135,
+			"commandClassName": "Indicator",
+			"property": "value",
+			"propertyName": "value",
+			"ccVersion": 1,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Indicator value",
+				"ccSpecific": {
+					"indicatorId": 0
+				},
+				"min": 0,
+				"max": 255
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 152
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 25602
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 256
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Off",
+					"1": "Heat",
+					"2": "Cool"
+				}
+			},
+			"value": 2
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "manufacturerData",
+			"propertyName": "manufacturerData",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 1,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Heating",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 1
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 72
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 2,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Cooling",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 2
+				},
+				"unit": "\u00b0F"
+			},
+			"value": 73
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		}
+	],
+	"isFrequentListening": false,
+	"maxDataRate": 100000,
+	"supportedDataRates": [40000, 100000],
+	"protocolVersion": 3,
+	"supportsBeaming": true,
+	"supportsSecurity": false,
+	"nodeType": 1,
+	"zwavePlusNodeType": 0,
+	"zwavePlusRoleType": 5,
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 8,
+			"label": "Thermostat"
+		},
+		"specific": {
+			"key": 6,
+			"label": "General Thermostat V2"
+		},
+		"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 49,
+			"name": "Multilevel Sensor",
+			"version": 5,
+			"isSecure": false
+		},
+		{
+			"id": 64,
+			"name": "Thermostat Mode",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 66,
+			"name": "Thermostat Operating State",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 67,
+			"name": "Thermostat Setpoint",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 68,
+			"name": "Thermostat Fan Mode",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 69,
+			"name": "Thermostat Fan State",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 89,
+			"name": "Association Group Information",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 90,
+			"name": "Device Reset Locally",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 94,
+			"name": "Z-Wave Plus Info",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 96,
+			"name": "Multi Channel",
+			"version": 4,
+			"isSecure": false
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 122,
+			"name": "Firmware Update Meta Data",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 128,
+			"name": "Battery",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 129,
+			"name": "Clock",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 135,
+			"name": "Indicator",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 142,
+			"name": "Multi Channel Association",
+			"version": 3,
+			"isSecure": false
+		}
+	]
 }


### PR DESCRIPTION
- Check all endpoints for zwave_js.climate fan mode and operating state ([@raman325] - [#48800]) ([zwave_js docs])
- Add missing super call in Verisure Camera entity ([@JohNan] - [#48812]) ([verisure docs])
- Fix iCloud extra attributes ([@nzapponi] - [#48815]) ([icloud docs])
- Replace redacted stream recorder credentials with '****' ([@emontnemery] - [#48832]) ([stream docs])
- Fix mysensor cover closed state ([@MartinHjelmare] - [#48833]) ([mysensors docs])
- Validate supported_color_modes for MQTT JSON light ([@emontnemery] - [#48836]) ([light docs]) ([mqtt docs])
- Bump speedtest-cli to 2.1.3 ([@spacegaier] - [#48861]) ([speedtestdotnet docs])
- Correct wrong x in frontend manifest ([@bramkragten] - [#48865]) ([frontend docs])
- Fix motion_blinds gateway signal strength sensor ([@starkillerOG] - [#48866]) ([motion_blinds docs])
- Fix possibly missing changed_by in Verisure Alarm ([@frenck] - [#48867]) ([verisure docs])
- Fix optional data payload in Prowl messaging service ([@frenck] - [#48868]) ([prowl docs])
- Update frontend to 20210407.2 ([@bramkragten] - [#48888]) ([frontend docs])

[#48800]: https://github.com/home-assistant/core/pull/48800
[#48812]: https://github.com/home-assistant/core/pull/48812
[#48815]: https://github.com/home-assistant/core/pull/48815
[#48832]: https://github.com/home-assistant/core/pull/48832
[#48833]: https://github.com/home-assistant/core/pull/48833
[#48836]: https://github.com/home-assistant/core/pull/48836
[#48861]: https://github.com/home-assistant/core/pull/48861
[#48865]: https://github.com/home-assistant/core/pull/48865
[#48866]: https://github.com/home-assistant/core/pull/48866
[#48867]: https://github.com/home-assistant/core/pull/48867
[#48868]: https://github.com/home-assistant/core/pull/48868
[#48888]: https://github.com/home-assistant/core/pull/48888
[@JohNan]: https://github.com/JohNan
[@MartinHjelmare]: https://github.com/MartinHjelmare
[@bramkragten]: https://github.com/bramkragten
[@emontnemery]: https://github.com/emontnemery
[@frenck]: https://github.com/frenck
[@nzapponi]: https://github.com/nzapponi
[@raman325]: https://github.com/raman325
[@spacegaier]: https://github.com/spacegaier
[@starkillerOG]: https://github.com/starkillerOG
[frontend docs]: https://www.home-assistant.io/integrations/frontend/
[icloud docs]: https://www.home-assistant.io/integrations/icloud/
[light docs]: https://www.home-assistant.io/integrations/light/
[motion_blinds docs]: https://www.home-assistant.io/integrations/motion_blinds/
[mqtt docs]: https://www.home-assistant.io/integrations/mqtt/
[mysensors docs]: https://www.home-assistant.io/integrations/mysensors/
[prowl docs]: https://www.home-assistant.io/integrations/prowl/
[speedtestdotnet docs]: https://www.home-assistant.io/integrations/speedtestdotnet/
[stream docs]: https://www.home-assistant.io/integrations/stream/
[verisure docs]: https://www.home-assistant.io/integrations/verisure/
[zwave_js docs]: https://www.home-assistant.io/integrations/zwave_js/