### PR TITLE
Fix tilting functionality in soma integration

### DIFF
--- a/homeassistant/components/soma/cover.py
+++ b/homeassistant/components/soma/cover.py
@@ -66,9 +66,7 @@ class SomaCover(SomaEntity, CoverEntity):
 
     def close_cover_tilt(self, **kwargs):
         """Close the cover tilt."""
-        response = self.api.set_shade_position(
-            self.device["mac"], 100
-        )  # Close in 'down' direction
+        response = self.api.set_shade_position(self.device["mac"], 100)
         if response["result"] == "success":
             self.current_position = 0
         else:
@@ -78,7 +76,7 @@ class SomaCover(SomaEntity, CoverEntity):
 
     def open_cover_tilt(self, **kwargs):
         """Open the cover tilt."""
-        response = self.api.set_shade_position(self.device["mac"], 0)  # Fully open
+        response = self.api.set_shade_position(self.device["mac"], 0)
         if response["result"] == "success":
             self.current_position = 50
         else:
@@ -92,7 +90,7 @@ class SomaCover(SomaEntity, CoverEntity):
         # 50 -> Fully open (api: 0)
         # 100 -> Closed up (api: -100)
         if kwargs[ATTR_TILT_POSITION] == 50:
-            target_api_position = 0  # Fully open
+            target_api_position = 0
         else:
             target_api_position = 100 - ((kwargs[ATTR_TILT_POSITION] / 50) * 100)
         response = self.api.set_shade_position(self.device["mac"], target_api_position)


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Soma integration doesn't implement the *_tilt functions for the cover entity, and therefore use the same functions "set_cover_position, open_cover, etc..." for the Soma Shade and Soma Tilt products. This is 100% functional for the shades product but for the Tilt product, these function only allow to tilt venetian blinds to 50% of the possible positions: fully closed down all the way to fully open. All the "closed up" range can't be reached.
As the Soma api actually supports this feature by allowing tilt position to be received as negative values (-100..0..100), this PR include the implementation of the *_tilt functions, in which a mapping is done from the HA tilt position value (0..100) to the Soma api tilt positions value (-100..0..100).
The mapping is done like this:
0% in HA -> 100 in Soma API (Fully closed down)
...
50% in HA -> 0 in Soma API (Fully opened)
...
100% in HA -> -100 in Soma API (Fully closed up)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #48728
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
