### PR TITLE
Prevent calling stop or restart services during db upgrade

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -131,31 +131,38 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             and await recorder.async_migration_in_progress(hass)
         ):
             _LOGGER.error(
-                "The system cannot %s while a database upgrade in progress.",
+                "The system cannot %s while a database upgrade in progress",
                 call.service,
             )
-            return
+            raise HomeAssistantError(
+                f"The system cannot {call.service} while a database upgrade in progress."
+            )
 
         if call.service == SERVICE_HOMEASSISTANT_STOP:
-            hass.async_create_task(hass.async_stop())
+            # Must not be tracked so we can make this a blocking call
+            asyncio.create_task(hass.async_stop())
             return
 
-        try:
-            errors = await conf_util.async_check_ha_config_file(hass)
-        except HomeAssistantError:
-            return
+        errors = await conf_util.async_check_ha_config_file(hass)
 
         if errors:
-            _LOGGER.error(errors)
+            _LOGGER.error(
+                "The system cannot %s because the configuration is not valid: %s",
+                call.service,
+                errors,
+            )
             hass.components.persistent_notification.async_create(
                 "Config error. See [the logs](/config/logs) for details.",
                 "Config validating",
                 f"{ha.DOMAIN}.check_config",
             )
-            return
+            raise HomeAssistantError(
+                f"The system cannot {call.service} because the configuration is not valid: {errors}"
+            )
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:
-            hass.async_create_task(hass.async_stop(RESTART_EXIT_CODE))
+            # Must not be tracked so we can make this a blocking call
+            asyncio.create_task(hass.async_stop(RESTART_EXIT_CODE))
 
     async def async_handle_update_service(call):
         """Service handler for updating an entity."""

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
 )
 import homeassistant.core as ha
 from homeassistant.exceptions import HomeAssistantError, Unauthorized, UnknownUser
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, recorder
 from homeassistant.helpers.service import (
     async_extract_config_entry_ids,
     async_extract_referenced_entity_ids,
@@ -126,15 +126,15 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
 
     async def async_handle_core_service(call):
         """Service handler for handling core services."""
-        if call.service in SHUTDOWN_SERVICES and "recorder" in hass.config.components:
-            from homeassistant.components import (  # pylint: disable=import-outside-toplevel
-                recorder,
+        if (
+            call.service in SHUTDOWN_SERVICES
+            and await recorder.async_migration_in_progress(hass)
+        ):
+            _LOGGER.error(
+                "The system cannot %s while a database upgrade in progress.",
+                call.service,
             )
-
-            if await recorder.async_migration_in_progress(hass):
-                raise HomeAssistantError(
-                    f"The system cannot {call.service} while a database upgrade in progress."
-                )
+            return
 
         if call.service == SERVICE_HOMEASSISTANT_STOP:
             hass.async_create_task(hass.async_stop())

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -139,8 +139,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             )
 
         if call.service == SERVICE_HOMEASSISTANT_STOP:
-            # Must not be tracked so we can make this a blocking call
-            asyncio.create_task(hass.async_stop())
+            hass.async_create_task(hass.async_stop())
             return
 
         errors = await conf_util.async_check_ha_config_file(hass)
@@ -161,8 +160,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             )
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:
-            # Must not be tracked so we can make this a blocking call
-            asyncio.create_task(hass.async_stop(RESTART_EXIT_CODE))
+            hass.async_create_task(hass.async_stop(RESTART_EXIT_CODE))
 
     async def async_handle_update_service(call):
         """Service handler for updating an entity."""

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -168,8 +168,9 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
         if call.service == SERVICE_HOMEASSISTANT_RESTART:
             # We delay the restart by WEBSOCKET_RECEIVE_DELAY to ensure the frontend
             # can receive the response before the webserver shuts down
-            async def _async_stop_with_code(_):
-                await hass.async_stop(RESTART_EXIT_CODE)
+            @ha.callback
+            def _async_stop_with_code(_):
+                hass.async_create_task(hass.async_stop(RESTART_EXIT_CODE))
 
             async_call_later(
                 hass,

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -126,15 +126,12 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
 
     async def async_handle_core_service(call):
         """Service handler for handling core services."""
-        if "recorder" in hass.config.components:
+        if call.service in SHUTDOWN_SERVICES and "recorder" in hass.config.components:
             from homeassistant.components import (  # pylint: disable=import-outside-toplevel
                 recorder,
             )
 
-            if (
-                call.service in SHUTDOWN_SERVICES
-                and await recorder.async_migration_in_progress(hass)
-            ):
+            if await recorder.async_migration_in_progress(hass):
                 raise HomeAssistantError(
                     f"The system cannot {call.service} while a database upgrade in progress."
                 )

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -137,7 +137,7 @@ CONFIG_SCHEMA = vol.Schema(
 async def async_migration_in_progress(hass):
     """Determine is a migration is in progress.
 
-    This is a thin wrapper that allow us to change
+    This is a thin wrapper that allows us to change
     out the implementation later.
     """
     if DATA_INSTANCE not in hass.data:

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.entityfilter import (
 )
 from homeassistant.helpers.event import async_track_time_interval, track_time_change
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import bind_hass
 import homeassistant.util.dt as dt_util
 
 from . import migration, purge
@@ -130,6 +131,18 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+
+@bind_hass
+async def async_migration_in_progress(hass):
+    """Determine is a migration is in progress.
+
+    This is a thin wrapper that allow us to change
+    out the implementation later.
+    """
+    if DATA_INSTANCE not in hass.data:
+        return False
+    return hass.data[DATA_INSTANCE].migration_in_progress
 
 
 def run_information(hass, point_in_time: datetime | None = None):
@@ -291,7 +304,8 @@ class Recorder(threading.Thread):
         self.get_session = None
         self._completed_database_setup = None
         self._event_listener = None
-
+        self.async_migration_event = asyncio.Event()
+        self.migration_in_progress = False
         self._queue_watcher = None
 
         self.enabled = True
@@ -510,6 +524,11 @@ class Recorder(threading.Thread):
 
         return None
 
+    @callback
+    def _async_migration_started(self):
+        """Set the migration started event."""
+        self.async_migration_event.set()
+
     def _migrate_schema_and_setup_run(self, current_version) -> bool:
         """Migrate schema to the latest version."""
         persistent_notification.create(
@@ -518,6 +537,8 @@ class Recorder(threading.Thread):
             "Database upgrade in progress",
             "recorder_database_migration",
         )
+        self.migration_in_progress = True
+        self.hass.add_job(self._async_migration_started)
 
         try:
             migration.migrate_schema(self, current_version)
@@ -533,6 +554,7 @@ class Recorder(threading.Thread):
             self._setup_run()
             return True
         finally:
+            self.migration_in_progress = False
             persistent_notification.dismiss(self.hass, "recorder_database_migration")
 
     def _run_purge(self, keep_days, repack, apply_filter):

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -134,7 +134,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 @bind_hass
-async def async_migration_in_progress(hass):
+async def async_migration_in_progress(hass: HomeAssistant) -> bool:
     """Determine is a migration is in progress.
 
     This is a thin wrapper that allows us to change

--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -432,11 +432,13 @@ class Recorder(threading.Thread):
         schema_is_current = migration.schema_is_current(current_version)
         if schema_is_current:
             self._setup_run()
+        else:
+            self.migration_in_progress = True
 
         self.hass.add_job(self.async_connection_success)
-
         # If shutdown happened before Home Assistant finished starting
         if hass_started.result() is shutdown_task:
+            self.migration_in_progress = False
             # Make sure we cleanly close the run if
             # we restart before startup finishes
             self._shutdown()
@@ -537,7 +539,6 @@ class Recorder(threading.Thread):
             "Database upgrade in progress",
             "recorder_database_migration",
         )
-        self.migration_in_progress = True
         self.hass.add_job(self._async_migration_started)
 
         try:

--- a/homeassistant/components/websocket_api/commands.py
+++ b/homeassistant/components/websocket_api/commands.py
@@ -8,7 +8,7 @@ from homeassistant.auth.permissions.const import CAT_ENTITIES, POLICY_READ
 from homeassistant.bootstrap import SIGNAL_BOOTSTRAP_INTEGRATONS
 from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
 from homeassistant.const import EVENT_STATE_CHANGED, EVENT_TIME_CHANGED, MATCH_ALL
-from homeassistant.core import DOMAIN as HASS_DOMAIN, callback
+from homeassistant.core import callback
 from homeassistant.exceptions import (
     HomeAssistantError,
     ServiceNotFound,
@@ -157,9 +157,6 @@ def handle_unsubscribe_events(hass, connection, msg):
 async def handle_call_service(hass, connection, msg):
     """Handle call service command."""
     blocking = True
-    if msg["domain"] == HASS_DOMAIN and msg["service"] in ["restart", "stop"]:
-        blocking = False
-
     # We do not support templates.
     target = msg.get("target")
     if template.is_complex(target):

--- a/homeassistant/helpers/recorder.py
+++ b/homeassistant/helpers/recorder.py
@@ -1,0 +1,15 @@
+"""Helpers to check recorder."""
+
+
+from homeassistant.core import HomeAssistant
+
+
+async def async_migration_in_progress(hass: HomeAssistant) -> bool:
+    """Check to see if a recorder migration is in progress."""
+    if "recorder" not in hass.config.components:
+        return False
+    from homeassistant.components import (  # pylint: disable=import-outside-toplevel
+        recorder,
+    )
+
+    return await recorder.async_migration_in_progress(hass)

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -131,8 +131,6 @@ IGNORE_VIOLATIONS = {
     ("openalpr_cloud", "openalpr_local"),
     ("lutron_caseta", "lutron"),
     ("ffmpeg_noise", "ffmpeg_motion"),
-    # Conditional that only checks if the recorder is actually loaded
-    ("homeassistant", "recorder"),
     # Demo
     ("demo", "manual"),
     ("demo", "openalpr_local"),

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -131,6 +131,8 @@ IGNORE_VIOLATIONS = {
     ("openalpr_cloud", "openalpr_local"),
     ("lutron_caseta", "lutron"),
     ("ffmpeg_noise", "ffmpeg_motion"),
+    # Conditional that only checks if the recorder is actually loaded
+    ("homeassistant", "recorder"),
     # Demo
     ("demo", "manual"),
     ("demo", "openalpr_local"),

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -452,32 +452,11 @@ async def test_reload_config_entry_by_entry_id(hass):
 @pytest.mark.parametrize(
     "service", [SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP]
 )
-async def test_raises_when_db_upgrade_in_progress_recorder_not_loaded(hass, service):
-    """Test services not raise an exception when the recorder is not loaded."""
-    await async_setup_component(hass, "persistent_notification", {})
-    await async_setup_component(hass, "homeassistant", {})
-    with patch("homeassistant.core.HomeAssistant.async_stop") as stop_mock, patch(
-        "homeassistant.config.async_check_ha_config_file", return_value=False
-    ):
-        await hass.services.async_call(
-            "homeassistant",
-            service,
-            blocking=True,
-        )
-
-    assert stop_mock.called
-
-
-@pytest.mark.parametrize(
-    "service", [SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP]
-)
-async def test_raises_when_db_upgrade_in_progress_recorder_loaded(
-    hass, service, caplog
-):
-    """Test an error is logged when they try to restart during migration."""
+async def test_raises_when_db_upgrade_in_progress(hass, service, caplog):
+    """Test an exception is raised when the database migration is in progress."""
     await async_setup_component(hass, "homeassistant", {})
 
-    with patch(
+    with pytest.raises(HomeAssistantError), patch(
         "homeassistant.helpers.recorder.async_migration_in_progress",
         return_value=True,
     ) as mock_async_migration_in_progress:
@@ -490,12 +469,14 @@ async def test_raises_when_db_upgrade_in_progress_recorder_loaded(
         assert "while a database upgrade in progress" in caplog.text
 
     assert mock_async_migration_in_progress.called
-
     caplog.clear()
+
     with patch(
         "homeassistant.helpers.recorder.async_migration_in_progress",
         return_value=False,
-    ) as mock_async_migration_in_progress:
+    ) as mock_async_migration_in_progress, patch(
+        "homeassistant.config.async_check_ha_config_file", return_value=None
+    ):
         await hass.services.async_call(
             "homeassistant",
             service,
@@ -505,3 +486,40 @@ async def test_raises_when_db_upgrade_in_progress_recorder_loaded(
         assert "while a database upgrade in progress" not in caplog.text
 
     assert mock_async_migration_in_progress.called
+
+
+async def test_raises_when_config_is_invalid(hass, caplog):
+    """Test an exception is raised when the configuration is invalid."""
+    await async_setup_component(hass, "homeassistant", {})
+
+    with pytest.raises(HomeAssistantError), patch(
+        "homeassistant.helpers.recorder.async_migration_in_progress",
+        return_value=False,
+    ), patch(
+        "homeassistant.config.async_check_ha_config_file", return_value=["Error 1"]
+    ) as mock_async_check_ha_config_file:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_HOMEASSISTANT_RESTART,
+            blocking=True,
+        )
+        assert "The system cannot" in caplog.text
+        assert "because the configuration is not valid" in caplog.text
+        assert "Error 1" in caplog.text
+
+    assert mock_async_check_ha_config_file.called
+    caplog.clear()
+
+    with patch(
+        "homeassistant.helpers.recorder.async_migration_in_progress",
+        return_value=False,
+    ), patch(
+        "homeassistant.config.async_check_ha_config_file", return_value=None
+    ) as mock_async_check_ha_config_file:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_HOMEASSISTANT_RESTART,
+            blocking=True,
+        )
+
+    assert mock_async_check_ha_config_file.called

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -37,6 +37,7 @@ from homeassistant.setup import async_setup_component
 from tests.common import (
     MockConfigEntry,
     async_capture_events,
+    async_init_recorder_component,
     async_mock_service,
     get_test_home_assistant,
     mock_registry,
@@ -475,7 +476,7 @@ async def test_raises_when_db_upgrade_in_progress_recorder_loaded(hass, service)
     """Test services raise an exception when a db upgrade is in progress."""
     await async_setup_component(hass, "persistent_notification", {})
     await async_setup_component(hass, "homeassistant", {})
-    await async_setup_component(hass, "recorder", {})
+    await async_init_recorder_component(hass)
 
     with pytest.raises(HomeAssistantError), patch(
         "homeassistant.components.recorder.async_migration_in_progress",

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -447,3 +447,41 @@ async def test_reload_config_entry_by_entry_id(hass):
 
     assert len(mock_reload.mock_calls) == 1
     assert mock_reload.mock_calls[0][1][0] == "8955375327824e14ba89e4b29cc3ec9a"
+
+
+@pytest.mark.parametrize(
+    "service", [SERVICE_HOMEASSISTANT_RESTART, SERVICE_HOMEASSISTANT_STOP]
+)
+async def test_raises_when_db_upgrade_in_progress(hass, service):
+    """Test services raise an exception when a db upgrade is in progress."""
+    await async_setup_component(hass, "persistent_notification", {})
+    await async_setup_component(hass, "homeassistant", {})
+
+    with pytest.raises(HomeAssistantError), patch(
+        "homeassistant.components.recorder.async_migration_in_progress",
+        return_value=True,
+    ) as mock_async_migration_in_progress:
+        await hass.services.async_call(
+            "homeassistant",
+            service,
+            blocking=True,
+        )
+
+    assert mock_async_migration_in_progress.called
+
+    with patch(
+        "homeassistant.components.recorder.async_migration_in_progress",
+        return_value=False,
+    ) as mock_async_migration_in_progress, patch(
+        "homeassistant.core.HomeAssistant.async_stop"
+    ) as stop_mock, patch(
+        "homeassistant.config.async_check_ha_config_file", return_value=False
+    ):
+        await hass.services.async_call(
+            "homeassistant",
+            service,
+            blocking=True,
+        )
+
+    assert stop_mock.called
+    assert mock_async_migration_in_progress.called

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -1,6 +1,7 @@
 """The tests for Core components."""
 # pylint: disable=protected-access
 import asyncio
+from datetime import timedelta
 import unittest
 from unittest.mock import Mock, patch
 
@@ -33,10 +34,12 @@ import homeassistant.core as ha
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers import entity
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
     async_capture_events,
+    async_fire_time_changed,
     async_mock_service,
     get_test_home_assistant,
     mock_registry,
@@ -212,22 +215,6 @@ class TestComponentsCore(unittest.TestCase):
 
         assert mock_error.called
         assert mock_process.called is False
-
-    @patch("homeassistant.core.HomeAssistant.async_stop", return_value=None)
-    def test_stop_homeassistant(self, mock_stop):
-        """Test stop service."""
-        stop(self.hass)
-        self.hass.block_till_done()
-        assert mock_stop.called
-
-    @patch("homeassistant.core.HomeAssistant.async_stop", return_value=None)
-    @patch("homeassistant.config.async_check_ha_config_file", return_value=None)
-    def test_restart_homeassistant(self, mock_check, mock_restart):
-        """Test stop service."""
-        restart(self.hass)
-        self.hass.block_till_done()
-        assert mock_restart.called
-        assert mock_check.called
 
     @patch("homeassistant.core.HomeAssistant.async_stop", return_value=None)
     @patch(
@@ -523,3 +510,41 @@ async def test_raises_when_config_is_invalid(hass, caplog):
         )
 
     assert mock_async_check_ha_config_file.called
+
+
+async def test_restart_homeassistant(hass):
+    """Test we can restart when there is no configuration error."""
+    await async_setup_component(hass, "homeassistant", {})
+    with patch(
+        "homeassistant.config.async_check_ha_config_file", return_value=None
+    ) as mock_check, patch(
+        "homeassistant.core.HomeAssistant.async_stop", return_value=None
+    ) as mock_restart:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_HOMEASSISTANT_RESTART,
+            blocking=True,
+        )
+        assert mock_check.called
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done()
+        assert mock_restart.called
+
+
+async def test_stop_homeassistant(hass):
+    """Test we can stop when there is a configuration error."""
+    await async_setup_component(hass, "homeassistant", {})
+    with patch(
+        "homeassistant.config.async_check_ha_config_file", return_value=None
+    ) as mock_check, patch(
+        "homeassistant.core.HomeAssistant.async_stop", return_value=None
+    ) as mock_restart:
+        await hass.services.async_call(
+            "homeassistant",
+            SERVICE_HOMEASSISTANT_STOP,
+            blocking=True,
+        )
+        assert not mock_check.called
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
+        await hass.async_block_till_done()
+        assert mock_restart.called

--- a/tests/components/recorder/test_migrate.py
+++ b/tests/components/recorder/test_migrate.py
@@ -48,6 +48,7 @@ def create_engine_test(*args, **kwargs):
 
 async def test_schema_update_calls(hass):
     """Test that schema migrations occur in correct order."""
+    assert await recorder.async_migration_in_progress(hass) is False
     await async_setup_component(hass, "persistent_notification", {})
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
@@ -60,6 +61,7 @@ async def test_schema_update_calls(hass):
         )
         await async_wait_recording_done_without_instance(hass)
 
+    assert await recorder.async_migration_in_progress(hass) is False
     update.assert_has_calls(
         [
             call(hass.data[DATA_INSTANCE].engine, version + 1, 0)
@@ -68,11 +70,30 @@ async def test_schema_update_calls(hass):
     )
 
 
+async def test_migration_in_progress(hass):
+    """Test that we can check for migration in progress."""
+    assert await recorder.async_migration_in_progress(hass) is False
+    await async_setup_component(hass, "persistent_notification", {})
+
+    with patch(
+        "homeassistant.components.recorder.create_engine", new=create_engine_test
+    ):
+        await async_setup_component(
+            hass, "recorder", {"recorder": {"db_url": "sqlite://"}}
+        )
+        await hass.data[DATA_INSTANCE].async_migration_event.wait()
+        assert await recorder.async_migration_in_progress(hass) is True
+        await async_wait_recording_done_without_instance(hass)
+
+    assert await recorder.async_migration_in_progress(hass) is False
+
+
 async def test_database_migration_failed(hass):
     """Test we notify if the migration fails."""
     await async_setup_component(hass, "persistent_notification", {})
     create_calls = async_mock_service(hass, "persistent_notification", "create")
     dismiss_calls = async_mock_service(hass, "persistent_notification", "dismiss")
+    assert await recorder.async_migration_in_progress(hass) is False
 
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
@@ -89,6 +110,7 @@ async def test_database_migration_failed(hass):
         await hass.async_add_executor_job(hass.data[DATA_INSTANCE].join)
         await hass.async_block_till_done()
 
+    assert await recorder.async_migration_in_progress(hass) is False
     assert len(create_calls) == 2
     assert len(dismiss_calls) == 1
 
@@ -96,6 +118,7 @@ async def test_database_migration_failed(hass):
 async def test_database_migration_encounters_corruption(hass):
     """Test we move away the database if its corrupt."""
     await async_setup_component(hass, "persistent_notification", {})
+    assert await recorder.async_migration_in_progress(hass) is False
 
     sqlite3_exception = DatabaseError("statement", {}, [])
     sqlite3_exception.__cause__ = sqlite3.DatabaseError()
@@ -116,6 +139,7 @@ async def test_database_migration_encounters_corruption(hass):
         hass.states.async_set("my.entity", "off", {})
         await async_wait_recording_done_without_instance(hass)
 
+    assert await recorder.async_migration_in_progress(hass) is False
     assert move_away.called
 
 
@@ -124,6 +148,7 @@ async def test_database_migration_encounters_corruption_not_sqlite(hass):
     await async_setup_component(hass, "persistent_notification", {})
     create_calls = async_mock_service(hass, "persistent_notification", "create")
     dismiss_calls = async_mock_service(hass, "persistent_notification", "dismiss")
+    assert await recorder.async_migration_in_progress(hass) is False
 
     with patch(
         "homeassistant.components.recorder.migration.schema_is_current",
@@ -143,6 +168,7 @@ async def test_database_migration_encounters_corruption_not_sqlite(hass):
         await hass.async_add_executor_job(hass.data[DATA_INSTANCE].join)
         await hass.async_block_till_done()
 
+    assert await recorder.async_migration_in_progress(hass) is False
     assert not move_away.called
     assert len(create_calls) == 2
     assert len(dismiss_calls) == 1
@@ -151,6 +177,7 @@ async def test_database_migration_encounters_corruption_not_sqlite(hass):
 async def test_events_during_migration_are_queued(hass):
     """Test that events during migration are queued."""
 
+    assert await recorder.async_migration_in_progress(hass) is False
     await async_setup_component(hass, "persistent_notification", {})
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
@@ -167,6 +194,7 @@ async def test_events_during_migration_are_queued(hass):
         await hass.data[DATA_INSTANCE].async_recorder_ready.wait()
         await async_wait_recording_done_without_instance(hass)
 
+    assert await recorder.async_migration_in_progress(hass) is False
     db_states = await hass.async_add_executor_job(_get_native_states, hass, "my.entity")
     assert len(db_states) == 2
 
@@ -174,6 +202,7 @@ async def test_events_during_migration_are_queued(hass):
 async def test_events_during_migration_queue_exhausted(hass):
     """Test that events during migration takes so long the queue is exhausted."""
     await async_setup_component(hass, "persistent_notification", {})
+    assert await recorder.async_migration_in_progress(hass) is False
 
     with patch(
         "homeassistant.components.recorder.create_engine", new=create_engine_test
@@ -191,6 +220,7 @@ async def test_events_during_migration_queue_exhausted(hass):
         await hass.data[DATA_INSTANCE].async_recorder_ready.wait()
         await async_wait_recording_done_without_instance(hass)
 
+    assert await recorder.async_migration_in_progress(hass) is False
     db_states = await hass.async_add_executor_job(_get_native_states, hass, "my.entity")
     assert len(db_states) == 1
     hass.states.async_set("my.entity", "on", {})

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -126,7 +126,7 @@ async def test_call_service_blocking(hass, websocket_client, command):
     assert msg["type"] == const.TYPE_RESULT
     assert msg["success"]
     mock_call.assert_called_once_with(
-        ANY, "homeassistant", "restart", ANY, blocking=False, context=ANY, target=ANY
+        ANY, "homeassistant", "restart", ANY, blocking=True, context=ANY, target=ANY
     )
 
 

--- a/tests/helpers/test_recorder.py
+++ b/tests/helpers/test_recorder.py
@@ -1,0 +1,32 @@
+"""The tests for the recorder helpers."""
+
+from unittest.mock import patch
+
+from homeassistant.helpers import recorder
+
+from tests.common import async_init_recorder_component
+
+
+async def test_async_migration_in_progress(hass):
+    """Test async_migration_in_progress wraps the recorder."""
+    with patch(
+        "homeassistant.components.recorder.async_migration_in_progress",
+        return_value=False,
+    ):
+        assert await recorder.async_migration_in_progress(hass) is False
+
+    # The recorder is not loaded
+    with patch(
+        "homeassistant.components.recorder.async_migration_in_progress",
+        return_value=True,
+    ):
+        assert await recorder.async_migration_in_progress(hass) is False
+
+    await async_init_recorder_component(hass)
+
+    # The recorder is now loaded
+    with patch(
+        "homeassistant.components.recorder.async_migration_in_progress",
+        return_value=True,
+    ):
+        assert await recorder.async_migration_in_progress(hass) is True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Prevent the `homeassistant.stop` and `homeassistant.restart` services from doing
a shutdown while a background database upgrade is in progress.

While shutdown will block until the database upgrade is completed, the webserver
will shutdown successfully which will leave the user without feedback. Instead we
abort and log an error when they call the service to prevent confusion.

These service calls previously forced `blocking` to `False` in https://github.com/home-assistant/core/pull/15803 Since we now use `asyncio.create_task` this is no longer needed and we can now give feedback to the UI / api calls when something fails. 

<img width="698" alt="Screen Shot 2021-04-12 at 9 13 54 AM" src="https://user-images.githubusercontent.com/663432/114448574-6ef29980-9b6f-11eb-8cfe-14666e362ab4.png">
<img width="677" alt="Screen Shot 2021-04-12 at 9 13 49 AM" src="https://user-images.githubusercontent.com/663432/114448578-7023c680-9b6f-11eb-8315-2d5e8685c4c5.png">
<img width="1077" alt="Screen Shot 2021-04-12 at 10 16 33 AM" src="https://user-images.githubusercontent.com/663432/114456100-2ee3e480-9b78-11eb-9beb-6f5df5702231.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
