### PR TITLE
Fix Coronavirus integration robustness

### DIFF
--- a/homeassistant/components/coronavirus/__init__.py
+++ b/homeassistant/components/coronavirus/__init__.py
@@ -15,14 +15,14 @@ from .const import DOMAIN
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the Coronavirus component."""
     # Make sure coordinator is initialized.
     await get_coordinator(hass)
     return True
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Coronavirus from a config entry."""
     if isinstance(entry.data["country"], int):
         hass.config_entries.async_update_entry(
@@ -44,6 +44,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if not entry.unique_id:
         hass.config_entries.async_update_entry(entry, unique_id=entry.data["country"])
 
+    coordinator = await get_coordinator(hass)
+    if not coordinator.last_update_success:
+        await coordinator.async_config_entry_first_refresh()
+
     for platform in PLATFORMS:
         hass.async_create_task(
             hass.config_entries.async_forward_entry_setup(entry, platform)
@@ -52,9 +56,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = all(
+    return all(
         await asyncio.gather(
             *[
                 hass.config_entries.async_forward_entry_unload(entry, platform)
@@ -63,10 +67,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
         )
     )
 
-    return unload_ok
 
-
-async def get_coordinator(hass):
+async def get_coordinator(hass) -> update_coordinator.DataUpdateCoordinator:
     """Get the data update coordinator."""
     if DOMAIN in hass.data:
         return hass.data[DOMAIN]

--- a/homeassistant/components/coronavirus/__init__.py
+++ b/homeassistant/components/coronavirus/__init__.py
@@ -68,7 +68,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
 
-async def get_coordinator(hass) -> update_coordinator.DataUpdateCoordinator:
+async def get_coordinator(hass: HomeAssistant) -> update_coordinator.DataUpdateCoordinator:
     """Get the data update coordinator."""
     if DOMAIN in hass.data:
         return hass.data[DOMAIN]

--- a/homeassistant/components/coronavirus/__init__.py
+++ b/homeassistant/components/coronavirus/__init__.py
@@ -68,7 +68,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
 
-async def get_coordinator(hass: HomeAssistant) -> update_coordinator.DataUpdateCoordinator:
+async def get_coordinator(
+    hass: HomeAssistant,
+) -> update_coordinator.DataUpdateCoordinator:
     """Get the data update coordinator."""
     if DOMAIN in hass.data:
         return hass.data[DOMAIN]

--- a/homeassistant/components/coronavirus/config_flow.py
+++ b/homeassistant/components/coronavirus/config_flow.py
@@ -1,4 +1,8 @@
 """Config flow for Coronavirus integration."""
+from __future__ import annotations
+
+from typing import Any
+
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -15,13 +19,18 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     _options = None
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
         """Handle the initial step."""
         errors = {}
 
         if self._options is None:
-            self._options = {OPTION_WORLDWIDE: "Worldwide"}
             coordinator = await get_coordinator(self.hass)
+            if not coordinator.last_update_success:
+                return self.async_abort(reason="cannot_connect")
+
+            self._options = {OPTION_WORLDWIDE: "Worldwide"}
             for case in sorted(
                 coordinator.data.values(), key=lambda case: case.country
             ):

--- a/homeassistant/components/coronavirus/strings.json
+++ b/homeassistant/components/coronavirus/strings.json
@@ -7,6 +7,7 @@
       }
     },
     "abort": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     }
   }

--- a/homeassistant/components/coronavirus/translations/en.json
+++ b/homeassistant/components/coronavirus/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Service is already configured"
+            "already_configured": "Service is already configured",
+            "cannot_connect": "Failed to connect"
         },
         "step": {
             "user": {

--- a/tests/components/coronavirus/test_config_flow.py
+++ b/tests/components/coronavirus/test_config_flow.py
@@ -1,9 +1,14 @@
 """Test the Coronavirus config flow."""
+from unittest.mock import MagicMock, patch
+
+from aiohttp import ClientError
+
 from homeassistant import config_entries, setup
 from homeassistant.components.coronavirus.const import DOMAIN, OPTION_WORLDWIDE
+from homeassistant.core import HomeAssistant
 
 
-async def test_form(hass):
+async def test_form(hass: HomeAssistant) -> None:
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
@@ -24,3 +29,22 @@ async def test_form(hass):
     }
     await hass.async_block_till_done()
     assert len(hass.states.async_all()) == 4
+
+
+@patch(
+    "coronavirus.get_cases",
+    side_effect=ClientError,
+)
+async def test_abort_on_connection_error(
+    mock_get_cases: MagicMock, hass: HomeAssistant
+) -> None:
+    """Test we abort on connection error."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert "type" in result
+    assert result["type"] == "abort"
+    assert "reason" in result
+    assert result["reason"] == "cannot_connect"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

There are quite a few issue reports open on the Coronavirus integration, that indicate connection or download issue. However, we do not have handling for those, thus causing quite a few stack traces along the way. This can happen when, for example, on startup, the network stack isn't fully ready yet (Wi-Fi connection?)

As a result, we do not recover from such an error at this point, keeping the sensor unavailable.

This PR handles config entry retries when there is no data available, additionally, the config flow will abort when it could not get the data needed to continue.

Some small typing changes added along the way.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32496 fixes #41060 fixes #44321 fixes #44383 fixes #46036 fixes #47811
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
