### PR TITLE
Raise exception for invalid call to DeviceRegistry.async_get_or_create

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -171,3 +171,18 @@ class MaxLengthExceeded(HomeAssistantError):
         self.value = value
         self.property_name = property_name
         self.max_length = max_length
+
+
+class RequiredParameterMissing(HomeAssistantError):
+    """Raised when a required parameter is missing from a function call."""
+
+    def __init__(self, parameter_names: list[str]) -> None:
+        """Initialize error."""
+        super().__init__(
+            self,
+            (
+                "Call must include at least one of the following parameters: "
+                f"{', '.join(parameter_names)}"
+            ),
+        )
+        self.parameter_names = parameter_names

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -10,6 +10,7 @@ import attr
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import RequiredParameterMissing
 from homeassistant.loader import bind_hass
 import homeassistant.util.uuid as uuid_util
 
@@ -259,10 +260,10 @@ class DeviceRegistry:
         # To disable a device if it gets created
         disabled_by: str | None | UndefinedType = UNDEFINED,
         suggested_area: str | None | UndefinedType = UNDEFINED,
-    ) -> DeviceEntry | None:
+    ) -> DeviceEntry:
         """Get device. Create if it doesn't exist."""
         if not identifiers and not connections:
-            return None
+            raise RequiredParameterMissing(["identifiers", "connections"])
 
         if identifiers is None:
             identifiers = set()
@@ -300,7 +301,7 @@ class DeviceRegistry:
         else:
             via_device_id = UNDEFINED
 
-        return self._async_update_device(
+        device = self._async_update_device(
             device.id,
             add_config_entry_id=config_entry_id,
             via_device_id=via_device_id,
@@ -314,6 +315,11 @@ class DeviceRegistry:
             disabled_by=disabled_by,
             suggested_area=suggested_area,
         )
+
+        # This is safe because _async_update_device will always return a device
+        # in this use case.
+        assert device
+        return device
 
     @callback
     def async_update_device(

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -24,7 +24,11 @@ from homeassistant.core import (
     split_entity_id,
     valid_entity_id,
 )
-from homeassistant.exceptions import HomeAssistantError, PlatformNotReady
+from homeassistant.exceptions import (
+    HomeAssistantError,
+    PlatformNotReady,
+    RequiredParameterMissing,
+)
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dev_reg,
@@ -436,9 +440,11 @@ class EntityPlatform:
                     if key in device_info:
                         processed_dev_info[key] = device_info[key]
 
-                device = device_registry.async_get_or_create(**processed_dev_info)
-                if device:
+                try:
+                    device = device_registry.async_get_or_create(**processed_dev_info)
                     device_id = device.id
+                except RequiredParameterMissing:
+                    pass
 
             disabled_by: str | None = None
             if not entity.entity_registry_enabled_default:

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -6,6 +6,7 @@ import pytest
 
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CoreState, callback
+from homeassistant.exceptions import RequiredParameterMissing
 from homeassistant.helpers import device_registry, entity_registry
 
 from tests.common import (
@@ -114,18 +115,21 @@ async def test_requirement_for_identifier_or_connection(registry):
         manufacturer="manufacturer",
         model="model",
     )
-    entry3 = registry.async_get_or_create(
-        config_entry_id="1234",
-        connections=set(),
-        identifiers=set(),
-        manufacturer="manufacturer",
-        model="model",
-    )
 
     assert len(registry.devices) == 2
     assert entry
     assert entry2
-    assert entry3 is None
+
+    with pytest.raises(RequiredParameterMissing) as exc_info:
+        registry.async_get_or_create(
+            config_entry_id="1234",
+            connections=set(),
+            identifiers=set(),
+            manufacturer="manufacturer",
+            model="model",
+        )
+
+    assert exc_info.value.parameter_names == ["identifiers", "connections"]
 
 
 async def test_multiple_config_entries(registry):


### PR DESCRIPTION
## Proposed change
As discussed in https://github.com/home-assistant/core/pull/48963#discussion_r610990821 `async_get_or_create` will always return a device so the return typehint should be updated accordingly. In order to do this, we:

1. Raise an exception instead of returning `None` when neither `identifiers` nor `connections` are provided in the function call
2. Assert the response from `_async_update_device` because it can legitimately return `None` but we know it will never do that in this context


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
