### PR TITLE
Enable passing Amcrest/Dahua signals through as HA events

### DIFF
--- a/homeassistant/components/amcrest/manifest.json
+++ b/homeassistant/components/amcrest/manifest.json
@@ -2,7 +2,7 @@
   "domain": "amcrest",
   "name": "Amcrest",
   "documentation": "https://www.home-assistant.io/integrations/amcrest",
-  "requirements": ["amcrest==1.7.1"],
+  "requirements": ["amcrest==1.7.2"],
   "dependencies": ["ffmpeg"],
   "codeowners": ["@pnbruckner"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -251,7 +251,7 @@ alpha_vantage==2.3.1
 ambiclimate==0.2.1
 
 # homeassistant.components.amcrest
-amcrest==1.7.1
+amcrest==1.7.2
 
 # homeassistant.components.androidtv
 androidtv[async]==0.0.57


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some of the compatible hardware sends event signals that wouldn't map
well to entities, e.g. NTP sync notifications, SIP registering
information, or « doorbell button pressed » events with no « return to
rest state » matching event to have a properly behaved binary sensor.

Instead of only monitoring specific events, subscribe to all of them,
and pass them through (in addition to handling them as before if they
correspond to a configured binary sensor).

This PR intentionally avoids adding new configuration entries, as per the policy in place. The work done by @blademckain in #40496 to add a proper config flow could then be continued with less pressure.

Also bump python-amcrest to 1.7.2. Digest of the changes:

* The library now passes through the event data instead of just presence of a
 "Start" member in it.
* Connection to some devices has been fixed by not throwing the towel on
  minor errors.

Changelog: https://github.com/tchellomello/python-amcrest/compare/1.7.1...1.7.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

This is a feature that has been asked for a lot, and crystalized some tensions. The goal is to find a way forward and relieve the otherwise good config flow rewrite from interference. I would welcome @blademckain resuming work in #40496, or take over if he lacks time.

This PR also replaces #43135

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Tests pass. **Your PR cannot be merged unless tests pass**

I was unable to run the tests locally as `requirements_all.txt` wants `certifi:2020.x.x` whereas `eebrightbox` wants `certify:2018.x.x`. `tox` stops on a dependency error.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

Documentation PR: https://github.com/home-assistant/home-assistant.io/pull/17449

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two^Wone other [open pull request][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
