### PR TITLE
Implement percentage_step and preset_mode is not not speed fix for MQTT fan

### DIFF
--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -651,18 +651,18 @@ class MqttFan(MqttEntity, FanEntity):
         This method is a coroutine.
         """
         speed_payload = None
-        if self._feature_legacy_speeds:
+        if speed in self._legacy_speeds_list:
             if speed == SPEED_LOW:
                 speed_payload = self._payload["SPEED_LOW"]
             elif speed == SPEED_MEDIUM:
                 speed_payload = self._payload["SPEED_MEDIUM"]
             elif speed == SPEED_HIGH:
                 speed_payload = self._payload["SPEED_HIGH"]
-            elif speed == SPEED_OFF:
-                speed_payload = self._payload["SPEED_OFF"]
             else:
-                _LOGGER.warning("'%s'is not a valid speed", speed)
-                return
+                speed_payload = self._payload["SPEED_OFF"]
+        else:
+            _LOGGER.warning("'%s' is not a valid speed", speed)
+            return
 
         if speed_payload:
             mqtt.async_publish(

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -32,6 +32,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 from homeassistant.util.percentage import (
+    int_states_in_range,
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
     percentage_to_ranged_value,
@@ -224,6 +225,9 @@ class MqttFan(MqttEntity, FanEntity):
         self._optimistic_preset_mode = None
         self._optimistic_speed = None
 
+        self._legacy_speeds_list = []
+        self._legacy_speeds_list_no_off = []
+
         MqttEntity.__init__(self, hass, config, config_entry, discovery_data)
 
     @staticmethod
@@ -284,28 +288,18 @@ class MqttFan(MqttEntity, FanEntity):
             self._legacy_speeds_list_no_off = speed_list_without_preset_modes(
                 self._legacy_speeds_list
             )
-        else:
-            self._legacy_speeds_list = []
 
         self._feature_percentage = CONF_PERCENTAGE_COMMAND_TOPIC in config
         self._feature_preset_mode = CONF_PRESET_MODE_COMMAND_TOPIC in config
         if self._feature_preset_mode:
-            self._speeds_list = speed_list_without_preset_modes(
-                self._legacy_speeds_list + config[CONF_PRESET_MODES_LIST]
-            )
-            self._preset_modes = (
-                self._legacy_speeds_list + config[CONF_PRESET_MODES_LIST]
-            )
+            self._preset_modes = config[CONF_PRESET_MODES_LIST]
         else:
-            self._speeds_list = speed_list_without_preset_modes(
-                self._legacy_speeds_list
-            )
             self._preset_modes = []
 
-        if not self._speeds_list or self._feature_percentage:
-            self._speed_count = 100
+        if self._feature_percentage:
+            self._speed_count = min(int_states_in_range(self._speed_range), 100)
         else:
-            self._speed_count = len(self._speeds_list)
+            self._speed_count = len(self._legacy_speeds_list_no_off) or 100
 
         optimistic = config[CONF_OPTIMISTIC]
         self._optimistic = optimistic or self._topic[CONF_STATE_TOPIC] is None
@@ -327,11 +321,7 @@ class MqttFan(MqttEntity, FanEntity):
             self._topic[CONF_OSCILLATION_COMMAND_TOPIC] is not None
             and SUPPORT_OSCILLATE
         )
-        if self._feature_preset_mode and self._speeds_list:
-            self._supported_features |= SUPPORT_SET_SPEED
-        if self._feature_percentage:
-            self._supported_features |= SUPPORT_SET_SPEED
-        if self._feature_legacy_speeds:
+        if self._feature_percentage or self._feature_legacy_speeds:
             self._supported_features |= SUPPORT_SET_SPEED
         if self._feature_preset_mode:
             self._supported_features |= SUPPORT_PRESET_MODE
@@ -414,10 +404,6 @@ class MqttFan(MqttEntity, FanEntity):
                 return
 
             self._preset_mode = preset_mode
-            if not self._implemented_percentage and (preset_mode in self.speed_list):
-                self._percentage = ordered_list_item_to_percentage(
-                    self.speed_list, preset_mode
-                )
             self.async_write_ha_state()
 
         if self._topic[CONF_PRESET_MODE_STATE_TOPIC] is not None:
@@ -455,10 +441,10 @@ class MqttFan(MqttEntity, FanEntity):
                 )
                 return
 
-            if not self._implemented_percentage:
-                if speed in self._speeds_list:
+            if not self._feature_percentage:
+                if speed in self._legacy_speeds_list_no_off:
                     self._percentage = ordered_list_item_to_percentage(
-                        self._speeds_list, speed
+                        self._legacy_speeds_list_no_off, speed
                     )
                 elif speed == SPEED_OFF:
                     self._percentage = 0
@@ -506,19 +492,9 @@ class MqttFan(MqttEntity, FanEntity):
         """Return true if device is on."""
         return self._state
 
-    @property
-    def _implemented_percentage(self):
-        """Return true if percentage has been implemented."""
-        return self._feature_percentage
-
-    @property
-    def _implemented_preset_mode(self):
-        """Return true if preset_mode has been implemented."""
-        return self._feature_preset_mode
-
     # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
     @property
-    def _implemented_speed(self):
+    def _implemented_speed(self) -> bool:
         """Return true if speed has been implemented."""
         return self._feature_legacy_speeds
 
@@ -541,7 +517,7 @@ class MqttFan(MqttEntity, FanEntity):
     @property
     def speed_list(self) -> list:
         """Get the list of available speeds."""
-        return self._speeds_list
+        return self._legacy_speeds_list_no_off
 
     @property
     def supported_features(self) -> int:
@@ -555,7 +531,7 @@ class MqttFan(MqttEntity, FanEntity):
 
     @property
     def speed_count(self) -> int:
-        """Return the number of speeds the fan supports or 100 if percentage is supported."""
+        """Return the number of speeds the fan supports."""
         return self._speed_count
 
     @property
@@ -620,20 +596,8 @@ class MqttFan(MqttEntity, FanEntity):
             percentage_to_ranged_value(self._speed_range, percentage)
         )
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)
-        if self._implemented_preset_mode:
-            if percentage:
-                await self.async_set_preset_mode(
-                    preset_mode=percentage_to_ordered_list_item(
-                        self.speed_list, percentage
-                    )
-                )
-            # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
-            elif self._feature_legacy_speeds and (
-                SPEED_OFF in self._legacy_speeds_list
-            ):
-                await self.async_set_preset_mode(SPEED_OFF)
         # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
-        elif self._feature_legacy_speeds:
+        if self._feature_legacy_speeds:
             if percentage:
                 await self.async_set_speed(
                     percentage_to_ordered_list_item(
@@ -644,7 +608,7 @@ class MqttFan(MqttEntity, FanEntity):
             elif SPEED_OFF in self._legacy_speeds_list:
                 await self.async_set_speed(SPEED_OFF)
 
-        if self._implemented_percentage:
+        if self._feature_percentage:
             mqtt.async_publish(
                 self.hass,
                 self._topic[CONF_PERCENTAGE_COMMAND_TOPIC],
@@ -665,13 +629,7 @@ class MqttFan(MqttEntity, FanEntity):
         if preset_mode not in self.preset_modes:
             _LOGGER.warning("'%s'is not a valid preset mode", preset_mode)
             return
-        # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
-        if preset_mode in self._legacy_speeds_list:
-            await self.async_set_speed(speed=preset_mode)
-        if not self._implemented_percentage and preset_mode in self.speed_list:
-            self._percentage = ordered_list_item_to_percentage(
-                self.speed_list, preset_mode
-            )
+
         mqtt_payload = self._command_templates[ATTR_PRESET_MODE](preset_mode)
 
         mqtt.async_publish(

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -85,11 +85,11 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
                 "preset_mode_state_topic": "preset-mode-state-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_modes": [
-                    "medium",
-                    "medium-high",
-                    "high",
-                    "very-high",
-                    "freaking-high",
+                    "auto",
+                    "smart",
+                    "whoosh",
+                    "eco",
+                    "breeze",
                     "silent",
                 ],
                 "speed_range_min": 1,
@@ -153,16 +153,16 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
     caplog.clear()
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "low")
-    state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") is None
+    assert "not a valid preset mode" in caplog.text
+    caplog.clear()
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", "medium")
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", "auto")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "medium"
+    assert state.attributes.get("preset_mode") == "auto"
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", "very-high")
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", "eco")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "very-high"
+    assert state.attributes.get("preset_mode") == "eco"
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "silent")
     state = hass.states.get("fan.test")
@@ -277,9 +277,11 @@ async def test_controlling_state_via_topic_no_percentage_topics(
                 "preset_mode_state_topic": "preset-mode-state-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_modes": [
-                    "high",
-                    "freaking-high",
-                    "silent",
+                    "auto",
+                    "smart",
+                    "whoosh",
+                    "eco",
+                    "breeze",
                 ],
                 # use of speeds is deprecated, support will be removed after a quarter (2021.7)
                 "speeds": ["off", "low", "medium"],
@@ -292,23 +294,23 @@ async def test_controlling_state_via_topic_no_percentage_topics(
     assert state.state == STATE_OFF
     assert not state.attributes.get(ATTR_ASSUMED_STATE)
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", "freaking-high")
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", "smart")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "freaking-high"
+    assert state.attributes.get("preset_mode") == "smart"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     assert state.attributes.get("speed") == fan.SPEED_OFF
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", "high")
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", "auto")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "high"
+    assert state.attributes.get("preset_mode") == "auto"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     assert state.attributes.get("speed") == fan.SPEED_OFF
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", "silent")
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", "whoosh")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "silent"
+    assert state.attributes.get("preset_mode") == "whoosh"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     assert state.attributes.get("speed") == fan.SPEED_OFF
@@ -324,19 +326,19 @@ async def test_controlling_state_via_topic_no_percentage_topics(
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     async_fire_mqtt_message(hass, "speed-state-topic", "medium")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "silent"
+    assert state.attributes.get("preset_mode") == "whoosh"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 100
     assert state.attributes.get("speed") == fan.SPEED_MEDIUM
 
     async_fire_mqtt_message(hass, "speed-state-topic", "low")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "silent"
+    assert state.attributes.get("preset_mode") == "whoosh"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 50
     assert state.attributes.get("speed") == fan.SPEED_LOW
 
     async_fire_mqtt_message(hass, "speed-state-topic", "off")
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "silent"
+    assert state.attributes.get("preset_mode") == "whoosh"
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 0
     assert state.attributes.get("speed") == fan.SPEED_OFF
 
@@ -359,11 +361,11 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, cap
                 "preset_mode_state_topic": "preset-mode-state-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_modes": [
-                    "medium",
-                    "medium-high",
-                    "high",
-                    "very-high",
-                    "freaking-high",
+                    "auto",
+                    "smart",
+                    "whoosh",
+                    "eco",
+                    "breeze",
                     "silent",
                 ],
                 "state_value_template": "{{ value_json.val }}",
@@ -410,13 +412,13 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, cap
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "medium"}')
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "auto"}')
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "medium"
+    assert state.attributes.get("preset_mode") == "auto"
 
-    async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "freaking-high"}')
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "breeze"}')
     state = hass.states.get("fan.test")
-    assert state.attributes.get("preset_mode") == "freaking-high"
+    assert state.attributes.get("preset_mode") == "breeze"
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "silent"}')
     state = hass.states.get("fan.test")
@@ -445,8 +447,8 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
                 # use of speeds is deprecated, support will be removed after a quarter (2021.7)
                 "speeds": ["off", "low", "medium"],
                 "preset_modes": [
-                    "high",
-                    "freaking-high",
+                    "whoosh",
+                    "breeze",
                     "silent",
                 ],
                 # use of speeds is deprecated, support will be removed after a quarter (2021.7)
@@ -539,22 +541,22 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    await common.async_set_preset_mode(hass, "fan.test", "high")
+    await common.async_set_preset_mode(hass, "fan.test", "whoosh")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "high", 0, False
+        "preset-mode-command-topic", "whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "high"
+    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "whoosh"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_set_preset_mode(hass, "fan.test", "freaking-high")
+    await common.async_set_preset_mode(hass, "fan.test", "breeze")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "freaking-high", 0, False
+        "preset-mode-command-topic", "breeze", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "freaking-high"
+    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "breeze"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_preset_mode(hass, "fan.test", "silent")
@@ -588,13 +590,8 @@ async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):
 
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "speed_High", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
+    assert "not a valid speed" in caplog.text
+    caplog.clear()
 
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
@@ -708,8 +705,8 @@ async def test_sending_mqtt_commands_and_optimistic_no_legacy(hass, mqtt_mock, c
                 "percentage_command_topic": "percentage-command-topic",
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_modes": [
-                    "high",
-                    "freaking-high",
+                    "whoosh",
+                    "breeze",
                     "silent",
                 ],
             }
@@ -764,26 +761,26 @@ async def test_sending_mqtt_commands_and_optimistic_no_legacy(hass, mqtt_mock, c
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    await common.async_set_preset_mode(hass, "fan.test", "medium")
+    await common.async_set_preset_mode(hass, "fan.test", "auto")
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    await common.async_set_preset_mode(hass, "fan.test", "high")
+    await common.async_set_preset_mode(hass, "fan.test", "whoosh")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "high", 0, False
+        "preset-mode-command-topic", "whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "high"
+    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "whoosh"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_set_preset_mode(hass, "fan.test", "freaking-high")
+    await common.async_set_preset_mode(hass, "fan.test", "breeze")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "freaking-high", 0, False
+        "preset-mode-command-topic", "breeze", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "freaking-high"
+    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "breeze"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_preset_mode(hass, "fan.test", "silent")
@@ -811,11 +808,11 @@ async def test_sending_mqtt_commands_and_optimistic_no_legacy(hass, mqtt_mock, c
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_turn_on(hass, "fan.test", preset_mode="high")
+    await common.async_turn_on(hass, "fan.test", preset_mode="whoosh")
     assert mqtt_mock.async_publish.call_count == 2
     mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
     mqtt_mock.async_publish.assert_any_call(
-        "preset-mode-command-topic", "high", 0, False
+        "preset-mode-command-topic", "whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
@@ -823,7 +820,7 @@ async def test_sending_mqtt_commands_and_optimistic_no_legacy(hass, mqtt_mock, c
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     with pytest.raises(NotValidPresetModeError):
-        await common.async_turn_on(hass, "fan.test", preset_mode="low")
+        await common.async_turn_on(hass, "fan.test", preset_mode="freaking-high")
 
 
 async def test_sending_mqtt_command_templates_(hass, mqtt_mock, caplog):
@@ -844,8 +841,8 @@ async def test_sending_mqtt_command_templates_(hass, mqtt_mock, caplog):
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "preset_mode_command_template": "preset_mode: {{ value }}",
                 "preset_modes": [
-                    "high",
-                    "freaking-high",
+                    "whoosh",
+                    "breeze",
                     "silent",
                 ],
             }
@@ -908,22 +905,22 @@ async def test_sending_mqtt_command_templates_(hass, mqtt_mock, caplog):
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    await common.async_set_preset_mode(hass, "fan.test", "high")
+    await common.async_set_preset_mode(hass, "fan.test", "whoosh")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "preset_mode: high", 0, False
+        "preset-mode-command-topic", "preset_mode: whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "high"
+    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "whoosh"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_set_preset_mode(hass, "fan.test", "freaking-high")
+    await common.async_set_preset_mode(hass, "fan.test", "breeze")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "preset_mode: freaking-high", 0, False
+        "preset-mode-command-topic", "preset_mode: breeze", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
-    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "freaking-high"
+    assert state.attributes.get(fan.ATTR_PRESET_MODE) == "breeze"
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_preset_mode(hass, "fan.test", "silent")
@@ -953,11 +950,11 @@ async def test_sending_mqtt_command_templates_(hass, mqtt_mock, caplog):
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_turn_on(hass, "fan.test", preset_mode="high")
+    await common.async_turn_on(hass, "fan.test", preset_mode="whoosh")
     assert mqtt_mock.async_publish.call_count == 2
     mqtt_mock.async_publish.assert_any_call("command-topic", "state: ON", 0, False)
     mqtt_mock.async_publish.assert_any_call(
-        "preset-mode-command-topic", "preset_mode: high", 0, False
+        "preset-mode-command-topic", "preset_mode: whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
@@ -988,9 +985,10 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
                 # use of speeds is deprecated, support will be removed after a quarter (2021.7)
                 "speeds": ["off", "low", "medium"],
                 "preset_modes": [
-                    "high",
-                    "freaking-high",
+                    "whoosh",
+                    "breeze",
                     "silent",
+                    "high",
                 ],
             }
         },
@@ -1031,18 +1029,18 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    await common.async_set_preset_mode(hass, "fan.test", "high")
+    await common.async_set_preset_mode(hass, "fan.test", "whoosh")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "high", 0, False
+        "preset-mode-command-topic", "whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PRESET_MODE) is None
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_set_preset_mode(hass, "fan.test", "freaking-high")
+    await common.async_set_preset_mode(hass, "fan.test", "breeze")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "freaking-high", 0, False
+        "preset-mode-command-topic", "breeze", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
@@ -1078,14 +1076,8 @@ async def test_sending_mqtt_commands_and_optimistic_no_percentage_topic(
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "high", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
-
+    assert "not a valid speed" in caplog.text
+    caplog.clear()
     await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
 
     mqtt_mock.async_publish.assert_any_call("speed-command-topic", "off", 0, False)
@@ -1267,8 +1259,8 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
                 # use of speeds is deprecated, support will be removed after a quarter (2021.7)
                 "speeds": ["off", "low", "medium"],
                 "preset_modes": [
-                    "high",
-                    "freaking-high",
+                    "whoosh",
+                    "breeze",
                     "silent",
                 ],
                 "optimistic": True,
@@ -1333,13 +1325,13 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
 
     # use of speeds is deprecated, support will be removed after a quarter (2021.7)
     with pytest.raises(NotValidPresetModeError):
-        await common.async_turn_on(hass, "fan.test", preset_mode="medium")
+        await common.async_turn_on(hass, "fan.test", preset_mode="auto")
 
-    await common.async_turn_on(hass, "fan.test", preset_mode="high")
+    await common.async_turn_on(hass, "fan.test", preset_mode="whoosh")
     assert mqtt_mock.async_publish.call_count == 2
     mqtt_mock.async_publish.assert_any_call("command-topic", "ON", 0, False)
     mqtt_mock.async_publish.assert_any_call(
-        "preset-mode-command-topic", "high", 0, False
+        "preset-mode-command-topic", "whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
@@ -1476,9 +1468,9 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
-    await common.async_set_preset_mode(hass, "fan.test", "high")
+    await common.async_set_preset_mode(hass, "fan.test", "whoosh")
     mqtt_mock.async_publish.assert_called_once_with(
-        "preset-mode-command-topic", "high", 0, False
+        "preset-mode-command-topic", "whoosh", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test")
@@ -1494,7 +1486,7 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.state == STATE_OFF
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
-    await common.async_set_preset_mode(hass, "fan.test", "ModeX")
+    await common.async_set_preset_mode(hass, "fan.test", "freaking-high")
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
 
@@ -1514,13 +1506,8 @@ async def test_sending_mqtt_commands_and_explicit_optimistic(hass, mqtt_mock, ca
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
     await common.async_set_speed(hass, "fan.test", fan.SPEED_HIGH)
-    mqtt_mock.async_publish.assert_called_once_with(
-        "speed-command-topic", "high", 0, False
-    )
-    mqtt_mock.async_publish.reset_mock()
-    state = hass.states.get("fan.test")
-    assert state.state == STATE_OFF
-    assert state.attributes.get(ATTR_ASSUMED_STATE)
+    assert "not a valid speed" in caplog.text
+    caplog.clear()
 
     await common.async_set_speed(hass, "fan.test", fan.SPEED_OFF)
     mqtt_mock.async_publish.assert_called_once_with(
@@ -1552,7 +1539,7 @@ async def test_attributes(hass, mqtt_mock, caplog):
                 "preset_mode_command_topic": "preset-mode-command-topic",
                 "percentage_command_topic": "percentage-command-topic",
                 "preset_modes": [
-                    "freaking-high",
+                    "breeze",
                     "silent",
                 ],
             }
@@ -1719,14 +1706,14 @@ async def test_supported_features(hass, mqtt_mock):
                     "name": "test3c2",
                     "command_topic": "command-topic",
                     "preset_mode_command_topic": "preset-mode-command-topic",
-                    "preset_modes": ["very-fast", "auto"],
+                    "preset_modes": ["eco", "auto"],
                 },
                 {
                     "platform": "mqtt",
                     "name": "test3c3",
                     "command_topic": "command-topic",
                     "preset_mode_command_topic": "preset-mode-command-topic",
-                    "preset_modes": ["off", "on", "auto"],
+                    "preset_modes": ["eco", "smart", "auto"],
                 },
                 {
                     "platform": "mqtt",
@@ -1761,7 +1748,7 @@ async def test_supported_features(hass, mqtt_mock):
                     "name": "test5pr_mb",
                     "command_topic": "command-topic",
                     "preset_mode_command_topic": "preset-mode-command-topic",
-                    "preset_modes": ["off", "on", "auto"],
+                    "preset_modes": ["whoosh", "silent", "auto"],
                 },
                 {
                     "platform": "mqtt",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recent introduction of present_mode support does not update the percentage_step if less than 100 speeds are with the speed range. Also the incorrect behaviour of preset_modes with presumed speeds making the percent slider to show up is corrected when no percentage is configured.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
The following example will have preset_modes and a percentage slider with 10 speeds and a percentage_step of
 10.0

```yaml
# Example configuration.yaml
# Example using percentage based speeds with preset modes configuration.yaml
fan:
  - platform: mqtt
    name: "Bedroom Fan"
    state_topic: "bedroom_fan/on/state"
    command_topic: "bedroom_fan/on/set"
    oscillation_state_topic: "bedroom_fan/oscillation/state"
    oscillation_command_topic: "bedroom_fan/oscillation/set"
    percentage_state_topic: "bedroom_fan/speed/percentage_state"
    percentage_command_topic: "bedroom_fan/speed/percentage"
    preset_mode_state_topic: "bedroom_fan/speed/preset_mode_state"
    preset_mode_command_topic: "bedroom_fan/speed/preset_mode"
    preset_modes:
       -  "auto"
       -  "smart"
       -  "whoosh"
       -  "eco"
       -  "breeze"
    qos: 0
    payload_on: "true"
    payload_off: "false"
    payload_oscillation_on: "true"
    payload_oscillation_off: "false"
    speed_range_min: 1
    speed_range_max: 10
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48802 https://github.com/home-assistant/core/issues/48802
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/17369

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ x Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]
https://www.home-assistant.io/integrations/fan.mqtt/

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
