### PR TITLE
Fix "notify.events" trim() issue + add initial tests

### DIFF
--- a/homeassistant/components/notify_events/notify.py
+++ b/homeassistant/components/notify_events/notify.py
@@ -116,12 +116,9 @@ class NotifyEventsNotificationService(BaseNotificationService):
 
     def send_message(self, message, **kwargs):
         """Send a message."""
-        token = self.token
         data = kwargs.get(ATTR_DATA) or {}
+        token = data.get(ATTR_TOKEN, self.token)
 
         msg = self.prepare_message(message, data)
-
-        if data.get(ATTR_TOKEN, "").strip():
-            token = data[ATTR_TOKEN]
 
         msg.send(token)

--- a/homeassistant/components/notify_events/notify.py
+++ b/homeassistant/components/notify_events/notify.py
@@ -121,7 +121,7 @@ class NotifyEventsNotificationService(BaseNotificationService):
 
         msg = self.prepare_message(message, data)
 
-        if data.get(ATTR_TOKEN, "").trim():
+        if data.get(ATTR_TOKEN, "").strip():
             token = data[ATTR_TOKEN]
 
         msg.send(token)

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -532,6 +532,9 @@ netdisco==2.8.2
 # homeassistant.components.nexia
 nexia==0.9.5
 
+# homeassistant.components.notify_events
+notify-events==1.0.4
+
 # homeassistant.components.nsw_fuel_station
 nsw-fuel-api-client==1.0.10
 

--- a/tests/components/notify_events/__init__.py
+++ b/tests/components/notify_events/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the notify_events integration."""

--- a/tests/components/notify_events/test_init.py
+++ b/tests/components/notify_events/test_init.py
@@ -1,0 +1,12 @@
+"""The tests for notify_events."""
+from homeassistant.components.notify_events.const import DOMAIN
+from homeassistant.setup import async_setup_component
+
+
+async def test_setup(hass):
+    """Test setup of the integration."""
+    config = {"notify_events": {"token": "ABC"}}
+    assert await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()
+
+    assert DOMAIN in hass.data

--- a/tests/components/notify_events/test_notify.py
+++ b/tests/components/notify_events/test_notify.py
@@ -1,0 +1,38 @@
+"""The tests for notify_events."""
+from homeassistant.components.notify import ATTR_DATA, ATTR_MESSAGE, DOMAIN
+from homeassistant.components.notify_events.notify import (
+    ATTR_LEVEL,
+    ATTR_PRIORITY,
+    ATTR_TOKEN,
+)
+
+from tests.common import async_mock_service
+
+
+async def test_send_msg(hass):
+    """Test notify.events service."""
+    notify_calls = async_mock_service(hass, DOMAIN, "events")
+
+    await hass.services.async_call(
+        DOMAIN,
+        "events",
+        {
+            ATTR_MESSAGE: "message content",
+            ATTR_DATA: {
+                ATTR_TOKEN: "XYZ",
+                ATTR_LEVEL: "warning",
+                ATTR_PRIORITY: "high",
+            },
+        },
+        blocking=True,
+    )
+
+    assert len(notify_calls) == 1
+    call = notify_calls[-1]
+
+    assert call.domain == DOMAIN
+    assert call.service == "events"
+    assert call.data.get(ATTR_MESSAGE) == "message content"
+    assert call.data.get(ATTR_DATA).get(ATTR_TOKEN) == "XYZ"
+    assert call.data.get(ATTR_DATA).get(ATTR_LEVEL) == "warning"
+    assert call.data.get(ATTR_DATA).get(ATTR_PRIORITY) == "high"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

Replace `trim()` with `strip()`. Added some initial testing setup.

Note: I do not actually use the integration myself, so I cannot actually test it at runtime.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48739
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
