### PR TITLE
Add `search` and `match` as Jinja tests

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1432,8 +1432,10 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["base64_decode"] = base64_decode
         self.filters["ordinal"] = ordinal
         self.filters["regex_match"] = regex_match
+        self.tests["match"] = regex_match
         self.filters["regex_replace"] = regex_replace
         self.filters["regex_search"] = regex_search
+        self.tests["search"] = regex_search
         self.filters["regex_findall_index"] = regex_findall_index
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or

--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -1432,10 +1432,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["base64_decode"] = base64_decode
         self.filters["ordinal"] = ordinal
         self.filters["regex_match"] = regex_match
-        self.tests["match"] = regex_match
         self.filters["regex_replace"] = regex_replace
         self.filters["regex_search"] = regex_search
-        self.tests["search"] = regex_search
         self.filters["regex_findall_index"] = regex_findall_index
         self.filters["bitwise_and"] = bitwise_and
         self.filters["bitwise_or"] = bitwise_or
@@ -1461,6 +1459,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.globals["urlencode"] = urlencode
         self.globals["max"] = max
         self.globals["min"] = min
+        self.tests["match"] = regex_match
+        self.tests["search"] = regex_search
 
         if hass is None:
             return

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1013,30 +1013,6 @@ def test_match_test(hass):
     )
     assert tpl.async_render() is True
 
-    tpl = template.Template(
-        """
-{{ 'Home Assistant test' is match('home', True) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-    {{ 'Another Home Assistant test' is match('Home') }}
-                    """,
-        hass,
-    )
-    assert tpl.async_render() is False
-
-    tpl = template.Template(
-        """
-{{ ['Home Assistant test'] is match('.*Assist') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
 
 def test_regex_search(hass):
     """Test regex_search method."""
@@ -1078,30 +1054,6 @@ def test_search_test(hass):
     tpl = template.Template(
         r"""
 {{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-{{ 'Home Assistant test' is search('home', True) }}
-            """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-    {{ 'Another Home Assistant test' is search('Home') }}
-                    """,
-        hass,
-    )
-    assert tpl.async_render() is True
-
-    tpl = template.Template(
-        """
-{{ ['Home Assistant test'] is search('Assist') }}
             """,
         hass,
     )

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -1003,6 +1003,41 @@ def test_regex_match(hass):
     assert tpl.async_render() is True
 
 
+def test_match_test(hass):
+    """Test match test."""
+    tpl = template.Template(
+        r"""
+{{ '123-456-7890' is match('(\\d{3})-(\\d{3})-(\\d{4})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+{{ 'Home Assistant test' is match('home', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+    {{ 'Another Home Assistant test' is match('Home') }}
+                    """,
+        hass,
+    )
+    assert tpl.async_render() is False
+
+    tpl = template.Template(
+        """
+{{ ['Home Assistant test'] is match('.*Assist') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
 def test_regex_search(hass):
     """Test regex_search method."""
     tpl = template.Template(
@@ -1032,6 +1067,41 @@ def test_regex_search(hass):
     tpl = template.Template(
         """
 {{ ['Home Assistant test'] | regex_search('Assist') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+
+def test_search_test(hass):
+    """Test search test."""
+    tpl = template.Template(
+        r"""
+{{ '123-456-7890' is search('(\\d{3})-(\\d{3})-(\\d{4})') }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+{{ 'Home Assistant test' is search('home', True) }}
+            """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+    {{ 'Another Home Assistant test' is search('Home') }}
+                    """,
+        hass,
+    )
+    assert tpl.async_render() is True
+
+    tpl = template.Template(
+        """
+{{ ['Home Assistant test'] is search('Assist') }}
             """,
         hass,
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently `regex_match` and `regex_search` are added to Jinja as filters. While this works its not really correct. According to Jinja [filters](https://jinja.palletsprojects.com/en/2.11.x/templates/#filters) modify a given input and return new output. These test an input to see if it meets a given condition and return `true` or `false` which means the proper way to define them in Jinja is as a [test](https://jinja.palletsprojects.com/en/2.11.x/templates/#tests).

While this seems minor it actually has some rather annoying consequences. Jinja has two very valuable and powerful filters for HA users - [selectattr](https://jinja.palletsprojects.com/en/2.11.x/templates/#selectattr) and [rejectattr](https://jinja.palletsprojects.com/en/2.11.x/templates/#rejectattr). These can be used for fast and easy filtering of lists of entities. The problem is that they only allow you to use tests in the comparison, they won't allow you to use filters.

To take this to an example, lets say I wanted to find all binary sensor entities for when an update is available and count the number with `on`. Today I would have to do this:
```j2
{% set ns = namespace(count=0) %}
{% for e in states.binary_sensor if e.entity_id | regex_match('_update_available$') and e.state == 'on' %}
   {% set ns.count = ns.count + 1 %}
{% endfor %}
{{ ns.count }}
```
Which works but it's wordy. With this PR I can accomplish that same task with this:
```j2
{{ states.binary_sensor | select_attr('entity_id', 'search', '_update_available$') | select_attr('state', 'eq', 'on') | list | count }}
```
Or if I wanted to get a list of all battery entities with a less then 10% remaining I'd need the same for loop and namespace structure today, after this PR it would be a one-liner like this:
```j2
{{ states.sensor | select_attr('device_class', 'eq', 'battery') | select_attr('state', 'match', '^[0-9]$') | list | join(', ') }}
```

In order to keep things backwards compatible I left the `regex_search` and `regex_match` filters in for now. Although personally I would recommend deprecating them in favor of the tests. The tests can do everything the filters can do and more (since they work in the `selectattr` and `rejectattr` clauses). For normal non-list based use you simply use them like this:
```j2
{{ 'Home Assistant' is match('Home') }}
```
Basically just use `is` instead of `|`, still returns a boolean value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
sensor:
- platform: template
  sensors:
    updates_available:
      friendly_name: Updates Available
      value_template: "{{ states.binary_sensor | select_attr('search', '_update_available$') | select_attr('state', 'eq', 'on') | list | count }}"
      attribute_templates:
        entities: "{{ states.binary_sensor | select_attr('search', '_update_available$') | select_attr('state', 'eq', 'on') | list }}"
    low_batteries:
      friendly_name: Devices with low battery
      value_template: "{{ states.sensor | select_attr('device_class', 'eq', 'battery') | select_attr('state', 'match', '^[0-9]$') | list | count }}"
      attribute_templates:
        entities: "{{ states.sensor | select_attr('device_class', 'eq', 'battery') | select_attr('state', 'match', '^[0-9]$') | list }}"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17469

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
