### PR TITLE
Add config flow for ProxmoxVE

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -831,7 +831,9 @@ omit =
     homeassistant/components/progettihwsw/switch.py
     homeassistant/components/prometheus/*
     homeassistant/components/prowl/notify.py
-    homeassistant/components/proxmoxve/*
+    homeassistant/components/proxmoxve/__init__.py
+    homeassistant/components/proxmoxve/const.py
+    homeassistant/components/proxmoxve/binary_sensor.py
     homeassistant/components/proxy/camera.py
     homeassistant/components/pulseaudio_loopback/switch.py
     homeassistant/components/pushbullet/notify.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -409,7 +409,7 @@ homeassistant/components/profiler/* @bdraco
 homeassistant/components/progettihwsw/* @ardaseremet
 homeassistant/components/prometheus/* @knyar
 homeassistant/components/prosegur/* @dgomes
-homeassistant/components/proxmoxve/* @k4ds3 @jhollowe @Corbeno
+homeassistant/components/proxmoxve/* @k4ds3 @jhollowe @Corbeno @edofullin
 homeassistant/components/ps4/* @ktnrg45
 homeassistant/components/push/* @dgomes
 homeassistant/components/pvoutput/* @fabaff

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -11,6 +11,7 @@ import requests.exceptions
 from requests.exceptions import ConnectTimeout, SSLError
 import voluptuous as vol
 
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -147,17 +148,22 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 =======
 >>>>>>> changed existing code to support config flow
 
-    if DOMAIN not in config:
-        return True  # we are using UI, will be handled by setup_async_entry
+    hass.data[DOMAIN] = {}
 
-    for host in config[DOMAIN]:
-        await async_setup_entry(hass, host)
-        return True
+    # import to config flow
+    if DOMAIN in config:
+        for conf in config[DOMAIN]:
+            hass.async_create_task(
+                hass.config_entries.flow.async_init(
+                    DOMAIN, context={"source": SOURCE_IMPORT}, data=conf
+                )
+            )
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry):
     """Set up the platform."""
-    hass.data.setdefault(DOMAIN, {})
 
     entry_data = config_entry.data
 

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -90,7 +90,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the platform."""
-<<<<<<< HEAD
     hass.data.setdefault(DOMAIN, {})
 
     def build_client() -> ProxmoxAPI:
@@ -144,8 +143,6 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     for host_config in config[DOMAIN]:
         host_name = host_config["host"]
         coordinators[host_name] = {}
-=======
->>>>>>> changed existing code to support config flow
 
     # import to config flow
     if DOMAIN in config:

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -9,7 +9,6 @@ from proxmoxer.backends.https import AuthenticationError
 from proxmoxer.core import ResourceException
 import requests.exceptions
 from requests.exceptions import ConnectTimeout, SSLError
-import voluptuous as vol
 
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
@@ -28,15 +27,8 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .const import (
-    CONF_CONTAINERS,
-    CONF_NODE,
-    CONF_NODES,
     CONF_REALM,
-    CONF_VMS,
     COORDINATORS,
-    DEFAULT_PORT,
-    DEFAULT_REALM,
-    DEFAULT_VERIFY_SSL,
     DOMAIN,
     PLATFORMS,
     PROXMOX_CLIENT,
@@ -48,44 +40,7 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-CONFIG_SCHEMA = vol.Schema(
-    {
-        DOMAIN: vol.All(
-            cv.ensure_list,
-            [
-                vol.Schema(
-                    {
-                        vol.Required(CONF_HOST): cv.string,
-                        vol.Required(CONF_USERNAME): cv.string,
-                        vol.Required(CONF_PASSWORD): cv.string,
-                        vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
-                        vol.Optional(CONF_REALM, default=DEFAULT_REALM): cv.string,
-                        vol.Optional(
-                            CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL
-                        ): cv.boolean,
-                        vol.Required(CONF_NODES): vol.All(
-                            cv.ensure_list,
-                            [
-                                vol.Schema(
-                                    {
-                                        vol.Required(CONF_NODE): cv.string,
-                                        vol.Optional(CONF_VMS, default=[]): [
-                                            cv.positive_int
-                                        ],
-                                        vol.Optional(CONF_CONTAINERS, default=[]): [
-                                            cv.positive_int
-                                        ],
-                                    }
-                                )
-                            ],
-                        ),
-                    }
-                )
-            ],
-        )
-    },
-    extra=vol.ALLOW_EXTRA,
-)
+CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -98,11 +53,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         for entry in config[DOMAIN]:
             host = entry[CONF_HOST]
-            port = entry[CONF_PORT]
+            port = entry[CONF_PORT] if CONF_PORT in entry else 8006
             user = entry[CONF_USERNAME]
-            realm = entry[CONF_REALM]
+            realm = entry[CONF_REALM] if CONF_REALM in entry else "pam"
             password = entry[CONF_PASSWORD]
-            verify_ssl = entry[CONF_VERIFY_SSL]
+            verify_ssl = entry[CONF_VERIFY_SSL] if CONF_VERIFY_SSL in entry else True
 
             hass.data[PROXMOX_CLIENTS][host] = None
 

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -27,25 +27,23 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import DOMAIN
-
-PLATFORMS = ["binary_sensor"]
-PROXMOX_CLIENTS = "proxmox_clients"
-CONF_REALM = "realm"
-CONF_NODE = "node"
-CONF_NODES = "nodes"
-CONF_VMS = "vms"
-CONF_CONTAINERS = "containers"
-
-COORDINATORS = "coordinators"
-API_DATA = "api_data"
-
-DEFAULT_PORT = 8006
-DEFAULT_REALM = "pam"
-DEFAULT_VERIFY_SSL = True
-TYPE_VM = 0
-TYPE_CONTAINER = 1
-UPDATE_INTERVAL = 60
+from .const import (
+    CONF_CONTAINERS,
+    CONF_NODE,
+    CONF_NODES,
+    CONF_REALM,
+    CONF_VMS,
+    COORDINATORS,
+    DEFAULT_PORT,
+    DEFAULT_REALM,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+    PLATFORMS,
+    PROXMOX_CLIENTS,
+    TYPE_CONTAINER,
+    TYPE_VM,
+    UPDATE_INTERVAL,
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -90,6 +90,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the platform."""
+<<<<<<< HEAD
     hass.data.setdefault(DOMAIN, {})
 
     def build_client() -> ProxmoxAPI:
@@ -143,63 +144,33 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     for host_config in config[DOMAIN]:
         host_name = host_config["host"]
         coordinators[host_name] = {}
+=======
+>>>>>>> changed existing code to support config flow
 
-        proxmox_client = hass.data[PROXMOX_CLIENTS][host_name]
+    if DOMAIN not in config:
+        return True  # we are using UI, will be handled by setup_async_entry
 
-        # Skip invalid hosts
-        if proxmox_client is None:
-            continue
-
-        proxmox = proxmox_client.get_api_client()
-
-        for node_config in host_config["nodes"]:
-            node_name = node_config["node"]
-            node_coordinators = coordinators[host_name][node_name] = {}
-
-            for vm_id in node_config["vms"]:
-                coordinator = create_coordinator_container_vm(
-                    hass, proxmox, host_name, node_name, vm_id, TYPE_VM
-                )
-
-                # Fetch initial data
-                await coordinator.async_refresh()
-
-                node_coordinators[vm_id] = coordinator
-
-            for container_id in node_config["containers"]:
-                coordinator = create_coordinator_container_vm(
-                    hass, proxmox, host_name, node_name, container_id, TYPE_CONTAINER
-                )
-
-                # Fetch initial data
-                await coordinator.async_refresh()
-
-                node_coordinators[container_id] = coordinator
-
-    for component in PLATFORMS:
-        await hass.async_create_task(
-            hass.helpers.discovery.async_load_platform(
-                component, DOMAIN, {"config": config}, config
-            )
-        )
-
-    return True
+    for host in config[DOMAIN]:
+        await async_setup_entry(hass, host)
+        return True
 
 
-async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices):
+async def async_setup_entry(hass: HomeAssistant, config_entry):
     """Set up the platform."""
     hass.data.setdefault(DOMAIN, {})
+
+    entry_data = config_entry.data
 
     def build_client() -> ProxmoxAPI:
         """Build the Proxmox client connection."""
         hass.data[PROXMOX_CLIENTS] = {}
 
-        host = config_entry[CONF_HOST]
-        port = config_entry[CONF_PORT]
-        user = config_entry[CONF_USERNAME]
-        realm = config_entry[CONF_REALM]
-        password = config_entry[CONF_PASSWORD]
-        verify_ssl = config_entry[CONF_VERIFY_SSL]
+        host = entry_data[CONF_HOST]
+        port = entry_data[CONF_PORT]
+        user = entry_data[CONF_USERNAME]
+        realm = entry_data[CONF_REALM]
+        password = entry_data[CONF_PASSWORD]
+        verify_ssl = entry_data[CONF_VERIFY_SSL]
 
         hass.data[PROXMOX_CLIENTS][host] = None
 
@@ -213,6 +184,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
             _LOGGER.warning(
                 "Invalid credentials for proxmox instance %s:%d", host, port
             )
+            return False
         except SSLError:
             _LOGGER.error(
                 "Unable to verify proxmox server SSL. "
@@ -220,8 +192,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
                 host,
                 port,
             )
+            return False
         except ConnectTimeout:
             _LOGGER.warning("Connection to host %s timed out during setup", host)
+            return False
 
         hass.data[PROXMOX_CLIENTS][host] = proxmox_client
 
@@ -229,14 +203,14 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
 
     coordinators = hass.data[DOMAIN][COORDINATORS] = {}
 
-    host_name = config_entry["host"]
+    host_name = entry_data["host"]
     coordinators[host_name] = {}
 
     proxmox_client = hass.data[PROXMOX_CLIENTS][host_name]
 
     proxmox = proxmox_client.get_api_client()
 
-    for node_config in config_entry["nodes"]:
+    for node_config in entry_data["nodes"]:
         node_name = node_config["name"]
         node_coordinators = coordinators[host_name][node_name] = {}
 
@@ -260,11 +234,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_devices
 
             node_coordinators[container_id] = coordinator
 
-    for component in PLATFORMS:
-        await hass.async_create_task(
-            hass.helpers.discovery.async_load_platform(
-                component, DOMAIN, {"config": config_entry}, config_entry
-            )
+    # setup platforms
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(config_entry, platform)
         )
 
     return True

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -29,6 +29,9 @@ from homeassistant.helpers.update_coordinator import (
 from .const import (
     CONF_REALM,
     COORDINATORS,
+    DEFAULT_PORT,
+    DEFAULT_REALM,
+    DEFAULT_VERIFY_SSL,
     DOMAIN,
     PLATFORMS,
     PROXMOX_CLIENT,
@@ -53,11 +56,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
         for entry in config[DOMAIN]:
             host = entry[CONF_HOST]
-            port = entry[CONF_PORT] if CONF_PORT in entry else 8006
+            port = entry.get(CONF_PORT, DEFAULT_PORT)
             user = entry[CONF_USERNAME]
-            realm = entry[CONF_REALM] if CONF_REALM in entry else "pam"
+            realm = entry.get(CONF_REALM, DEFAULT_REALM)
             password = entry[CONF_PASSWORD]
-            verify_ssl = entry[CONF_VERIFY_SSL] if CONF_VERIFY_SSL in entry else True
+            verify_ssl = entry.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
 
             hass.data[PROXMOX_CLIENTS][host] = None
 

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -21,7 +21,7 @@ async def async_setup_platform(hass, config, add_entities, discovery_info=None):
             continue
 
         for node_config in host_config["nodes"]:
-            node_name = node_config["node"]
+            node_name = node_config["name"]
 
             for vm_id in node_config["vms"]:
                 coordinator = host_name_coordinators[node_name][vm_id]

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -13,22 +13,22 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
+    hass: HomeAssistantType,
+    config_entry: ConfigEntry,
+    async_add_entities,
 ) -> None:
     """Set up binary sensors."""
 
     sensors = []
 
-    _LOGGER.info("Setting up ProxmoxVE platform")
-
-    host_name = config_entry.data["host"]
-    host_name_coordinators = hass.data[DOMAIN][COORDINATORS][host_name]
+    # host_name = config_entry.data["host"]
+    coordinators = hass.data[DOMAIN][config_entry.entry_id][COORDINATORS]
 
     for node_config in config_entry.data["nodes"]:
         node_name = node_config["name"]
 
         for vm_id in node_config["vms"]:
-            coordinator = host_name_coordinators[node_name][vm_id]
+            coordinator = coordinators[node_name][vm_id]
             coordinator_data = coordinator.data
 
             # unfound vm case
@@ -36,13 +36,11 @@ async def async_setup_entry(
                 continue
 
             vm_name = coordinator_data["name"]
-            vm_sensor = create_binary_sensor(
-                coordinator, host_name, node_name, vm_id, vm_name
-            )
+            vm_sensor = create_binary_sensor(coordinator, node_name, vm_id, vm_name)
             sensors.append(vm_sensor)
 
         for container_id in node_config["containers"]:
-            coordinator = host_name_coordinators[node_name][container_id]
+            coordinator = coordinators[node_name][container_id]
             coordinator_data = coordinator.data
 
             # unfound container case
@@ -51,21 +49,20 @@ async def async_setup_entry(
 
             container_name = coordinator_data["name"]
             container_sensor = create_binary_sensor(
-                coordinator, host_name, node_name, container_id, container_name
+                coordinator, node_name, container_id, container_name
             )
             sensors.append(container_sensor)
 
     async_add_entities(sensors)
 
 
-def create_binary_sensor(coordinator, host_name, node_name, vm_id, name):
+def create_binary_sensor(coordinator, node_name, vm_id, name):
     """Create a binary sensor based on the given data."""
     return ProxmoxBinarySensor(
         coordinator=coordinator,
         unique_id=f"proxmox_{node_name}_{vm_id}_running",
         name=f"{node_name}_{name}_running",
         icon="",
-        host_name=host_name,
         node_name=node_name,
         vm_id=vm_id,
     )
@@ -80,14 +77,11 @@ class ProxmoxBinarySensor(ProxmoxEntity, BinarySensorEntity):
         unique_id,
         name,
         icon,
-        host_name,
         node_name,
         vm_id,
     ):
         """Create the binary sensor for vms or containers."""
-        super().__init__(
-            coordinator, unique_id, name, icon, host_name, node_name, vm_id
-        )
+        super().__init__(coordinator, unique_id, name, icon, node_name, vm_id)
 
     @property
     def is_on(self):

--- a/homeassistant/components/proxmoxve/binary_sensor.py
+++ b/homeassistant/components/proxmoxve/binary_sensor.py
@@ -13,15 +13,11 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
-    config_entry: ConfigEntry,
-    async_add_entities,
+    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up binary sensors."""
 
     sensors = []
-
-    # host_name = config_entry.data["host"]
     coordinators = hass.data[DOMAIN][config_entry.entry_id][COORDINATORS]
 
     for node_config in config_entry.data["nodes"]:

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -1,0 +1,128 @@
+"""Config Flow for ProxmoxVE."""
+from proxmoxer.backends.https import AuthenticationError
+from requests.exceptions import ConnectTimeout, SSLError
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+
+from . import ProxmoxClient
+from .const import (
+    CONF_DEFAULT_REALM,
+    CONF_REALM,
+    DEFAULT_PORT,
+    DEFAULT_VERIFY_SSL,
+    DOMAIN,
+)
+
+
+class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """ProxmoxVE Config Flow class."""
+
+    def __init__(self):
+        """Init for ProxmoxVE config flow."""
+        super().__init__()
+
+        self._config = {}
+        self._proxmox_client = None  # type: ProxmoxClient
+
+    # pylint: disable=arguments-differ
+    async def async_step_user(self, info):
+        """Async step user for proxmoxve config flow."""
+        errors = {}
+
+        if info is not None:
+
+            host = info.get(CONF_HOST, "")
+            port = info.get(CONF_PORT, DEFAULT_PORT)
+            username = info.get(CONF_USERNAME, "")
+            password = info.get(CONF_PASSWORD, "")
+            realm = info.get(CONF_REALM, CONF_DEFAULT_REALM)
+            verify_ssl = info.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
+
+            try:
+                self._proxmox_client = ProxmoxClient(
+                    host,
+                    port=port,
+                    user=username,
+                    realm=realm,
+                    password=password,
+                    verify_ssl=verify_ssl,
+                )
+
+                await self.hass.async_add_executor_job(
+                    self._proxmox_client.build_client
+                )
+
+            except AuthenticationError:
+                errors[CONF_USERNAME] = "auth_error"
+            except SSLError:
+                errors[CONF_VERIFY_SSL] = "ssl_rejection"
+            except ConnectTimeout:
+                errors[CONF_HOST] = "cant_connect"
+            except Exception:  # pylint: disable=broad-except
+                errors[CONF_HOST] = "general_error"
+
+            if not errors:
+                # get all vms and containers and add them
+
+                if "nodes" not in self._config:
+                    self._config["nodes"] = []
+
+                self._config[CONF_HOST] = host
+                self._config[CONF_PORT] = port
+                self._config[CONF_USERNAME] = username
+                self._config[CONF_PASSWORD] = password
+                self._config[CONF_REALM] = realm
+                self._config[CONF_VERIFY_SSL] = verify_ssl
+
+                await self.hass.async_add_executor_job(self._add_vms_to_config)
+
+                self.async_create_entry(title="ProxmoxVE", data=self._config)
+
+        if info is None:
+            info = {}
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST, default=info.get(CONF_HOST, "")): str,
+                vol.Required(CONF_USERNAME, default=info.get(CONF_USERNAME, "")): str,
+                vol.Required(CONF_PASSWORD, default=info.get(CONF_PASSWORD, "")): str,
+                vol.Required(
+                    CONF_REALM, default=info.get(CONF_REALM, CONF_DEFAULT_REALM)
+                ): str,
+                vol.Required(CONF_PORT, default=info.get(CONF_PORT, DEFAULT_PORT)): int,
+                vol.Required(
+                    CONF_VERIFY_SSL,
+                    default=info.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL),
+                ): bool,
+            }
+        )
+
+        return self.async_show_form(
+            step_id="user", data_schema=data_schema, errors=errors
+        )
+
+    def _add_vms_to_config(self):
+        proxmox = self._proxmox_client.get_api_client()
+
+        for node in proxmox.nodes.get():
+
+            vms = []
+            containers = []
+
+            for virtman in proxmox.nodes(node["node"]).qemu.get():
+                vms.append(virtman["vmid"])
+
+            for cont in proxmox.nodes(node["node"]).lxc.get():
+                containers.append(cont["vmid"])
+
+            self._config["nodes"].append(
+                {"name": node["node"], "vms": vms, "containers": containers}
+            )

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -84,7 +84,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 await self.hass.async_add_executor_job(self._add_vms_to_config)
 
-                self.async_create_entry(title="ProxmoxVE", data=self._config)
+                return self.async_create_entry(title="ProxmoxVE", data=self._config)
 
         if info is None:
             info = {}

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -15,13 +15,7 @@ from homeassistant.const import (
 )
 
 from . import ProxmoxClient
-from .const import (
-    CONF_DEFAULT_REALM,
-    CONF_REALM,
-    DEFAULT_PORT,
-    DEFAULT_VERIFY_SSL,
-    DOMAIN,
-)
+from .const import CONF_REALM, DEFAULT_PORT, DEFAULT_REALM, DEFAULT_VERIFY_SSL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,7 +55,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             port = info.get(CONF_PORT, DEFAULT_PORT)
             username = info.get(CONF_USERNAME, "")
             password = info.get(CONF_PASSWORD, "")
-            realm = info.get(CONF_REALM, CONF_DEFAULT_REALM)
+            realm = info.get(CONF_REALM, DEFAULT_REALM)
             verify_ssl = info.get(CONF_VERIFY_SSL, DEFAULT_VERIFY_SSL)
 
             if await self._async_endpoint_exists(f"{host}/{port}"):
@@ -134,7 +128,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_USERNAME, default=info.get(CONF_USERNAME, "")): str,
                 vol.Required(CONF_PASSWORD, default=info.get(CONF_PASSWORD, "")): str,
                 vol.Required(
-                    CONF_REALM, default=info.get(CONF_REALM, CONF_DEFAULT_REALM)
+                    CONF_REALM, default=info.get(CONF_REALM, DEFAULT_REALM)
                 ): str,
                 vol.Required(CONF_PORT, default=info.get(CONF_PORT, DEFAULT_PORT)): int,
                 vol.Required(

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -122,10 +122,11 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         info = {}
 
-        if errors is not None and is_import:
+        if errors and is_import:
             _LOGGER.error(
                 "Could not import ProxmoxVE configuration, please configure it manually from Integrations"
             )
+            return self.async_abort(reason="import_failed")
 
         data_schema = vol.Schema(
             {

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -35,8 +35,6 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(self, import_config=None):
         """Import existing configuration."""
-        _LOGGER.info("Importing ProxmoxVE config")
-
         return await self.async_step_init(import_config, True)
 
     async def async_step_user(self, user_input=None) -> FlowResult:

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -24,14 +24,13 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """ProxmoxVE Config Flow class."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_POLL
 
     def __init__(self):
         """Init for ProxmoxVE config flow."""
         super().__init__()
 
         self._config = {}
-        self._proxmox_client = None  # type: ProxmoxClient
+        self._proxmox_client = None
 
     async def async_step_import(self, import_config=None):
         """Import existing configuration."""
@@ -39,12 +38,10 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_init(import_config, True)
 
-    # pylint: disable=signature-differs
     async def async_step_user(self, user_input):
         """Manual user configuration."""
         return await self.async_step_init(user_input, False)
 
-    # pylint: disable=signature-differs
     async def async_step_init(self, info, is_import):
         """Async step user for proxmoxve config flow."""
         errors = {}
@@ -93,7 +90,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 except Exception:  # pylint: disable=broad-except
                     errors["base"] = "general_error"
 
-                if not errors:
+                else:
                     # get all vms and containers and add them
 
                     if "nodes" not in self._config:
@@ -107,10 +104,6 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     self._config[CONF_VERIFY_SSL] = verify_ssl
 
                     await self.hass.async_add_executor_job(self._add_vms_to_config)
-
-                    _LOGGER.info(
-                        "ProxmoxVE configuration successfully imported, you can remove it from configuration.yaml"
-                    )
 
                     return self.async_create_entry(title="ProxmoxVE", data=self._config)
 

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -87,7 +87,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors[CONF_VERIFY_SSL] = "ssl_rejection"
                 except ConnectTimeout:
                     errors[CONF_HOST] = "cant_connect"
-                except Exception:  # pylint: disable=broad-except
+                except Exception:
                     errors["base"] = "general_error"
 
                 else:

--- a/homeassistant/components/proxmoxve/config_flow.py
+++ b/homeassistant/components/proxmoxve/config_flow.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.data_entry_flow import FlowResult
 
 from . import ProxmoxClient
 from .const import CONF_REALM, DEFAULT_PORT, DEFAULT_REALM, DEFAULT_VERIFY_SSL, DOMAIN
@@ -38,7 +39,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_init(import_config, True)
 
-    async def async_step_user(self, user_input):
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Manual user configuration."""
         return await self.async_step_init(user_input, False)
 
@@ -87,7 +88,7 @@ class ProxmoxVEConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     errors[CONF_VERIFY_SSL] = "ssl_rejection"
                 except ConnectTimeout:
                     errors[CONF_HOST] = "cant_connect"
-                except Exception:
+                except Exception:  # pylint: disable=broad-except
                     errors["base"] = "general_error"
 
                 else:

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -1,0 +1,7 @@
+"""Constants for ProxmoxVE."""
+DOMAIN = "proxmoxve"
+DEFAULT_PORT = 8006
+DEFAULT_VERIFY_SSL = True
+
+CONF_REALM = "realm"
+CONF_DEFAULT_REALM = "pve"

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -1,7 +1,22 @@
 """Constants for ProxmoxVE."""
 DOMAIN = "proxmoxve"
-DEFAULT_PORT = 8006
-DEFAULT_VERIFY_SSL = True
 
 CONF_REALM = "realm"
-CONF_DEFAULT_REALM = "pve"
+CONF_NODE = "node"
+CONF_NODES = "nodes"
+CONF_VMS = "vms"
+CONF_CONTAINERS = "containers"
+
+DEFAULT_PORT = 8006
+DEFAULT_REALM = "pam"
+DEFAULT_VERIFY_SSL = True
+
+PLATFORMS = ["binary_sensor"]
+PROXMOX_CLIENTS = "proxmox_clients"
+
+COORDINATORS = "coordinators"
+API_DATA = "api_data"
+
+TYPE_VM = 0
+TYPE_CONTAINER = 1
+UPDATE_INTERVAL = 60

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -7,6 +7,10 @@ PLATFORMS = ["binary_sensor"]
 PROXMOX_CLIENTS = "proxmox_clients"
 PROXMOX_CLIENT = "proxmox_client"
 
+DEFAULT_PORT = 8006
+DEFAULT_REALM = "pam"
+DEFAULT_VERIFY_SSL = True
+
 COORDINATORS = "coordinators"
 API_DATA = "api_data"
 

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -13,6 +13,7 @@ DEFAULT_VERIFY_SSL = True
 
 PLATFORMS = ["binary_sensor"]
 PROXMOX_CLIENTS = "proxmox_clients"
+PROXMOX_CLIENT = "proxmox_client"
 
 COORDINATORS = "coordinators"
 API_DATA = "api_data"

--- a/homeassistant/components/proxmoxve/const.py
+++ b/homeassistant/components/proxmoxve/const.py
@@ -2,14 +2,6 @@
 DOMAIN = "proxmoxve"
 
 CONF_REALM = "realm"
-CONF_NODE = "node"
-CONF_NODES = "nodes"
-CONF_VMS = "vms"
-CONF_CONTAINERS = "containers"
-
-DEFAULT_PORT = 8006
-DEFAULT_REALM = "pam"
-DEFAULT_VERIFY_SSL = True
 
 PLATFORMS = ["binary_sensor"]
 PROXMOX_CLIENTS = "proxmox_clients"

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -4,5 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
   "codeowners": ["@k4ds3", "@jhollowe", "@Corbeno"],
   "requirements": ["proxmoxer==1.1.1"],
-  "iot_class": "local_polling"
+  "iot_class": "local_polling",
+  "config_flow": true
 }

--- a/homeassistant/components/proxmoxve/manifest.json
+++ b/homeassistant/components/proxmoxve/manifest.json
@@ -2,7 +2,7 @@
   "domain": "proxmoxve",
   "name": "Proxmox VE",
   "documentation": "https://www.home-assistant.io/integrations/proxmoxve",
-  "codeowners": ["@k4ds3", "@jhollowe", "@Corbeno"],
+  "codeowners": ["@k4ds3", "@jhollowe", "@Corbeno", "@edofullin"],
   "requirements": ["proxmoxer==1.1.1"],
   "iot_class": "local_polling",
   "config_flow": true

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -18,7 +18,8 @@
           "auth_error": "[%key:common::config_flow::error::invalid_auth%]",
           "ssl_rejection": "Could not verify the SSL certificate",
           "cant_connect": "[%key:common::config_flow::error::cannot_connect%]",
-          "general_error": "[%key:common::config_flow::error::unknown%]"
+          "general_error": "[%key:common::config_flow::error::unknown%]",
+          "invalid_port": "Invalid port number"
       },
       "abort": {
 

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -1,0 +1,27 @@
+{
+    "config": {
+      "step": {
+        "user": {
+          "title": "ProxmoxVE",
+          "description": "Please fill out the form and then press submit when you're ready",
+          "data": {
+            "host": "[%key:common::config_flow::data::host%]",
+            "port": "[%key:common::config_flow::data::port%]",
+            "username": "[%key:common::config_flow::data::username%]",
+            "password": "[%key:common::config_flow::data::password%]",
+            "realm": "Realm",
+            "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]"
+          }
+        }
+      },
+      "error": {
+          "auth_error": "[%key:common::config_flow::error::invalid_auth%]",
+          "ssl_rejection": "Could not verify the SSL certificate",
+          "cant_connect": "[%key:common::config_flow::error::cannot_connect%]",
+          "general_error": "[%key:common::config_flow::error::unknown%]"
+      },
+      "abort": {
+
+      }
+    }
+  }

--- a/homeassistant/components/proxmoxve/translations/en.json
+++ b/homeassistant/components/proxmoxve/translations/en.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "abort": {},
+        "error": {
+            "auth_error": "Invalid authentication",
+            "cant_connect": "Failed to connect",
+            "general_error": "Unexpected error",
+            "ssl_rejection": "Could not verify the SSL certificate"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host",
+                    "password": "Password",
+                    "port": "Port",
+                    "realm": "Realm",
+                    "username": "Username",
+                    "verify_ssl": "Verify SSL certificate"
+                },
+                "description": "Please fill out the form and then press submit when you're ready",
+                "title": "ProxmoxVE"
+            }
+        }
+    }
+}

--- a/homeassistant/components/proxmoxve/translations/en.json
+++ b/homeassistant/components/proxmoxve/translations/en.json
@@ -5,6 +5,7 @@
             "auth_error": "Invalid authentication",
             "cant_connect": "Failed to connect",
             "general_error": "Unexpected error",
+            "invalid_port": "Invalid port number",
             "ssl_rejection": "Could not verify the SSL certificate"
         },
         "step": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -232,6 +232,7 @@ FLOWS = [
     "profiler",
     "progettihwsw",
     "prosegur",
+    "proxmoxve",
     "ps4",
     "pvpc_hourly_pricing",
     "rachio",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -764,6 +764,9 @@ progettihwsw==0.1.1
 # homeassistant.components.prometheus
 prometheus_client==0.7.1
 
+# homeassistant.components.proxmoxve
+proxmoxer==1.1.1
+
 # homeassistant.components.androidtv
 pure-python-adb[async]==0.3.0.dev0
 

--- a/tests/components/proxmoxve/__init__.py
+++ b/tests/components/proxmoxve/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ProxmoxVE component."""

--- a/tests/components/proxmoxve/test_config_flow.py
+++ b/tests/components/proxmoxve/test_config_flow.py
@@ -1,0 +1,1 @@
+"""Testing file for config flow ProxmoxVE."""

--- a/tests/components/proxmoxve/test_config_flow.py
+++ b/tests/components/proxmoxve/test_config_flow.py
@@ -1,1 +1,160 @@
 """Testing file for config flow ProxmoxVE."""
+import proxmoxer
+from requests.exceptions import ConnectTimeout, SSLError
+
+from homeassistant.components.proxmoxve.const import CONF_REALM, DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+from tests.common import patch
+
+USER_INPUT_OK = {
+    CONF_HOST: "192.168.10.11",
+    CONF_PORT: 8006,
+    CONF_USERNAME: "root",
+    CONF_PASSWORD: "secret",
+    CONF_REALM: "pam",
+    CONF_VERIFY_SSL: True,
+}
+
+USER_INPUT_PORT_TOO_BIG = {
+    CONF_HOST: "192.168.10.11",
+    CONF_PORT: 255555,
+    CONF_USERNAME: "root",
+    CONF_PASSWORD: "secret",
+    CONF_REALM: "pam",
+    CONF_VERIFY_SSL: True,
+}
+
+USER_INPUT_PORT_TOO_SMALL = {
+    CONF_HOST: "192.168.10.11",
+    CONF_PORT: 0,
+    CONF_USERNAME: "root",
+    CONF_PASSWORD: "secret",
+    CONF_REALM: "pam",
+    CONF_VERIFY_SSL: True,
+}
+
+MOCK_GET_RESPONSE = [{"node": "node", "vmid": 100}, {"node": "node", "vmid": 100}]
+
+
+async def test_flow_ok(hass: HomeAssistant):
+    """Test flow ok."""
+
+    with patch("proxmoxer.ProxmoxResource.get", return_value=MOCK_GET_RESPONSE), patch(
+        "proxmoxer.backends.https.ProxmoxHTTPAuth._getNewTokens",
+        return_value=None,
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_OK
+        )
+
+        assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+        assert result["data"][CONF_HOST] == USER_INPUT_OK[CONF_HOST]
+
+
+async def test_flow_port_small(hass: HomeAssistant):
+    """Test if port number too small."""
+
+    with patch(
+        "proxmoxer.backends.https.ProxmoxHTTPAuth._getNewTokens", return_value=None
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_PORT_TOO_SMALL
+        )
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"][CONF_PORT] == "invalid_port"
+
+
+async def test_flow_port_big(hass: HomeAssistant):
+    """Test if port number too big."""
+
+    with patch(
+        "proxmoxer.backends.https.ProxmoxHTTPAuth._getNewTokens", return_value=None
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_PORT_TOO_BIG
+        )
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"][CONF_PORT] == "invalid_port"
+
+
+async def test_flow_auth_error(hass: HomeAssistant):
+    """Test errors in case username or password are incorrect."""
+
+    with patch(
+        "homeassistant.components.proxmoxve.ProxmoxClient.build_client",
+        side_effect=proxmoxer.backends.https.AuthenticationError("mock msg"),
+        return_value=None,
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_OK
+        )
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"][CONF_USERNAME] == "auth_error"
+
+
+async def test_flow_cant_connect(hass: HomeAssistant):
+    """Test errors in case the connection fails."""
+
+    with patch(
+        "homeassistant.components.proxmoxve.ProxmoxClient.build_client",
+        side_effect=ConnectTimeout,
+        return_value=None,
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_OK
+        )
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"][CONF_HOST] == "cant_connect"
+
+
+async def test_flow_ssl_error(hass: HomeAssistant):
+    """Test errors in case the SSL certificare is not present or is not valid or is expired."""
+
+    with patch(
+        "homeassistant.components.proxmoxve.ProxmoxClient.build_client",
+        side_effect=SSLError,
+        return_value=None,
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_OK
+        )
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"][CONF_VERIFY_SSL] == "ssl_rejection"
+
+
+async def test_flow_unknown_exception(hass: HomeAssistant):
+    """Test errors in case of an unknown exception occurs."""
+
+    with patch(
+        "homeassistant.components.proxmoxve.ProxmoxClient.build_client",
+        side_effect=Exception,
+        return_value=None,
+    ):
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_USER}, data=USER_INPUT_OK
+        )
+
+        assert result["type"] == RESULT_TYPE_FORM
+        assert result["errors"]["base"] == "general_error"

--- a/tests/components/proxmoxve/test_config_flow.py
+++ b/tests/components/proxmoxve/test_config_flow.py
@@ -29,6 +29,12 @@ USER_INPUT_OK = {
     CONF_VERIFY_SSL: True,
 }
 
+USER_INPUT_REQONLY = {
+    CONF_HOST: "192.168.10.11",
+    CONF_USERNAME: "root",
+    CONF_PASSWORD: "secret",
+}
+
 USER_INPUT_PORT_TOO_BIG = {
     CONF_HOST: "192.168.10.11",
     CONF_PORT: 255555,
@@ -178,6 +184,26 @@ async def test_flow_import_ok(hass: HomeAssistant):
         # imported config is identical to the one generated from config flow
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": SOURCE_IMPORT}, data=USER_INPUT_OK
+        )
+
+        assert result["type"] == RESULT_TYPE_ABORT
+        assert result["reason"] == "already_configured"
+
+
+async def test_flow_import_ok_onlyrequired(hass: HomeAssistant):
+    """Test flow ok."""
+
+    with patch("proxmoxer.ProxmoxResource.get", return_value=MOCK_GET_RESPONSE), patch(
+        "proxmoxer.backends.https.ProxmoxHTTPAuth._getNewTokens",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.proxmoxve.config_flow.ProxmoxVEConfigFlow._async_endpoint_exists",
+        return_value=True,
+    ):
+
+        # imported config is identical to the one generated from config flow
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=USER_INPUT_REQONLY
         )
 
         assert result["type"] == RESULT_TYPE_ABORT

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -1,0 +1,1 @@
+"""Testing init for ProxmoxVE."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR allows the ProxmoxVE integration to be configured from the UI and import an existing configuration if present.

I had another draft PR for this but I eventually didn't continue because the integration code needed a major rewrite first.

Now that it has been done I I scrapped my old code and rewrote it from scratch, this time I also added tests for config_flow and added the import logic. 

I chose to add all containers and vms from all nodes, the user can then disable the ones he does not need directly from home assistant "Entities" but I was not sure on how to handle import from configuration.yaml.

Do we add all vms and containers or only the one that were previously specified in configuration.yaml?  For now it adds everything, let me know if it needs changing, I think it needs a discussion first.

I also have only one Proxmox node, so it needs to be tested by someone with multiple nodes first.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml (relevant only for import)

proxmoxve:
  - host: proxmox.myhost.net
    username: homeassistant
    password: secret
    realm: pve
    nodes:
      - node: node1
        vms:
          - 101
          - 102
        containers:
          - 201
          - 202


```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
