### PR TITLE
Fix Shelly button device triggers

### DIFF
--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     EVENT_SHELLY_CLICK,
     INPUTS_EVENTS_SUBTYPES,
+    SHBTN_1_INPUTS_EVENTS_TYPES,
     SUPPORTED_INPUTS_EVENTS_TYPES,
 )
 from .utils import get_device_wrapper, get_input_triggers
@@ -45,7 +46,7 @@ async def async_validate_trigger_config(hass, config):
 
     # if device is available verify parameters against device capabilities
     wrapper = get_device_wrapper(hass, config[CONF_DEVICE_ID])
-    if not wrapper:
+    if not wrapper or not wrapper.device.initialized:
         return config
 
     trigger = (config[CONF_TYPE], config[CONF_SUBTYPE])
@@ -67,6 +68,19 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
     wrapper = get_device_wrapper(hass, device_id)
     if not wrapper:
         raise InvalidDeviceAutomationConfig(f"Device not found: {device_id}")
+
+    if wrapper.model in ("SHBTN-1", "SHBTN-2"):
+        for trigger in SHBTN_1_INPUTS_EVENTS_TYPES:
+            triggers.append(
+                {
+                    CONF_PLATFORM: "device",
+                    CONF_DEVICE_ID: device_id,
+                    CONF_DOMAIN: DOMAIN,
+                    CONF_TYPE: trigger,
+                    CONF_SUBTYPE: "button",
+                }
+            )
+        return triggers
 
     for block in wrapper.device.blocks:
         input_triggers = get_input_triggers(wrapper.device, block)

--- a/tests/components/shelly/test_device_trigger.py
+++ b/tests/components/shelly/test_device_trigger.py
@@ -1,4 +1,6 @@
 """The tests for Shelly device triggers."""
+from unittest.mock import AsyncMock, Mock
+
 import pytest
 
 from homeassistant import setup
@@ -6,10 +8,13 @@ from homeassistant.components import automation
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
+from homeassistant.components.shelly import ShellyDeviceWrapper
 from homeassistant.components.shelly.const import (
     ATTR_CHANNEL,
     ATTR_CLICK_TYPE,
+    COAP,
     CONF_SUBTYPE,
+    DATA_CONFIG_ENTRY,
     DOMAIN,
     EVENT_SHELLY_CLICK,
 )
@@ -42,6 +47,71 @@ async def test_get_triggers(hass, coap_wrapper):
             CONF_DOMAIN: DOMAIN,
             CONF_TYPE: "long",
             CONF_SUBTYPE: "button1",
+        },
+    ]
+
+    triggers = await async_get_device_automations(
+        hass, "trigger", coap_wrapper.device_id
+    )
+
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_get_triggers_button(hass):
+    """Test we get the expected triggers from a shelly button."""
+    await async_setup_component(hass, "shelly", {})
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"sleep_period": 43200, "model": "SHBTN-1"},
+        unique_id="12345678",
+    )
+    config_entry.add_to_hass(hass)
+
+    device = Mock(
+        blocks=None,
+        settings=None,
+        shelly=None,
+        update=AsyncMock(),
+        initialized=False,
+    )
+
+    hass.data[DOMAIN] = {DATA_CONFIG_ENTRY: {}}
+    hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id] = {}
+    coap_wrapper = hass.data[DOMAIN][DATA_CONFIG_ENTRY][config_entry.entry_id][
+        COAP
+    ] = ShellyDeviceWrapper(hass, config_entry, device)
+
+    await coap_wrapper.async_setup()
+
+    expected_triggers = [
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: coap_wrapper.device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "single",
+            CONF_SUBTYPE: "button",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: coap_wrapper.device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "double",
+            CONF_SUBTYPE: "button",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: coap_wrapper.device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "triple",
+            CONF_SUBTYPE: "button",
+        },
+        {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: coap_wrapper.device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_TYPE: "long",
+            CONF_SUBTYPE: "button",
         },
     ]
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly button is a sleeping device which it is not initialized after HA core restart until manually waked up by a button press.
When having device automations based input triggers for this device getting or validating the triggers will fail when device is not initialized.
Since this device has fixed input triggers it is not needed to wait for the device to wake up and input triggers types can be fixed.

**Should be tagged for milestone 2021.4.3**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/48837
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
