### PR TITLE
Migrate existing zwave_js entities if endpoint has changed

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -87,7 +87,7 @@ def register_node_in_dev_reg(
     dev_reg: device_registry.DeviceRegistry,
     client: ZwaveClient,
     node: ZwaveNode,
-) -> None:
+) -> device_registry.DeviceEntry:
     """Register node in dev reg."""
     params = {
         "config_entry_id": entry.entry_id,
@@ -102,6 +102,10 @@ def register_node_in_dev_reg(
     device = dev_reg.async_get_or_create(**params)
 
     async_dispatcher_send(hass, EVENT_DEVICE_ADDED_TO_REGISTRY, device)
+
+    # We can assert here because we will always get a device
+    assert device
+    return device
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -120,6 +124,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry_hass_data[DATA_UNSUBSCRIBE] = unsubscribe_callbacks
     entry_hass_data[DATA_PLATFORM_SETUP] = {}
 
+    registered_unique_ids: dict[str, dict[str, set[str]]] = {}
+
     async def async_on_node_ready(node: ZwaveNode) -> None:
         """Handle node ready event."""
         LOGGER.debug("Processing node %s", node)
@@ -127,14 +133,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         platform_setup_tasks = entry_hass_data[DATA_PLATFORM_SETUP]
 
         # register (or update) node in device registry
-        register_node_in_dev_reg(hass, entry, dev_reg, client, node)
+        device = register_node_in_dev_reg(hass, entry, dev_reg, client, node)
+
+        registered_unique_ids.setdefault(device.id, {})
 
         # run discovery on all node values and create/update entities
         for disc_info in async_discover_values(node):
+            platform = disc_info.platform
+            registered_unique_ids[device.id].setdefault(platform, set())
+
             # This migration logic was added in 2021.3 to handle a breaking change to
             # the value_id format. Some time in the future, this call (as well as the
             # helper functions) can be removed.
-            async_migrate_discovered_value(ent_reg, client, disc_info)
+            async_migrate_discovered_value(
+                hass,
+                ent_reg,
+                registered_unique_ids[device.id][platform],
+                device,
+                client,
+                disc_info,
+            )
+
             if disc_info.platform not in platform_setup_tasks:
                 platform_setup_tasks[disc_info.platform] = hass.async_create_task(
                     hass.config_entries.async_forward_entry_setup(
@@ -143,11 +162,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
 
             await platform_setup_tasks[disc_info.platform]
-
             LOGGER.debug("Discovered entity: %s", disc_info)
-            async_dispatcher_send(
-                hass, f"{DOMAIN}_{entry.entry_id}_add_{disc_info.platform}", disc_info
-            )
 
         # add listener for stateless node value notification events
         unsubscribe_callbacks.append(
@@ -189,6 +204,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device = dev_reg.async_get_device({dev_id})
         # note: removal of entity registry entry is handled by core
         dev_reg.async_remove_device(device.id)  # type: ignore
+        registered_unique_ids.pop(device.id, None)  # type: ignore
 
     @callback
     def async_on_value_notification(notification: ValueNotification) -> None:

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -153,18 +153,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 disc_info,
             )
 
-            if disc_info.platform not in platform_setup_tasks:
-                platform_setup_tasks[disc_info.platform] = hass.async_create_task(
-                    hass.config_entries.async_forward_entry_setup(
-                        entry, disc_info.platform
-                    )
+            if platform not in platform_setup_tasks:
+                platform_setup_tasks[platform] = hass.async_create_task(
+                    hass.config_entries.async_forward_entry_setup(entry, platform)
                 )
 
-            await platform_setup_tasks[disc_info.platform]
+            await platform_setup_tasks[platform]
 
             LOGGER.debug("Discovered entity: %s", disc_info)
             async_dispatcher_send(
-                hass, f"{DOMAIN}_{entry.entry_id}_add_{disc_info.platform}", disc_info
+                hass, f"{DOMAIN}_{entry.entry_id}_add_{platform}", disc_info
             )
 
         # add listener for stateless node value notification events

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -135,11 +135,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # register (or update) node in device registry
         device = register_node_in_dev_reg(hass, entry, dev_reg, client, node)
+        registered_unique_ids[device.id] = defaultdict(set)
 
         # run discovery on all node values and create/update entities
         for disc_info in async_discover_values(node):
             platform = disc_info.platform
-            registered_unique_ids[device.id] = defaultdict(set)
 
             # This migration logic was added in 2021.3 to handle a breaking change to
             # the value_id format. Some time in the future, this call (as well as the

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -135,7 +135,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         # register (or update) node in device registry
         device = register_node_in_dev_reg(hass, entry, dev_reg, client, node)
-        registered_unique_ids[device.id] = defaultdict(set)
+        # We only want to create the defaultdict once, even on reinterviews
+        if device.id not in registered_unique_ids:
+            registered_unique_ids[device.id] = defaultdict(set)
 
         # run discovery on all node values and create/update entities
         for disc_info in async_discover_values(node):

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -161,7 +161,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
 
             await platform_setup_tasks[disc_info.platform]
+
             LOGGER.debug("Discovered entity: %s", disc_info)
+            async_dispatcher_send(
+                hass, f"{DOMAIN}_{entry.entry_id}_add_{disc_info.platform}", disc_info
+            )
 
         # add listener for stateless node value notification events
         unsubscribe_callbacks.append(

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from typing import Callable
 
 from async_timeout import timeout
@@ -124,7 +125,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry_hass_data[DATA_UNSUBSCRIBE] = unsubscribe_callbacks
     entry_hass_data[DATA_PLATFORM_SETUP] = {}
 
-    registered_unique_ids: dict[str, dict[str, set[str]]] = {}
+    registered_unique_ids: dict[str, dict[str, set[str]]] = defaultdict(dict)
 
     async def async_on_node_ready(node: ZwaveNode) -> None:
         """Handle node ready event."""
@@ -135,12 +136,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # register (or update) node in device registry
         device = register_node_in_dev_reg(hass, entry, dev_reg, client, node)
 
-        registered_unique_ids.setdefault(device.id, {})
-
         # run discovery on all node values and create/update entities
         for disc_info in async_discover_values(node):
             platform = disc_info.platform
-            registered_unique_ids[device.id].setdefault(platform, set())
+            registered_unique_ids[device.id] = defaultdict(set)
 
             # This migration logic was added in 2021.3 to handle a breaking change to
             # the value_id format. Some time in the future, this call (as well as the

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -33,6 +33,16 @@ class ValueID:
     property_key: str | None = None
 
     @staticmethod
+    def from_unique_id(unique_id: str) -> ValueID:
+        """
+        Get a ValueID from a unique ID.
+
+        This also works for Notification CC Binary Sensors which have their own unique ID
+        format.
+        """
+        return ValueID.from_string_id(unique_id.split(".")[1])
+
+    @staticmethod
     def from_string_id(value_id_str: str) -> ValueID:
         """Get a ValueID from a string representation of the value ID."""
         parts = value_id_str.split("-")
@@ -46,16 +56,6 @@ class ValueID:
             and self.property_ == other.property_
             and self.property_key == other.property_key
         )
-
-
-def value_id_str_from_unique_id(unique_id: str) -> str:
-    """
-    Get a value ID from a standard Z-Wave JS unique ID.
-
-    This also works for Notification CC Binary Sensors which have their own unique ID
-    format.
-    """
-    return unique_id.split(".")[1]
 
 
 @callback
@@ -72,8 +72,7 @@ def async_migrate_old_entity(
     if ent_reg.async_get_entity_id(platform, DOMAIN, unique_id):
         return
 
-    value_id_str = value_id_str_from_unique_id(unique_id)
-    value_id = ValueID.from_string_id(value_id_str)
+    value_id = ValueID.from_unique_id(unique_id)
 
     # Look for existing entities in the registry that could be the same value but on
     # a different endpoint
@@ -84,8 +83,7 @@ def async_migrate_old_entity(
         if entity.domain != platform or entity.unique_id in registered_unique_ids:
             continue
 
-        old_ent_value_id_str = value_id_str_from_unique_id(entity.unique_id)
-        old_ent_value_id = ValueID.from_string_id(old_ent_value_id_str)
+        old_ent_value_id = ValueID.from_unique_id(entity.unique_id)
 
         if value_id.is_same_value_different_endpoints(old_ent_value_id):
             existing_entities.append(entity)

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -48,7 +48,7 @@ class ValueID:
         )
 
 
-def value_id_from_unique_id(unique_id: str) -> str:
+def value_id_str_from_unique_id(unique_id: str) -> str:
     """
     Get a value ID from a standard Z-Wave JS unique ID.
 
@@ -72,7 +72,7 @@ def async_migrate_old_entity(
     if ent_reg.async_get_entity_id(platform, DOMAIN, unique_id):
         return
 
-    value_id_str = value_id_from_unique_id(unique_id)
+    value_id_str = value_id_str_from_unique_id(unique_id)
     value_id = ValueID.from_string_id(value_id_str)
 
     # Look for existing entities in the registry that could be the same value but on
@@ -84,7 +84,7 @@ def async_migrate_old_entity(
         if entity.domain != platform or entity.unique_id in registered_unique_ids:
             continue
 
-        old_ent_value_id_str = value_id_from_unique_id(entity.unique_id)
+        old_ent_value_id_str = value_id_str_from_unique_id(entity.unique_id)
         old_ent_value_id = ValueID.from_string_id(old_ent_value_id_str)
 
         if value_id.is_same_value_different_endpoints(old_ent_value_id):

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -87,9 +87,12 @@ def async_migrate_old_entity(
 
         if value_id.is_same_value_different_endpoints(old_ent_value_id):
             existing_entities.append(entity)
+            # We can return early if we get more than one result
+            if len(existing_entities) > 1:
+                return
 
-    # If we can't find exactly one existing entity, there's nothing to migrate
-    if len(existing_entities) != 1:
+    # If we couldn't find any results, return early
+    if not existing_entities:
         return
 
     entity = existing_entities[0]

--- a/homeassistant/components/zwave_js/migrate.py
+++ b/homeassistant/components/zwave_js/migrate.py
@@ -1,13 +1,20 @@
 """Functions used to migrate unique IDs for Z-Wave JS entities."""
 from __future__ import annotations
 
+from dataclasses import dataclass
 import logging
 
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.value import Value as ZwaveValue
 
-from homeassistant.core import callback
-from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.entity_registry import (
+    EntityRegistry,
+    RegistryEntry,
+    async_entries_for_device,
+)
 
 from .const import DOMAIN
 from .discovery import ZwaveDiscoveryInfo
@@ -16,8 +23,86 @@ from .helpers import get_unique_id
 _LOGGER = logging.getLogger(__name__)
 
 
+@dataclass
+class ValueID:
+    """Class to represent a Value ID."""
+
+    command_class: str
+    endpoint: str
+    property_: str
+    property_key: str | None = None
+
+    @staticmethod
+    def from_string_id(value_id_str: str) -> ValueID:
+        """Get a ValueID from a string representation of the value ID."""
+        parts = value_id_str.split("-")
+        property_key = parts[4] if len(parts) > 4 else None
+        return ValueID(parts[1], parts[2], parts[3], property_key=property_key)
+
+    def is_same_value_different_endpoints(self, other: ValueID) -> bool:
+        """Return whether two value IDs are the same excluding endpoint."""
+        return (
+            self.command_class == other.command_class
+            and self.property_ == other.property_
+            and self.property_key == other.property_key
+        )
+
+
+def value_id_from_unique_id(unique_id: str) -> str:
+    """
+    Get a value ID from a standard Z-Wave JS unique ID.
+
+    This also works for Notification CC Binary Sensors which have their own unique ID
+    format.
+    """
+    return unique_id.split(".")[1]
+
+
 @callback
-def async_migrate_entity(
+def async_migrate_old_entity(
+    hass: HomeAssistant,
+    ent_reg: EntityRegistry,
+    registered_unique_ids: set[str],
+    platform: str,
+    device: DeviceEntry,
+    unique_id: str,
+) -> None:
+    """Migrate existing entity if current one can't be found and an old one exists."""
+    # If we can find an existing entity with this unique ID, there's nothing to migrate
+    if ent_reg.async_get_entity_id(platform, DOMAIN, unique_id):
+        return
+
+    value_id_str = value_id_from_unique_id(unique_id)
+    value_id = ValueID.from_string_id(value_id_str)
+
+    # Look for existing entities in the registry that could be the same value but on
+    # a different endpoint
+    existing_entities: list[RegistryEntry] = []
+    for entity in async_entries_for_device(ent_reg, device.id):
+        # If entity is not in the domain for this discovery info or entity has already
+        # been processed, skip it
+        if entity.domain != platform or entity.unique_id in registered_unique_ids:
+            continue
+
+        old_ent_value_id_str = value_id_from_unique_id(entity.unique_id)
+        old_ent_value_id = ValueID.from_string_id(old_ent_value_id_str)
+
+        if value_id.is_same_value_different_endpoints(old_ent_value_id):
+            existing_entities.append(entity)
+
+    # If we can't find exactly one existing entity, there's nothing to migrate
+    if len(existing_entities) != 1:
+        return
+
+    entity = existing_entities[0]
+    state = hass.states.get(entity.entity_id)
+
+    if not state or state.state == STATE_UNAVAILABLE:
+        async_migrate_unique_id(ent_reg, platform, entity.unique_id, unique_id)
+
+
+@callback
+def async_migrate_unique_id(
     ent_reg: EntityRegistry, platform: str, old_unique_id: str, new_unique_id: str
 ) -> None:
     """Check if entity with old unique ID exists, and if so migrate it to new ID."""
@@ -29,10 +114,7 @@ def async_migrate_entity(
             new_unique_id,
         )
         try:
-            ent_reg.async_update_entity(
-                entity_id,
-                new_unique_id=new_unique_id,
-            )
+            ent_reg.async_update_entity(entity_id, new_unique_id=new_unique_id)
         except ValueError:
             _LOGGER.debug(
                 (
@@ -46,43 +128,87 @@ def async_migrate_entity(
 
 @callback
 def async_migrate_discovered_value(
-    ent_reg: EntityRegistry, client: ZwaveClient, disc_info: ZwaveDiscoveryInfo
+    hass: HomeAssistant,
+    ent_reg: EntityRegistry,
+    registered_unique_ids: set[str],
+    device: DeviceEntry,
+    client: ZwaveClient,
+    disc_info: ZwaveDiscoveryInfo,
 ) -> None:
     """Migrate unique ID for entity/entities tied to discovered value."""
+
     new_unique_id = get_unique_id(
         client.driver.controller.home_id,
         disc_info.primary_value.value_id,
     )
 
+    # On reinterviews, there is no point in going through this logic again for already
+    # discovered values
+    if new_unique_id in registered_unique_ids:
+        return
+
+    # Migration logic was added in 2021.3 to handle a breaking change to the value_id
+    # format. Some time in the future, the logic to migrate unique IDs can be removed.
+
     # 2021.2.*, 2021.3.0b0, and 2021.3.0 formats
-    for value_id in get_old_value_ids(disc_info.primary_value):
-        old_unique_id = get_unique_id(
+    old_unique_ids = [
+        get_unique_id(
             client.driver.controller.home_id,
             value_id,
         )
-        # Most entities have the same ID format, but notification binary sensors
-        # have a state key in their ID so we need to handle them differently
-        if (
-            disc_info.platform == "binary_sensor"
-            and disc_info.platform_hint == "notification"
-        ):
-            for state_key in disc_info.primary_value.metadata.states:
-                # ignore idle key (0)
-                if state_key == "0":
-                    continue
+        for value_id in get_old_value_ids(disc_info.primary_value)
+    ]
 
-                async_migrate_entity(
+    if (
+        disc_info.platform == "binary_sensor"
+        and disc_info.platform_hint == "notification"
+    ):
+        for state_key in disc_info.primary_value.metadata.states:
+            # ignore idle key (0)
+            if state_key == "0":
+                continue
+
+            new_bin_sensor_unique_id = f"{new_unique_id}.{state_key}"
+
+            # On reinterviews, there is no point in going through this logic again
+            # for already discovered values
+            if new_bin_sensor_unique_id in registered_unique_ids:
+                continue
+
+            # Unique ID migration
+            for old_unique_id in old_unique_ids:
+                async_migrate_unique_id(
                     ent_reg,
                     disc_info.platform,
                     f"{old_unique_id}.{state_key}",
-                    f"{new_unique_id}.{state_key}",
+                    new_bin_sensor_unique_id,
                 )
 
-            # Once we've iterated through all state keys, we can move on to the
-            # next item
-            continue
+            # Migrate entities in case upstream changes cause endpoint change
+            async_migrate_old_entity(
+                hass,
+                ent_reg,
+                registered_unique_ids,
+                disc_info.platform,
+                device,
+                new_bin_sensor_unique_id,
+            )
+            registered_unique_ids.add(new_bin_sensor_unique_id)
 
-        async_migrate_entity(ent_reg, disc_info.platform, old_unique_id, new_unique_id)
+        # Once we've iterated through all state keys, we are done
+        return
+
+    # Unique ID migration
+    for old_unique_id in old_unique_ids:
+        async_migrate_unique_id(
+            ent_reg, disc_info.platform, old_unique_id, new_unique_id
+        )
+
+    # Migrate entities in case upstream changes cause endpoint change
+    async_migrate_old_entity(
+        hass, ent_reg, registered_unique_ids, disc_info.platform, device, new_unique_id
+    )
+    registered_unique_ids.add(new_unique_id)
 
 
 @callback

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -166,15 +166,23 @@ async def test_unique_id_migration_dupes(
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id_2) is None
 
 
-async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integration):
-    """Test unique ID is migrated from old format to new (version 1)."""
+@pytest.mark.parametrize(
+    "id",
+    [
+        ("52.52-49-00-Air temperature-00"),
+        ("52.52-49-0-Air temperature-00-00"),
+        ("52-49-0-Air temperature-00-00"),
+    ],
+)
+async def test_unique_id_migration(hass, multisensor_6_state, client, integration, id):
+    """Test unique ID is migrated from old format to new."""
     ent_reg = er.async_get(hass)
 
     # Migrate version 1
     entity_name = AIR_TEMPERATURE_SENSOR.split(".")[1]
 
     # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.52.52-49-00-Air temperature-00"
+    old_unique_id = f"{client.driver.controller.home_id}.{id}"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,
@@ -200,159 +208,25 @@ async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integra
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
-async def test_unique_id_migration_v2(hass, multisensor_6_state, client, integration):
-    """Test unique ID is migrated from old format to new (version 2)."""
-    ent_reg = er.async_get(hass)
-    # Migrate version 2
-    ILLUMINANCE_SENSOR = "sensor.multisensor_6_illuminance"
-    entity_name = ILLUMINANCE_SENSOR.split(".")[1]
-
-    # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.52.52-49-0-Illuminance-00-00"
-    entity_entry = ent_reg.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        old_unique_id,
-        suggested_object_id=entity_name,
-        config_entry=integration,
-        original_name=entity_name,
-    )
-    assert entity_entry.entity_id == ILLUMINANCE_SENSOR
-    assert entity_entry.unique_id == old_unique_id
-
-    # Add a ready node, unique ID should be migrated
-    node = Node(client, multisensor_6_state)
-    event = {"node": node}
-
-    client.driver.controller.emit("node added", event)
-    await hass.async_block_till_done()
-
-    # Check that new RegistryEntry is using new unique ID format
-    entity_entry = ent_reg.async_get(ILLUMINANCE_SENSOR)
-    new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance"
-    assert entity_entry.unique_id == new_unique_id
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
-
-
-async def test_unique_id_migration_v3(hass, multisensor_6_state, client, integration):
-    """Test unique ID is migrated from old format to new (version 3)."""
-    ent_reg = er.async_get(hass)
-    # Migrate version 2
-    ILLUMINANCE_SENSOR = "sensor.multisensor_6_illuminance"
-    entity_name = ILLUMINANCE_SENSOR.split(".")[1]
-
-    # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance-00-00"
-    entity_entry = ent_reg.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        old_unique_id,
-        suggested_object_id=entity_name,
-        config_entry=integration,
-        original_name=entity_name,
-    )
-    assert entity_entry.entity_id == ILLUMINANCE_SENSOR
-    assert entity_entry.unique_id == old_unique_id
-
-    # Add a ready node, unique ID should be migrated
-    node = Node(client, multisensor_6_state)
-    event = {"node": node}
-
-    client.driver.controller.emit("node added", event)
-    await hass.async_block_till_done()
-
-    # Check that new RegistryEntry is using new unique ID format
-    entity_entry = ent_reg.async_get(ILLUMINANCE_SENSOR)
-    new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance"
-    assert entity_entry.unique_id == new_unique_id
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
-
-
-async def test_unique_id_migration_property_key_v1(
-    hass, hank_binary_switch_state, client, integration
+@pytest.mark.parametrize(
+    "id",
+    [
+        ("32.32-50-00-value-W_Consumed"),
+        ("32.32-50-0-value-66049-W_Consumed"),
+        ("32-50-0-value-66049-W_Consumed"),
+    ],
+)
+async def test_unique_id_migration_property_key(
+    hass, hank_binary_switch_state, client, integration, id
 ):
-    """Test unique ID with property key is migrated from old format to new (version 1)."""
+    """Test unique ID with property key is migrated from old format to new."""
     ent_reg = er.async_get(hass)
 
     SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
     entity_name = SENSOR_NAME.split(".")[1]
 
     # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.32.32-50-00-value-W_Consumed"
-    entity_entry = ent_reg.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        old_unique_id,
-        suggested_object_id=entity_name,
-        config_entry=integration,
-        original_name=entity_name,
-    )
-    assert entity_entry.entity_id == SENSOR_NAME
-    assert entity_entry.unique_id == old_unique_id
-
-    # Add a ready node, unique ID should be migrated
-    node = Node(client, hank_binary_switch_state)
-    event = {"node": node}
-
-    client.driver.controller.emit("node added", event)
-    await hass.async_block_till_done()
-
-    # Check that new RegistryEntry is using new unique ID format
-    entity_entry = ent_reg.async_get(SENSOR_NAME)
-    new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
-    assert entity_entry.unique_id == new_unique_id
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
-
-
-async def test_unique_id_migration_property_key_v2(
-    hass, hank_binary_switch_state, client, integration
-):
-    """Test unique ID with property key is migrated from old format to new (version 2)."""
-    ent_reg = er.async_get(hass)
-
-    SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
-    entity_name = SENSOR_NAME.split(".")[1]
-
-    # Create entity RegistryEntry using old unique ID format
-    old_unique_id = (
-        f"{client.driver.controller.home_id}.32.32-50-0-value-66049-W_Consumed"
-    )
-    entity_entry = ent_reg.async_get_or_create(
-        "sensor",
-        DOMAIN,
-        old_unique_id,
-        suggested_object_id=entity_name,
-        config_entry=integration,
-        original_name=entity_name,
-    )
-    assert entity_entry.entity_id == SENSOR_NAME
-    assert entity_entry.unique_id == old_unique_id
-
-    # Add a ready node, unique ID should be migrated
-    node = Node(client, hank_binary_switch_state)
-    event = {"node": node}
-
-    client.driver.controller.emit("node added", event)
-    await hass.async_block_till_done()
-
-    # Check that new RegistryEntry is using new unique ID format
-    entity_entry = ent_reg.async_get(SENSOR_NAME)
-    new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
-    assert entity_entry.unique_id == new_unique_id
-    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
-
-
-async def test_unique_id_migration_property_key_v3(
-    hass, hank_binary_switch_state, client, integration
-):
-    """Test unique ID with property key is migrated from old format to new (version 3)."""
-    ent_reg = er.async_get(hass)
-
-    SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
-    entity_name = SENSOR_NAME.split(".")[1]
-
-    # Create entity RegistryEntry using old unique ID format
-    old_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049-W_Consumed"
+    old_unique_id = f"{client.driver.controller.home_id}.{id}"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
         DOMAIN,

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -162,8 +162,8 @@ async def test_unique_id_migration_dupes(
     entity_entry = ent_reg.async_get(AIR_TEMPERATURE_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Air temperature"
     assert entity_entry.unique_id == new_unique_id
-
-    assert ent_reg.async_get(f"{AIR_TEMPERATURE_SENSOR}_1") is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id_1) is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id_2) is None
 
 
 async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integration):
@@ -197,6 +197,7 @@ async def test_unique_id_migration_v1(hass, multisensor_6_state, client, integra
     entity_entry = ent_reg.async_get(AIR_TEMPERATURE_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Air temperature"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
 async def test_unique_id_migration_v2(hass, multisensor_6_state, client, integration):
@@ -230,6 +231,7 @@ async def test_unique_id_migration_v2(hass, multisensor_6_state, client, integra
     entity_entry = ent_reg.async_get(ILLUMINANCE_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
 async def test_unique_id_migration_v3(hass, multisensor_6_state, client, integration):
@@ -263,6 +265,7 @@ async def test_unique_id_migration_v3(hass, multisensor_6_state, client, integra
     entity_entry = ent_reg.async_get(ILLUMINANCE_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-49-0-Illuminance"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
 async def test_unique_id_migration_property_key_v1(
@@ -298,6 +301,7 @@ async def test_unique_id_migration_property_key_v1(
     entity_entry = ent_reg.async_get(SENSOR_NAME)
     new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
 async def test_unique_id_migration_property_key_v2(
@@ -335,6 +339,7 @@ async def test_unique_id_migration_property_key_v2(
     entity_entry = ent_reg.async_get(SENSOR_NAME)
     new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
 async def test_unique_id_migration_property_key_v3(
@@ -370,6 +375,7 @@ async def test_unique_id_migration_property_key_v3(
     entity_entry = ent_reg.async_get(SENSOR_NAME)
     new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
 async def test_unique_id_migration_notification_binary_sensor(
@@ -404,6 +410,94 @@ async def test_unique_id_migration_notification_binary_sensor(
     entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_BINARY_SENSOR)
     new_unique_id = f"{client.driver.controller.home_id}.52-113-0-Home Security-Motion sensor status.8"
     assert entity_entry.unique_id == new_unique_id
+    assert ent_reg.async_get_entity_id("binary_sensor", DOMAIN, old_unique_id) is None
+
+
+async def test_old_entity_migration(
+    hass, hank_binary_switch_state, client, integration
+):
+    """Test old entity on a different endpoint is migrated to a new one."""
+    node = Node(client, hank_binary_switch_state)
+
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+    )
+
+    SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
+    entity_name = SENSOR_NAME.split(".")[1]
+
+    # Create entity RegistryEntry using old unique ID format
+    old_unique_id = f"{client.driver.controller.home_id}.32-50-1-value-66049"
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id,
+        suggested_object_id=entity_name,
+        config_entry=integration,
+        original_name=entity_name,
+        device_id=device.id,
+    )
+    assert entity_entry.entity_id == SENSOR_NAME
+    assert entity_entry.unique_id == old_unique_id
+
+    # Do this twice to make sure re-interview doesn't do anything weird
+    for i in range(0, 2):
+        # Add a ready node, unique ID should be migrated
+        event = {"node": node}
+        client.driver.controller.emit("node added", event)
+        await hass.async_block_till_done()
+
+        # Check that new RegistryEntry is using new unique ID format
+        entity_entry = ent_reg.async_get(SENSOR_NAME)
+        new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
+        assert entity_entry.unique_id == new_unique_id
+        assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
+
+
+async def test_old_entity_migration_notification_binary_sensor(
+    hass, multisensor_6_state, client, integration
+):
+    """Test old entity on a different endpoint is migrated to a new one for a notification binary sensor."""
+    node = Node(client, multisensor_6_state)
+
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+    )
+
+    entity_name = NOTIFICATION_MOTION_BINARY_SENSOR.split(".")[1]
+
+    # Create entity RegistryEntry using old unique ID format
+    old_unique_id = f"{client.driver.controller.home_id}.52-113-1-Home Security-Motion sensor status.8"
+    entity_entry = ent_reg.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        old_unique_id,
+        suggested_object_id=entity_name,
+        config_entry=integration,
+        original_name=entity_name,
+        device_id=device.id,
+    )
+    assert entity_entry.entity_id == NOTIFICATION_MOTION_BINARY_SENSOR
+    assert entity_entry.unique_id == old_unique_id
+
+    # Do this twice to make sure re-interview doesn't do anything weird
+    for _ in range(0, 2):
+        # Add a ready node, unique ID should be migrated
+        event = {"node": node}
+        client.driver.controller.emit("node added", event)
+        await hass.async_block_till_done()
+
+        # Check that new RegistryEntry is using new unique ID format
+        entity_entry = ent_reg.async_get(NOTIFICATION_MOTION_BINARY_SENSOR)
+        new_unique_id = f"{client.driver.controller.home_id}.52-113-0-Home Security-Motion sensor status.8"
+        assert entity_entry.unique_id == new_unique_id
+        assert (
+            ent_reg.async_get_entity_id("binary_sensor", DOMAIN, old_unique_id) is None
+        )
 
 
 async def test_on_node_added_not_ready(

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -330,7 +330,7 @@ async def test_old_entity_migration(
         assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
 
 
-async def test_skip_old_entity_migration_for_multiiple(
+async def test_skip_old_entity_migration_for_multiple(
     hass, hank_binary_switch_state, client, integration
 ):
     """Test that multiple entities of the same value but on a different endpoint get skipped."""

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -302,7 +302,7 @@ async def test_old_entity_migration(
     SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
     entity_name = SENSOR_NAME.split(".")[1]
 
-    # Create entity RegistryEntry using old unique ID format
+    # Create entity RegistryEntry using fake endpoint
     old_unique_id = f"{client.driver.controller.home_id}.32-50-1-value-66049"
     entity_entry = ent_reg.async_get_or_create(
         "sensor",
@@ -328,6 +328,63 @@ async def test_old_entity_migration(
         new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
         assert entity_entry.unique_id == new_unique_id
         assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None
+
+
+async def test_skip_old_entity_migration_for_multiiple(
+    hass, hank_binary_switch_state, client, integration
+):
+    """Test that multiple entities of the same value but on a different endpoint get skipped."""
+    node = Node(client, hank_binary_switch_state)
+
+    ent_reg = er.async_get(hass)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=integration.entry_id, identifiers={get_device_id(client, node)}
+    )
+
+    SENSOR_NAME = "sensor.smart_plug_with_two_usb_ports_value_electric_consumed"
+    entity_name = SENSOR_NAME.split(".")[1]
+
+    # Create two entity entrrys using different endpoints
+    old_unique_id_1 = f"{client.driver.controller.home_id}.32-50-1-value-66049"
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id_1,
+        suggested_object_id=f"{entity_name}_1",
+        config_entry=integration,
+        original_name=f"{entity_name}_1",
+        device_id=device.id,
+    )
+    assert entity_entry.entity_id == f"{SENSOR_NAME}_1"
+    assert entity_entry.unique_id == old_unique_id_1
+
+    # Create two entity entrrys using different endpoints
+    old_unique_id_2 = f"{client.driver.controller.home_id}.32-50-2-value-66049"
+    entity_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id_2,
+        suggested_object_id=f"{entity_name}_2",
+        config_entry=integration,
+        original_name=f"{entity_name}_2",
+        device_id=device.id,
+    )
+    assert entity_entry.entity_id == f"{SENSOR_NAME}_2"
+    assert entity_entry.unique_id == old_unique_id_2
+    # Add a ready node, unique ID should be migrated
+    event = {"node": node}
+    client.driver.controller.emit("node added", event)
+    await hass.async_block_till_done()
+
+    # Check that new RegistryEntry is created using new unique ID format
+    entity_entry = ent_reg.async_get(SENSOR_NAME)
+    new_unique_id = f"{client.driver.controller.home_id}.32-50-0-value-66049"
+    assert entity_entry.unique_id == new_unique_id
+
+    # Check that the old entities stuck around because we skipped the migration step
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id_1)
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id_2)
 
 
 async def test_old_entity_migration_notification_binary_sensor(


### PR DESCRIPTION
## Proposed change
There were already changes introduced in `zwave-js 7.0.x` that resulted in values getting mapped to different endpoints. This caused existing entities that were created before the update to be left as orphaned. In this PR, before we create a new entity, we check to see if there are any orphaned entities that exist with the same value ID minus the endpoint. If there is, and there's exactly one, then we assume that the new value we discovered used to be this entity and we update its unique ID so that when we create the new entity, it gets linked to the existing registry entry.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
