### PR TITLE
Expose window detection attribute for Danfoss eTRV

### DIFF
--- a/homeassistant/components/zha/core/channels/hvac.py
+++ b/homeassistant/components/zha/core/channels/hvac.py
@@ -111,6 +111,7 @@ class ThermostatChannel(ZigbeeChannel):
             "system_mode": False,
             "unoccupied_heating_setpoint": False,
             "unoccupied_cooling_setpoint": False,
+            "etrv_open_windows_detection": False,
         }
         self._abs_max_cool_setpoint_limit = 3200  # 32C
         self._abs_min_cool_setpoint_limit = 1600  # 16C
@@ -132,6 +133,7 @@ class ThermostatChannel(ZigbeeChannel):
         self._system_mode = None
         self._unoccupied_cooling_setpoint = None
         self._unoccupied_heating_setpoint = None
+        self._etrv_open_windows_detection = None
         self._report_config = [
             {"attr": "local_temp", "config": REPORT_CONFIG_CLIMATE},
             {"attr": "occupied_cooling_setpoint", "config": REPORT_CONFIG_CLIMATE},
@@ -253,6 +255,11 @@ class ThermostatChannel(ZigbeeChannel):
     def unoccupied_heating_setpoint(self) -> int | None:
         """Temperature when room is not occupied."""
         return self._unoccupied_heating_setpoint
+
+    @property
+    def window_open(self) -> int | None:
+        """TRV detection for open windows."""
+        return self._etrv_open_windows_detection
 
     @callback
     def attribute_updated(self, attrid, value):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Danfoss eTRVs have a custom attribute on the Thermostat cluster that reports whether the TRV thinks a window nerby is opened or closed (based on temperature drop).

This attribute is already supported in the zigpy/zha-device-handlers repo, but is not exposed as an attribute in the UI.
The changes in this PR adds the detected window state as an attribute for the device so that it can e.g., be used in automations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- The attribute state decoding is based on the description of the "eTRV Open Window Detection" attribute from [Common ZigBee Cluster Specification Danfoss eTRV](https://github.com/SimpleUserHA/DanfosseTRV/raw/main/Danfoss%20Ally%20Radiator%20Thermostat%201.08%20Zigbee%20Cluster%20Specifications%2016122020.pdf)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
