### PR TITLE
Expose devices as KNOWN_SPOTIFY_DEVICES needed by custom components

### DIFF
--- a/homeassistant/components/spotify/const.py
+++ b/homeassistant/components/spotify/const.py
@@ -6,7 +6,7 @@ DATA_SPOTIFY_CLIENT = "spotify_client"
 DATA_SPOTIFY_ME = "spotify_me"
 DATA_SPOTIFY_SESSION = "spotify_session"
 
-# Stores the devices retrievd from Spotify
+# Stores the devices retrieved from Spotify
 # Used by custom components so another spotify auth
 # won't be required
 KNOWN_SPOTIFY_DEVICES = "known_spotify_devices"

--- a/homeassistant/components/spotify/const.py
+++ b/homeassistant/components/spotify/const.py
@@ -6,6 +6,11 @@ DATA_SPOTIFY_CLIENT = "spotify_client"
 DATA_SPOTIFY_ME = "spotify_me"
 DATA_SPOTIFY_SESSION = "spotify_session"
 
+# Stores the devices retrievd from Spotify
+# Used by custom components so another spotify auth
+# won't be required
+KNOWN_SPOTIFY_DEVICES = "known_spotify_devices"
+
 SPOTIFY_SCOPES = [
     # Needed to be able to control playback
     "user-modify-playback-state",

--- a/homeassistant/components/spotify/media_player.py
+++ b/homeassistant/components/spotify/media_player.py
@@ -62,6 +62,7 @@ from .const import (
     DATA_SPOTIFY_ME,
     DATA_SPOTIFY_SESSION,
     DOMAIN,
+    KNOWN_SPOTIFY_DEVICES,
     SPOTIFY_SCOPES,
 )
 
@@ -199,6 +200,7 @@ async def async_setup_entry(
         entry.data[CONF_NAME],
     )
     async_add_entities([spotify], True)
+    hass.data.setdefault(KNOWN_SPOTIFY_DEVICES, [])
 
 
 def spotify_exception_handler(func):
@@ -506,6 +508,8 @@ class SpotifyMediaPlayer(MediaPlayerEntity):
 
         devices = self._spotify.devices() or {}
         self._devices = devices.get("devices", [])
+        # Needed by custom components
+        self.hass.data[KNOWN_SPOTIFY_DEVICES] = self._devices
 
     async def async_browse_media(self, media_content_type=None, media_content_id=None):
         """Implement the websocket media browsing helper."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Minor addition
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Due to issues with how Spotify has locked down their api wrt scopes come integrations (spotcast for one) needs to get the devices list from spotify/me dia_player.py. 
This PR exposes the discovered devices under `hass.data[KNOWN_SPOTIFY_DEVICES]

This PR is marked as bugfix because soo many users use the combination home-assistant/spotcast and the alternative solution is bad. That would be to ask users to create another app client and have spotcast do another authentication to Spotify to get its own token.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

Links:
- [Spotipy issue](https://github.com/plamere/spotipy/issues/659)
- [Spotcast issue](https://github.com/fondberg/spotcast/issues/170)
- [Spotcast PR](https://github.com/fondberg/spotcast/pull/176)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
