### PR TITLE
Adds locked attribute to KNX covers

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -25,6 +25,7 @@ CONF_STATE_ADDRESS = "state_address"
 CONF_SYNC_STATE = "sync_state"
 CONF_RESET_AFTER = "reset_after"
 
+ATTR_MOVEMENT_LOCKED = "movement_locked"
 ATTR_COUNTER = "counter"
 
 

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_utc_time_change
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import DOMAIN
+from .const import ATTR_MOVEMENT_LOCKED, DOMAIN
 from .knx_entity import KnxEntity
 
 
@@ -112,6 +112,13 @@ class KNXCover(KnxEntity, CoverEntity):
     def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         return self._device.is_closing()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return device specific state attributes."""
+        if self._device.supports_locked:
+            return {ATTR_MOVEMENT_LOCKED: self._device.is_locked()}
+        return None
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the cover."""

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -135,9 +135,9 @@ class KNXExposeSensor:
             value = self.expose_default
 
         if self.type == "binary":
-            if value == STATE_ON:
+            if value in (1, STATE_ON, "True"):
                 value = True
-            elif value == STATE_OFF:
+            elif value in (0, STATE_OFF, "False"):
                 value = False
 
         await self.device.set(value)

--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -84,6 +84,7 @@ def _create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
         ),
         group_address_angle=config.get(CoverSchema.CONF_ANGLE_ADDRESS),
         group_address_angle_state=config.get(CoverSchema.CONF_ANGLE_STATE_ADDRESS),
+        group_address_locked_state=config.get(CoverSchema.CONF_LOCKED_STATE_ADDRESS),
         group_address_position=config.get(CoverSchema.CONF_POSITION_ADDRESS),
         travel_time_down=config[CoverSchema.CONF_TRAVELLING_TIME_DOWN],
         travel_time_up=config[CoverSchema.CONF_TRAVELLING_TIME_UP],

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -220,6 +220,7 @@ class CoverSchema:
     CONF_POSITION_STATE_ADDRESS = "position_state_address"
     CONF_ANGLE_ADDRESS = "angle_address"
     CONF_ANGLE_STATE_ADDRESS = "angle_state_address"
+    CONF_LOCKED_STATE_ADDRESS = "locked_state_address"
     CONF_TRAVELLING_TIME_DOWN = "travelling_time_down"
     CONF_TRAVELLING_TIME_UP = "travelling_time_up"
     CONF_INVERT_POSITION = "invert_position"
@@ -238,6 +239,7 @@ class CoverSchema:
             vol.Optional(CONF_POSITION_STATE_ADDRESS): ga_list_validator,
             vol.Optional(CONF_ANGLE_ADDRESS): ga_list_validator,
             vol.Optional(CONF_ANGLE_STATE_ADDRESS): ga_list_validator,
+            vol.Optional(CONF_LOCKED_STATE_ADDRESS): ga_list_validator,
             vol.Optional(
                 CONF_TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
             ): cv.positive_float,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change adds support for having a locked attribute to KNX covers/windows which usually happens when it starts to rain or any other alarm is triggered on the KNX bus.

Unfortunately a user will still be able to click on those covers and absolutely nothing will happen. 

There is a pending architecture issue here: https://github.com/home-assistant/architecture/issues/429

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/17382

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
