### PR TITLE
Detach aiohttp.ClientSession created by config entry setup on unload

### DIFF
--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextvars import ContextVar
 import functools
 import logging
 from types import MappingProxyType, MethodType
@@ -133,6 +134,7 @@ class ConfigEntry:
         "_setup_lock",
         "update_listeners",
         "_async_cancel_retry_setup",
+        "_on_unload",
     )
 
     def __init__(
@@ -198,6 +200,9 @@ class ConfigEntry:
         # Function to cancel a scheduled retry
         self._async_cancel_retry_setup: Callable[[], Any] | None = None
 
+        # Hold list for functions to call on unload.
+        self._on_unload: list[CALLBACK_TYPE] | None = None
+
     async def async_setup(
         self,
         hass: HomeAssistant,
@@ -206,6 +211,7 @@ class ConfigEntry:
         tries: int = 0,
     ) -> None:
         """Set up an entry."""
+        current_entry.set(self)
         if self.source == SOURCE_IGNORE or self.disabled_by:
             return
 
@@ -290,6 +296,8 @@ class ConfigEntry:
                 self._async_cancel_retry_setup = hass.bus.async_listen_once(
                     EVENT_HOMEASSISTANT_STARTED, setup_again
                 )
+
+            self._async_process_on_unload()
             return
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception(
@@ -357,6 +365,8 @@ class ConfigEntry:
             # Only adjust state if we unloaded the component
             if result and integration.domain == self.domain:
                 self.state = ENTRY_STATE_NOT_LOADED
+
+            self._async_process_on_unload()
 
             return result
         except Exception:  # pylint: disable=broad-except
@@ -469,6 +479,25 @@ class ConfigEntry:
             "unique_id": self.unique_id,
             "disabled_by": self.disabled_by,
         }
+
+    @callback
+    def async_on_unload(self, func: CALLBACK_TYPE) -> None:
+        """Add a function to call when config entry is unloaded."""
+        if self._on_unload is None:
+            self._on_unload = []
+        self._on_unload.append(func)
+
+    @callback
+    def _async_process_on_unload(self) -> None:
+        """Process the on_unload callbacks."""
+        if self._on_unload is not None:
+            while self._on_unload:
+                self._on_unload.pop()()
+
+
+current_entry: ContextVar[ConfigEntry | None] = ContextVar(
+    "current_entry", default=None
+)
 
 
 class ConfigEntriesFlowManager(data_entry_flow.FlowManager):

--- a/homeassistant/helpers/aiohttp_client.py
+++ b/homeassistant/helpers/aiohttp_client.py
@@ -5,7 +5,7 @@ import asyncio
 from contextlib import suppress
 from ssl import SSLContext
 import sys
-from typing import Any, Awaitable, cast
+from typing import Any, Awaitable, Callable, cast
 
 import aiohttp
 from aiohttp import web
@@ -13,6 +13,7 @@ from aiohttp.hdrs import CONTENT_TYPE, USER_AGENT
 from aiohttp.web_exceptions import HTTPBadGateway, HTTPGatewayTimeout
 import async_timeout
 
+from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.frame import warn_use
@@ -27,6 +28,8 @@ SERVER_SOFTWARE = "HomeAssistant/{0} aiohttp/{1} Python/{2[0]}.{2[1]}".format(
     __version__, aiohttp.__version__, sys.version_info
 )
 
+WARN_CLOSE_MSG = "closes the Home Assistant aiohttp session"
+
 
 @callback
 @bind_hass
@@ -37,12 +40,14 @@ def async_get_clientsession(
 
     This method must be run in the event loop.
     """
-    key = DATA_CLIENTSESSION_NOTVERIFY
-    if verify_ssl:
-        key = DATA_CLIENTSESSION
+    key = DATA_CLIENTSESSION if verify_ssl else DATA_CLIENTSESSION_NOTVERIFY
 
     if key not in hass.data:
-        hass.data[key] = async_create_clientsession(hass, verify_ssl)
+        hass.data[key] = _async_create_clientsession(
+            hass,
+            verify_ssl,
+            auto_cleanup_method=_async_register_default_clientsession_shutdown,
+        )
 
     return cast(aiohttp.ClientSession, hass.data[key])
 
@@ -59,24 +64,44 @@ def async_create_clientsession(
 
     If auto_cleanup is False, you need to call detach() after the session
     returned is no longer used. Default is True, the session will be
-    automatically detached on homeassistant_stop.
+    automatically detached on homeassistant_stop or when being created
+    in config entry setup, the config entry is unloaded.
 
     This method must be run in the event loop.
     """
-    connector = _async_get_connector(hass, verify_ssl)
+    auto_cleanup_method = None
+    if auto_cleanup:
+        auto_cleanup_method = _async_register_clientsession_shutdown
 
+    clientsession = _async_create_clientsession(
+        hass,
+        verify_ssl,
+        auto_cleanup_method=auto_cleanup_method,
+        **kwargs,
+    )
+
+    return clientsession
+
+
+@callback
+def _async_create_clientsession(
+    hass: HomeAssistant,
+    verify_ssl: bool = True,
+    auto_cleanup_method: Callable[[HomeAssistant, aiohttp.ClientSession], None]
+    | None = None,
+    **kwargs: Any,
+) -> aiohttp.ClientSession:
+    """Create a new ClientSession with kwargs, i.e. for cookies."""
     clientsession = aiohttp.ClientSession(
-        connector=connector,
+        connector=_async_get_connector(hass, verify_ssl),
         headers={USER_AGENT: SERVER_SOFTWARE},
         **kwargs,
     )
 
-    clientsession.close = warn_use(  # type: ignore
-        clientsession.close, "closes the Home Assistant aiohttp session"
-    )
+    clientsession.close = warn_use(clientsession.close, WARN_CLOSE_MSG)  # type: ignore
 
-    if auto_cleanup:
-        _async_register_clientsession_shutdown(hass, clientsession)
+    if auto_cleanup_method:
+        auto_cleanup_method(hass, clientsession)
 
     return clientsession
 
@@ -146,7 +171,33 @@ async def async_aiohttp_proxy_stream(
 def _async_register_clientsession_shutdown(
     hass: HomeAssistant, clientsession: aiohttp.ClientSession
 ) -> None:
-    """Register ClientSession close on Home Assistant shutdown.
+    """Register ClientSession close on Home Assistant shutdown or config entry unload.
+
+    This method must be run in the event loop.
+    """
+
+    @callback
+    def _async_close_websession(*_: Any) -> None:
+        """Close websession."""
+        clientsession.detach()
+
+    unsub = hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_CLOSE, _async_close_websession
+    )
+
+    config_entry = config_entries.current_entry.get()
+    if not config_entry:
+        return
+
+    config_entry.async_on_unload(unsub)
+    config_entry.async_on_unload(_async_close_websession)
+
+
+@callback
+def _async_register_default_clientsession_shutdown(
+    hass: HomeAssistant, clientsession: aiohttp.ClientSession
+) -> None:
+    """Register default ClientSession close on Home Assistant shutdown.
 
     This method must be run in the event loop.
     """

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -6,10 +6,11 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant import config_entries, data_entry_flow, loader
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt
 
@@ -2489,3 +2490,58 @@ async def test_updating_entry_with_and_without_changes(manager):
     assert manager.async_update_entry(entry, title="newtitle") is True
     assert manager.async_update_entry(entry, unique_id="abc123") is False
     assert manager.async_update_entry(entry, unique_id="abc1234") is True
+
+
+async def test_entry_reload_cleans_up_aiohttp_session(hass, manager):
+    """Test reload cleans up aiohttp sessions their close listener created by the config entry."""
+    entry = MockConfigEntry(domain="comp", state=config_entries.ENTRY_STATE_LOADED)
+    entry.add_to_hass(hass)
+    async_setup_calls = 0
+
+    async def async_setup_entry(hass, entry):
+        """Mock setup entry."""
+        nonlocal async_setup_calls
+        async_setup_calls += 1
+        async_create_clientsession(hass)
+        return True
+
+    async_setup = AsyncMock(return_value=True)
+    async_unload_entry = AsyncMock(return_value=True)
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup=async_setup,
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=async_unload_entry,
+        ),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+
+    assert await manager.async_reload(entry.entry_id)
+    assert len(async_unload_entry.mock_calls) == 1
+    assert async_setup_calls == 1
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
+
+    original_close_listeners = hass.bus.async_listeners()[EVENT_HOMEASSISTANT_CLOSE]
+
+    assert await manager.async_reload(entry.entry_id)
+    assert len(async_unload_entry.mock_calls) == 2
+    assert async_setup_calls == 2
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
+
+    assert (
+        hass.bus.async_listeners()[EVENT_HOMEASSISTANT_CLOSE]
+        == original_close_listeners
+    )
+
+    assert await manager.async_reload(entry.entry_id)
+    assert len(async_unload_entry.mock_calls) == 3
+    assert async_setup_calls == 3
+    assert entry.state == config_entries.ENTRY_STATE_LOADED
+
+    assert (
+        hass.bus.async_listeners()[EVENT_HOMEASSISTANT_CLOSE]
+        == original_close_listeners
+    )

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -2498,7 +2498,7 @@ async def test_entry_reload_cleans_up_aiohttp_session(hass, manager):
     entry.add_to_hass(hass)
     async_setup_calls = 0
 
-    async def async_setup_entry(hass, entry):
+    async def async_setup_entry(hass, _):
         """Mock setup entry."""
         nonlocal async_setup_calls
         async_setup_calls += 1

--- a/tests/test_util/aiohttp.py
+++ b/tests/test_util/aiohttp.py
@@ -288,7 +288,7 @@ def mock_aiohttp_client():
         return session
 
     with mock.patch(
-        "homeassistant.helpers.aiohttp_client.async_create_clientsession",
+        "homeassistant.helpers.aiohttp_client._async_create_clientsession",
         side_effect=create_session,
     ):
         yield mocker


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Detach `aiohttp.ClientSession` created by config entry setup on unload to fix memory leak

The primary cause of this leak was config entry retry and reloads

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
