### PR TITLE
Bump pykmtronic to 0.3.0

### DIFF
--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -48,10 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 await hub.async_update_relays()
         except aiohttp.client_exceptions.ClientResponseError as err:
             raise UpdateFailed(f"Wrong credentials: {err}") from err
-        except (
-            asyncio.TimeoutError,
-            aiohttp.client_exceptions.ClientConnectorError,
-        ) as err:
+        except aiohttp.client_exceptions.ClientConnectorError as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
     coordinator = DataUpdateCoordinator(

--- a/homeassistant/components/kmtronic/manifest.json
+++ b/homeassistant/components/kmtronic/manifest.json
@@ -3,6 +3,6 @@
     "name": "KMtronic",
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/integrations/kmtronic",
-    "requirements": ["pykmtronic==0.0.3"],
+    "requirements": ["pykmtronic==0.2.1"],
     "codeowners": ["@dgomes"]
 }

--- a/homeassistant/components/kmtronic/manifest.json
+++ b/homeassistant/components/kmtronic/manifest.json
@@ -3,6 +3,6 @@
     "name": "KMtronic",
     "config_flow": true,
     "documentation": "https://www.home-assistant.io/integrations/kmtronic",
-    "requirements": ["pykmtronic==0.2.1"],
+    "requirements": ["pykmtronic==0.3.0"],
     "codeowners": ["@dgomes"]
 }

--- a/homeassistant/components/kmtronic/switch.py
+++ b/homeassistant/components/kmtronic/switch.py
@@ -45,21 +45,26 @@ class KMtronicSwitch(CoordinatorEntity, SwitchEntity):
     def is_on(self):
         """Return entity state."""
         if self._reverse:
-            return not self._relay.is_on
-        return self._relay.is_on
+            return not self._relay.is_energised
+        return self._relay.is_energised
 
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the switch on."""
         if self._reverse:
-            await self._relay.turn_off()
+            await self._relay.de_energise()
         else:
-            await self._relay.turn_on()
+            await self._relay.energise()
         self.async_write_ha_state()
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the switch off."""
         if self._reverse:
-            await self._relay.turn_on()
+            await self._relay.energise()
         else:
-            await self._relay.turn_off()
+            await self._relay.de_energise()
+        self.async_write_ha_state()
+
+    async def async_toggle(self, **kwargs) -> None:
+        """Toggle the switch."""
+        await self._relay.toggle()
         self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1485,7 +1485,7 @@ pyitachip2ir==0.0.7
 pykira==0.1.1
 
 # homeassistant.components.kmtronic
-pykmtronic==0.0.3
+pykmtronic==0.2.1
 
 # homeassistant.components.kodi
 pykodi==0.2.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1485,7 +1485,7 @@ pyitachip2ir==0.0.7
 pykira==0.1.1
 
 # homeassistant.components.kmtronic
-pykmtronic==0.2.1
+pykmtronic==0.3.0
 
 # homeassistant.components.kodi
 pykodi==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -808,7 +808,7 @@ pyisy==2.1.1
 pykira==0.1.1
 
 # homeassistant.components.kmtronic
-pykmtronic==0.0.3
+pykmtronic==0.2.1
 
 # homeassistant.components.kodi
 pykodi==0.2.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -808,7 +808,7 @@ pyisy==2.1.1
 pykira==0.1.1
 
 # homeassistant.components.kmtronic
-pykmtronic==0.2.1
+pykmtronic==0.3.0
 
 # homeassistant.components.kodi
 pykodi==0.2.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Bumps version of supporting library addressing #47893 and #48446
- Adds toggle service

[CHANGES](https://github.com/dgomes/pykmtronic/blob/master/CHANGES.md)
[DIFF](https://github.com/dgomes/pykmtronic/compare/20de217...master)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47893, #48446
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
