### PR TITLE
Prevent ping id allocation conflict with device_tracker

### DIFF
--- a/homeassistant/components/ping/__init__.py
+++ b/homeassistant/components/ping/__init__.py
@@ -24,20 +24,22 @@ async def async_setup(hass, config):
 
 
 @callback
-def async_get_next_ping_id(hass):
+def async_get_next_ping_id(hass, count=1):
     """Find the next id to use in the outbound ping.
+
+    When using multiping, we increment the id
+    by the number of ids that multiping
+    will use.
 
     Must be called in async
     """
-    current_id = hass.data[DOMAIN][PING_ID]
-    if current_id == MAX_PING_ID:
-        next_id = DEFAULT_START_ID
-    else:
-        next_id = current_id + 1
-
-    hass.data[DOMAIN][PING_ID] = next_id
-
-    return next_id
+    allocated_id = hass.data[DOMAIN][PING_ID] + 1
+    if allocated_id > MAX_PING_ID:
+        allocated_id -= MAX_PING_ID - DEFAULT_START_ID
+    hass.data[DOMAIN][PING_ID] += count
+    if hass.data[DOMAIN][PING_ID] > MAX_PING_ID:
+        hass.data[DOMAIN][PING_ID] -= MAX_PING_ID - DEFAULT_START_ID
+    return allocated_id
 
 
 def _can_use_icmp_lib_with_privilege() -> None | bool:

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -125,7 +125,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
                     count=PING_ATTEMPTS_COUNT,
                     timeout=ICMP_TIMEOUT,
                     privileged=privileged,
-                    id=async_get_next_ping_id(hass, len(ip_to_dev_id.keys())),
+                    id=async_get_next_ping_id(hass, len(ip_to_dev_id)),
                 )
             )
             _LOGGER.debug("Multiping responses: %s", responses)

--- a/homeassistant/components/ping/device_tracker.py
+++ b/homeassistant/components/ping/device_tracker.py
@@ -125,7 +125,7 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
                     count=PING_ATTEMPTS_COUNT,
                     timeout=ICMP_TIMEOUT,
                     privileged=privileged,
-                    id=async_get_next_ping_id(hass),
+                    id=async_get_next_ping_id(hass, len(ip_to_dev_id.keys())),
                 )
             )
             _LOGGER.debug("Multiping responses: %s", responses)

--- a/tests/components/ping/test_init.py
+++ b/tests/components/ping/test_init.py
@@ -1,0 +1,27 @@
+"""Test ping id allocation."""
+
+from homeassistant.components.ping import async_get_next_ping_id
+from homeassistant.components.ping.const import (
+    DEFAULT_START_ID,
+    DOMAIN,
+    MAX_PING_ID,
+    PING_ID,
+)
+
+
+async def test_async_get_next_ping_id(hass):
+    """Verify we allocate ping ids as expected."""
+    hass.data[DOMAIN] = {PING_ID: DEFAULT_START_ID}
+
+    assert async_get_next_ping_id(hass) == DEFAULT_START_ID + 1
+    assert async_get_next_ping_id(hass) == DEFAULT_START_ID + 2
+    assert async_get_next_ping_id(hass, 2) == DEFAULT_START_ID + 3
+    assert async_get_next_ping_id(hass) == DEFAULT_START_ID + 5
+
+    hass.data[DOMAIN][PING_ID] = MAX_PING_ID
+    assert async_get_next_ping_id(hass) == DEFAULT_START_ID + 1
+    assert async_get_next_ping_id(hass) == DEFAULT_START_ID + 2
+
+    hass.data[DOMAIN][PING_ID] = MAX_PING_ID
+    assert async_get_next_ping_id(hass, 2) == DEFAULT_START_ID + 1
+    assert async_get_next_ping_id(hass) == DEFAULT_START_ID + 3


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent ping id allocation conflict with device_tracker

The `multiping` call used an additional ping id for each
host it pinged. The allocator is now aware of this behavior

- Solves id conflict resulting in unexpected home state


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48871
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
