### PR TITLE
Add names to cast threads

### DIFF
--- a/homeassistant/components/cast/discovery.py
+++ b/homeassistant/components/cast/discovery.py
@@ -87,6 +87,7 @@ def setup_internal_discovery(hass: HomeAssistant, config_entry) -> None:
         ChromeCastZeroconf.get_zeroconf(),
         config_entry.data.get(CONF_KNOWN_HOSTS),
     )
+    browser.host_browser.name = "Cast HostBrowser"
     hass.data[CAST_BROWSER_KEY] = browser
     browser.start_discovery()
 

--- a/homeassistant/components/cast/media_player.py
+++ b/homeassistant/components/cast/media_player.py
@@ -237,6 +237,7 @@ class CastDevice(MediaPlayerEntity):
             ),
             ChromeCastZeroconf.get_zeroconf(),
         )
+        chromecast.socket_client.name = f"Cast {self._cast_info.friendly_name}"
         self._chromecast = chromecast
 
         if CAST_MULTIZONE_MANAGER_KEY not in self.hass.data:
@@ -854,6 +855,7 @@ class DynamicCastGroup:
             ),
             ChromeCastZeroconf.get_zeroconf(),
         )
+        chromecast.socket_client.name = "Cast Dynamic group"
         self._chromecast = chromecast
 
         if CAST_MULTIZONE_MANAGER_KEY not in self.hass.data:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add names to cast threads

- Easier to debug when an exception is thrown on py-spy dump (we don't have to guess what `Thread-13` is)

Example `py-spy`:
```
bash-5.0# ./py-spy dump --pid 213
Process 213: /usr/local/bin/python3 /usr/src/homeassistant/homeassistant/__main__.py --config /config
Python v3.8.7 (/usr/local/bin/python3.8)

....
Thread 916 (idle): "zeroconf-ServiceBrowser__googlecast._tcp.local._916"
    wait (threading.py:306)
    wait (zeroconf/__init__.py:2547)
    run (zeroconf/__init__.py:1735)
    _bootstrap_inner (threading.py:932)
    _bootstrap (threading.py:890)
Thread 917 (idle): "Cast HostBrowser"
    do_handshake (ssl.py:1309)
    _create (ssl.py:1040)
    wrap_socket (ssl.py:500)
    connect (http/client.py:1424)
    send (http/client.py:950)
    _send_output (http/client.py:1010)
    endheaders (http/client.py:1250)
    _send_request (http/client.py:1301)
    request (http/client.py:1255)
    do_open (urllib/request.py:1350)
    https_open (urllib/request.py:1393)
    _call_chain (urllib/request.py:502)
    _open (urllib/request.py:542)
    open (urllib/request.py:525)
    urlopen (urllib/request.py:222)
    _get_status (pychromecast/dial.py:88)
    get_device_status (pychromecast/dial.py:109)
    _poll_hosts (pychromecast/discovery.py:268)
    run (pychromecast/discovery.py:252)
    _bootstrap_inner (threading.py:932)
    _bootstrap (threading.py:890)
Thread 930 (idle): "Cast Backyard Speaker"
    run_once (pychromecast/socket_client.py:558)
    run (pychromecast/socket_client.py:527)
    _bootstrap_inner (threading.py:932)
    _bootstrap (threading.py:890)
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
