### PR TITLE
mqtt fan percentage to speed_range and received speed_state fix

### DIFF
--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -594,7 +594,6 @@ class MqttFan(MqttEntity, FanEntity):
         """
         percentage_payload = math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
             math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
-        )
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)
         # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
         if self._feature_legacy_speeds:

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -592,7 +592,9 @@ class MqttFan(MqttEntity, FanEntity):
 
         This method is a coroutine.
         """
-        percentage_payload = math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
+        percentage_payload = math.ceil(
+            percentage_to_ranged_value(self._speed_range, percentage)
+        )
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)
         # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
         if self._feature_legacy_speeds:

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -1,6 +1,7 @@
 """Support for MQTT fans."""
 import functools
 import logging
+import math
 
 import voluptuous as vol
 
@@ -441,13 +442,12 @@ class MqttFan(MqttEntity, FanEntity):
                 )
                 return
 
-            if not self._feature_percentage:
-                if speed in self._legacy_speeds_list_no_off:
-                    self._percentage = ordered_list_item_to_percentage(
-                        self._legacy_speeds_list_no_off, speed
-                    )
-                elif speed == SPEED_OFF:
-                    self._percentage = 0
+            if speed in self._legacy_speeds_list_no_off:
+                self._percentage = ordered_list_item_to_percentage(
+                    self._legacy_speeds_list_no_off, speed
+                )
+            elif speed == SPEED_OFF:
+                self._percentage = 0
 
             self.async_write_ha_state()
 
@@ -593,7 +593,7 @@ class MqttFan(MqttEntity, FanEntity):
         This method is a coroutine.
         """
         percentage_payload = int(
-            percentage_to_ranged_value(self._speed_range, percentage)
+            math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
         )
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)
         # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -593,7 +593,6 @@ class MqttFan(MqttEntity, FanEntity):
         This method is a coroutine.
         """
         percentage_payload = math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
-            math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)
         # Legacy are deprecated in the schema, support will be removed after a quarter (2021.7)
         if self._feature_legacy_speeds:

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -592,7 +592,7 @@ class MqttFan(MqttEntity, FanEntity):
 
         This method is a coroutine.
         """
-        percentage_payload = int(
+        percentage_payload = math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
             math.ceil(percentage_to_ranged_value(self._speed_range, percentage))
         )
         mqtt_payload = self._command_templates[ATTR_PERCENTAGE](percentage_payload)

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -618,7 +618,7 @@ async def test_sending_mqtt_commands_with_alternate_speed_range(hass, mqtt_mock)
                     "percentage_state_topic": "percentage-state-topic1",
                     "percentage_command_topic": "percentage-command-topic1",
                     "speed_range_min": 1,
-                    "speed_range_max": 100,
+                    "speed_range_max": 3,
                 },
                 {
                     "platform": "mqtt",
@@ -651,9 +651,25 @@ async def test_sending_mqtt_commands_with_alternate_speed_range(hass, mqtt_mock)
     state = hass.states.get("fan.test1")
     assert state.attributes.get(ATTR_ASSUMED_STATE)
 
+    await common.async_set_percentage(hass, "fan.test1", 33)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic1", "1", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get("fan.test1")
+    assert state.attributes.get(ATTR_ASSUMED_STATE)
+
+    await common.async_set_percentage(hass, "fan.test1", 66)
+    mqtt_mock.async_publish.assert_called_once_with(
+        "percentage-command-topic1", "2", 0, False
+    )
+    mqtt_mock.async_publish.reset_mock()
+    state = hass.states.get("fan.test1")
+    assert state.attributes.get(ATTR_ASSUMED_STATE)
+
     await common.async_set_percentage(hass, "fan.test1", 100)
     mqtt_mock.async_publish.assert_called_once_with(
-        "percentage-command-topic1", "100", 0, False
+        "percentage-command-topic1", "3", 0, False
     )
     mqtt_mock.async_publish.reset_mock()
     state = hass.states.get("fan.test1")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Two bugs will be fixed with this PR.
1. When a small speed range is defined that results in a fractured pecentage step ronding of percentage to range value is incorrect.
2. When legacy speeds are combined with the percentage feature a received speed_state will not update the actual percentage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49018 #49059
- This PR is related to issue: #48802
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
