### PR TITLE
Fix race when restarting script

### DIFF
--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1144,7 +1144,7 @@ class Script:
                     self._log("Already running", level=LOGSEVERITY[self._max_exceeded])
                 script_execution_set("failed_single")
                 return
-            elif self.script_mode != SCRIPT_MODE_RESTART and self.runs == self.max_runs:
+            if self.script_mode != SCRIPT_MODE_RESTART and self.runs == self.max_runs:
                 if self._max_exceeded != "SILENT":
                     self._log(
                         "Maximum number of runs exceeded",

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -1144,10 +1144,7 @@ class Script:
                     self._log("Already running", level=LOGSEVERITY[self._max_exceeded])
                 script_execution_set("failed_single")
                 return
-            if self.script_mode == SCRIPT_MODE_RESTART:
-                self._log("Restarting")
-                await self.async_stop(update_state=False)
-            elif len(self._runs) == self.max_runs:
+            elif self.script_mode != SCRIPT_MODE_RESTART and self.runs == self.max_runs:
                 if self._max_exceeded != "SILENT":
                     self._log(
                         "Maximum number of runs exceeded",
@@ -1186,6 +1183,14 @@ class Script:
             self._hass, self, cast(dict, variables), context, self._log_exceptions
         )
         self._runs.append(run)
+        if self.script_mode == SCRIPT_MODE_RESTART:
+            # When script mode is SCRIPT_MODE_RESTART, first add the new run and then
+            # stop any other runs. If we stop other runs first, self.is_running will
+            # return false after the other script runs were stopped until our task
+            # resumes running.
+            self._log("Restarting")
+            await self.async_stop(update_state=False, spare=run)
+
         if started_action:
             self._hass.async_run_job(started_action)
         self.last_triggered = utcnow()
@@ -1198,17 +1203,21 @@ class Script:
             self._changed()
             raise
 
-    async def _async_stop(self, update_state):
-        aws = [asyncio.create_task(run.async_stop()) for run in self._runs]
+    async def _async_stop(self, update_state, spare=None):
+        aws = [
+            asyncio.create_task(run.async_stop()) for run in self._runs if run != spare
+        ]
         if not aws:
             return
         await asyncio.wait(aws)
         if update_state:
             self._changed()
 
-    async def async_stop(self, update_state: bool = True) -> None:
+    async def async_stop(
+        self, update_state: bool = True, spare: _ScriptRun | None = None
+    ) -> None:
         """Stop running script."""
-        await asyncio.shield(self._async_stop(update_state))
+        await asyncio.shield(self._async_stop(update_state, spare))
 
     async def _async_get_condition(self, config):
         if isinstance(config, template.Template):

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -156,8 +156,8 @@ async def test_motion_light(hass):
     # Turn on motion
     hass.states.async_set("binary_sensor.kitchen", "on")
     # Can't block till done because delay is active
-    # So wait 5 event loop iterations to process script
-    for _ in range(5):
+    # So wait 10 event loop iterations to process script
+    for _ in range(10):
         await asyncio.sleep(0)
 
     assert len(turn_on_calls) == 1
@@ -165,7 +165,7 @@ async def test_motion_light(hass):
     # Test light doesn't turn off if motion stays
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=200))
 
-    for _ in range(5):
+    for _ in range(10):
         await asyncio.sleep(0)
 
     assert len(turn_off_calls) == 0
@@ -173,7 +173,7 @@ async def test_motion_light(hass):
     # Test light turns off off 120s after last motion
     hass.states.async_set("binary_sensor.kitchen", "off")
 
-    for _ in range(5):
+    for _ in range(10):
         await asyncio.sleep(0)
 
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=120))
@@ -184,7 +184,7 @@ async def test_motion_light(hass):
     # Test restarting the script
     hass.states.async_set("binary_sensor.kitchen", "on")
 
-    for _ in range(5):
+    for _ in range(10):
         await asyncio.sleep(0)
 
     assert len(turn_on_calls) == 2
@@ -192,7 +192,7 @@ async def test_motion_light(hass):
 
     hass.states.async_set("binary_sensor.kitchen", "off")
 
-    for _ in range(5):
+    for _ in range(10):
         await asyncio.sleep(0)
 
     hass.states.async_set("binary_sensor.kitchen", "on")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix race when restarting script

### Background
For scripts in mode `restart`, any ongoing script run is stopped before a new run is started.

### Problem
When starting the script, `self.is_running` was evaluated, and if `True` we would stop the running script run before starting a new one.
During script restart `self.is_running` would return false after the other script runs were stopped and until the task waiting for the stop resumed running and add the new run.
If there were additional script starts during this time, multiple script runs would execute in parallel.

### Solution
Fixed by adding the new script run _before_ stopping the ongoing script runs, and then stopping all script runs except the newly added one. Any additional triggers will now see and stop all the runs.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49171

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
