### PR TITLE
Add pymodbus exception handling and isolate pymodbus to class modbusHub

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 
-from pymodbus.exceptions import ConnectionException, ModbusException
-from pymodbus.pdu import ExceptionResponse
 import voluptuous as vol
 
 from homeassistant.components.binary_sensor import (
@@ -165,16 +163,11 @@ class ModbusBinarySensor(BinarySensorEntity):
 
     def _update(self):
         """Update the state of the sensor."""
-        try:
-            if self._input_type == CALL_TYPE_COIL:
-                result = self._hub.read_coils(self._slave, self._address, 1)
-            else:
-                result = self._hub.read_discrete_inputs(self._slave, self._address, 1)
-        except ConnectionException:
-            self._available = False
-            return
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
+        if self._input_type == CALL_TYPE_COIL:
+            result = self._hub.read_coils(self._slave, self._address, 1)
+        else:
+            result = self._hub.read_discrete_inputs(self._slave, self._address, 1)
+        if result is None:
             self._available = False
             return
 

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -6,9 +6,6 @@ import logging
 import struct
 from typing import Any
 
-from pymodbus.exceptions import ConnectionException, ModbusException
-from pymodbus.pdu import ExceptionResponse
-
 from homeassistant.components.climate import ClimateEntity
 from homeassistant.components.climate.const import (
     HVAC_MODE_AUTO,
@@ -212,7 +209,11 @@ class ModbusThermostat(ClimateEntity):
         )
         byte_string = struct.pack(self._structure, target_temperature)
         register_value = struct.unpack(">h", byte_string[0:2])[0]
-        self._write_register(self._target_temperature_register, register_value)
+        self._available = self._hub.write_registers(
+            self._slave,
+            self._target_temperature_register,
+            register_value,
+        )
         self._update()
 
     @property
@@ -233,20 +234,13 @@ class ModbusThermostat(ClimateEntity):
 
     def _read_register(self, register_type, register) -> float | None:
         """Read register using the Modbus hub slave."""
-        try:
-            if register_type == CALL_TYPE_REGISTER_INPUT:
-                result = self._hub.read_input_registers(
-                    self._slave, register, self._count
-                )
-            else:
-                result = self._hub.read_holding_registers(
-                    self._slave, register, self._count
-                )
-        except ConnectionException:
-            self._available = False
-            return
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
+        if register_type == CALL_TYPE_REGISTER_INPUT:
+            result = self._hub.read_input_registers(self._slave, register, self._count)
+        else:
+            result = self._hub.read_holding_registers(
+                self._slave, register, self._count
+            )
+        if result is None:
             self._available = False
             return
 
@@ -269,13 +263,3 @@ class ModbusThermostat(ClimateEntity):
         self._available = True
 
         return register_value
-
-    def _write_register(self, register, value):
-        """Write holding register using the Modbus hub slave."""
-        try:
-            self._hub.write_registers(self._slave, register, value)
-        except ConnectionException:
-            self._available = False
-            return
-
-        self._available = True

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
-from pymodbus.exceptions import ConnectionException, ModbusException
-from pymodbus.pdu import ExceptionResponse
-
 from homeassistant.components.cover import SUPPORT_CLOSE, SUPPORT_OPEN, CoverEntity
 from homeassistant.const import (
     CONF_COVERS,
@@ -179,22 +176,17 @@ class ModbusCover(CoverEntity, RestoreEntity):
 
     def _read_status_register(self) -> int | None:
         """Read status register using the Modbus hub slave."""
-        try:
-            if self._status_register_type == CALL_TYPE_REGISTER_INPUT:
-                result = self._hub.read_input_registers(
-                    self._slave, self._status_register, 1
-                )
-            else:
-                result = self._hub.read_holding_registers(
-                    self._slave, self._status_register, 1
-                )
-        except ConnectionException:
+        if self._status_register_type == CALL_TYPE_REGISTER_INPUT:
+            result = self._hub.read_input_registers(
+                self._slave, self._status_register, 1
+            )
+        else:
+            result = self._hub.read_holding_registers(
+                self._slave, self._status_register, 1
+            )
+        if result is None:
             self._available = False
-            return
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
-            self._available = False
-            return
+            return None
 
         value = int(result.registers[0])
         self._available = True
@@ -203,37 +195,18 @@ class ModbusCover(CoverEntity, RestoreEntity):
 
     def _write_register(self, value):
         """Write holding register using the Modbus hub slave."""
-        try:
-            self._hub.write_register(self._slave, self._register, value)
-        except ConnectionException:
-            self._available = False
-            return
-
-        self._available = True
+        self._available = self._hub.write_register(self._slave, self._register, value)
 
     def _read_coil(self) -> bool | None:
         """Read coil using the Modbus hub slave."""
-        try:
-            result = self._hub.read_coils(self._slave, self._coil, 1)
-        except ConnectionException:
+        result = self._hub.read_coils(self._slave, self._coil, 1)
+        if result is None:
             self._available = False
-            return
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
-            self._available = False
-            return
+            return None
 
         value = bool(result.bits[0] & 1)
-        self._available = True
-
         return value
 
     def _write_coil(self, value):
         """Write coil using the Modbus hub slave."""
-        try:
-            self._hub.write_coil(self._slave, self._coil, value)
-        except ConnectionException:
-            self._available = False
-            return
-
-        self._available = True
+        self._available = self._hub.write_coil(self._slave, self._coil, value)

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -3,6 +3,7 @@ import logging
 import threading
 
 from pymodbus.client.sync import ModbusSerialClient, ModbusTcpClient, ModbusUdpClient
+from pymodbus.exceptions import ModbusException
 from pymodbus.transaction import ModbusRtuFramer
 
 from homeassistant.const import (
@@ -37,6 +38,7 @@ from .const import (
     CONF_SENSOR,
     CONF_STOPBITS,
     CONF_SWITCH,
+    DEFAULT_HUB,
     MODBUS_DOMAIN as DOMAIN,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
@@ -49,8 +51,8 @@ def modbus_setup(
     hass, config, service_write_register_schema, service_write_coil_schema
 ):
     """Set up Modbus component."""
-    hass.data[DOMAIN] = hub_collect = {}
 
+    hass.data[DOMAIN] = hub_collect = {}
     for conf_hub in config[DOMAIN]:
         hub_collect[conf_hub[CONF_NAME]] = ModbusHub(conf_hub)
 
@@ -71,15 +73,19 @@ def modbus_setup(
 
     def stop_modbus(event):
         """Stop Modbus service."""
+
         for client in hub_collect.values():
             client.close()
+            del client
 
     def write_register(service):
         """Write Modbus registers."""
         unit = int(float(service.data[ATTR_UNIT]))
         address = int(float(service.data[ATTR_ADDRESS]))
         value = service.data[ATTR_VALUE]
-        client_name = service.data[ATTR_HUB]
+        client_name = (
+            service.data[ATTR_HUB] if ATTR_HUB in service.data else DEFAULT_HUB
+        )
         if isinstance(value, list):
             hub_collect[client_name].write_registers(
                 unit, address, [int(float(i)) for i in value]
@@ -92,7 +98,9 @@ def modbus_setup(
         unit = service.data[ATTR_UNIT]
         address = service.data[ATTR_ADDRESS]
         state = service.data[ATTR_STATE]
-        client_name = service.data[ATTR_HUB]
+        client_name = (
+            service.data[ATTR_HUB] if ATTR_HUB in service.data else DEFAULT_HUB
+        )
         if isinstance(state, list):
             hub_collect[client_name].write_coils(unit, address, state)
         else:
@@ -122,6 +130,7 @@ class ModbusHub:
 
         # generic configuration
         self._client = None
+        self._in_error = False
         self._lock = threading.Lock()
         self._config_name = client_config[CONF_NAME]
         self._config_type = client_config[CONF_TYPE]
@@ -140,48 +149,58 @@ class ModbusHub:
             # network configuration
             self._config_host = client_config[CONF_HOST]
             self._config_delay = client_config[CONF_DELAY]
-            if self._config_delay > 0:
-                _LOGGER.warning(
-                    "Parameter delay is accepted but not used in this version"
-                )
+
+        if self._config_delay > 0:
+            _LOGGER.warning("Parameter delay is accepted but not used in this version")
 
     @property
     def name(self):
         """Return the name of this hub."""
         return self._config_name
 
+    def _log_error(self, exception_error: ModbusException, error_state=True):
+        if self._in_error:
+            _LOGGER.debug(str(exception_error))
+        else:
+            _LOGGER.error(str(exception_error))
+            self._in_error = error_state
+
     def setup(self):
         """Set up pymodbus client."""
-        if self._config_type == "serial":
-            self._client = ModbusSerialClient(
-                method=self._config_method,
-                port=self._config_port,
-                baudrate=self._config_baudrate,
-                stopbits=self._config_stopbits,
-                bytesize=self._config_bytesize,
-                parity=self._config_parity,
-                timeout=self._config_timeout,
-                retry_on_empty=True,
-            )
-        elif self._config_type == "rtuovertcp":
-            self._client = ModbusTcpClient(
-                host=self._config_host,
-                port=self._config_port,
-                framer=ModbusRtuFramer,
-                timeout=self._config_timeout,
-            )
-        elif self._config_type == "tcp":
-            self._client = ModbusTcpClient(
-                host=self._config_host,
-                port=self._config_port,
-                timeout=self._config_timeout,
-            )
-        elif self._config_type == "udp":
-            self._client = ModbusUdpClient(
-                host=self._config_host,
-                port=self._config_port,
-                timeout=self._config_timeout,
-            )
+        try:
+            if self._config_type == "serial":
+                self._client = ModbusSerialClient(
+                    method=self._config_method,
+                    port=self._config_port,
+                    baudrate=self._config_baudrate,
+                    stopbits=self._config_stopbits,
+                    bytesize=self._config_bytesize,
+                    parity=self._config_parity,
+                    timeout=self._config_timeout,
+                    retry_on_empty=True,
+                )
+            elif self._config_type == "rtuovertcp":
+                self._client = ModbusTcpClient(
+                    host=self._config_host,
+                    port=self._config_port,
+                    framer=ModbusRtuFramer,
+                    timeout=self._config_timeout,
+                )
+            elif self._config_type == "tcp":
+                self._client = ModbusTcpClient(
+                    host=self._config_host,
+                    port=self._config_port,
+                    timeout=self._config_timeout,
+                )
+            elif self._config_type == "udp":
+                self._client = ModbusUdpClient(
+                    host=self._config_host,
+                    port=self._config_port,
+                    timeout=self._config_timeout,
+                )
+        except ModbusException as exception_error:
+            self._log_error(exception_error, error_state=False)
+            return
 
         # Connect device
         self.connect()
@@ -189,57 +208,115 @@ class ModbusHub:
     def close(self):
         """Disconnect client."""
         with self._lock:
-            self._client.close()
+            try:
+                self._client.close()
+                del self._client
+                self._client = None
+            except ModbusException as exception_error:
+                self._log_error(exception_error, error_state=False)
+                return
 
     def connect(self):
         """Connect client."""
         with self._lock:
-            self._client.connect()
+            try:
+                self._client.connect()
+            except ModbusException as exception_error:
+                self._log_error(exception_error, error_state=False)
+                return
 
     def read_coils(self, unit, address, count):
         """Read coils."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            return self._client.read_coils(address, count, **kwargs)
+            try:
+                result = self._client.read_coils(address, count, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return None
+            self._in_error = False
+            return result
 
     def read_discrete_inputs(self, unit, address, count):
         """Read discrete inputs."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            return self._client.read_discrete_inputs(address, count, **kwargs)
+            try:
+                result = self._client.read_discrete_inputs(address, count, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return None
+            self._in_error = False
+            return result
 
     def read_input_registers(self, unit, address, count):
         """Read input registers."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            return self._client.read_input_registers(address, count, **kwargs)
+            try:
+                result = self._client.read_input_registers(address, count, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return None
+            self._in_error = False
+            return result
 
     def read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            return self._client.read_holding_registers(address, count, **kwargs)
+            try:
+                result = self._client.read_holding_registers(address, count, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return None
+            self._in_error = False
+            return result
 
-    def write_coil(self, unit, address, value):
+    def write_coil(self, unit, address, value) -> bool:
         """Write coil."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            self._client.write_coil(address, value, **kwargs)
+            try:
+                self._client.write_coil(address, value, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return False
+            self._in_error = False
+            return True
 
-    def write_coils(self, unit, address, value):
+    def write_coils(self, unit, address, values) -> bool:
         """Write coil."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            self._client.write_coils(address, value, **kwargs)
+            try:
+                self._client.write_coils(address, values, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return False
+            self._in_error = False
+            return True
 
-    def write_register(self, unit, address, value):
+    def write_register(self, unit, address, value) -> bool:
         """Write register."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            self._client.write_register(address, value, **kwargs)
+            try:
+                self._client.write_register(address, value, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return False
+            self._in_error = False
+            return True
 
-    def write_registers(self, unit, address, values):
+    def write_registers(self, unit, address, values) -> bool:
         """Write registers."""
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
-            self._client.write_registers(address, values, **kwargs)
+            try:
+                self._client.write_registers(address, values, **kwargs)
+            except ModbusException as exception_error:
+                self._log_error(exception_error)
+                return False
+            self._in_error = False
+            return True

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -6,8 +6,6 @@ import logging
 import struct
 from typing import Any
 
-from pymodbus.exceptions import ConnectionException, ModbusException
-from pymodbus.pdu import ExceptionResponse
 import voluptuous as vol
 
 from homeassistant.components.sensor import (
@@ -285,20 +283,15 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
 
     def _update(self):
         """Update the state of the sensor."""
-        try:
-            if self._register_type == CALL_TYPE_REGISTER_INPUT:
-                result = self._hub.read_input_registers(
-                    self._slave, self._register, self._count
-                )
-            else:
-                result = self._hub.read_holding_registers(
-                    self._slave, self._register, self._count
-                )
-        except ConnectionException:
-            self._available = False
-            return
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
+        if self._register_type == CALL_TYPE_REGISTER_INPUT:
+            result = self._hub.read_input_registers(
+                self._slave, self._register, self._count
+            )
+        else:
+            result = self._hub.read_holding_registers(
+                self._slave, self._register, self._count
+            )
+        if result is None:
             self._available = False
             return
 

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -6,8 +6,6 @@ from datetime import timedelta
 import logging
 from typing import Any
 
-from pymodbus.exceptions import ConnectionException, ModbusException
-from pymodbus.pdu import ExceptionResponse
 import voluptuous as vol
 
 from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
@@ -213,13 +211,8 @@ class ModbusCoilSwitch(ModbusBaseSwitch, SwitchEntity):
 
     def _read_coil(self, coil) -> bool:
         """Read coil using the Modbus hub slave."""
-        try:
-            result = self._hub.read_coils(self._slave, coil, 1)
-        except ConnectionException:
-            self._available = False
-            return False
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
+        result = self._hub.read_coils(self._slave, coil, 1)
+        if result is None:
             self._available = False
             return False
 
@@ -231,13 +224,7 @@ class ModbusCoilSwitch(ModbusBaseSwitch, SwitchEntity):
 
     def _write_coil(self, coil, value):
         """Write coil using the Modbus hub slave."""
-        try:
-            self._hub.write_coil(self._slave, coil, value)
-        except ConnectionException:
-            self._available = False
-            return
-
-        self._available = True
+        self._available = self._hub.write_coil(self._slave, coil, value)
 
 
 class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
@@ -301,33 +288,21 @@ class ModbusRegisterSwitch(ModbusBaseSwitch, SwitchEntity):
         self.schedule_update_ha_state()
 
     def _read_register(self) -> int | None:
-        try:
-            if self._register_type == CALL_TYPE_REGISTER_INPUT:
-                result = self._hub.read_input_registers(
-                    self._slave, self._verify_register, 1
-                )
-            else:
-                result = self._hub.read_holding_registers(
-                    self._slave, self._verify_register, 1
-                )
-        except ConnectionException:
+        if self._register_type == CALL_TYPE_REGISTER_INPUT:
+            result = self._hub.read_input_registers(
+                self._slave, self._verify_register, 1
+            )
+        else:
+            result = self._hub.read_holding_registers(
+                self._slave, self._verify_register, 1
+            )
+        if result is None:
             self._available = False
             return
-
-        if isinstance(result, (ModbusException, ExceptionResponse)):
-            self._available = False
-            return
-
         self._available = True
 
         return int(result.registers[0])
 
     def _write_register(self, value):
         """Write holding register using the Modbus hub slave."""
-        try:
-            self._hub.write_register(self._slave, self._register, value)
-        except ConnectionException:
-            self._available = False
-            return
-
-        self._available = True
+        self._available = self._hub.write_register(self._slave, self._register, value)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add pymodbus exception handling directly in the class modbusHub in order to isolate the pymodbus library.

This has 2 consequences:
- platforms using modbusHub do not receive exceptions, but may receive None
- Testing of the pymodbus library are limited to class pymodbus (see PR #49053).

The old code could deliver wrong data during startup, especially if the device were slow to connect, this
Should now be history.

STATE_UNAVIALABLE was not set in all platforms, so sometimes there were not data, but HA was not made aware
That the data was invalid.

There is a major rewrite of the test_modbus.py module, submitted in the next PR, to thoroughly test exceptions/writes etc.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # 
fixes #40936
fixes #45079
fixes #49011
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
