### PR TITLE
Add support for multiple Overkiz gateways to Somfy TaHoma integration

### DIFF
--- a/homeassistant/components/tahoma/__init__.py
+++ b/homeassistant/components/tahoma/__init__.py
@@ -62,16 +62,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         scenarios = await client.get_scenarios()
         places = await client.get_places()
     except BadCredentialsException:
-        _LOGGER.error("Invalid authentication.")
+        _LOGGER.error("Invalid authentication")
         return False
     except TooManyRequestsException as exception:
-        _LOGGER.error("Too many requests, try again later.")
+        _LOGGER.error("Too many requests, try again later")
         raise ConfigEntryNotReady from exception
     except (TimeoutError, ClientError, ServerDisconnectedError) as exception:
-        _LOGGER.error("Failed to connect.")
+        _LOGGER.error("Failed to connect")
         raise ConfigEntryNotReady from exception
     except MaintenanceException as exception:
-        _LOGGER.error("Server is down for maintenance.")
+        _LOGGER.error("Server is down for maintenance")
         raise ConfigEntryNotReady from exception
     except Exception as exception:  # pylint: disable=broad-except
         _LOGGER.exception(exception)
@@ -92,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     _LOGGER.debug(
-        "Initialized DataUpdateCoordinator with %s interval.", str(update_interval)
+        "Initialized DataUpdateCoordinator with %s interval", str(update_interval)
     )
 
     await tahoma_coordinator.async_refresh()

--- a/homeassistant/components/tahoma/config_flow.py
+++ b/homeassistant/components/tahoma/config_flow.py
@@ -15,13 +15,24 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, MIN_UPDATE_INTERVAL
+from .const import (
+    CONF_HUB,
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_HUB,
+    DEFAULT_UPDATE_INTERVAL,
+    MIN_UPDATE_INTERVAL,
+    SUPPORTED_ENDPOINTS,
+)
 from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
-    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_HUB, default=DEFAULT_HUB): vol.In(SUPPORTED_ENDPOINTS.keys()),
+    }
 )
 
 
@@ -42,7 +53,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         username = user_input.get(CONF_USERNAME)
         password = user_input.get(CONF_PASSWORD)
 
-        async with TahomaClient(username, password) as client:
+        hub = user_input.get(CONF_HUB, DEFAULT_HUB)
+        endpoint = SUPPORTED_ENDPOINTS[hub]
+
+        async with TahomaClient(username, password, api_url=endpoint) as client:
             await client.login()
             return self.async_create_entry(title=username, data=user_input)
 

--- a/homeassistant/components/tahoma/const.py
+++ b/homeassistant/components/tahoma/const.py
@@ -7,7 +7,7 @@ from homeassistant.components.lock import DOMAIN as LOCK
 DOMAIN = "tahoma"
 
 CONF_HUB = "hub"
-DEFAULT_HUB = "Somfy TaHoma"
+DEFAULT_HUB = "Somfy TaHoma (Europe)"
 
 MIN_UPDATE_INTERVAL = 30
 DEFAULT_UPDATE_INTERVAL = 30

--- a/homeassistant/components/tahoma/const.py
+++ b/homeassistant/components/tahoma/const.py
@@ -6,16 +6,30 @@ from homeassistant.components.lock import DOMAIN as LOCK
 
 DOMAIN = "tahoma"
 
+CONF_HUB = "hub"
+DEFAULT_HUB = "Somfy TaHoma"
+
 MIN_UPDATE_INTERVAL = 30
 DEFAULT_UPDATE_INTERVAL = 30
 
-IGNORED_TAHOMA_TYPES = [
+SUPPORTED_ENDPOINTS = {
+    "Cozytouch": "https://ha110-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "eedomus": "https://ha101-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "Hi Kumo": "https://ha117-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "Rexel Energeasy Connect": "https://ha112-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "Somfy Connexoon (Europe)": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+    "Somfy Connexoon (Australia)": "https://ha201-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "Somfy TaHoma (Europe)": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+    "Somfy TaHoma (North America)": "https://ha401-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+}
+
+IGNORED_TAHOMA_DEVICES = [
     "ProtocolGateway",
     "Pod",
 ]
 
 # Used to map the Somfy widget and ui_class to the Home Assistant platform
-TAHOMA_TYPES = {
+TAHOMA_DEVICE_TO_PLATFORM = {
     "AdjustableSlatsRollerShutter": COVER,
     "AirFlowSensor": BINARY_SENSOR,  # widgetName, uiClass is AirSensor (sensor)
     "Awning": COVER,

--- a/homeassistant/components/tahoma/const.py
+++ b/homeassistant/components/tahoma/const.py
@@ -7,7 +7,7 @@ from homeassistant.components.lock import DOMAIN as LOCK
 DOMAIN = "tahoma"
 
 CONF_HUB = "hub"
-DEFAULT_HUB = "Somfy TaHoma (Europe)"
+DEFAULT_HUB = "Somfy (Europe)"
 
 MIN_UPDATE_INTERVAL = 30
 DEFAULT_UPDATE_INTERVAL = 30
@@ -17,10 +17,9 @@ SUPPORTED_ENDPOINTS = {
     "eedomus": "https://ha101-1.overkiz.com/enduser-mobile-web/enduserAPI/",
     "Hi Kumo": "https://ha117-1.overkiz.com/enduser-mobile-web/enduserAPI/",
     "Rexel Energeasy Connect": "https://ha112-1.overkiz.com/enduser-mobile-web/enduserAPI/",
-    "Somfy Connexoon (Europe)": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
-    "Somfy Connexoon (Australia)": "https://ha201-1.overkiz.com/enduser-mobile-web/enduserAPI/",
-    "Somfy TaHoma (Europe)": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
-    "Somfy TaHoma (North America)": "https://ha401-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "Somfy (Australia)": "https://ha201-1.overkiz.com/enduser-mobile-web/enduserAPI/",
+    "Somfy (Europe)": "https://tahomalink.com/enduser-mobile-web/enduserAPI/",
+    "Somfy (North America)": "https://ha401-1.overkiz.com/enduser-mobile-web/enduserAPI/",
 }
 
 IGNORED_TAHOMA_DEVICES = [

--- a/homeassistant/components/tahoma/manifest.json
+++ b/homeassistant/components/tahoma/manifest.json
@@ -10,5 +10,11 @@
     "@imicknl",
     "@vlebourl",
     "@tetienne"
+  ],
+  "dhcp": [
+    {
+      "hostname": "gateway*",
+      "macaddress": "F8811A*"
+    }
   ]
 }

--- a/homeassistant/components/tahoma/strings.json
+++ b/homeassistant/components/tahoma/strings.json
@@ -5,7 +5,8 @@
         "description": "Enter your TaHoma credentials for the TaHoma App or the tahomalink.com platform.",
         "data": {
           "username": "[%key:common::config_flow::data::username%]",
-          "password": "[%key:common::config_flow::data::password%]"
+          "password": "[%key:common::config_flow::data::password%]",
+          "hub": "Hub"
         }
       }
     },

--- a/homeassistant/components/tahoma/translations/en.json
+++ b/homeassistant/components/tahoma/translations/en.json
@@ -5,7 +5,8 @@
                 "description": "Enter your TaHoma credentials for the TaHoma App or the tahomalink.com platform.",
                 "data": {
                     "username": "Username",
-                    "password": "Password"
+                    "password": "Password",
+                    "hub": "Hub"
                 }
             }
         },

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -171,6 +171,11 @@ DHCP = [
         "macaddress": "000420*"
     },
     {
+        "domain": "tahoma",
+        "hostname": "gateway*",
+        "macaddress": "F8811A*"
+    },
+    {
         "domain": "tesla",
         "hostname": "tesla_*",
         "macaddress": "4CFCAA*"

--- a/tests/components/tahoma/test_config_flow.py
+++ b/tests/components/tahoma/test_config_flow.py
@@ -18,7 +18,7 @@ from tests.common import MockConfigEntry
 
 TEST_EMAIL = "test@testdomain.com"
 TEST_PASSWORD = "test-password"
-TEST_HUB = "Somfy TaHoma"
+TEST_HUB = "Somfy TaHoma (Europe)"
 
 
 async def test_form(hass):

--- a/tests/components/tahoma/test_config_flow.py
+++ b/tests/components/tahoma/test_config_flow.py
@@ -18,7 +18,7 @@ from tests.common import MockConfigEntry
 
 TEST_EMAIL = "test@testdomain.com"
 TEST_PASSWORD = "test-password"
-TEST_HUB = "Somfy TaHoma (Europe)"
+TEST_HUB = "Somfy (Europe)"
 
 
 async def test_form(hass):

--- a/tests/components/tahoma/test_config_flow.py
+++ b/tests/components/tahoma/test_config_flow.py
@@ -18,6 +18,7 @@ from tests.common import MockConfigEntry
 
 TEST_EMAIL = "test@testdomain.com"
 TEST_PASSWORD = "test-password"
+TEST_HUB = "Somfy TaHoma"
 
 
 async def test_form(hass):
@@ -36,7 +37,7 @@ async def test_form(hass):
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
         )
 
     assert result2["type"] == "create_entry"
@@ -44,6 +45,7 @@ async def test_form(hass):
     assert result2["data"] == {
         "username": TEST_EMAIL,
         "password": TEST_PASSWORD,
+        "hub": TEST_HUB,
     }
 
     await hass.async_block_till_done()
@@ -72,7 +74,7 @@ async def test_form_invalid(hass, side_effect, error):
     with patch("pyhoma.client.TahomaClient.login", side_effect=side_effect):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
         )
 
     assert result2["type"] == "form"
@@ -84,7 +86,7 @@ async def test_abort_on_duplicate_entry(hass):
     MockConfigEntry(
         domain=config_flow.DOMAIN,
         unique_id=TEST_EMAIL,
-        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -120,7 +122,7 @@ async def test_allow_multiple_unique_entries(hass):
     ), patch("homeassistant.components.tahoma.async_setup_entry", return_value=True):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"username": TEST_EMAIL, "password": TEST_PASSWORD},
+            {"username": TEST_EMAIL, "password": TEST_PASSWORD, "hub": TEST_HUB},
         )
 
     assert result2["type"] == "create_entry"
@@ -128,6 +130,7 @@ async def test_allow_multiple_unique_entries(hass):
     assert result2["data"] == {
         "username": TEST_EMAIL,
         "password": TEST_PASSWORD,
+        "hub": TEST_HUB,
     }
 
 


### PR DESCRIPTION
## Proposed change
Add support for multiple Overkiz gateways to Somfy TaHoma integration. Part of bigger TaHoma integration rewrite, target of this PR is rework-tahoma branch.

While working on the Somfy TaHoma refactor, we found out that it is based on the Overkiz platform and that multiple vendors use the same hub + platform. This change will add support for CozyTouch, eedomus, Hi Kumo, Rexel Energeasy connect and Somfy Australia / North America to this integration.

The Overkiz platform supports about 6000 devices and is used a lot. For example, there are currently custom integrations for Hi Kumo and CozyTouch, which can directly benefit from this change in core.

## Discussion point
Should we rename the domain to Overkiz, add proper autodiscover and remove the TaHoma mentions in the integration? Overkiz is not a name that is used a lot, however Somfy TaHoma doesn't make a lot of sense for the other integration platforms.

Since it is not possible (yet) to use aliases or multiple keywords, my preference would be to rename the platform to Overkiz, as long as autodiscover is set up for all the vendors.

After this PR is merged + we decided on a possible rename, this feature branch is almost ready to be merged in core. Other platforms can follow later, but we believe the basics need to be in to not have too many breaking changes in the next updates.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/14920

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

<img width="619" alt="Screen Shot 2021-04-18 at 19 43 32" src="https://user-images.githubusercontent.com/1424596/115155062-6ffb5d80-a07e-11eb-9da4-95cfee2049cc.png">
