### PR TITLE
Fix Shelly brightness offset

### DIFF
--- a/homeassistant/components/shelly/light.py
+++ b/homeassistant/components/shelly/light.py
@@ -118,15 +118,16 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
         """Brightness of light."""
         if self.mode == "color":
             if self.control_result:
-                brightness = self.control_result["gain"]
+                brightness_pct = self.control_result["gain"]
             else:
-                brightness = self.block.gain
+                brightness_pct = self.block.gain
         else:
             if self.control_result:
-                brightness = self.control_result["brightness"]
+                brightness_pct = self.control_result["brightness"]
             else:
-                brightness = self.block.brightness
-        return int(brightness / 100 * 255)
+                brightness_pct = self.block.brightness
+
+        return round(255 * brightness_pct / 100)
 
     @property
     def white_value(self) -> int:
@@ -188,11 +189,11 @@ class ShellyLight(ShellyBlockEntity, LightEntity):
         set_mode = None
         params = {"turn": "on"}
         if ATTR_BRIGHTNESS in kwargs:
-            tmp_brightness = int(kwargs[ATTR_BRIGHTNESS] / 255 * 100)
+            brightness_pct = int(100 * (kwargs[ATTR_BRIGHTNESS] + 1) / 255)
             if hasattr(self.block, "gain"):
-                params["gain"] = tmp_brightness
+                params["gain"] = brightness_pct
             if hasattr(self.block, "brightness"):
-                params["brightness"] = tmp_brightness
+                params["brightness"] = brightness_pct
         if ATTR_COLOR_TEMP in kwargs:
             color_temp = color_temperature_mired_to_kelvin(kwargs[ATTR_COLOR_TEMP])
             color_temp = min(self._max_kelvin, max(self._min_kelvin, color_temp))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly devices uses brightness in range of 1 to 100, while HA defaults to use range of 1 to 255, when user is setting brightness in percentage via the frontend or via service call HA core use the following to calculate the brightness in rage of 1 to 255:
https://github.com/home-assistant/core/blob/1a38d2089d0d4a162608b6c4d5a62f00f121154b/homeassistant/components/light/__init__.py#L216
Which is later passed to Shelly integration which calculates back a value in a range of 1 to 100.
Currently the implementation in Shelly integration (and possibly other integrations) does not match the calculations used by HA core, which results in an offset of 1 between the request value and the actual value.
This PR aligns Shelly integration brightness calculations with HA core light so that values set by frontend or by scene (which uses range 1 to 255) will be correct. Value reported from the device is also calculated correctly so that HA will report back the correct brightness.

**Should be tagged for milestone 2021.4.4**

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/47016
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
