### PR TITLE
Fix logic of entity id extraction

### DIFF
--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -363,11 +363,14 @@ async def async_extract_referenced_entity_ids(
 
     for ent_entry in ent_reg.entities.values():
         if (
+            # when area matches the target area
             ent_entry.area_id in selector.area_ids
+            # when device matches a referenced devices with no explicitly set area
             or (
                 not ent_entry.area_id
                 and ent_entry.device_id in selected.referenced_devices
             )
+            # when device matches target device and it's not missing
             or (
                 ent_entry.device_id not in selected.missing_devices
                 and ent_entry.device_id in selector.device_ids

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -362,8 +362,9 @@ async def async_extract_referenced_entity_ids(
         return selected
 
     for ent_entry in ent_reg.entities.values():
-        if ent_entry.area_id in selector.area_ids or (
-            not ent_entry.area_id and ent_entry.device_id in selected.referenced_devices
+        if (
+            ent_entry.area_id in selector.area_ids
+            or ent_entry.device_id in selected.referenced_devices
         ):
             selected.indirectly_referenced.add(ent_entry.entity_id)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -355,10 +355,7 @@ async def async_extract_referenced_entity_ids(
     # Find devices for this area
     selected.referenced_devices.update(selector.device_ids)
     for device_entry in dev_reg.devices.values():
-        if (
-            device_entry.area_id in selector.area_ids
-            or device_entry.id in selector.device_ids
-        ):
+        if device_entry.area_id in selector.area_ids:
             selected.referenced_devices.add(device_entry.id)
     if not selector.area_ids and not selected.referenced_devices:
         return selected

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -370,7 +370,7 @@ async def async_extract_referenced_entity_ids(
                 not ent_entry.area_id
                 and ent_entry.device_id in selected.referenced_devices
             )
-            or (ent_entry.device_id in selector.device_ids)
+            or ent_entry.device_id in selector.device_ids
         ):
             selected.indirectly_referenced.add(ent_entry.entity_id)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -357,6 +357,7 @@ async def async_extract_referenced_entity_ids(
     for device_entry in dev_reg.devices.values():
         if device_entry.area_id in selector.area_ids:
             selected.referenced_devices.add(device_entry.id)
+
     if not selector.area_ids and not selected.referenced_devices:
         return selected
 
@@ -367,7 +368,10 @@ async def async_extract_referenced_entity_ids(
                 not ent_entry.area_id
                 and ent_entry.device_id in selected.referenced_devices
             )
-            or ent_entry.device_id in selector.device_ids
+            or (
+                ent_entry.device_id not in selected.missing_devices
+                and ent_entry.device_id in selector.device_ids
+            )
         ):
             selected.indirectly_referenced.add(ent_entry.entity_id)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -355,16 +355,22 @@ async def async_extract_referenced_entity_ids(
     # Find devices for this area
     selected.referenced_devices.update(selector.device_ids)
     for device_entry in dev_reg.devices.values():
-        if device_entry.area_id in selector.area_ids:
+        if (
+            device_entry.area_id in selector.area_ids
+            or device_entry.id in selector.device_ids
+        ):
             selected.referenced_devices.add(device_entry.id)
-
     if not selector.area_ids and not selected.referenced_devices:
         return selected
 
     for ent_entry in ent_reg.entities.values():
         if (
             ent_entry.area_id in selector.area_ids
-            or ent_entry.device_id in selected.referenced_devices
+            or (
+                not ent_entry.area_id
+                and ent_entry.device_id in selected.referenced_devices
+            )
+            or (ent_entry.device_id in selector.device_ids)
         ):
             selected.indirectly_referenced.add(ent_entry.entity_id)
 

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -370,11 +370,8 @@ async def async_extract_referenced_entity_ids(
                 not ent_entry.area_id
                 and ent_entry.device_id in selected.referenced_devices
             )
-            # when device matches target device and it's not missing
-            or (
-                ent_entry.device_id not in selected.missing_devices
-                and ent_entry.device_id in selector.device_ids
-            )
+            # when device matches target device
+            or ent_entry.device_id in selector.device_ids
         ):
             selected.indirectly_referenced.add(ent_entry.entity_id)
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -152,6 +152,13 @@ def area_mock(hass):
         device_id=device_area_a.id,
         area_id="area-a",
     )
+    entity_in_area_b = ent_reg.RegistryEntry(
+        entity_id="light.in_area_b",
+        unique_id="in-area-b-id",
+        platform="test",
+        device_id=device_area_a.id,
+        area_id="area-b",
+    )
     mock_registry(
         hass,
         {
@@ -162,6 +169,7 @@ def area_mock(hass):
             entity_no_area.entity_id: entity_no_area,
             entity_diff_area.entity_id: entity_diff_area,
             entity_in_area_a.entity_id: entity_in_area_a,
+            entity_in_area_b.entity_id: entity_in_area_b,
         },
     )
 
@@ -421,6 +429,7 @@ async def test_extract_entity_ids_from_devices(hass, area_mock):
         hass, ha.ServiceCall("light", "turn_on", {"device_id": "device-area-a-id"})
     ) == {
         "light.in_area_a",
+        "light.in_area_b",
     }
 
     assert (

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -95,9 +95,7 @@ def area_mock(hass):
     device_in_area = dev_reg.DeviceEntry(area_id="test-area")
     device_no_area = dev_reg.DeviceEntry(id="device-no-area-id")
     device_diff_area = dev_reg.DeviceEntry(area_id="diff-area")
-    device_other_area = dev_reg.DeviceEntry(
-        id="device-other-area-id", area_id="other-area"
-    )
+    device_area_a = dev_reg.DeviceEntry(id="device-area-a-id", area_id="area-a")
 
     mock_device_registry(
         hass,
@@ -105,7 +103,7 @@ def area_mock(hass):
             device_in_area.id: device_in_area,
             device_no_area.id: device_no_area,
             device_diff_area.id: device_diff_area,
-            device_other_area.id: device_other_area,
+            device_area_a.id: device_area_a,
         },
     )
 
@@ -123,7 +121,7 @@ def area_mock(hass):
     )
     entity_in_other_area = ent_reg.RegistryEntry(
         entity_id="light.in_other_area",
-        unique_id="in-other-area-id",
+        unique_id="in-area-a-id",
         platform="test",
         device_id=device_in_area.id,
         area_id="other-area",
@@ -147,12 +145,12 @@ def area_mock(hass):
         platform="test",
         device_id=device_diff_area.id,
     )
-    entity_in_yet_another_area = ent_reg.RegistryEntry(
-        entity_id="light.in_yet_another_area",
-        unique_id="in-other-area-id",
+    entity_in_area_a = ent_reg.RegistryEntry(
+        entity_id="light.in_area_a",
+        unique_id="in-area-a-id",
         platform="test",
-        device_id=device_other_area.id,
-        area_id="other-area",
+        device_id=device_area_a.id,
+        area_id="area-a",
     )
     mock_registry(
         hass,
@@ -163,7 +161,7 @@ def area_mock(hass):
             entity_assigned_to_area.entity_id: entity_assigned_to_area,
             entity_no_area.entity_id: entity_no_area,
             entity_diff_area.entity_id: entity_diff_area,
-            entity_in_yet_another_area.entity_id: entity_in_yet_another_area,
+            entity_in_area_a.entity_id: entity_in_area_a,
         },
     )
 
@@ -420,9 +418,9 @@ async def test_extract_entity_ids_from_devices(hass, area_mock):
     }
 
     assert await service.async_extract_entity_ids(
-        hass, ha.ServiceCall("light", "turn_on", {"device_id": "device-other-area-id"})
+        hass, ha.ServiceCall("light", "turn_on", {"device_id": "device-area-a-id"})
     ) == {
-        "light.in_yet_another_area",
+        "light.in_area_a",
     }
 
     assert (

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -105,6 +105,7 @@ def area_mock(hass):
             device_in_area.id: device_in_area,
             device_no_area.id: device_no_area,
             device_diff_area.id: device_diff_area,
+            device_other_area.id: device_other_area,
         },
     )
 
@@ -146,7 +147,7 @@ def area_mock(hass):
         platform="test",
         device_id=device_diff_area.id,
     )
-    entity_in_other_area = ent_reg.RegistryEntry(
+    entity_in_yet_another_area = ent_reg.RegistryEntry(
         entity_id="light.in_yet_another_area",
         unique_id="in-other-area-id",
         platform="test",
@@ -162,6 +163,7 @@ def area_mock(hass):
             entity_assigned_to_area.entity_id: entity_assigned_to_area,
             entity_no_area.entity_id: entity_no_area,
             entity_diff_area.entity_id: entity_diff_area,
+            entity_in_yet_another_area.entity_id: entity_in_yet_another_area,
         },
     )
 

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -381,6 +381,7 @@ async def test_extract_entity_ids_from_area(hass, area_mock):
     assert {
         "light.in_area",
         "light.assigned_to_area",
+        "light.in_other_area",
     } == await service.async_extract_entity_ids(hass, call)
 
     call = ha.ServiceCall("light", "turn_on", {"area_id": ["test-area", "diff-area"]})
@@ -389,11 +390,28 @@ async def test_extract_entity_ids_from_area(hass, area_mock):
         "light.in_area",
         "light.diff_area",
         "light.assigned_to_area",
+        "light.in_other_area",
     } == await service.async_extract_entity_ids(hass, call)
 
     assert (
         await service.async_extract_entity_ids(
             hass, ha.ServiceCall("light", "turn_on", {"area_id": ENTITY_MATCH_NONE})
+        )
+        == set()
+    )
+
+
+async def test_extract_entity_ids_from_devices(hass, area_mock):
+    """Test extract_entity_ids method with devices."""
+    call = ha.ServiceCall("light", "turn_on", {"device_id": "device-no-area-id"})
+
+    assert {
+        "light.no_area",
+    } == await service.async_extract_entity_ids(hass, call)
+
+    assert (
+        await service.async_extract_entity_ids(
+            hass, ha.ServiceCall("light", "turn_on", {"device_id": "non-existing-id"})
         )
         == set()
     )

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -95,6 +95,9 @@ def area_mock(hass):
     device_in_area = dev_reg.DeviceEntry(area_id="test-area")
     device_no_area = dev_reg.DeviceEntry(id="device-no-area-id")
     device_diff_area = dev_reg.DeviceEntry(area_id="diff-area")
+    device_other_area = dev_reg.DeviceEntry(
+        id="device-other-area-id", area_id="other-area"
+    )
 
     mock_device_registry(
         hass,
@@ -142,6 +145,13 @@ def area_mock(hass):
         unique_id="diff-area-id",
         platform="test",
         device_id=device_diff_area.id,
+    )
+    entity_in_other_area = ent_reg.RegistryEntry(
+        entity_id="light.in_yet_another_area",
+        unique_id="in-other-area-id",
+        platform="test",
+        device_id=device_other_area.id,
+        area_id="other-area",
     )
     mock_registry(
         hass,
@@ -381,7 +391,6 @@ async def test_extract_entity_ids_from_area(hass, area_mock):
     assert {
         "light.in_area",
         "light.assigned_to_area",
-        "light.in_other_area",
     } == await service.async_extract_entity_ids(hass, call)
 
     call = ha.ServiceCall("light", "turn_on", {"area_id": ["test-area", "diff-area"]})
@@ -390,7 +399,6 @@ async def test_extract_entity_ids_from_area(hass, area_mock):
         "light.in_area",
         "light.diff_area",
         "light.assigned_to_area",
-        "light.in_other_area",
     } == await service.async_extract_entity_ids(hass, call)
 
     assert (
@@ -407,6 +415,12 @@ async def test_extract_entity_ids_from_devices(hass, area_mock):
 
     assert {
         "light.no_area",
+    } == await service.async_extract_entity_ids(hass, call)
+
+    call = ha.ServiceCall("light", "turn_on", {"device_id": "device-other-area-id"})
+
+    assert {
+        "light.in_yet_another_area",
     } == await service.async_extract_entity_ids(hass, call)
 
     assert (

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -413,17 +413,17 @@ async def test_extract_entity_ids_from_area(hass, area_mock):
 
 async def test_extract_entity_ids_from_devices(hass, area_mock):
     """Test extract_entity_ids method with devices."""
-    call = ha.ServiceCall("light", "turn_on", {"device_id": "device-no-area-id"})
-
-    assert {
+    assert await service.async_extract_entity_ids(
+        hass, ha.ServiceCall("light", "turn_on", {"device_id": "device-no-area-id"})
+    ) == {
         "light.no_area",
-    } == await service.async_extract_entity_ids(hass, call)
+    }
 
-    call = ha.ServiceCall("light", "turn_on", {"device_id": "device-other-area-id"})
-
-    assert {
+    assert await service.async_extract_entity_ids(
+        hass, ha.ServiceCall("light", "turn_on", {"device_id": "device-other-area-id"})
+    ) == {
         "light.in_yet_another_area",
-    } == await service.async_extract_entity_ids(hass, call)
+    }
 
     assert (
         await service.async_extract_entity_ids(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes the logic for extracting entity_ids, to also include entities that are directly referenced as a device_id in the device selector AND have an overridden area in the entity ID.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
