### PR TITLE
Replace old style type comments

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -8,7 +8,6 @@ from typing import Any, Callable
 
 from aiohttp import web
 import attr
-import av.audio.stream
 import av.container
 import av.video
 
@@ -29,7 +28,7 @@ class StreamBuffer:
     segment: io.BytesIO = attr.ib()
     output: av.container.OutputContainer = attr.ib()
     vstream: av.video.VideoStream = attr.ib()
-    astream: av.audio.stream.AudioStream | None = attr.ib(default=None)
+    astream = attr.ib(default=None)  # type=Optional[av.audio.AudioStream]
 
 
 @attr.s

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -8,6 +8,9 @@ from typing import Any, Callable
 
 from aiohttp import web
 import attr
+import av.audio.stream
+import av.container
+import av.video
 
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
@@ -24,9 +27,9 @@ class StreamBuffer:
     """Represent a segment."""
 
     segment: io.BytesIO = attr.ib()
-    output = attr.ib()  # type=av.OutputContainer
-    vstream = attr.ib()  # type=av.VideoStream
-    astream = attr.ib(default=None)  # type=Optional[av.AudioStream]
+    output: av.container.OutputContainer = attr.ib()
+    vstream: av.video.VideoStream = attr.ib()
+    astream: av.audio.stream.AudioStream | None = attr.ib(default=None)
 
 
 @attr.s


### PR DESCRIPTION
## Proposed change
Replace old style type comments for `stream/core.py`. I also noticed that the types probably won't work, since they don't correspond to any in [`PyAV/av/__init__.py`](https://github.com/PyAV-Org/PyAV/blob/b23648467fc5beb634c05690b853ea0bf749a593/av/__init__.py). Instead they need to be imported from their respective packages.

Additionally `AudioStream` is only exported from `av.audio.stream.AudioStream` not `av.audio.AudioStream`. For a fix see: https://github.com/PyAV-Org/PyAV/pull/775

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
