### PR TITLE
Tests for behavior on changing attributes for KNX lights

### DIFF
--- a/tests/components/knx/conftest.py
+++ b/tests/components/knx/conftest.py
@@ -1,14 +1,30 @@
 """conftest for knx."""
 
+from typing import List
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 
+class KNXIPMock(Mock):
+    """Class for mocked KNX IP class."""
+
+    def assert_telegrams_gas(self, gas: List[str], msg: str):
+        """Assert telegram count and group addresses."""
+        assert self.send_telegram.call_count == len(
+            gas
+        ), f"Expected telegram count mismatch for {msg}"
+        for idx in range(0, len(gas)):
+            assert (
+                str(self.send_telegram.mock_calls[idx][1][0].destination_address)
+                == gas[idx]
+            ), f"Expected telegram address mismatch for {msg}"
+
+
 @pytest.fixture(autouse=True)
 def knx_ip_interface_mock():
     """Create a knx ip interface mock."""
-    mock = Mock()
+    mock = KNXIPMock()
     mock.start = AsyncMock()
     mock.stop = AsyncMock()
     mock.send_telegram = AsyncMock()

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -1,22 +1,24 @@
 """Test knx expose."""
 
-
 from homeassistant.components.knx import CONF_KNX_EXPOSE, KNX_ADDRESS
 from homeassistant.const import CONF_ATTRIBUTE, CONF_ENTITY_ID, CONF_TYPE
 
 from . import setup_knx_integration
 
+from tests.components.knx.conftest import KNXIPMock
 
-async def test_binary_expose(hass, knx_ip_interface_mock):
+
+async def test_binary_expose(hass, knx_ip_interface_mock: KNXIPMock):
     """Test that a binary expose sends only telegrams on state change."""
     entity_id = "fake.entity"
+    ga_expose = "1/1/8"
     await setup_knx_integration(
         hass,
         knx_ip_interface_mock,
         {
             CONF_KNX_EXPOSE: {
                 CONF_TYPE: "binary",
-                KNX_ADDRESS: "1/1/8",
+                KNX_ADDRESS: ga_expose,
                 CONF_ENTITY_ID: entity_id,
             }
         },
@@ -27,38 +29,33 @@ async def test_binary_expose(hass, knx_ip_interface_mock):
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "on", {})
     await hass.async_block_till_done()
-    assert (
-        knx_ip_interface_mock.send_telegram.call_count == 1
-    ), "Expected telegram for state change"
+    knx_ip_interface_mock.assert_telegrams_gas([ga_expose], "state change")
 
     # Change attribute; keep state
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "on", {"brightness": 180})
     await hass.async_block_till_done()
-    assert (
-        knx_ip_interface_mock.send_telegram.call_count == 0
-    ), "Expected no telegram; state not changed"
+    knx_ip_interface_mock.assert_telegrams_gas([], "state not changed")
 
     # Change attribute and state
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "off", {"brightness": 0})
     await hass.async_block_till_done()
-    assert (
-        knx_ip_interface_mock.send_telegram.call_count == 1
-    ), "Expected telegram for state change"
+    knx_ip_interface_mock.assert_telegrams_gas([ga_expose], "state change")
 
 
 async def test_expose_attribute(hass, knx_ip_interface_mock):
     """Test that an expose sends only telegrams on attribute change."""
     entity_id = "fake.entity"
     attribute = "fake_attribute"
+    ga_expose = "1/1/8"
     await setup_knx_integration(
         hass,
         knx_ip_interface_mock,
         {
             CONF_KNX_EXPOSE: {
                 CONF_TYPE: "percentU8",
-                KNX_ADDRESS: "1/1/8",
+                KNX_ADDRESS: ga_expose,
                 CONF_ENTITY_ID: entity_id,
                 CONF_ATTRIBUTE: attribute,
             }
@@ -70,22 +67,22 @@ async def test_expose_attribute(hass, knx_ip_interface_mock):
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "on", {})
     await hass.async_block_till_done()
-    assert knx_ip_interface_mock.send_telegram.call_count == 0
+    knx_ip_interface_mock.assert_telegrams_gas([], "no attribute change")
 
     # Change attribute; keep state
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "on", {attribute: 1})
     await hass.async_block_till_done()
-    assert knx_ip_interface_mock.send_telegram.call_count == 1
+    knx_ip_interface_mock.assert_telegrams_gas([ga_expose], "attribute change")
 
     # Change state keep attribute
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "off", {attribute: 1})
     await hass.async_block_till_done()
-    assert knx_ip_interface_mock.send_telegram.call_count == 0
+    knx_ip_interface_mock.assert_telegrams_gas([], "no attribute change")
 
     # Change state and attribute
     knx_ip_interface_mock.reset_mock()
     hass.states.async_set(entity_id, "on", {attribute: 0})
     await hass.async_block_till_done()
-    assert knx_ip_interface_mock.send_telegram.call_count == 1
+    knx_ip_interface_mock.assert_telegrams_gas([ga_expose], "attribute change")

--- a/tests/components/knx/test_light.py
+++ b/tests/components/knx/test_light.py
@@ -1,0 +1,191 @@
+"""Test knx light."""
+
+from homeassistant.components.knx import KNX_ADDRESS, SupportedPlatforms
+from homeassistant.components.knx.schema import LightSchema
+from homeassistant.const import CONF_NAME
+
+from . import setup_knx_integration
+
+from tests.components.knx.conftest import KNXIPMock
+
+
+async def test_light_brightness(hass, knx_ip_interface_mock: KNXIPMock):
+    """Test that a turn_on with unsupported attribute turns a light on."""
+    name_onoff = "knx_no_brightness"
+    name_brightness = "knx_with_brightness"
+    name_color = "knx_with_color"
+    name_white = "knx_with_white"
+    name_colortemp = "knx_with_colortemp"
+    entity_onoff = "light." + name_onoff
+    entity_brightness = "light." + name_brightness
+    entity_color = "light." + name_color
+    entity_white = "light." + name_white
+    entity_colortemp = "light." + name_colortemp
+    ga_onoff = "1/1/8"
+    ga_brightness = "1/1/10"
+    ga_color = "1/1/12"
+    ga_white_onoff = "1/1/13"
+    ga_white = "1/1/14"
+    ga_colortemp = "1/1/16"
+    await setup_knx_integration(
+        hass,
+        knx_ip_interface_mock,
+        {
+            SupportedPlatforms.LIGHT.value: [
+                {
+                    CONF_NAME: name_onoff,
+                    KNX_ADDRESS: ga_onoff,
+                },
+                {
+                    CONF_NAME: name_brightness,
+                    KNX_ADDRESS: "1/1/9",
+                    LightSchema.CONF_BRIGHTNESS_ADDRESS: ga_brightness,
+                },
+                {
+                    CONF_NAME: name_color,
+                    KNX_ADDRESS: "1/1/11",
+                    LightSchema.CONF_COLOR_ADDRESS: ga_color,
+                },
+                {
+                    CONF_NAME: name_white,
+                    KNX_ADDRESS: ga_white_onoff,
+                    LightSchema.CONF_RGBW_ADDRESS: ga_white,
+                },
+                {
+                    CONF_NAME: name_colortemp,
+                    KNX_ADDRESS: "1/1/15",
+                    LightSchema.CONF_COLOR_TEMP_ADDRESS: ga_colortemp,
+                },
+            ]
+        },
+    )
+    # check count of defined lights
+    assert len(hass.states.async_all()) == 5
+
+    # Turn on/off simple lamp
+    knx_ip_interface_mock.reset_mock()
+    await hass.services.async_call(
+        "light", "turn_on", {"entity_id": entity_onoff}, blocking=True
+    )
+    await hass.services.async_call(
+        "light", "turn_off", {"entity_id": entity_onoff}, blocking=True
+    )
+    knx_ip_interface_mock.assert_telegrams_gas([ga_onoff, ga_onoff], "switch on/off")
+
+    for entity, attr, value, ga in [
+        [entity_brightness, "brightness", 100, ga_brightness],
+        [entity_color, "color_name", "blue", ga_color],
+        [entity_white, "white_value", 88, ga_white],
+        [entity_colortemp, "color_temp", 88, ga_colortemp],
+    ]:
+        # Turn on with specific attribute on lamp which supports specific attribute
+        # Only the specific telegram is send; this implicitly switches the lamp on
+        knx_ip_interface_mock.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": entity, attr: value},
+            blocking=True,
+        )
+        knx_ip_interface_mock.assert_telegrams_gas([ga], attr)
+
+    for attr, value in [
+        ["brightness", 100],
+        ["color_name", "blue"],
+        ["white_value", 88],
+        ["color_temp", 88],
+    ]:
+        # Turn on with specific attribute on simple lamp
+        knx_ip_interface_mock.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": entity_onoff, attr: value},
+            blocking=True,
+        )
+        await hass.services.async_call(
+            "light", "turn_off", {"entity_id": entity_onoff}, blocking=True
+        )
+        assert knx_ip_interface_mock.send_telegram.call_count == 2, (
+            "Expected telegrams for switch on/off while using " + attr
+        )
+        assert (
+            str(
+                knx_ip_interface_mock.send_telegram.call_args.args[
+                    0
+                ].destination_address
+            )
+            == ga_onoff
+        ), ("Expected telegram for on/off address with attribute " + attr)
+
+
+async def test_light_multi_change(hass, knx_ip_interface_mock: KNXIPMock):
+    """Test that a change on an attribute changes only that attribute."""
+    ga_onoff = "1/1/8"
+    ga_onoff2 = "1/1/9"
+    ga_brightness = "1/1/10"
+    ga_color = "1/1/12"
+    ga_white = "1/1/14"
+    ga_colortemp = "1/1/16"
+    await setup_knx_integration(
+        hass,
+        knx_ip_interface_mock,
+        {
+            SupportedPlatforms.LIGHT.value: [
+                {
+                    CONF_NAME: "lamp1",
+                    KNX_ADDRESS: ga_onoff,
+                    LightSchema.CONF_BRIGHTNESS_ADDRESS: ga_brightness,
+                    LightSchema.CONF_COLOR_ADDRESS: ga_color,
+                    LightSchema.CONF_COLOR_TEMP_ADDRESS: ga_colortemp,
+                },
+                {
+                    CONF_NAME: "lamp2",
+                    KNX_ADDRESS: ga_onoff2,
+                    LightSchema.CONF_BRIGHTNESS_ADDRESS: ga_brightness,
+                    LightSchema.CONF_RGBW_ADDRESS: ga_white,
+                    LightSchema.CONF_COLOR_TEMP_ADDRESS: ga_colortemp,
+                },
+            ]
+        },
+    )
+    # check count of defined lights
+    assert len(hass.states.async_all()) == 2
+
+    for lamp, ga_c in [["lamp1", ga_color], ["lamp2", ga_white]]:
+        # Turn on lamp by setting color
+        knx_ip_interface_mock.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": f"light.{lamp}", "color_name": "blue"},
+            blocking=True,
+        )
+        knx_ip_interface_mock.assert_telegrams_gas([ga_c], f"color for {lamp}")
+
+        # Change brightness
+        knx_ip_interface_mock.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": f"light.{lamp}", "brightness": 88},
+            blocking=True,
+        )
+        knx_ip_interface_mock.assert_telegrams_gas(
+            [ga_brightness], f"brightness for {lamp}"
+        )
+
+    for attribute, value, ga in [
+        ["color_name", "red", ga_color],
+        ["color_temp", 77, ga_colortemp],
+        ["brightness", 55, ga_brightness],
+    ]:
+        # Change attribute
+        knx_ip_interface_mock.reset_mock()
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": "light.lamp1", attribute: value},
+            blocking=True,
+        )
+        knx_ip_interface_mock.assert_telegrams_gas([ga], attribute)

--- a/tests/components/knx/test_light.py
+++ b/tests/components/knx/test_light.py
@@ -75,7 +75,12 @@ async def test_light_brightness(hass, knx_ip_interface_mock: KNXIPMock):
     for entity, attr, value, ga in [
         [entity_brightness, "brightness", 100, ga_brightness],
         [entity_color, "color_name", "blue", ga_color],
-        [entity_white, "white_value", 88, ga_white],
+        [
+            entity_white,
+            "white_value",
+            88,
+            ga_white_onoff,
+        ],  # white value is removed because of light supports rgb
         [entity_colortemp, "color_temp", 88, ga_colortemp],
     ]:
         # Turn on with specific attribute on lamp which supports specific attribute
@@ -177,7 +182,11 @@ async def test_light_multi_change(hass, knx_ip_interface_mock: KNXIPMock):
 
     for attribute, value, ga in [
         ["color_name", "red", ga_color],
-        ["color_temp", 77, ga_colortemp],
+        [
+            "color_temp",
+            77,
+            ga_color,
+        ],  # color_temp change is performed via color address
         ["brightness", 55, ga_brightness],
     ]:
         # Change attribute


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixing the problem that KNX lights which supports no brightness do not
turn on when a brightness is given (via profile).

First commit: Adds a test for the use case: turn-on simple light with brightness => fails
Second commit: Fixes that problem by determing the update_brightness state with respect to support of the lamp. This introduces a fixing pattern.
Third commit: Adds test for other attributes than brightness, because here the same problem exists. It follows the fixing pattern of the second commit to fix that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

# Example light_profiles.csv
```csv
profile,color_x,color_y,brightness,transition
group.all_lights.default,,,255,1
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49110
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
