### PR TITLE
Fix cpu temperature reporting for Armbian on Odroid

### DIFF
--- a/homeassistant/components/systemmonitor/sensor.py
+++ b/homeassistant/components/systemmonitor/sensor.py
@@ -180,6 +180,7 @@ CPU_SENSOR_PREFIXES = [
     "soc-thermal 1",
     "soc_thermal 1",
     "Tctl",
+    "cpu0-thermal",
 ]
 
 
@@ -504,7 +505,9 @@ def _read_cpu_temperature() -> float | None:
             # In case the label is empty (e.g. on Raspberry PI 4),
             # construct it ourself here based on the sensor key name.
             _label = f"{name} {i}" if not entry.label else entry.label
-            if _label in CPU_SENSOR_PREFIXES:
+            # check both name and label because some systems embed cpu# in the
+            # name, which makes label not match because label adds cpu# at end.
+            if _label in CPU_SENSOR_PREFIXES or name in CPU_SENSOR_PREFIXES:
                 return cast(float, round(entry.current, 1))
 
     return None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some systems expose cpu temperatures differently in
psutil. Specifically, running armbian on the Odroid xu4 sbc gives the
following temerature output:
```
pp.pprint(psutil.sensors_temperatures())
{   'cpu0-thermal':
    [   shwtemp(label='', current=54.0, high=115.0, critical=115.0)],
    'cpu1-thermal':
    [   shwtemp(label='', current=56.0, high=115.0, critical=115.0)],
    'cpu2-thermal':
    [   shwtemp(label='', current=58.0, high=115.0, critical=115.0)],
    'cpu3-thermal':
    [   shwtemp(label='', current=56.0, high=115.0, critical=115.0)],
}
```
Since the cpu number is embedded inside the name, the current systemmonitor 
component code can't find it.

To fix this, check both the name and the constructed label for matches
against CPU_SENSOR_PREFIXES, and add the appropriate label
cpu0-thermal in the prefix list.

While this is slightly less efficient that just generating the label
and checking it, it results in easier to understand code.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
