### PR TITLE
Don't import stdlib typing types from helpers.typing

### DIFF
--- a/homeassistant/components/edl21/sensor.py
+++ b/homeassistant/components/edl21/sensor.py
@@ -1,4 +1,5 @@
 """Support for EDL21 Smart Meters."""
+from __future__ import annotations
 
 from datetime import timedelta
 import logging
@@ -16,7 +17,6 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity_registry import async_get_registry
-from homeassistant.helpers.typing import Optional
 from homeassistant.util.dt import utcnow
 
 _LOGGER = logging.getLogger(__name__)
@@ -258,7 +258,7 @@ class EDL21Entity(SensorEntity):
         return self._obis
 
     @property
-    def name(self) -> Optional[str]:
+    def name(self) -> str | None:
         """Return a name."""
         return self._name
 

--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -1,4 +1,5 @@
 """Representation of ISYEntity Types."""
+from __future__ import annotations
 
 from pyisy.constants import (
     COMMAND_FRIENDLY_NAME,
@@ -11,7 +12,6 @@ from pyisy.helpers import NodeProperty
 
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import Dict
 
 from .const import _LOGGER, DOMAIN
 
@@ -134,7 +134,7 @@ class ISYNodeEntity(ISYEntity):
     """Representation of a ISY Nodebase (Node/Group) entity."""
 
     @property
-    def extra_state_attributes(self) -> Dict:
+    def extra_state_attributes(self) -> dict:
         """Get the state attributes for the device.
 
         The 'aux_properties' in the pyisy Node class are combined with the
@@ -186,7 +186,7 @@ class ISYProgramEntity(ISYEntity):
         self._actions = actions
 
     @property
-    def extra_state_attributes(self) -> Dict:
+    def extra_state_attributes(self) -> dict:
         """Get the state attributes for the device."""
         attr = {}
         if self._actions:

--- a/homeassistant/components/kodi/config_flow.py
+++ b/homeassistant/components/kodi/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow for Kodi integration."""
+from __future__ import annotations
+
 import logging
 
 from pykodi import CannotConnectError, InvalidAuthError, Kodi, get_kodi_connection
@@ -16,7 +18,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import DiscoveryInfoType, Optional
+from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import (
     CONF_WS_PORT,
@@ -90,14 +92,14 @@ class KodiConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     def __init__(self):
         """Initialize flow."""
-        self._host: Optional[str] = None
-        self._port: Optional[int] = DEFAULT_PORT
-        self._ws_port: Optional[int] = DEFAULT_WS_PORT
-        self._name: Optional[str] = None
-        self._username: Optional[str] = None
-        self._password: Optional[str] = None
-        self._ssl: Optional[bool] = DEFAULT_SSL
-        self._discovery_name: Optional[str] = None
+        self._host: str | None = None
+        self._port: int | None = DEFAULT_PORT
+        self._ws_port: int | None = DEFAULT_WS_PORT
+        self._name: str | None = None
+        self._username: str | None = None
+        self._password: str | None = None
+        self._ssl: bool | None = DEFAULT_SSL
+        self._discovery_name: str | None = None
 
     async def async_step_zeroconf(self, discovery_info: DiscoveryInfoType):
         """Handle zeroconf discovery."""

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -4,22 +4,6 @@ from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import homeassistant.core
 
-__all__ = (
-    "GPSType",
-    "ConfigType",
-    "ContextType",
-    "DiscoveryInfoType",
-    "EventType",
-    "HomeAssistantType",
-    "ServiceCallType",
-    "ServiceDataType",
-    "StateType",
-    "TemplateVarsType",
-    "QueryType",
-    "UndefinedType",
-    "UNDEFINED",
-)
-
 GPSType = Tuple[float, float]
 ConfigType = Dict[str, Any]
 ContextType = homeassistant.core.Context

--- a/homeassistant/helpers/typing.py
+++ b/homeassistant/helpers/typing.py
@@ -4,6 +4,22 @@ from typing import Any, Dict, Mapping, Optional, Tuple, Union
 
 import homeassistant.core
 
+__all__ = (
+    "GPSType",
+    "ConfigType",
+    "ContextType",
+    "DiscoveryInfoType",
+    "EventType",
+    "HomeAssistantType",
+    "ServiceCallType",
+    "ServiceDataType",
+    "StateType",
+    "TemplateVarsType",
+    "QueryType",
+    "UndefinedType",
+    "UNDEFINED",
+)
+
 GPSType = Tuple[float, float]
 ConfigType = Dict[str, Any]
 ContextType = homeassistant.core.Context

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -1,12 +1,16 @@
 """The tests for the Command line Binary sensor platform."""
+from __future__ import annotations
+
+from typing import Any
+
 from homeassistant import setup
 from homeassistant.components.binary_sensor import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.helpers.typing import Any, Dict, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 
 
 async def setup_test_entity(
-    hass: HomeAssistantType, config_dict: Dict[str, Any]
+    hass: HomeAssistantType, config_dict: dict[str, Any]
 ) -> None:
     """Set up a test command line binary_sensor entity."""
     assert await setup.async_setup_component(

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -1,6 +1,9 @@
 """The tests the cover command line platform."""
+from __future__ import annotations
+
 import os
 import tempfile
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant import config as hass_config, setup
@@ -12,14 +15,14 @@ from homeassistant.const import (
     SERVICE_RELOAD,
     SERVICE_STOP_COVER,
 )
-from homeassistant.helpers.typing import Any, Dict, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 
 
 async def setup_test_entity(
-    hass: HomeAssistantType, config_dict: Dict[str, Any]
+    hass: HomeAssistantType, config_dict: dict[str, Any]
 ) -> None:
     """Set up a test command line notify service."""
     assert await setup.async_setup_component(

--- a/tests/components/command_line/test_notify.py
+++ b/tests/components/command_line/test_notify.py
@@ -1,16 +1,19 @@
 """The tests for the command line notification platform."""
+from __future__ import annotations
+
 import os
 import subprocess
 import tempfile
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant import setup
 from homeassistant.components.notify import DOMAIN
-from homeassistant.helpers.typing import Any, Dict, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 
 
 async def setup_test_service(
-    hass: HomeAssistantType, config_dict: Dict[str, Any]
+    hass: HomeAssistantType, config_dict: dict[str, Any]
 ) -> None:
     """Set up a test command line notify service."""
     assert await setup.async_setup_component(

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -1,13 +1,16 @@
 """The tests for the Command line sensor platform."""
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant import setup
 from homeassistant.components.sensor import DOMAIN
-from homeassistant.helpers.typing import Any, Dict, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 
 
 async def setup_test_entities(
-    hass: HomeAssistantType, config_dict: Dict[str, Any]
+    hass: HomeAssistantType, config_dict: dict[str, Any]
 ) -> None:
     """Set up a test command line sensor entity."""
     assert await setup.async_setup_component(

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -1,8 +1,11 @@
 """The tests for the Command line switch platform."""
+from __future__ import annotations
+
 import json
 import os
 import subprocess
 import tempfile
+from typing import Any
 from unittest.mock import patch
 
 from homeassistant import setup
@@ -14,14 +17,14 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.helpers.typing import Any, Dict, HomeAssistantType
+from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 
 
 async def setup_test_entity(
-    hass: HomeAssistantType, config_dict: Dict[str, Any]
+    hass: HomeAssistantType, config_dict: dict[str, Any]
 ) -> None:
     """Set up a test command line switch entity."""
     assert await setup.async_setup_component(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`helpers/typing.py` should not be used to import types from stdlib `typing.py` that are implicitly reexported.
Unfortunately we can't quite limit which types are importable from `helpers/typing.py`. Nevertheless I added `__all__` which would enable use to use wildcard imports from that module.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
