### PR TITLE
Stop ssdp scans when stop event happens

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -9,7 +9,7 @@ from async_upnp_client.search import async_search
 from defusedxml import ElementTree
 from netdisco import ssdp, util
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.loader import async_get_ssdp
@@ -43,12 +43,18 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup(hass, config):
     """Set up the SSDP integration."""
 
-    async def initialize(_):
+    async def _async_initialize(_):
         scanner = Scanner(hass, await async_get_ssdp(hass))
         await scanner.async_scan(None)
-        async_track_time_interval(hass, scanner.async_scan, SCAN_INTERVAL)
+        cancel_scan = async_track_time_interval(hass, scanner.async_scan, SCAN_INTERVAL)
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, initialize)
+        @callback
+        def _async_stop_scans(event):
+            cancel_scan()
+
+        hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_scans)
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_initialize)
 
     return True
 

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -185,14 +185,13 @@ class Scanner:
         """Fetch an XML description."""
         session = self.hass.helpers.aiohttp_client.async_get_clientsession()
         try:
-            resp = await session.get(xml_location, timeout=5)
-            xml = await resp.text(errors="replace")
-
-            # Samsung Smart TV sometimes returns an empty document the
-            # first time. Retry once.
-            if not xml:
+            for _ in range(2):
                 resp = await session.get(xml_location, timeout=5)
                 xml = await resp.text(errors="replace")
+                # Samsung Smart TV sometimes returns an empty document the
+                # first time. Retry once.
+                if xml:
+                    break
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             _LOGGER.debug("Error fetching %s: %s", xml_location, err)
             return {}

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -1,7 +1,7 @@
 """Test the SSDP integration."""
 import asyncio
 from datetime import timedelta
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 import aiohttp
 import pytest
@@ -18,18 +18,20 @@ async def test_scan_match_st(hass, caplog):
     """Test matching based on ST."""
     scanner = ssdp.Scanner(hass, {"mock-domain": [{"st": "mock-st"}]})
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(
-                st="mock-st",
-                location=None,
-                values={"usn": "mock-usn", "server": "mock-server", "ext": ""},
-            )
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": None,
+                "usn": "mock-usn",
+                "server": "mock-server",
+                "ext": "",
+            }
         )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -65,19 +67,25 @@ async def test_scan_match_upnp_devicedesc(hass, aioclient_mock, key):
     )
     scanner = ssdp.Scanner(hass, {"mock-domain": [{key: "Paulus"}]})
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(st="mock-st", location="http://1.1.1.1", values={})
-        )
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        for _ in range(5):
+            await async_callback(
+                {
+                    "st": "mock-st",
+                    "location": "http://1.1.1.1",
+                }
+            )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
         await scanner.async_scan(None)
 
+    # If we get duplicate respones, ensure we only look it up once
+    assert len(aioclient_mock.mock_calls) == 1
     assert len(mock_init.mock_calls) == 1
     assert mock_init.mock_calls[0][1][0] == "mock-domain"
     assert mock_init.mock_calls[0][2]["context"] == {"source": "ssdp"}
@@ -107,14 +115,17 @@ async def test_scan_not_all_present(hass, aioclient_mock):
         },
     )
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(st="mock-st", location="http://1.1.1.1", values={})
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": "http://1.1.1.1",
+            }
         )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -148,14 +159,17 @@ async def test_scan_not_all_match(hass, aioclient_mock):
         },
     )
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(st="mock-st", location="http://1.1.1.1", values={})
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": "http://1.1.1.1",
+            }
         )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -170,14 +184,17 @@ async def test_scan_description_fetch_fail(hass, aioclient_mock, exc):
     aioclient_mock.get("http://1.1.1.1", exc=exc)
     scanner = ssdp.Scanner(hass, {})
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(st="mock-st", location="http://1.1.1.1", values={})
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": "http://1.1.1.1",
+            }
         )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ):
         await scanner.async_scan(None)
 
@@ -192,14 +209,17 @@ async def test_scan_description_parse_fail(hass, aioclient_mock):
     )
     scanner = ssdp.Scanner(hass, {})
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(st="mock-st", location="http://1.1.1.1", values={})
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": "http://1.1.1.1",
+            }
         )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ):
         await scanner.async_scan(None)
 
@@ -228,14 +248,17 @@ async def test_invalid_characters(hass, aioclient_mock):
         },
     )
 
-    async def _inject_entry(*args, **kwargs):
-        scanner.async_store_entry(
-            Mock(st="mock-st", location="http://1.1.1.1", values={})
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": "http://1.1.1.1",
+            }
         )
 
     with patch(
         "homeassistant.components.ssdp.async_search",
-        side_effect=_inject_entry,
+        side_effect=_mock_async_scan,
     ), patch.object(
         hass.config_entries.flow, "async_init", return_value=mock_coro()
     ) as mock_init:
@@ -268,3 +291,49 @@ async def test_start_stop_scanner(async_search_mock, hass):
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=200))
     await hass.async_block_till_done()
     assert async_search_mock.call_count == 2
+
+
+async def test_unexpected_exception_while_fetching(hass, aioclient_mock, caplog):
+    """Test unexpected exception while fetching."""
+    aioclient_mock.get(
+        "http://1.1.1.1",
+        text="""
+<root>
+  <device>
+    <deviceType>ABC</deviceType>
+    <serialNumber>\xff\xff\xff\xff</serialNumber>
+  </device>
+</root>
+    """,
+    )
+    scanner = ssdp.Scanner(
+        hass,
+        {
+            "mock-domain": [
+                {
+                    ssdp.ATTR_UPNP_DEVICE_TYPE: "ABC",
+                }
+            ]
+        },
+    )
+
+    async def _mock_async_scan(*args, async_callback=None, **kwargs):
+        await async_callback(
+            {
+                "st": "mock-st",
+                "location": "http://1.1.1.1",
+            }
+        )
+
+    with patch(
+        "homeassistant.components.ssdp.ElementTree.fromstring", side_effect=ValueError
+    ), patch(
+        "homeassistant.components.ssdp.async_search",
+        side_effect=_mock_async_scan,
+    ), patch.object(
+        hass.config_entries.flow, "async_init", return_value=mock_coro()
+    ) as mock_init:
+        await scanner.async_scan(None)
+
+    assert len(mock_init.mock_calls) == 0
+    assert "Failed to fetch ssdp data from: http://1.1.1.1" in caplog.text


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Stop ssdp scans when stop event happens as this would delay shutdown https://github.com/home-assistant/core/pull/49138#issuecomment-818321735

- 100% coverage `homeassistant/components/ssdp/__init__.py     137      0   100%`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
