### PR TITLE
Allow top level non-trigger template entities

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -6,7 +6,6 @@ import logging
 from typing import Callable
 
 from homeassistant import config as conf_util
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_START, SERVICE_RELOAD
 from homeassistant.core import CoreState, Event, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -57,23 +56,41 @@ async def async_setup(hass, config):
     return True
 
 
-async def _process_config(hass, config):
+async def _process_config(hass, hass_config):
     """Process config."""
-    coordinators: list[TriggerUpdateCoordinator] | None = hass.data.get(DOMAIN)
+    coordinators: list[TriggerUpdateCoordinator] | None = hass.data.pop(DOMAIN, None)
 
     # Remove old ones
     if coordinators:
         for coordinator in coordinators:
             coordinator.async_remove()
 
-    async def init_coordinator(hass, conf):
-        coordinator = TriggerUpdateCoordinator(hass, conf)
-        await coordinator.async_setup(config)
+    async def init_coordinator(hass, conf_section):
+        coordinator = TriggerUpdateCoordinator(hass, conf_section)
+        await coordinator.async_setup(hass_config)
         return coordinator
 
-    hass.data[DOMAIN] = await asyncio.gather(
-        *[init_coordinator(hass, conf) for conf in config[DOMAIN]]
-    )
+    coordinator_tasks = []
+
+    for conf_section in hass_config[DOMAIN]:
+        if CONF_TRIGGER in conf_section:
+            coordinator_tasks.append(init_coordinator(hass, conf_section))
+            continue
+
+        for platform_domain in PLATFORMS:
+            if platform_domain in conf_section:
+                hass.async_create_task(
+                    discovery.async_load_platform(
+                        hass,
+                        platform_domain,
+                        DOMAIN,
+                        {"entities": conf_section[platform_domain]},
+                        hass_config,
+                    )
+                )
+
+    if coordinator_tasks:
+        hass.data[DOMAIN] = await asyncio.gather(*coordinator_tasks)
 
 
 class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
@@ -110,16 +127,17 @@ class TriggerUpdateCoordinator(update_coordinator.DataUpdateCoordinator):
                 EVENT_HOMEASSISTANT_START, self._attach_triggers
             )
 
-        for platform_domain in (SENSOR_DOMAIN,):
-            self.hass.async_create_task(
-                discovery.async_load_platform(
-                    self.hass,
-                    platform_domain,
-                    DOMAIN,
-                    {"coordinator": self, "entities": self.config[platform_domain]},
-                    hass_config,
+        for platform_domain in PLATFORMS:
+            if platform_domain in self.config:
+                self.hass.async_create_task(
+                    discovery.async_load_platform(
+                        self.hass,
+                        platform_domain,
+                        DOMAIN,
+                        {"coordinator": self, "entities": self.config[platform_domain]},
+                        hass_config,
+                    )
                 )
-            )
 
     async def _attach_triggers(self, start_event=None) -> None:
         """Attach the triggers."""

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -47,7 +47,9 @@ async def async_validate_config(hass, config):
 
         if CONF_SENSORS in cfg:
             logging.getLogger(__name__).warning(
-                "The entity definition format under template: differs from the platform configuration format. See https://www.home-assistant.io/integrations/template#configuration-for-trigger-based-template-sensors"
+                "The entity definition format under template: differs from the platform "
+                "configuration format. See "
+                "https://www.home-assistant.io/integrations/template#configuration-for-trigger-based-template-sensors"
             )
             sensors = list(cfg[SENSOR_DOMAIN]) if SENSOR_DOMAIN in cfg else []
             sensors.extend(

--- a/homeassistant/components/template/config.py
+++ b/homeassistant/components/template/config.py
@@ -3,99 +3,27 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.sensor import (
-    DEVICE_CLASSES_SCHEMA as SENSOR_DEVICE_CLASSES_SCHEMA,
-    DOMAIN as SENSOR_DOMAIN,
-)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config import async_log_exception, config_without_domain
-from homeassistant.const import (
-    CONF_DEVICE_CLASS,
-    CONF_ENTITY_PICTURE_TEMPLATE,
-    CONF_FRIENDLY_NAME,
-    CONF_FRIENDLY_NAME_TEMPLATE,
-    CONF_ICON,
-    CONF_ICON_TEMPLATE,
-    CONF_NAME,
-    CONF_SENSORS,
-    CONF_STATE,
-    CONF_UNIQUE_ID,
-    CONF_UNIT_OF_MEASUREMENT,
-    CONF_VALUE_TEMPLATE,
-)
-from homeassistant.helpers import config_validation as cv, template
+from homeassistant.const import CONF_SENSORS, CONF_UNIQUE_ID
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.trigger import async_validate_trigger_config
 
-from .const import (
-    CONF_ATTRIBUTE_TEMPLATES,
-    CONF_ATTRIBUTES,
-    CONF_AVAILABILITY,
-    CONF_AVAILABILITY_TEMPLATE,
-    CONF_PICTURE,
-    CONF_TRIGGER,
-    DOMAIN,
-)
-from .sensor import SENSOR_SCHEMA as PLATFORM_SENSOR_SCHEMA
-
-LEGACY_SENSOR = {
-    CONF_ICON_TEMPLATE: CONF_ICON,
-    CONF_ENTITY_PICTURE_TEMPLATE: CONF_PICTURE,
-    CONF_AVAILABILITY_TEMPLATE: CONF_AVAILABILITY,
-    CONF_ATTRIBUTE_TEMPLATES: CONF_ATTRIBUTES,
-    CONF_FRIENDLY_NAME_TEMPLATE: CONF_NAME,
-    CONF_FRIENDLY_NAME: CONF_NAME,
-    CONF_VALUE_TEMPLATE: CONF_STATE,
-}
-
-
-SENSOR_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_NAME): cv.template,
-        vol.Required(CONF_STATE): cv.template,
-        vol.Optional(CONF_ICON): cv.template,
-        vol.Optional(CONF_PICTURE): cv.template,
-        vol.Optional(CONF_AVAILABILITY): cv.template,
-        vol.Optional(CONF_ATTRIBUTES): vol.Schema({cv.string: cv.template}),
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-        vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
-        vol.Optional(CONF_UNIQUE_ID): cv.string,
-    }
-)
+from . import sensor as sensor_platform
+from .const import CONF_TRIGGER, DOMAIN
 
 CONFIG_SECTION_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_UNIQUE_ID): cv.string,
-        vol.Required(CONF_TRIGGER): cv.TRIGGER_SCHEMA,
-        vol.Optional(SENSOR_DOMAIN): vol.All(cv.ensure_list, [SENSOR_SCHEMA]),
-        vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(PLATFORM_SENSOR_SCHEMA),
+        vol.Optional(CONF_TRIGGER): cv.TRIGGER_SCHEMA,
+        vol.Optional(SENSOR_DOMAIN): vol.All(
+            cv.ensure_list, [sensor_platform.SENSOR_SCHEMA]
+        ),
+        vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(
+            sensor_platform.LEGACY_SENSOR_SCHEMA
+        ),
     }
 )
-
-
-def _rewrite_legacy_to_modern_trigger_conf(cfg: dict):
-    """Rewrite a legacy to a modern trigger-basd conf."""
-    logging.getLogger(__name__).warning(
-        "The entity definition format under template: differs from the platform configuration format. See https://www.home-assistant.io/integrations/template#configuration-for-trigger-based-template-sensors"
-    )
-    sensor = list(cfg[SENSOR_DOMAIN]) if SENSOR_DOMAIN in cfg else []
-
-    for device_id, entity_cfg in cfg[CONF_SENSORS].items():
-        entity_cfg = {**entity_cfg}
-
-        for from_key, to_key in LEGACY_SENSOR.items():
-            if from_key not in entity_cfg or to_key in entity_cfg:
-                continue
-
-            val = entity_cfg.pop(from_key)
-            if isinstance(val, str):
-                val = template.Template(val)
-            entity_cfg[to_key] = val
-
-        if CONF_NAME not in entity_cfg:
-            entity_cfg[CONF_NAME] = template.Template(device_id)
-
-        sensor.append(entity_cfg)
-
-    return {**cfg, "sensor": sensor}
 
 
 async def async_validate_config(hass, config):
@@ -108,15 +36,24 @@ async def async_validate_config(hass, config):
     for cfg in cv.ensure_list(config[DOMAIN]):
         try:
             cfg = CONFIG_SECTION_SCHEMA(cfg)
-            cfg[CONF_TRIGGER] = await async_validate_trigger_config(
-                hass, cfg[CONF_TRIGGER]
-            )
+
+            if CONF_TRIGGER in cfg:
+                cfg[CONF_TRIGGER] = await async_validate_trigger_config(
+                    hass, cfg[CONF_TRIGGER]
+                )
         except vol.Invalid as err:
             async_log_exception(err, DOMAIN, cfg, hass)
             continue
 
-        if CONF_TRIGGER in cfg and CONF_SENSORS in cfg:
-            cfg = _rewrite_legacy_to_modern_trigger_conf(cfg)
+        if CONF_SENSORS in cfg:
+            logging.getLogger(__name__).warning(
+                "The entity definition format under template: differs from the platform configuration format. See https://www.home-assistant.io/integrations/template#configuration-for-trigger-based-template-sensors"
+            )
+            sensors = list(cfg[SENSOR_DOMAIN]) if SENSOR_DOMAIN in cfg else []
+            sensors.extend(
+                sensor_platform.rewrite_legacy_to_modern_conf(cfg[CONF_SENSORS])
+            )
+            cfg = {**cfg, "sensor": sensors}
 
         config_sections.append(cfg)
 

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -24,3 +24,4 @@ PLATFORMS = [
 CONF_AVAILABILITY = "availability"
 CONF_ATTRIBUTES = "attributes"
 CONF_PICTURE = "picture"
+CONF_DEVICE_ID = "device_id"

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -24,4 +24,4 @@ PLATFORMS = [
 CONF_AVAILABILITY = "availability"
 CONF_ATTRIBUTES = "attributes"
 CONF_PICTURE = "picture"
-CONF_DEVICE_ID = "device_id"
+CONF_OBJECT_ID = "object_id"

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -135,7 +135,6 @@ PLATFORM_SCHEMA = vol.All(
         {
             vol.Optional(CONF_TRIGGER): cv.match_all,  # to raise custom warning
             vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(LEGACY_SENSOR_SCHEMA),
-            vol.Optional(SENSOR_DOMAIN): vol.All(cv.ensure_list, [SENSOR_SCHEMA]),
         }
     ),
     extra_validation_checks,

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -238,6 +238,7 @@ class SensorTemplate(TemplateEntity, SensorEntity):
         self._name: str | None = None
         self._friendly_name_template = friendly_name_template
 
+        # Try to render the name as it can influence the entity ID
         if friendly_name_template:
             friendly_name_template.hass = hass
             try:

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -245,10 +245,6 @@ class SensorTemplate(TemplateEntity, SensorEntity):
                 self._name = friendly_name_template.async_render(parse_result=False)
             except template.TemplateError:
                 pass
-            finally:
-                # This is so TemplateEntity can group
-                # them together correctly.
-                friendly_name_template.hass = None
 
         self._unit_of_measurement = unit_of_measurement
         self._template = state_template

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -44,7 +44,7 @@ from .const import (
 from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
-LEGACY_SENSOR_FIELDS = {
+LEGACY_FIELDS = {
     CONF_ICON_TEMPLATE: CONF_ICON,
     CONF_ENTITY_PICTURE_TEMPLATE: CONF_PICTURE,
     CONF_AVAILABILITY_TEMPLATE: CONF_AVAILABILITY,
@@ -113,7 +113,7 @@ def rewrite_legacy_to_modern_conf(cfg: dict[str, dict]) -> list[dict]:
     for device_id, entity_cfg in cfg.items():
         entity_cfg = {**entity_cfg, CONF_DEVICE_ID: device_id}
 
-        for from_key, to_key in LEGACY_SENSOR_FIELDS.items():
+        for from_key, to_key in LEGACY_FIELDS.items():
             if from_key not in entity_cfg or to_key in entity_cfg:
                 continue
 

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -1,6 +1,8 @@
 """Allows the creation of a sensor that breaks out state_attributes."""
 from __future__ import annotations
 
+from itertools import chain
+
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -16,7 +18,9 @@ from homeassistant.const import (
     CONF_ENTITY_PICTURE_TEMPLATE,
     CONF_FRIENDLY_NAME,
     CONF_FRIENDLY_NAME_TEMPLATE,
+    CONF_ICON,
     CONF_ICON_TEMPLATE,
+    CONF_NAME,
     CONF_SENSORS,
     CONF_STATE,
     CONF_UNIQUE_ID,
@@ -25,14 +29,48 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.exceptions import TemplateError
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, template
 from homeassistant.helpers.entity import async_generate_entity_id
 
-from .const import CONF_ATTRIBUTE_TEMPLATES, CONF_AVAILABILITY_TEMPLATE, CONF_TRIGGER
+from .const import (
+    CONF_ATTRIBUTE_TEMPLATES,
+    CONF_ATTRIBUTES,
+    CONF_AVAILABILITY,
+    CONF_AVAILABILITY_TEMPLATE,
+    CONF_DEVICE_ID,
+    CONF_PICTURE,
+    CONF_TRIGGER,
+)
 from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
 
-SENSOR_SCHEMA = vol.All(
+LEGACY_SENSOR_FIELDS = {
+    CONF_ICON_TEMPLATE: CONF_ICON,
+    CONF_ENTITY_PICTURE_TEMPLATE: CONF_PICTURE,
+    CONF_AVAILABILITY_TEMPLATE: CONF_AVAILABILITY,
+    CONF_ATTRIBUTE_TEMPLATES: CONF_ATTRIBUTES,
+    CONF_FRIENDLY_NAME_TEMPLATE: CONF_NAME,
+    CONF_FRIENDLY_NAME: CONF_NAME,
+    CONF_VALUE_TEMPLATE: CONF_STATE,
+}
+
+
+SENSOR_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME): cv.template,
+        vol.Required(CONF_STATE): cv.template,
+        vol.Optional(CONF_ICON): cv.template,
+        vol.Optional(CONF_PICTURE): cv.template,
+        vol.Optional(CONF_AVAILABILITY): cv.template,
+        vol.Optional(CONF_ATTRIBUTES): vol.Schema({cv.string: cv.template}),
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+    }
+)
+
+
+LEGACY_SENSOR_SCHEMA = vol.All(
     cv.deprecated(ATTR_ENTITY_ID),
     vol.Schema(
         {
@@ -54,50 +92,79 @@ SENSOR_SCHEMA = vol.All(
 )
 
 
-def trigger_warning(val):
-    """Warn if a trigger is defined."""
+def extra_validation_checks(val):
+    """Run extra validation checks."""
     if CONF_TRIGGER in val:
         raise vol.Invalid(
             "You can only add triggers to template entities if they are defined under `template:`. "
             "See the template documentation for more information: https://www.home-assistant.io/integrations/template/"
         )
 
+    if CONF_SENSORS not in val and SENSOR_DOMAIN not in val:
+        raise vol.Invalid(f"Required key {SENSOR_DOMAIN} not defined")
+
     return val
+
+
+def rewrite_legacy_to_modern_conf(cfg: dict[str, dict]) -> list[dict]:
+    """Rewrite a legacy sensor definitions to modern ones."""
+    sensors = []
+
+    for device_id, entity_cfg in cfg.items():
+        entity_cfg = {**entity_cfg, CONF_DEVICE_ID: device_id}
+
+        for from_key, to_key in LEGACY_SENSOR_FIELDS.items():
+            if from_key not in entity_cfg or to_key in entity_cfg:
+                continue
+
+            val = entity_cfg.pop(from_key)
+            if isinstance(val, str):
+                val = template.Template(val)
+            entity_cfg[to_key] = val
+
+        if CONF_NAME not in entity_cfg:
+            entity_cfg[CONF_NAME] = template.Template(device_id)
+
+        sensors.append(entity_cfg)
+
+    return sensors
 
 
 PLATFORM_SCHEMA = vol.All(
     PLATFORM_SCHEMA.extend(
         {
             vol.Optional(CONF_TRIGGER): cv.match_all,  # to raise custom warning
-            vol.Required(CONF_SENSORS): cv.schema_with_slug_keys(SENSOR_SCHEMA),
+            vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(LEGACY_SENSOR_SCHEMA),
+            vol.Optional(SENSOR_DOMAIN): vol.All(cv.ensure_list, [SENSOR_SCHEMA]),
         }
     ),
-    trigger_warning,
+    extra_validation_checks,
 )
 
 
 @callback
-def _async_create_template_tracking_entities(hass, config):
+def _async_create_template_tracking_entities(async_add_entities, hass, definitions):
     """Create the template sensors."""
     sensors = []
 
-    for device, device_config in config[CONF_SENSORS].items():
-        state_template = device_config[CONF_VALUE_TEMPLATE]
-        icon_template = device_config.get(CONF_ICON_TEMPLATE)
-        entity_picture_template = device_config.get(CONF_ENTITY_PICTURE_TEMPLATE)
-        availability_template = device_config.get(CONF_AVAILABILITY_TEMPLATE)
-        friendly_name = device_config.get(CONF_FRIENDLY_NAME, device)
-        friendly_name_template = device_config.get(CONF_FRIENDLY_NAME_TEMPLATE)
-        unit_of_measurement = device_config.get(CONF_UNIT_OF_MEASUREMENT)
-        device_class = device_config.get(CONF_DEVICE_CLASS)
-        attribute_templates = device_config.get(CONF_ATTRIBUTE_TEMPLATES, {})
-        unique_id = device_config.get(CONF_UNIQUE_ID)
+    for entity_conf in definitions:
+        # Still available on legacy
+        device_id = entity_conf.get(CONF_DEVICE_ID)
+
+        state_template = entity_conf[CONF_STATE]
+        icon_template = entity_conf.get(CONF_ICON)
+        entity_picture_template = entity_conf.get(CONF_PICTURE)
+        availability_template = entity_conf.get(CONF_AVAILABILITY)
+        friendly_name_template = entity_conf.get(CONF_NAME)
+        unit_of_measurement = entity_conf.get(CONF_UNIT_OF_MEASUREMENT)
+        device_class = entity_conf.get(CONF_DEVICE_CLASS)
+        attribute_templates = entity_conf.get(CONF_ATTRIBUTES, {})
+        unique_id = entity_conf.get(CONF_UNIQUE_ID)
 
         sensors.append(
             SensorTemplate(
                 hass,
-                device,
-                friendly_name,
+                device_id,
                 friendly_name_template,
                 unit_of_measurement,
                 state_template,
@@ -110,18 +177,33 @@ def _async_create_template_tracking_entities(hass, config):
             )
         )
 
-    return sensors
+    async_add_entities(sensors)
 
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template sensors."""
-    if discovery_info is None:
-        async_add_entities(_async_create_template_tracking_entities(hass, config))
-    else:
+    if discovery_info is not None:
+        if "coordinator" not in discovery_info:
+            _async_create_template_tracking_entities(
+                async_add_entities, hass, discovery_info["entities"]
+            )
+            return
+
         async_add_entities(
             TriggerSensorEntity(hass, discovery_info["coordinator"], config)
             for config in discovery_info["entities"]
         )
+        return
+
+    defs = []
+
+    if SENSOR_DOMAIN in config:
+        defs.append(config[SENSOR_DOMAIN])
+
+    if CONF_SENSORS in config:
+        defs.append(rewrite_legacy_to_modern_conf(config[CONF_SENSORS]))
+
+    _async_create_template_tracking_entities(async_add_entities, hass, chain(*defs))
 
 
 class SensorTemplate(TemplateEntity, SensorEntity):
@@ -130,17 +212,16 @@ class SensorTemplate(TemplateEntity, SensorEntity):
     def __init__(
         self,
         hass,
-        device_id,
-        friendly_name,
-        friendly_name_template,
-        unit_of_measurement,
-        state_template,
-        icon_template,
-        entity_picture_template,
-        availability_template,
-        device_class,
-        attribute_templates,
-        unique_id,
+        device_id: str | None,
+        friendly_name_template: template.Template,
+        unit_of_measurement: str | None,
+        state_template: template.Template,
+        icon_template: template.Template | None,
+        entity_picture_template: template.Template | None,
+        availability_template: template.Template | None,
+        device_class: str | None,
+        attribute_templates: dict[str, template.Template],
+        unique_id: str | None,
     ):
         """Initialize the sensor."""
         super().__init__(
@@ -149,11 +230,18 @@ class SensorTemplate(TemplateEntity, SensorEntity):
             icon_template=icon_template,
             entity_picture_template=entity_picture_template,
         )
-        self.entity_id = async_generate_entity_id(
-            ENTITY_ID_FORMAT, device_id, hass=hass
-        )
-        self._name = friendly_name
-        self._friendly_name_template = friendly_name_template
+        if device_id is not None:
+            self.entity_id = async_generate_entity_id(
+                ENTITY_ID_FORMAT, device_id, hass=hass
+            )
+
+        if friendly_name_template and friendly_name_template.is_static:
+            self._name = friendly_name_template.async_render(parse_result=False)
+            self._friendly_name_template = None
+        else:
+            self._friendly_name_template = friendly_name_template
+            self._name = None
+
         self._unit_of_measurement = unit_of_measurement
         self._template = state_template
         self._state = None

--- a/homeassistant/components/template/sensor.py
+++ b/homeassistant/components/template/sensor.py
@@ -37,7 +37,7 @@ from .const import (
     CONF_ATTRIBUTES,
     CONF_AVAILABILITY,
     CONF_AVAILABILITY_TEMPLATE,
-    CONF_DEVICE_ID,
+    CONF_OBJECT_ID,
     CONF_PICTURE,
     CONF_TRIGGER,
 )
@@ -110,8 +110,8 @@ def rewrite_legacy_to_modern_conf(cfg: dict[str, dict]) -> list[dict]:
     """Rewrite a legacy sensor definitions to modern ones."""
     sensors = []
 
-    for device_id, entity_cfg in cfg.items():
-        entity_cfg = {**entity_cfg, CONF_DEVICE_ID: device_id}
+    for object_id, entity_cfg in cfg.items():
+        entity_cfg = {**entity_cfg, CONF_OBJECT_ID: object_id}
 
         for from_key, to_key in LEGACY_FIELDS.items():
             if from_key not in entity_cfg or to_key in entity_cfg:
@@ -123,7 +123,7 @@ def rewrite_legacy_to_modern_conf(cfg: dict[str, dict]) -> list[dict]:
             entity_cfg[to_key] = val
 
         if CONF_NAME not in entity_cfg:
-            entity_cfg[CONF_NAME] = template.Template(device_id)
+            entity_cfg[CONF_NAME] = template.Template(object_id)
 
         sensors.append(entity_cfg)
 
@@ -149,7 +149,7 @@ def _async_create_template_tracking_entities(async_add_entities, hass, definitio
 
     for entity_conf in definitions:
         # Still available on legacy
-        device_id = entity_conf.get(CONF_DEVICE_ID)
+        object_id = entity_conf.get(CONF_OBJECT_ID)
 
         state_template = entity_conf[CONF_STATE]
         icon_template = entity_conf.get(CONF_ICON)
@@ -164,7 +164,7 @@ def _async_create_template_tracking_entities(async_add_entities, hass, definitio
         sensors.append(
             SensorTemplate(
                 hass,
-                device_id,
+                object_id,
                 friendly_name_template,
                 unit_of_measurement,
                 state_template,
@@ -212,7 +212,7 @@ class SensorTemplate(TemplateEntity, SensorEntity):
     def __init__(
         self,
         hass,
-        device_id: str | None,
+        object_id: str | None,
         friendly_name_template: template.Template,
         unit_of_measurement: str | None,
         state_template: template.Template,
@@ -230,9 +230,9 @@ class SensorTemplate(TemplateEntity, SensorEntity):
             icon_template=icon_template,
             entity_picture_template=entity_picture_template,
         )
-        if device_id is not None:
+        if object_id is not None:
             self.entity_id = async_generate_entity_id(
-                ENTITY_ID_FORMAT, device_id, hass=hass
+                ENTITY_ID_FORMAT, object_id, hass=hass
             )
 
         if friendly_name_template and friendly_name_template.is_static:

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -28,26 +28,37 @@ async def test_reloadable(hass):
                     },
                 },
             },
-            "template": {
-                "trigger": {"platform": "event", "event_type": "event_1"},
-                "sensor": {
-                    "name": "top level",
-                    "state": "{{ trigger.event.data.source }}",
+            "template": [
+                {
+                    "trigger": {"platform": "event", "event_type": "event_1"},
+                    "sensor": {
+                        "name": "top level",
+                        "state": "{{ trigger.event.data.source }}",
+                    },
                 },
-            },
+                {
+                    "sensor": {
+                        "name": "top level state",
+                        "state": "{{ states.sensor.top_level.state }} + 2",
+                    },
+                },
+            ],
         },
     )
     await hass.async_block_till_done()
 
     await hass.async_start()
     await hass.async_block_till_done()
+    assert hass.states.get("sensor.top_level_state").state == "unknown + 2"
 
     hass.bus.async_fire("event_1", {"source": "init"})
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 4
     assert hass.states.get("sensor.state").state == "mytest"
     assert hass.states.get("sensor.top_level").state == "init"
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.top_level_state").state == "init + 2"
 
     yaml_path = path.join(
         _get_fixtures_base_path(),

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -35,6 +35,33 @@ async def test_template(hass):
             {
                 "sensor": {
                     "platform": "template",
+                    "sensor": [{"state": "It {{ states.sensor.test_state.state }}."}],
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.unnamed_device")
+    assert state.state == "It ."
+
+    hass.states.async_set("sensor.test_state", "Works")
+    await hass.async_block_till_done()
+    state = hass.states.get("sensor.unnamed_device")
+    assert state.state == "It Works."
+
+
+async def test_template_legacy(hass):
+    """Test template."""
+    with assert_setup_component(1, sensor.DOMAIN):
+        assert await async_setup_component(
+            hass,
+            sensor.DOMAIN,
+            {
+                "sensor": {
+                    "platform": "template",
                     "sensors": {
                         "test_template_sensor": {
                             "value_template": "It {{ states.sensor.test_state.state }}."

--- a/tests/components/template/test_sensor.py
+++ b/tests/components/template/test_sensor.py
@@ -26,33 +26,6 @@ import homeassistant.util.dt as dt_util
 from tests.common import assert_setup_component, async_fire_time_changed
 
 
-async def test_template(hass):
-    """Test template."""
-    with assert_setup_component(1, sensor.DOMAIN):
-        assert await async_setup_component(
-            hass,
-            sensor.DOMAIN,
-            {
-                "sensor": {
-                    "platform": "template",
-                    "sensor": [{"state": "It {{ states.sensor.test_state.state }}."}],
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.unnamed_device")
-    assert state.state == "It ."
-
-    hass.states.async_set("sensor.test_state", "Works")
-    await hass.async_block_till_done()
-    state = hass.states.get("sensor.unnamed_device")
-    assert state.state == "It Works."
-
-
 async def test_template_legacy(hass):
     """Test template."""
     with assert_setup_component(1, sensor.DOMAIN):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Allow defining sensor entities under `template:` top-level configuration that do not rely on a trigger (in both old + new format).
- ~~Add support for the new config format in the platform config~~

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
