### PR TITLE
Lazy load zwave_js platforms when the first entity needs to be created

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -315,8 +315,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 dev_reg.async_remove_device(device.id)
 
         # run discovery on all ready nodes
-        for node in client.driver.controller.nodes.values():
-            await async_on_node_added(node)
+        await asyncio.gather(
+            *[
+                async_on_node_added(node)
+                for node in client.driver.controller.nodes.values()
+            ]
+        )
 
         # listen for new nodes being added to the mesh
         client.driver.controller.on(

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -362,7 +362,7 @@ async def client_listen(
     # All model instances will be replaced when the new state is acquired.
     if should_reload:
         LOGGER.info("Disconnected from server. Reloading integration")
-        asyncio.create_task(hass.config_entries.async_reload(entry.entry_id))
+        hass.async_create_task(hass.config_entries.async_reload(entry.entry_id))
 
 
 async def disconnect_client(

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -116,6 +116,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ent_reg = entity_registry.async_get(hass)
     entry_hass_data: dict = hass.data[DOMAIN].setdefault(entry.entry_id, {})
 
+    unsubscribe_callbacks: list[Callable] = []
+    entry_hass_data[DATA_CLIENT] = client
+    entry_hass_data[DATA_UNSUBSCRIBE] = unsubscribe_callbacks
+    entry_hass_data[DATA_PLATFORM_SETUP] = {}
+
     @callback
     def async_dispatch_discovery_info(
         disc_info: ZwaveDiscoveryInfo, task: asyncio.tasks.Task
@@ -274,11 +279,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         LOGGER.info("Connected to Zwave JS Server")
         entry_hass_data[DATA_CONNECT_FAILED_LOGGED] = False
         entry_hass_data[DATA_INVALID_SERVER_VERSION_LOGGED] = False
-
-    unsubscribe_callbacks: list[Callable] = []
-    entry_hass_data[DATA_CLIENT] = client
-    entry_hass_data[DATA_UNSUBSCRIBE] = unsubscribe_callbacks
-    entry_hass_data[DATA_PLATFORM_SETUP] = {}
 
     services = ZWaveServices(hass, ent_reg)
     services.async_register()

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -8,20 +8,10 @@ CONF_NETWORK_KEY = "network_key"
 CONF_USB_PATH = "usb_path"
 CONF_USE_ADDON = "use_addon"
 DOMAIN = "zwave_js"
-PLATFORMS = [
-    "binary_sensor",
-    "climate",
-    "cover",
-    "fan",
-    "light",
-    "lock",
-    "number",
-    "sensor",
-    "switch",
-]
 
 DATA_CLIENT = "client"
 DATA_UNSUBSCRIBE = "unsubs"
+DATA_PLATFORM_SETUP = "platform_setup"
 
 EVENT_DEVICE_ADDED_TO_REGISTRY = f"{DOMAIN}_device_added_to_registry"
 


### PR DESCRIPTION
## Proposed change
We currently load all entity platforms on entry setup even if we don't discover any entities for that particular platform. In this PR, we now lazy load the platform when we discover the first entity that needs to be created for it.

I didn't add any tests because it seemed like the existing tests should cover whether it works or not.

I also can't get a test to pass (both passes of `test_listen_failure` in `test_init.py`). The only difference in the tests before and after this change is that after this change, we get a `component_loaded` event after attempting to reload the integration but before we cancel start platforms. @MartinHjelmare any ideas on how I can resolve this?


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
