### PR TITLE
Fix ignorability of AdGuard hassio discovery step

### DIFF
--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -112,39 +112,10 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         This flow is triggered by the discovery component.
         """
-        entries = self._async_current_entries()
+        await self._async_handle_discovery_without_unique_id()
 
-        if not entries:
-            self._hassio_discovery = discovery_info
-            await self._async_handle_discovery_without_unique_id()
-            return await self.async_step_hassio_confirm()
-
-        cur_entry = entries[0]
-
-        if (
-            cur_entry.data[CONF_HOST] == discovery_info[CONF_HOST]
-            and cur_entry.data[CONF_PORT] == discovery_info[CONF_PORT]
-        ):
-            return self.async_abort(reason="already_configured")
-
-        is_loaded = cur_entry.state == config_entries.ENTRY_STATE_LOADED
-
-        if is_loaded:
-            await self.hass.config_entries.async_unload(cur_entry.entry_id)
-
-        self.hass.config_entries.async_update_entry(
-            cur_entry,
-            data={
-                **cur_entry.data,
-                CONF_HOST: discovery_info[CONF_HOST],
-                CONF_PORT: discovery_info[CONF_PORT],
-            },
-        )
-
-        if is_loaded:
-            await self.hass.config_entries.async_setup(cur_entry.entry_id)
-
-        return self.async_abort(reason="existing_instance_updated")
+        self._hassio_discovery = discovery_info
+        return await self.async_step_hassio_confirm()
 
     async def async_step_hassio_confirm(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/adguard/test_config_flow.py
+++ b/tests/components/adguard/test_config_flow.py
@@ -1,7 +1,4 @@
 """Tests for the AdGuard Home config flow."""
-
-from unittest.mock import patch
-
 import aiohttp
 
 from homeassistant import config_entries, data_entry_flow
@@ -120,88 +117,22 @@ async def test_hassio_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_hassio_update_instance_not_running(hass: HomeAssistant) -> None:
-    """Test we only allow a single config flow."""
-    entry = MockConfigEntry(
-        domain=DOMAIN, data={"host": "mock-adguard", "port": "3000"}
+async def test_hassio_ignored(hass: HomeAssistant) -> None:
+    """Test we supervisor discovered instance can be ignored."""
+    MockConfigEntry(domain=DOMAIN, source=config_entries.SOURCE_IGNORE).add_to_hass(
+        hass
     )
-    entry.add_to_hass(hass)
-    assert entry.state == config_entries.ENTRY_STATE_NOT_LOADED
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
-        data={
-            "addon": "AdGuard Home Addon",
-            "host": "mock-adguard-updated",
-            "port": "3000",
-        },
+        data={"addon": "AdGuard Home Addon", "host": "mock-adguard", "port": "3000"},
         context={"source": "hassio"},
     )
+
+    assert "type" in result
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "existing_instance_updated"
-
-
-async def test_hassio_update_instance_running(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test we only allow a single config flow."""
-    aioclient_mock.get(
-        "http://mock-adguard-updated:3000/control/status",
-        json={"version": "v0.99.0"},
-        headers={"Content-Type": CONTENT_TYPE_JSON},
-    )
-    aioclient_mock.get(
-        "http://mock-adguard:3000/control/status",
-        json={"version": "v0.99.0"},
-        headers={"Content-Type": CONTENT_TYPE_JSON},
-    )
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            "host": "mock-adguard",
-            "port": "3000",
-            "verify_ssl": False,
-            "username": None,
-            "password": None,
-            "ssl": False,
-        },
-    )
-    entry.add_to_hass(hass)
-
-    with patch.object(
-        hass.config_entries,
-        "async_forward_entry_setup",
-        return_value=True,
-    ) as mock_load:
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        assert entry.state == config_entries.ENTRY_STATE_LOADED
-        assert len(mock_load.mock_calls) == 2
-
-    with patch.object(
-        hass.config_entries,
-        "async_forward_entry_unload",
-        return_value=True,
-    ) as mock_unload, patch.object(
-        hass.config_entries,
-        "async_forward_entry_setup",
-        return_value=True,
-    ) as mock_load:
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            data={
-                "addon": "AdGuard Home Addon",
-                "host": "mock-adguard-updated",
-                "port": "3000",
-            },
-            context={"source": "hassio"},
-        )
-        assert len(mock_unload.mock_calls) == 2
-        assert len(mock_load.mock_calls) == 2
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-    assert result["reason"] == "existing_instance_updated"
-    assert entry.data["host"] == "mock-adguard-updated"
+    assert "reason" in result
+    assert result["reason"] == "already_configured"
 
 
 async def test_hassio_confirm(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A second attempt towards fixing #36660, this time, added tests to ensure its working 😓 

Additionally, now AdGuard supports multiple config entries, the update logic from hassio discovery has become useless, so that is cleaned up (as it is related to the bug as well).

AdGuard doesn't provide any kind of unique ID, thus we cannot be aware of the entry that needs updating. Old (current) logic just picks the first entry, which isn't viable.

As the add-on requires to be run on the host network, the connection data is fixed: 127.0.0.1, thus removing this update logic, isn't a big deal.

Due to other changes in this release cycle, this PR cannot be included in a patch release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36660
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
