### PR TITLE
Internally work with modern config syntax for template binary sensor platform config

### DIFF
--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -119,7 +119,7 @@ def rewrite_legacy_to_modern_conf(cfg: dict[str, dict]) -> list[dict]:
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(
+        vol.Required(CONF_SENSORS): cv.schema_with_slug_keys(
             LEGACY_BINARY_SENSOR_SCHEMA
         ),
     }

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -1,8 +1,13 @@
 """Support for exposing a templated binary sensor."""
+from __future__ import annotations
+
+from itertools import chain
+
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
+    DOMAIN as BINARY_SENSOR_DOMAIN,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
     BinarySensorEntity,
@@ -12,26 +17,64 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     CONF_DEVICE_CLASS,
     CONF_ENTITY_PICTURE_TEMPLATE,
+    CONF_FRIENDLY_NAME,
+    CONF_FRIENDLY_NAME_TEMPLATE,
+    CONF_ICON,
     CONF_ICON_TEMPLATE,
+    CONF_NAME,
     CONF_SENSORS,
+    CONF_STATE,
     CONF_UNIQUE_ID,
+    CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import TemplateError
+from homeassistant.helpers import template
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import async_generate_entity_id
 from homeassistant.helpers.event import async_call_later
-from homeassistant.helpers.template import result_as_boolean
 
-from .const import CONF_AVAILABILITY_TEMPLATE
+from .const import (
+    CONF_ATTRIBUTES,
+    CONF_AVAILABILITY,
+    CONF_AVAILABILITY_TEMPLATE,
+    CONF_OBJECT_ID,
+    CONF_PICTURE,
+)
 from .template_entity import TemplateEntity
 
 CONF_DELAY_ON = "delay_on"
 CONF_DELAY_OFF = "delay_off"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 
-SENSOR_SCHEMA = vol.All(
+LEGACY_FIELDS = {
+    CONF_ICON_TEMPLATE: CONF_ICON,
+    CONF_ENTITY_PICTURE_TEMPLATE: CONF_PICTURE,
+    CONF_AVAILABILITY_TEMPLATE: CONF_AVAILABILITY,
+    CONF_ATTRIBUTE_TEMPLATES: CONF_ATTRIBUTES,
+    CONF_FRIENDLY_NAME_TEMPLATE: CONF_NAME,
+    CONF_FRIENDLY_NAME: CONF_NAME,
+    CONF_VALUE_TEMPLATE: CONF_STATE,
+}
+
+BINARY_SENSOR_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_NAME): cv.template,
+        vol.Required(CONF_STATE): cv.template,
+        vol.Optional(CONF_ICON): cv.template,
+        vol.Optional(CONF_PICTURE): cv.template,
+        vol.Optional(CONF_AVAILABILITY): cv.template,
+        vol.Optional(CONF_ATTRIBUTES): vol.Schema({cv.string: cv.template}),
+        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_UNIQUE_ID): cv.string,
+        vol.Optional(CONF_DELAY_ON): vol.Any(cv.positive_time_period, cv.template),
+        vol.Optional(CONF_DELAY_OFF): vol.Any(cv.positive_time_period, cv.template),
+    }
+)
+
+LEGACY_BINARY_SENSOR_SCHEMA = vol.All(
     cv.deprecated(ATTR_ENTITY_ID),
     vol.Schema(
         {
@@ -52,51 +95,94 @@ SENSOR_SCHEMA = vol.All(
     ),
 )
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {vol.Required(CONF_SENSORS): cv.schema_with_slug_keys(SENSOR_SCHEMA)}
-)
 
-
-async def _async_create_entities(hass, config):
-    """Create the template binary sensors."""
+def rewrite_legacy_to_modern_conf(cfg: dict[str, dict]) -> list[dict]:
+    """Rewrite legacy binary sensor definitions to modern ones."""
     sensors = []
 
-    for device, device_config in config[CONF_SENSORS].items():
-        value_template = device_config[CONF_VALUE_TEMPLATE]
-        icon_template = device_config.get(CONF_ICON_TEMPLATE)
-        entity_picture_template = device_config.get(CONF_ENTITY_PICTURE_TEMPLATE)
-        availability_template = device_config.get(CONF_AVAILABILITY_TEMPLATE)
-        attribute_templates = device_config.get(CONF_ATTRIBUTE_TEMPLATES, {})
+    for object_id, entity_cfg in cfg.items():
+        entity_cfg = {**entity_cfg, CONF_OBJECT_ID: object_id}
 
-        friendly_name = device_config.get(ATTR_FRIENDLY_NAME, device)
-        device_class = device_config.get(CONF_DEVICE_CLASS)
-        delay_on_raw = device_config.get(CONF_DELAY_ON)
-        delay_off_raw = device_config.get(CONF_DELAY_OFF)
-        unique_id = device_config.get(CONF_UNIQUE_ID)
+        for from_key, to_key in LEGACY_FIELDS.items():
+            if from_key not in entity_cfg or to_key in entity_cfg:
+                continue
 
-        sensors.append(
-            BinarySensorTemplate(
-                hass,
-                device,
-                friendly_name,
-                device_class,
-                value_template,
-                icon_template,
-                entity_picture_template,
-                availability_template,
-                delay_on_raw,
-                delay_off_raw,
-                attribute_templates,
-                unique_id,
-            )
-        )
+            val = entity_cfg.pop(from_key)
+            if isinstance(val, str):
+                val = template.Template(val)
+            entity_cfg[to_key] = val
+
+        if CONF_NAME not in entity_cfg:
+            entity_cfg[CONF_NAME] = template.Template(object_id)
+
+        sensors.append(entity_cfg)
 
     return sensors
 
 
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(
+            LEGACY_BINARY_SENSOR_SCHEMA
+        ),
+        vol.Optional(BINARY_SENSOR_DOMAIN): vol.All(
+            cv.ensure_list, [BINARY_SENSOR_SCHEMA]
+        ),
+    }
+)
+
+
+@callback
+def _async_create_template_tracking_entities(async_add_entities, hass, definitions):
+    """Create the template binary sensors."""
+    sensors = []
+
+    for entity_conf in definitions:
+        # Still available on legacy
+        object_id = entity_conf.get(CONF_OBJECT_ID)
+
+        value = entity_conf[CONF_STATE]
+        icon = entity_conf.get(CONF_ICON)
+        entity_picture = entity_conf.get(CONF_PICTURE)
+        availability = entity_conf.get(CONF_AVAILABILITY)
+        attributes = entity_conf.get(CONF_ATTRIBUTES, {})
+        friendly_name = entity_conf.get(CONF_NAME)
+        device_class = entity_conf.get(CONF_DEVICE_CLASS)
+        delay_on_raw = entity_conf.get(CONF_DELAY_ON)
+        delay_off_raw = entity_conf.get(CONF_DELAY_OFF)
+        unique_id = entity_conf.get(CONF_UNIQUE_ID)
+
+        sensors.append(
+            BinarySensorTemplate(
+                hass,
+                object_id,
+                friendly_name,
+                device_class,
+                value,
+                icon,
+                entity_picture,
+                availability,
+                delay_on_raw,
+                delay_off_raw,
+                attributes,
+                unique_id,
+            )
+        )
+
+    async_add_entities(sensors)
+
+
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template binary sensors."""
-    async_add_entities(await _async_create_entities(hass, config))
+    defs = []
+
+    if BINARY_SENSOR_DOMAIN in config:
+        defs.append(config[BINARY_SENSOR_DOMAIN])
+
+    if CONF_SENSORS in config:
+        defs.append(rewrite_legacy_to_modern_conf(config[CONF_SENSORS]))
+
+    _async_create_template_tracking_entities(async_add_entities, hass, chain(*defs))
 
 
 class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
@@ -104,18 +190,18 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        hass,
-        device,
-        friendly_name,
-        device_class,
-        value_template,
-        icon_template,
-        entity_picture_template,
-        availability_template,
+        hass: HomeAssistant,
+        object_id: str | None,
+        friendly_name: template.Template | None,
+        device_class: str,
+        value_template: template.Template,
+        icon_template: template.Template | None,
+        entity_picture_template: template.Template | None,
+        availability_template: template.Template | None,
         delay_on_raw,
         delay_off_raw,
-        attribute_templates,
-        unique_id,
+        attribute_templates: dict[str, template.Template],
+        unique_id: str | None,
     ):
         """Initialize the Template binary sensor."""
         super().__init__(
@@ -124,8 +210,21 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
             icon_template=icon_template,
             entity_picture_template=entity_picture_template,
         )
-        self.entity_id = async_generate_entity_id(ENTITY_ID_FORMAT, device, hass=hass)
-        self._name = friendly_name
+        if object_id is not None:
+            self.entity_id = async_generate_entity_id(
+                ENTITY_ID_FORMAT, object_id, hass=hass
+            )
+
+        self._name: str | None = None
+        self._friendly_name_template: template.Template | None = friendly_name
+
+        if friendly_name:
+            friendly_name.hass = hass
+            try:
+                self._name = friendly_name.async_render(parse_result=False)
+            except template.TemplateError:
+                pass
+
         self._device_class = device_class
         self._template = value_template
         self._state = None
@@ -139,6 +238,11 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
     async def async_added_to_hass(self):
         """Register callbacks."""
         self.add_template_attribute("_state", self._template, None, self._update_state)
+        if (
+            self._friendly_name_template is not None
+            and not self._friendly_name_template.is_static
+        ):
+            self.add_template_attribute("_name", self._friendly_name_template)
 
         if self._delay_on_raw is not None:
             try:
@@ -166,7 +270,11 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
             self._delay_cancel()
             self._delay_cancel = None
 
-        state = None if isinstance(result, TemplateError) else result_as_boolean(result)
+        state = (
+            None
+            if isinstance(result, TemplateError)
+            else template.result_as_boolean(result)
+        )
 
         if state == self._state:
             return

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -1,13 +1,10 @@
 """Support for exposing a templated binary sensor."""
 from __future__ import annotations
 
-from itertools import chain
-
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASSES_SCHEMA,
-    DOMAIN as BINARY_SENSOR_DOMAIN,
     ENTITY_ID_FORMAT,
     PLATFORM_SCHEMA,
     BinarySensorEntity,
@@ -171,15 +168,9 @@ def _async_create_template_tracking_entities(async_add_entities, hass, definitio
 
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the template binary sensors."""
-    defs = []
-
-    if BINARY_SENSOR_DOMAIN in config:
-        defs.append(config[BINARY_SENSOR_DOMAIN])
-
-    if CONF_SENSORS in config:
-        defs.append(rewrite_legacy_to_modern_conf(config[CONF_SENSORS]))
-
-    _async_create_template_tracking_entities(async_add_entities, hass, chain(*defs))
+    _async_create_template_tracking_entities(
+        async_add_entities, hass, rewrite_legacy_to_modern_conf(config[CONF_SENSORS])
+    )
 
 
 class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -125,9 +125,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_SENSORS): cv.schema_with_slug_keys(
             LEGACY_BINARY_SENSOR_SCHEMA
         ),
-        vol.Optional(BINARY_SENSOR_DOMAIN): vol.All(
-            cv.ensure_list, [BINARY_SENSOR_SCHEMA]
-        ),
     }
 )
 

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -218,12 +218,17 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
         self._name: str | None = None
         self._friendly_name_template: template.Template | None = friendly_name
 
+        # Try to render the name as it can influence the entity ID
         if friendly_name:
             friendly_name.hass = hass
             try:
                 self._name = friendly_name.async_render(parse_result=False)
             except template.TemplateError:
                 pass
+            finally:
+                # This is so TemplateEntity can group
+                # them together correctly.
+                friendly_name.hass = None
 
         self._device_class = device_class
         self._template = value_template

--- a/homeassistant/components/template/binary_sensor.py
+++ b/homeassistant/components/template/binary_sensor.py
@@ -225,10 +225,6 @@ class BinarySensorTemplate(TemplateEntity, BinarySensorEntity):
                 self._name = friendly_name.async_render(parse_result=False)
             except template.TemplateError:
                 pass
-            finally:
-                # This is so TemplateEntity can group
-                # them together correctly.
-                friendly_name.hass = None
 
         self._device_class = device_class
         self._template = value_template

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -24,3 +24,4 @@ PLATFORMS = [
 CONF_AVAILABILITY = "availability"
 CONF_ATTRIBUTES = "attributes"
 CONF_PICTURE = "picture"
+CONF_OBJECT_ID = "object_id"

--- a/tests/components/template/test_binary_sensor.py
+++ b/tests/components/template/test_binary_sensor.py
@@ -906,37 +906,3 @@ async def test_template_validation_error(hass, caplog):
 
     state = hass.states.get("binary_sensor.test")
     assert state.attributes.get("icon") is None
-
-
-async def test_modern_template_with_templated_delay_on(hass):
-    """Test binary sensor template with template delay on."""
-    config = {
-        "binary_sensor": {
-            "platform": "template",
-            "binary_sensor": [
-                {
-                    "name": "virtual thingy {{ states.sensor.test_state.state }}",
-                    "state": "{{ states.sensor.test_state.state == 'on' }}",
-                    "device_class": "motion",
-                    "delay_on": '{{ ({ "seconds": 6 / 2 }) }}',
-                }
-            ],
-        }
-    }
-    await setup.async_setup_component(hass, binary_sensor.DOMAIN, config)
-    await hass.async_block_till_done()
-    await hass.async_start()
-
-    hass.states.async_set("sensor.test_state", "on")
-    await hass.async_block_till_done()
-
-    state = hass.states.get("binary_sensor.virtual_thingy")
-    assert state.state == "off"
-    assert state.name == "virtual thingy on"
-
-    future = dt_util.utcnow() + timedelta(seconds=3)
-    async_fire_time_changed(hass, future)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("binary_sensor.virtual_thingy")
-    assert state.state == "on"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This makes the binary sensor internally work with a modern config syntax. This is a requirement to add trigger support.

Aligns config set up with #48976

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
