### PR TITLE
Create KNX switch entity directly from config

### DIFF
--- a/homeassistant/components/knx/__init__.py
+++ b/homeassistant/components/knx/__init__.py
@@ -235,7 +235,15 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     # We need to wait until all entities are loaded into the device list since they could also be created from other platforms
     for platform in SupportedPlatforms:
         hass.async_create_task(
-            discovery.async_load_platform(hass, platform.value, DOMAIN, {}, config)
+            discovery.async_load_platform(
+                hass,
+                platform.value,
+                DOMAIN,
+                {
+                    "platform_config": config[DOMAIN].get(platform.value),
+                },
+                config,
+            )
         )
 
     hass.services.async_register(

--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -13,7 +13,6 @@ from xknx.devices import (
     Notification as XknxNotification,
     Scene as XknxScene,
     Sensor as XknxSensor,
-    Switch as XknxSwitch,
     Weather as XknxWeather,
 )
 
@@ -29,7 +28,6 @@ from .schema import (
     LightSchema,
     SceneSchema,
     SensorSchema,
-    SwitchSchema,
     WeatherSchema,
 )
 
@@ -38,7 +36,7 @@ def create_knx_device(
     platform: SupportedPlatforms,
     knx_module: XKNX,
     config: ConfigType,
-) -> XknxDevice:
+) -> XknxDevice | None:
     """Return the requested XKNX device."""
     if platform is SupportedPlatforms.LIGHT:
         return _create_light(knx_module, config)
@@ -48,9 +46,6 @@ def create_knx_device(
 
     if platform is SupportedPlatforms.CLIMATE:
         return _create_climate(knx_module, config)
-
-    if platform is SupportedPlatforms.SWITCH:
-        return _create_switch(knx_module, config)
 
     if platform is SupportedPlatforms.SENSOR:
         return _create_sensor(knx_module, config)
@@ -69,6 +64,8 @@ def create_knx_device(
 
     if platform is SupportedPlatforms.FAN:
         return _create_fan(knx_module, config)
+
+    return None
 
 
 def _create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
@@ -267,17 +264,6 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
         create_temperature_sensors=config[
             ClimateSchema.CONF_CREATE_TEMPERATURE_SENSORS
         ],
-    )
-
-
-def _create_switch(knx_module: XKNX, config: ConfigType) -> XknxSwitch:
-    """Return a KNX switch to be used within XKNX."""
-    return XknxSwitch(
-        knx_module,
-        name=config[CONF_NAME],
-        group_address=config[KNX_ADDRESS],
-        group_address_state=config.get(SwitchSchema.CONF_STATE_ADDRESS),
-        invert=config[SwitchSchema.CONF_INVERT],
     )
 
 

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -3,15 +3,18 @@ from __future__ import annotations
 
 from typing import Any, Callable, Iterable
 
+from xknx import XKNX
 from xknx.devices import Switch as XknxSwitch
 
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import DOMAIN
+from .const import DOMAIN, KNX_ADDRESS
 from .knx_entity import KnxEntity
+from .schema import SwitchSchema
 
 
 async def async_setup_platform(
@@ -21,20 +24,34 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up switch(es) for KNX platform."""
+    if not discovery_info or not discovery_info["platform_config"]:
+        return
+
+    platform_config = discovery_info["platform_config"]
+    xknx: XKNX = hass.data[DOMAIN].xknx
+
     entities = []
-    for device in hass.data[DOMAIN].xknx.devices:
-        if isinstance(device, XknxSwitch):
-            entities.append(KNXSwitch(device))
+    for entity_config in platform_config:
+        entities.append(KNXSwitch(xknx, entity_config))
+
     async_add_entities(entities)
 
 
 class KNXSwitch(KnxEntity, SwitchEntity):
     """Representation of a KNX switch."""
 
-    def __init__(self, device: XknxSwitch) -> None:
+    def __init__(self, xknx: XKNX, config: ConfigType) -> None:
         """Initialize of KNX switch."""
         self._device: XknxSwitch
-        super().__init__(device)
+        super().__init__(
+            device=XknxSwitch(
+                xknx,
+                name=config[CONF_NAME],
+                group_address=config[KNX_ADDRESS],
+                group_address_state=config.get(SwitchSchema.CONF_STATE_ADDRESS),
+                invert=config[SwitchSchema.CONF_INVERT],
+            )
+        )
 
     @property
     def is_on(self) -> bool:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We now create knx entities directly from configuration. 

Previously we created xknx.Device objects (in the knx lib) and used them to create HA entities from. This was necessary because xknx had its own yaml config - which is now deprecated since 2021.4.

This approach is better readable / cleaner and we do not have to pipe config values only used in HA through xknx (e.g., device_class).

This PR just moves the switch entity to the new instantiation schema. Other platforms will follow the same schema (if possible) when the review is done. This does not break anything as it is possible to run some platforms with the old, and others with the new schema.
When all platforms are done we shall not need `factory.py` anymore.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
