### PR TITLE
Fix use search instead of match to filter logs

### DIFF
--- a/homeassistant/components/logger/__init__.py
+++ b/homeassistant/components/logger/__init__.py
@@ -114,7 +114,7 @@ def _add_log_filter(logger, patterns):
     """Add a Filter to the logger based on a regexp of the filter_str."""
 
     def filter_func(logrecord):
-        return not any(p.match(logrecord.getMessage()) for p in patterns)
+        return not any(p.search(logrecord.getMessage()) for p in patterns)
 
     logger.addFilter(filter_func)
 

--- a/tests/components/logger/test_init.py
+++ b/tests/components/logger/test_init.py
@@ -42,6 +42,7 @@ async def test_log_filtering(hass, caplog):
                         "doesntmatchanything",
                         ".*shouldfilterall.*",
                         "^filterthis:.*",
+                        "in the middle",
                     ],
                     "test.other_filter": [".*otherfilterer"],
                 },
@@ -62,6 +63,7 @@ async def test_log_filtering(hass, caplog):
         filter_logger, False, "this line containing shouldfilterall should be filtered"
     )
     msg_test(filter_logger, True, "this line should not be filtered filterthis:")
+    msg_test(filter_logger, False, "this in the middle should be filtered")
     msg_test(filter_logger, False, "filterthis: should be filtered")
     msg_test(filter_logger, False, "format string shouldfilter%s", "all")
     msg_test(filter_logger, True, "format string shouldfilter%s", "not")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The new logget filter introduced in 2021.4 state in the documentation (including example):


```yaml
# Example configuration.yaml entry
logger:
  default: info
  logs:
    custom_components.my_integration: critical
  filters:
    custom_component.my_integartion:
      - "HTTP 429" # Filter all HTTP 429 errors
```

See: <https://www.home-assistant.io/integrations/logger#log-filters>

However, it uses `match()` instead of `search()`, which means it always filters from the beginning of the string. This PR adjusts it to fix the behavior as documented.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
logger:
  default: info
  logs:
    custom_components.my_integration: critical
  filters:
    custom_component.my_integartion:
      - "HTTP 429" # Filter all HTTP 429 errors
      - "Request to .*unreliable.com.* Timed Out"
    homeassistant.components.nws:
      - "^Error handling request$"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49012
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
