### PR TITLE
Rituals Perfume Genie improvements

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import ACCOUNT_HASH, COORDINATORS, DEVICES, DOMAIN, HUB, HUBLOT
 
@@ -47,14 +47,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for hublot, device in devices.items():
 
         async def async_update_data():
-            try:
-                await device.update_data()
-            except aiohttp.ClientError as err:
-                raise UpdateFailed(
-                    "Unable to retrieve data from rituals.sense-company.com"
-                ) from err
-            else:
-                return device.data
+            await device.update_data()
+            return device.data
 
         coordinator = DataUpdateCoordinator(
             hass,

--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -34,17 +34,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err
 
-    devices = {}
-    for device in account_devices:
-        hublot = device.data[HUB][HUBLOT]
-        devices[hublot] = device
-
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         COORDINATORS: {},
-        DEVICES: devices,
+        DEVICES: {},
     }
 
-    for hublot, device in devices.items():
+    for device in account_devices:
+        hublot = device.data[HUB][HUBLOT]
 
         async def async_update_data():
             await device.update_data()
@@ -60,6 +56,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
         await coordinator.async_refresh()
 
+        hass.data[DOMAIN][entry.entry_id][DEVICES][hublot] = device
         hass.data[DOMAIN][entry.entry_id][COORDINATORS][hublot] = coordinator
 
     for platform in PLATFORMS:

--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 import logging
 
 import aiohttp
-from pyrituals import Account
+from pyrituals import Account, Diffuser
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -42,18 +42,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for device in account_devices:
         hublot = device.data[HUB][HUBLOT]
 
-        async def async_update_data():
-            await device.update_data()
-            return device.data
-
-        coordinator = DataUpdateCoordinator(
-            hass,
-            _LOGGER,
-            name=f"{DOMAIN}-{hublot}",
-            update_method=async_update_data,
-            update_interval=UPDATE_INTERVAL,
-        )
-
+        coordinator = RitualsPerufmeGenieDataUpdateCoordinator(hass, device)
         await coordinator.async_refresh()
 
         hass.data[DOMAIN][entry.entry_id][DEVICES][hublot] = device
@@ -81,3 +70,22 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
+
+
+class RitualsPerufmeGenieDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Rituals Perufme Genie device data from single endpoint."""
+
+    def __init__(self, hass: HomeAssistant, device: Diffuser):
+        """Initialize global Rituals Perufme Genie data updater."""
+        self._device = device
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}-{device.data[HUB][HUBLOT]}",
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> dict:
+        """Fetch data from Rituals."""
+        await self._device.update_data()
+        return self._device.data

--- a/homeassistant/components/rituals_perfume_genie/binary_sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/binary_sensor.py
@@ -1,8 +1,15 @@
 """Support for Rituals Perfume Genie binary sensors."""
+from typing import Callable
+
+from pyrituals import Diffuser
+
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_BATTERY_CHARGING,
     BinarySensorEntity,
 )
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BATTERY, COORDINATORS, DEVICES, DOMAIN, HUB, ID
 from .entity import SENSORS, DiffuserEntity
@@ -11,7 +18,9 @@ CHARGING_SUFFIX = " Battery Charging"
 BATTERY_CHARGING_ID = 21
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
+) -> None:
     """Set up the diffuser binary sensors."""
     diffusers = hass.data[DOMAIN][config_entry.entry_id][DEVICES]
     coordinators = hass.data[DOMAIN][config_entry.entry_id][COORDINATORS]
@@ -27,18 +36,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DiffuserBatteryChargingBinarySensor(DiffuserEntity, BinarySensorEntity):
     """Representation of a diffuser battery charging binary sensor."""
 
-    def __init__(self, diffuser, coordinator):
+    def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the battery charging binary sensor."""
         super().__init__(diffuser, coordinator, CHARGING_SUFFIX)
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """Return the state of the battery charging binary sensor."""
-        return bool(
-            self.coordinator.data[HUB][SENSORS][BATTERY][ID] == BATTERY_CHARGING_ID
-        )
+        return self.coordinator.data[HUB][SENSORS][BATTERY][ID] == BATTERY_CHARGING_ID
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         """Return the device class of the battery charging binary sensor."""
         return DEVICE_CLASS_BATTERY_CHARGING

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.data_entry_flow import FlowResultDict
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import ACCOUNT_HASH, DOMAIN
@@ -27,7 +28,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input=None) -> FlowResultDict:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -25,7 +25,7 @@ class DiffuserEntity(CoordinatorEntity):
 
     def __init__(
         self, diffuser: Diffuser, coordinator: CoordinatorEntity, entity_suffix: str
-    ):
+    ) -> None:
         """Init from config, hookup diffuser and coordinator."""
         super().__init__(coordinator)
         self._diffuser = diffuser

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -46,7 +46,9 @@ class DiffuserEntity(CoordinatorEntity):
     @property
     def available(self) -> bool:
         """Return if the entity is available."""
-        return self.coordinator.data[HUB][STATUS] == AVAILABLE_STATE
+        return (
+            super().available and self.coordinator.data[HUB][STATUS] == AVAILABLE_STATE
+        )
 
     @property
     def device_info(self) -> dict[str, Any]:

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -1,19 +1,31 @@
 """Base class for Rituals Perfume Genie diffuser entity."""
+from __future__ import annotations
+
+from typing import Any
+
+from pyrituals import Diffuser
+
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTES, DOMAIN, HUB, HUBLOT, SENSORS
+from .const import ATTRIBUTES, BATTERY, DOMAIN, HUB, HUBLOT, SENSORS
 
 MANUFACTURER = "Rituals Cosmetics"
-MODEL = "Diffuser"
+MODEL = "The Perfume Genie"
+MODEL2 = "The Perfume Genie 2.0"
 
 ROOMNAME = "roomnamec"
+STATUS = "status"
 VERSION = "versionc"
+
+AVAILABLE_STATE = 1
 
 
 class DiffuserEntity(CoordinatorEntity):
     """Representation of a diffuser entity."""
 
-    def __init__(self, diffuser, coordinator, entity_suffix):
+    def __init__(
+        self, diffuser: Diffuser, coordinator: CoordinatorEntity, entity_suffix: str
+    ):
         """Init from config, hookup diffuser and coordinator."""
         super().__init__(coordinator)
         self._diffuser = diffuser
@@ -22,22 +34,27 @@ class DiffuserEntity(CoordinatorEntity):
         self._hubname = self.coordinator.data[HUB][ATTRIBUTES][ROOMNAME]
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return the unique ID of the entity."""
         return f"{self._hublot}{self._entity_suffix}"
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name of the entity."""
         return f"{self._hubname}{self._entity_suffix}"
 
     @property
-    def device_info(self):
+    def available(self) -> bool:
+        """Return if the entity is available."""
+        return self.coordinator.data[HUB][STATUS] == AVAILABLE_STATE
+
+    @property
+    def device_info(self) -> dict[str, Any]:
         """Return information about the device."""
         return {
             "name": self._hubname,
             "identifiers": {(DOMAIN, self._hublot)},
             "manufacturer": MANUFACTURER,
-            "model": MODEL,
+            "model": MODEL if BATTERY in self._diffuser.data[HUB][SENSORS] else MODEL2,
             "sw_version": self.coordinator.data[HUB][SENSORS][VERSION],
         }

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -1,10 +1,16 @@
 """Support for Rituals Perfume Genie sensors."""
+from typing import Callable
+
+from pyrituals import Diffuser
+
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_BATTERY_LEVEL,
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     PERCENTAGE,
 )
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import BATTERY, COORDINATORS, DEVICES, DOMAIN, HUB, ID, SENSORS
 from .entity import DiffuserEntity
@@ -26,7 +32,9 @@ WIFI_SUFFIX = " Wifi"
 ATTR_SIGNAL_STRENGTH = "signal_strength"
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
+) -> None:
     """Set up the diffuser sensors."""
     diffusers = hass.data[DOMAIN][config_entry.entry_id][DEVICES]
     coordinators = hass.data[DOMAIN][config_entry.entry_id][COORDINATORS]
@@ -45,19 +53,19 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DiffuserPerfumeSensor(DiffuserEntity):
     """Representation of a diffuser perfume sensor."""
 
-    def __init__(self, diffuser, coordinator):
+    def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the perfume sensor."""
         super().__init__(diffuser, coordinator, PERFUME_SUFFIX)
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the perfume sensor icon."""
         if self.coordinator.data[HUB][SENSORS][PERFUME][ID] == PERFUME_NO_CARTRIDGE_ID:
             return "mdi:tag-remove"
         return "mdi:tag-text"
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the perfume sensor."""
         return self.coordinator.data[HUB][SENSORS][PERFUME][TITLE]
 
@@ -65,19 +73,19 @@ class DiffuserPerfumeSensor(DiffuserEntity):
 class DiffuserFillSensor(DiffuserEntity):
     """Representation of a diffuser fill sensor."""
 
-    def __init__(self, diffuser, coordinator):
+    def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the fill sensor."""
         super().__init__(diffuser, coordinator, FILL_SUFFIX)
 
     @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the fill sensor icon."""
         if self.coordinator.data[HUB][SENSORS][FILL][ID] == FILL_NO_CARTRIDGE_ID:
             return "mdi:beaker-question"
         return "mdi:beaker"
 
     @property
-    def state(self):
+    def state(self) -> str:
         """Return the state of the fill sensor."""
         return self.coordinator.data[HUB][SENSORS][FILL][TITLE]
 
@@ -85,12 +93,12 @@ class DiffuserFillSensor(DiffuserEntity):
 class DiffuserBatterySensor(DiffuserEntity):
     """Representation of a diffuser battery sensor."""
 
-    def __init__(self, diffuser, coordinator):
+    def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the battery sensor."""
         super().__init__(diffuser, coordinator, BATTERY_SUFFIX)
 
     @property
-    def state(self):
+    def state(self) -> int:
         """Return the state of the battery sensor."""
         # Use ICON because TITLE may change in the future.
         # ICON filename does not match the image.
@@ -103,19 +111,12 @@ class DiffuserBatterySensor(DiffuserEntity):
         }[self.coordinator.data[HUB][SENSORS][BATTERY][ICON]]
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         """Return the class of the battery sensor."""
         return DEVICE_CLASS_BATTERY
 
     @property
-    def extra_state_attributes(self):
-        """Return the battery state attributes."""
-        return {
-            ATTR_BATTERY_LEVEL: self.coordinator.data[HUB][SENSORS][BATTERY][TITLE],
-        }
-
-    @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the battery unit of measurement."""
         return PERCENTAGE
 
@@ -123,12 +124,12 @@ class DiffuserBatterySensor(DiffuserEntity):
 class DiffuserWifiSensor(DiffuserEntity):
     """Representation of a diffuser wifi sensor."""
 
-    def __init__(self, diffuser, coordinator):
+    def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the wifi sensor."""
         super().__init__(diffuser, coordinator, WIFI_SUFFIX)
 
     @property
-    def state(self):
+    def state(self) -> int:
         """Return the state of the wifi sensor."""
         # Use ICON because TITLE may change in the future.
         return {
@@ -139,18 +140,11 @@ class DiffuserWifiSensor(DiffuserEntity):
         }[self.coordinator.data[HUB][SENSORS][WIFI][ICON]]
 
     @property
-    def device_class(self):
+    def device_class(self) -> str:
         """Return the class of the wifi sensor."""
         return DEVICE_CLASS_SIGNAL_STRENGTH
 
     @property
-    def extra_state_attributes(self):
-        """Return the wifi state attributes."""
-        return {
-            ATTR_SIGNAL_STRENGTH: self.coordinator.data[HUB][SENSORS][WIFI][TITLE],
-        }
-
-    @property
-    def unit_of_measurement(self):
+    def unit_of_measurement(self) -> str:
         """Return the wifi unit of measurement."""
         return PERCENTAGE

--- a/homeassistant/components/rituals_perfume_genie/switch.py
+++ b/homeassistant/components/rituals_perfume_genie/switch.py
@@ -1,20 +1,28 @@
 """Support for Rituals Perfume Genie switches."""
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from pyrituals import Diffuser
+
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.core import callback
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import ATTRIBUTES, COORDINATORS, DEVICES, DOMAIN, HUB
 from .entity import DiffuserEntity
 
-STATUS = "status"
 FAN = "fanc"
 SPEED = "speedc"
 ROOM = "roomc"
 
 ON_STATE = "1"
-AVAILABLE_STATE = 1
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
+) -> None:
     """Set up the diffuser switch."""
     diffusers = hass.data[DOMAIN][config_entry.entry_id][DEVICES]
     coordinators = hass.data[DOMAIN][config_entry.entry_id][COORDINATORS]
@@ -29,23 +37,18 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DiffuserSwitch(SwitchEntity, DiffuserEntity):
     """Representation of a diffuser switch."""
 
-    def __init__(self, diffuser, coordinator):
+    def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the diffuser switch."""
         super().__init__(diffuser, coordinator, "")
         self._is_on = self.coordinator.data[HUB][ATTRIBUTES][FAN] == ON_STATE
 
     @property
-    def available(self):
-        """Return if the device is available."""
-        return self.coordinator.data[HUB][STATUS] == AVAILABLE_STATE
-
-    @property
-    def icon(self):
+    def icon(self) -> str:
         """Return the icon of the device."""
         return "mdi:fan"
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         attributes = {
             "fan_speed": self.coordinator.data[HUB][ATTRIBUTES][SPEED],
@@ -54,24 +57,24 @@ class DiffuserSwitch(SwitchEntity, DiffuserEntity):
         return attributes
 
     @property
-    def is_on(self):
+    def is_on(self) -> bool:
         """If the device is currently on or off."""
         return self._is_on
 
-    async def async_turn_on(self, **kwargs):
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         await self._diffuser.turn_on()
         self._is_on = True
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
-    async def async_turn_off(self, **kwargs):
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
         await self._diffuser.turn_off()
         self._is_on = False
-        self.schedule_update_ha_state()
+        self.async_write_ha_state()
 
     @callback
-    def _handle_coordinator_update(self):
+    def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self._is_on = self.coordinator.data[HUB][ATTRIBUTES][FAN] == ON_STATE
         self.async_write_ha_state()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR processes after merge review comments from #48270 by @MartinHjelmare.
Additionally, it adds typing and adds `available` to all entities.
- Add typing
- ~~Catch expected errors as in #48870 fixes #48818~~
- Use async_write_ha_state https://github.com/home-assistant/core/pull/48270#discussion_r611460086
- Remove battery senor extra_state_attributes https://github.com/home-assistant/core/pull/48270#discussion_r611458852
- Remove hublots list https://github.com/home-assistant/core/pull/48270#discussion_r611454596, https://github.com/home-assistant/core/pull/48270#discussion_r611455757
- Move available to DiffuserEntity so it also applies to all platforms
- Check super().available too
- Show diffuser version in device info model.

Should have put typing in a separate commit, sorry. Hope the list above helps.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: ~~fixes #48818~~
- This PR is related to issue: 
- Link to documentation pull request: 


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
