### PR TITLE
Clean up superfluous integration setup - part 4

### DIFF
--- a/homeassistant/components/garmin_connect/__init__.py
+++ b/homeassistant/components/garmin_connect/__init__.py
@@ -24,12 +24,6 @@ PLATFORMS = ["sensor"]
 MIN_SCAN_INTERVAL = timedelta(minutes=10)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Garmin Connect component."""
-    hass.data[DOMAIN] = {}
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Garmin Connect from a config entry."""
     username = entry.data[CONF_USERNAME]
@@ -55,6 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         return False
 
     garmin_data = GarminConnectData(hass, garmin_client)
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = garmin_data
 
     for platform in PLATFORMS:

--- a/homeassistant/components/goalzero/__init__.py
+++ b/homeassistant/components/goalzero/__init__.py
@@ -23,14 +23,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["binary_sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config):
-    """Set up the Goal Zero Yeti component."""
-
-    hass.data[DOMAIN] = {}
-
-    return True
-
-
 async def async_setup_entry(hass, entry):
     """Set up Goal Zero Yeti from a config entry."""
     name = entry.data[CONF_NAME]
@@ -58,6 +50,7 @@ async def async_setup_entry(hass, entry):
         update_method=async_update_data,
         update_interval=MIN_TIME_BETWEEN_UPDATES,
     )
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_KEY_API: api,
         DATA_KEY_COORDINATOR: coordinator,

--- a/homeassistant/components/kmtronic/__init__.py
+++ b/homeassistant/components/kmtronic/__init__.py
@@ -24,13 +24,6 @@ PLATFORMS = ["switch"]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the kmtronic component."""
-    hass.data[DOMAIN] = {}
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up kmtronic from a config entry."""
     session = aiohttp_client.async_get_clientsession(hass)
@@ -60,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
     await coordinator.async_config_entry_first_refresh()
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_HUB: hub,
         DATA_COORDINATOR: coordinator,

--- a/homeassistant/components/kodi/__init__.py
+++ b/homeassistant/components/kodi/__init__.py
@@ -29,12 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["media_player"]
 
 
-async def async_setup(hass, config):
-    """Set up the Kodi integration."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Kodi from a config entry."""
     conn = get_kodi_connection(
@@ -66,6 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     remove_stop_listener = hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close)
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_CONNECTION: conn,
         DATA_KODI: kodi,

--- a/homeassistant/components/kulersky/__init__.py
+++ b/homeassistant/components/kulersky/__init__.py
@@ -9,11 +9,6 @@ from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 PLATFORMS = ["light"]
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Kuler Sky component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Kuler Sky from a config entry."""
     if DOMAIN not in hass.data:

--- a/homeassistant/components/met/__init__.py
+++ b/homeassistant/components/met/__init__.py
@@ -13,7 +13,6 @@ from homeassistant.const import (
     LENGTH_FEET,
     LENGTH_METERS,
 )
-from homeassistant.core import Config, HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.distance import convert as convert_distance
@@ -30,12 +29,6 @@ URL = "https://aa015h6buqvih86i1.api.met.no/weatherapi/locationforecast/2.0/comp
 
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistant, config: Config) -> bool:
-    """Set up configured Met."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
 
 
 async def async_setup_entry(hass, config_entry):
@@ -60,6 +53,7 @@ async def async_setup_entry(hass, config_entry):
     if config_entry.data.get(CONF_TRACK_HOME, False):
         coordinator.track_home()
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = coordinator
 
     hass.async_create_task(

--- a/homeassistant/components/onewire/__init__.py
+++ b/homeassistant/components/onewire/__init__.py
@@ -13,11 +13,6 @@ from .onewirehub import CannotConnect, OneWireHub
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass, config):
-    """Set up 1-Wire integrations."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
     """Set up a 1-Wire proxy for a config entry."""
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/ovo_energy/__init__.py
+++ b/homeassistant/components/ovo_energy/__init__.py
@@ -25,11 +25,6 @@ from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
-    """Set up the OVO Energy components."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up OVO Energy from a config entry."""
 

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -28,12 +28,6 @@ PLATFORMS = ["media_player", "remote"]
 LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Philips TV component."""
-    hass.data[DOMAIN] = {}
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Philips TV from a config entry."""
 
@@ -47,6 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     coordinator = PhilipsTVDataUpdateCoordinator(hass, tvapi)
 
     await coordinator.async_refresh()
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     for platform in PLATFORMS:

--- a/homeassistant/components/plaato/__init__.py
+++ b/homeassistant/components/plaato/__init__.py
@@ -84,15 +84,9 @@ WEBHOOK_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Plaato component."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Configure based on config entry."""
-
+    hass.data.setdefault(DOMAIN, {})
     use_webhook = entry.data[CONF_USE_WEBHOOK]
 
     if use_webhook:

--- a/homeassistant/components/plugwise/__init__.py
+++ b/homeassistant/components/plugwise/__init__.py
@@ -7,11 +7,6 @@ from homeassistant.core import HomeAssistant
 from .gateway import async_setup_entry_gw, async_unload_entry_gw
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Plugwise platform."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Plugwise components from a config entry."""
     if entry.data.get(CONF_HOST):

--- a/homeassistant/components/poolsense/__init__.py
+++ b/homeassistant/components/poolsense/__init__.py
@@ -25,13 +25,6 @@ PLATFORMS = ["sensor", "binary_sensor"]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the PoolSense component."""
-    # Make sure coordinator is initialized.
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up PoolSense from a config entry."""
 
@@ -50,6 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     await coordinator.async_config_entry_first_refresh()
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
     for platform in PLATFORMS:

--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -43,13 +43,6 @@ PLATFORMS = ["binary_sensor", "sensor"]
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Tesla Powerwall component."""
-    hass.data.setdefault(DOMAIN, {})
-
-    return True
-
-
 async def _migrate_old_unique_ids(hass, entry_id, powerwall_data):
     serial_numbers = powerwall_data[POWERWALL_API_SERIAL_NUMBERS]
     site_info = powerwall_data[POWERWALL_API_SITE_INFO]
@@ -96,6 +89,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     entry_id = entry.entry_id
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN].setdefault(entry_id, {})
     http_session = requests.Session()
 

--- a/homeassistant/components/profiler/__init__.py
+++ b/homeassistant/components/profiler/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.core import HomeAssistant, ServiceCall
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.service import async_register_admin_service
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
@@ -42,11 +41,6 @@ CONF_TYPE = "type"
 LOG_INTERVAL_SUB = "log_interval_subscription"
 
 _LOGGER = logging.getLogger(__name__)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the profiler component."""
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):

--- a/homeassistant/components/progettihwsw/__init__.py
+++ b/homeassistant/components/progettihwsw/__init__.py
@@ -13,16 +13,9 @@ from .const import DOMAIN
 PLATFORMS = ["switch", "binary_sensor"]
 
 
-async def async_setup(hass, config):
-    """Set up the ProgettiHWSW Automation component."""
-    hass.data[DOMAIN] = {}
-
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up ProgettiHWSW Automation from a config entry."""
-
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = ProgettiHWSWAPI(
         f'{entry.data["host"]}:{entry.data["port"]}'
     )

--- a/homeassistant/components/risco/__init__.py
+++ b/homeassistant/components/risco/__init__.py
@@ -27,12 +27,6 @@ LAST_EVENT_TIMESTAMP_KEY = "last_event_timestamp"
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Set up the Risco component."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Risco from a config entry."""
     data = entry.data
@@ -54,6 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     undo_listener = entry.add_update_listener(_update_listener)
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         DATA_COORDINATOR: coordinator,
         UNDO_UPDATE_LISTENER: undo_listener,

--- a/homeassistant/components/roon/__init__.py
+++ b/homeassistant/components/roon/__init__.py
@@ -6,14 +6,9 @@ from .const import DOMAIN
 from .server import RoonServer
 
 
-async def async_setup(hass, config):
-    """Set up the Roon platform."""
-    hass.data[DOMAIN] = {}
-    return True
-
-
 async def async_setup_entry(hass, entry):
     """Set up a roonserver from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
     host = entry.data[CONF_HOST]
     roonserver = RoonServer(hass, entry)
 

--- a/homeassistant/components/sharkiq/__init__.py
+++ b/homeassistant/components/sharkiq/__init__.py
@@ -23,12 +23,6 @@ class CannotConnect(exceptions.HomeAssistantError):
     """Error to indicate we cannot connect."""
 
 
-async def async_setup(hass, config):
-    """Set up the sharkiq environment."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_connect_or_timeout(ayla_api: AylaApi) -> bool:
     """Connect to vacuum."""
     try:
@@ -66,6 +60,7 @@ async def async_setup_entry(hass, config_entry):
 
     await coordinator.async_config_entry_first_refresh()
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][config_entry.entry_id] = coordinator
 
     for platform in PLATFORMS:

--- a/homeassistant/components/srp_energy/__init__.py
+++ b/homeassistant/components/srp_energy/__init__.py
@@ -16,11 +16,6 @@ _LOGGER = logging.getLogger(__name__)
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass, config):
-    """Old way of setting up the srp_energy component."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up the SRP Energy component from a config entry."""
     # Store an SrpEnergyClient object for your srp_energy to access

--- a/homeassistant/components/subaru/__init__.py
+++ b/homeassistant/components/subaru/__init__.py
@@ -37,12 +37,6 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass, base_config):
-    """Do nothing since this integration does not support configuration.yml setup."""
-    hass.data.setdefault(DOMAIN, {})
-    return True
-
-
 async def async_setup_entry(hass, entry):
     """Set up Subaru from a config entry."""
     config = entry.data
@@ -88,6 +82,7 @@ async def async_setup_entry(hass, entry):
 
     await coordinator.async_refresh()
 
+    hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
         ENTRY_CONTROLLER: controller,
         ENTRY_COORDINATOR: coordinator,

--- a/tests/components/garmin_connect/test_config_flow.py
+++ b/tests/components/garmin_connect/test_config_flow.py
@@ -45,7 +45,7 @@ async def test_step_user(hass, mock_garmin_connect):
 
     with patch(
         "homeassistant.components.garmin_connect.async_setup_entry", return_value=True
-    ), patch("homeassistant.components.garmin_connect.async_setup", return_value=True):
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": "user"}, data=MOCK_CONF
         )

--- a/tests/components/kmtronic/test_config_flow.py
+++ b/tests/components/kmtronic/test_config_flow.py
@@ -23,8 +23,6 @@ async def test_form(hass):
         "homeassistant.components.kmtronic.config_flow.KMTronicHubAPI.async_get_status",
         return_value=[Mock()],
     ), patch(
-        "homeassistant.components.kmtronic.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kmtronic.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -45,7 +43,6 @@ async def test_form(hass):
         "password": "test-password",
     }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/kodi/test_config_flow.py
+++ b/tests/components/kodi/test_config_flow.py
@@ -47,8 +47,6 @@ async def test_user_flow(hass, user_flow):
         "homeassistant.components.kodi.config_flow.get_kodi_connection",
         return_value=MockConnection(),
     ), patch(
-        "homeassistant.components.kodi.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kodi.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -66,7 +64,6 @@ async def test_user_flow(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -92,8 +89,6 @@ async def test_form_valid_auth(hass, user_flow):
         "homeassistant.components.kodi.config_flow.get_kodi_connection",
         return_value=MockConnection(),
     ), patch(
-        "homeassistant.components.kodi.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kodi.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -112,7 +107,6 @@ async def test_form_valid_auth(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -142,8 +136,6 @@ async def test_form_valid_ws_port(hass, user_flow):
         "homeassistant.components.kodi.config_flow.get_kodi_connection",
         return_value=MockConnection(),
     ), patch(
-        "homeassistant.components.kodi.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kodi.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -163,7 +155,6 @@ async def test_form_valid_ws_port(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -187,8 +178,6 @@ async def test_form_empty_ws_port(hass, user_flow):
     assert result["errors"] == {}
 
     with patch(
-        "homeassistant.components.kodi.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kodi.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -208,7 +197,6 @@ async def test_form_empty_ws_port(hass, user_flow):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -430,8 +418,6 @@ async def test_discovery(hass):
     assert result["step_id"] == "discovery_confirm"
 
     with patch(
-        "homeassistant.components.kodi.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kodi.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -451,7 +437,6 @@ async def test_discovery(hass):
         "timeout": DEFAULT_TIMEOUT,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -594,8 +579,6 @@ async def test_form_import(hass):
         "homeassistant.components.kodi.config_flow.get_kodi_connection",
         return_value=MockConnection(),
     ), patch(
-        "homeassistant.components.kodi.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kodi.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -610,7 +593,6 @@ async def test_form_import(hass):
     assert result["title"] == TEST_IMPORT["name"]
     assert result["data"] == TEST_IMPORT
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/kulersky/test_config_flow.py
+++ b/tests/components/kulersky/test_config_flow.py
@@ -23,8 +23,6 @@ async def test_flow_success(hass):
         "homeassistant.components.kulersky.config_flow.pykulersky.discover",
         return_value=[light],
     ), patch(
-        "homeassistant.components.kulersky.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kulersky.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -38,7 +36,6 @@ async def test_flow_success(hass):
     assert result2["title"] == "Kuler Sky"
     assert result2["data"] == {}
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -55,8 +52,6 @@ async def test_flow_no_devices_found(hass):
         "homeassistant.components.kulersky.config_flow.pykulersky.discover",
         return_value=[],
     ), patch(
-        "homeassistant.components.kulersky.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kulersky.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -68,7 +63,6 @@ async def test_flow_no_devices_found(hass):
     assert result2["type"] == "abort"
     assert result2["reason"] == "no_devices_found"
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 0
 
 
@@ -85,8 +79,6 @@ async def test_flow_exceptions_caught(hass):
         "homeassistant.components.kulersky.config_flow.pykulersky.discover",
         side_effect=pykulersky.PykulerskyException("TEST"),
     ), patch(
-        "homeassistant.components.kulersky.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.kulersky.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -98,5 +90,4 @@ async def test_flow_exceptions_caught(hass):
     assert result2["type"] == "abort"
     assert result2["reason"] == "no_devices_found"
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 0
     assert len(mock_setup_entry.mock_calls) == 0

--- a/tests/components/onewire/test_config_flow.py
+++ b/tests/components/onewire/test_config_flow.py
@@ -55,8 +55,6 @@ async def test_user_owserver(hass):
 
     # Valid server
     with patch("homeassistant.components.onewire.onewirehub.protocol.proxy",), patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -73,15 +71,12 @@ async def test_user_owserver(hass):
             CONF_PORT: 1234,
         }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_user_owserver_duplicate(hass):
     """Test OWServer flow."""
     with patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -111,7 +106,6 @@ async def test_user_owserver_duplicate(hass):
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -151,8 +145,6 @@ async def test_user_sysbus(hass):
         "homeassistant.components.onewire.onewirehub.os.path.isdir",
         return_value=True,
     ), patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -168,15 +160,12 @@ async def test_user_sysbus(hass):
         CONF_MOUNT_DIR: "/sys/bus/directory",
     }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_user_sysbus_duplicate(hass):
     """Test SysBus duplicate flow."""
     with patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -211,7 +200,6 @@ async def test_user_sysbus_duplicate(hass):
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -222,8 +210,6 @@ async def test_import_sysbus(hass):
         "homeassistant.components.onewire.onewirehub.os.path.isdir",
         return_value=True,
     ), patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -239,7 +225,6 @@ async def test_import_sysbus(hass):
         CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
     }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -250,8 +235,6 @@ async def test_import_sysbus_with_mount_dir(hass):
         "homeassistant.components.onewire.onewirehub.os.path.isdir",
         return_value=True,
     ), patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -270,7 +253,6 @@ async def test_import_sysbus_with_mount_dir(hass):
         CONF_MOUNT_DIR: DEFAULT_SYSBUS_MOUNT_DIR,
     }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -278,8 +260,6 @@ async def test_import_owserver(hass):
     """Test import step."""
 
     with patch("homeassistant.components.onewire.onewirehub.protocol.proxy",), patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -299,7 +279,6 @@ async def test_import_owserver(hass):
         CONF_PORT: DEFAULT_OWSERVER_PORT,
     }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -307,8 +286,6 @@ async def test_import_owserver_with_port(hass):
     """Test import step."""
 
     with patch("homeassistant.components.onewire.onewirehub.protocol.proxy",), patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -329,7 +306,6 @@ async def test_import_owserver_with_port(hass):
         CONF_PORT: 1234,
     }
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -337,8 +313,6 @@ async def test_import_owserver_duplicate(hass):
     """Test OWServer flow."""
     # Initialise with single entry
     with patch(
-        "homeassistant.components.onewire.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.onewire.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -358,5 +332,4 @@ async def test_import_owserver_duplicate(hass):
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "already_configured"
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/ovo_energy/test_config_flow.py
+++ b/tests/components/ovo_energy/test_config_flow.py
@@ -85,9 +85,6 @@ async def test_full_flow_implementation(hass: HomeAssistant) -> None:
         "homeassistant.components.ovo_energy.config_flow.OVOEnergy.authenticate",
         return_value=True,
     ), patch(
-        "homeassistant.components.ovo_energy.async_setup",
-        return_value=True,
-    ), patch(
         "homeassistant.components.ovo_energy.async_setup_entry",
         return_value=True,
     ):

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -19,15 +19,6 @@ from . import (
 
 
 @fixture(autouse=True)
-def mock_setup():
-    """Disable component setup."""
-    with patch(
-        "homeassistant.components.philips_js.async_setup", return_value=True
-    ) as mock_setup:
-        yield mock_setup
-
-
-@fixture(autouse=True)
 def mock_setup_entry():
     """Disable component setup."""
     with patch(
@@ -50,7 +41,7 @@ async def mock_tv_pairable(mock_tv):
     return mock_tv
 
 
-async def test_import(hass, mock_setup, mock_setup_entry):
+async def test_import(hass, mock_setup_entry):
     """Test we get an item on import."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -61,7 +52,6 @@ async def test_import(hass, mock_setup, mock_setup_entry):
     assert result["type"] == "create_entry"
     assert result["title"] == "Philips TV (1234567890)"
     assert result["data"] == MOCK_CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -77,7 +67,7 @@ async def test_import_exist(hass, mock_config_entry):
     assert result["reason"] == "already_configured"
 
 
-async def test_form(hass, mock_setup, mock_setup_entry):
+async def test_form(hass, mock_setup_entry):
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -94,7 +84,6 @@ async def test_form(hass, mock_setup, mock_setup_entry):
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Philips TV (1234567890)"
     assert result2["data"] == MOCK_CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -128,7 +117,7 @@ async def test_form_unexpected_error(hass, mock_tv):
     assert result["errors"] == {"base": "unknown"}
 
 
-async def test_pairing(hass, mock_tv_pairable, mock_setup, mock_setup_entry):
+async def test_pairing(hass, mock_tv_pairable, mock_setup_entry):
     """Test we get the form."""
     mock_tv = mock_tv_pairable
 
@@ -166,13 +155,10 @@ async def test_pairing(hass, mock_tv_pairable, mock_setup, mock_setup_entry):
     }
 
     await hass.async_block_till_done()
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_pair_request_failed(
-    hass, mock_tv_pairable, mock_setup, mock_setup_entry
-):
+async def test_pair_request_failed(hass, mock_tv_pairable, mock_setup_entry):
     """Test we get the form."""
     mock_tv = mock_tv_pairable
     mock_tv.pairRequest.side_effect = PairingFailure({})
@@ -197,7 +183,7 @@ async def test_pair_request_failed(
     }
 
 
-async def test_pair_grant_failed(hass, mock_tv_pairable, mock_setup, mock_setup_entry):
+async def test_pair_grant_failed(hass, mock_tv_pairable, mock_setup_entry):
     """Test we get the form."""
     mock_tv = mock_tv_pairable
 

--- a/tests/components/plaato/test_config_flow.py
+++ b/tests/components/plaato/test_config_flow.py
@@ -243,8 +243,6 @@ async def test_options(hass):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.plaato.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.plaato.async_setup_entry", return_value=True
     ) as mock_setup_entry:
 
@@ -266,7 +264,6 @@ async def test_options(hass):
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_SCAN_INTERVAL] == 10
 
-        assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -281,8 +278,6 @@ async def test_options_webhook(hass, webhook_id):
     config_entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.plaato.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.plaato.async_setup_entry", return_value=True
     ) as mock_setup_entry:
 
@@ -305,5 +300,4 @@ async def test_options_webhook(hass, webhook_id):
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert result["data"][CONF_WEBHOOK_ID] == CONF_WEBHOOK_ID
 
-        assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/plugwise/test_config_flow.py
+++ b/tests/components/plugwise/test_config_flow.py
@@ -72,9 +72,6 @@ async def test_form(hass):
         "homeassistant.components.plugwise.config_flow.Smile.connect",
         return_value=True,
     ), patch(
-        "homeassistant.components.plugwise.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
         "homeassistant.components.plugwise.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -93,7 +90,6 @@ async def test_form(hass):
         CONF_USERNAME: TEST_USERNAME,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -112,9 +108,6 @@ async def test_zeroconf_form(hass):
         "homeassistant.components.plugwise.config_flow.Smile.connect",
         return_value=True,
     ), patch(
-        "homeassistant.components.plugwise.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
         "homeassistant.components.plugwise.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -133,7 +126,6 @@ async def test_zeroconf_form(hass):
         CONF_USERNAME: TEST_USERNAME,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -149,9 +141,6 @@ async def test_form_username(hass):
         "homeassistant.components.plugwise.config_flow.Smile.connect",
         return_value=True,
     ), patch(
-        "homeassistant.components.plugwise.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
         "homeassistant.components.plugwise.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -174,7 +163,6 @@ async def test_form_username(hass):
         CONF_USERNAME: TEST_USERNAME2,
     }
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
     result3 = await hass.config_entries.flow.async_init(
@@ -189,9 +177,6 @@ async def test_form_username(hass):
         "homeassistant.components.plugwise.config_flow.Smile.connect",
         return_value=True,
     ), patch(
-        "homeassistant.components.plugwise.async_setup",
-        return_value=True,
-    ) as mock_setup, patch(
         "homeassistant.components.plugwise.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:

--- a/tests/components/poolsense/test_config_flow.py
+++ b/tests/components/poolsense/test_config_flow.py
@@ -38,8 +38,6 @@ async def test_valid_credentials(hass):
     with patch(
         "poolsense.PoolSense.test_poolsense_credentials", return_value=True
     ), patch(
-        "homeassistant.components.poolsense.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.poolsense.async_setup_entry", return_value=True
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_init(
@@ -52,5 +50,4 @@ async def test_valid_credentials(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "test-email"
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/powerwall/test_config_flow.py
+++ b/tests/components/powerwall/test_config_flow.py
@@ -35,8 +35,6 @@ async def test_form_source_user(hass):
         "homeassistant.components.powerwall.config_flow.Powerwall",
         return_value=mock_powerwall,
     ), patch(
-        "homeassistant.components.powerwall.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.powerwall.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -49,7 +47,6 @@ async def test_form_source_user(hass):
     assert result2["type"] == "create_entry"
     assert result2["title"] == "My site"
     assert result2["data"] == VALID_CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -197,8 +194,6 @@ async def test_dhcp_discovery(hass):
         "homeassistant.components.powerwall.config_flow.Powerwall",
         return_value=mock_powerwall,
     ), patch(
-        "homeassistant.components.powerwall.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.powerwall.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -211,7 +206,6 @@ async def test_dhcp_discovery(hass):
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Some site"
     assert result2["data"] == VALID_CONFIG
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -237,8 +231,6 @@ async def test_form_reauth(hass):
         "homeassistant.components.powerwall.config_flow.Powerwall",
         return_value=mock_powerwall,
     ), patch(
-        "homeassistant.components.powerwall.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.powerwall.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -253,5 +245,4 @@ async def test_form_reauth(hass):
 
     assert result2["type"] == "abort"
     assert result2["reason"] == "reauth_successful"
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/profiler/test_config_flow.py
+++ b/tests/components/profiler/test_config_flow.py
@@ -17,8 +17,6 @@ async def test_form_user(hass):
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.profiler.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.profiler.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -31,7 +29,6 @@ async def test_form_user(hass):
     assert result2["type"] == "create_entry"
     assert result2["title"] == "Profiler"
     assert result2["data"] == {}
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/progettihwsw/test_config_flow.py
+++ b/tests/components/progettihwsw/test_config_flow.py
@@ -48,9 +48,6 @@ async def test_form(hass):
     assert result2["errors"] == {}
 
     with patch(
-        "homeassistant.components.progettihwsw.async_setup",
-        return_value=True,
-    ), patch(
         "homeassistant.components.progettihwsw.async_setup_entry",
         return_value=True,
     ):

--- a/tests/components/risco/test_config_flow.py
+++ b/tests/components/risco/test_config_flow.py
@@ -59,8 +59,6 @@ async def test_form(hass):
     ), patch(
         "homeassistant.components.risco.config_flow.RiscoAPI.close"
     ) as mock_close, patch(
-        "homeassistant.components.risco.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.risco.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -72,7 +70,6 @@ async def test_form(hass):
     assert result2["type"] == "create_entry"
     assert result2["title"] == TEST_SITE_NAME
     assert result2["data"] == TEST_DATA
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     mock_close.assert_awaited_once()
 

--- a/tests/components/roon/test_config_flow.py
+++ b/tests/components/roon/test_config_flow.py
@@ -72,8 +72,6 @@ async def test_successful_discovery_and_auth(hass):
         "homeassistant.components.roon.config_flow.RoonDiscovery",
         return_value=RoonDiscoveryMock(),
     ), patch(
-        "homeassistant.components.roon.async_setup", return_value=True
-    ), patch(
         "homeassistant.components.roon.async_setup_entry",
         return_value=True,
     ):
@@ -111,8 +109,6 @@ async def test_unsuccessful_discovery_user_form_and_auth(hass):
     ), patch(
         "homeassistant.components.roon.config_flow.RoonDiscovery",
         return_value=RoonDiscoveryFailedMock(),
-    ), patch(
-        "homeassistant.components.roon.async_setup", return_value=True
     ), patch(
         "homeassistant.components.roon.async_setup_entry",
         return_value=True,
@@ -161,8 +157,6 @@ async def test_successful_discovery_no_auth(hass):
         "homeassistant.components.roon.config_flow.AUTHENTICATE_TIMEOUT",
         0.01,
     ), patch(
-        "homeassistant.components.roon.async_setup", return_value=True
-    ), patch(
         "homeassistant.components.roon.async_setup_entry",
         return_value=True,
     ):
@@ -195,8 +189,6 @@ async def test_unexpected_exception(hass):
     ), patch(
         "homeassistant.components.roon.config_flow.RoonDiscovery",
         return_value=RoonDiscoveryMock(),
-    ), patch(
-        "homeassistant.components.roon.async_setup", return_value=True
     ), patch(
         "homeassistant.components.roon.async_setup_entry",
         return_value=True,

--- a/tests/components/sharkiq/test_config_flow.py
+++ b/tests/components/sharkiq/test_config_flow.py
@@ -24,8 +24,6 @@ async def test_form(hass):
     assert result["errors"] == {}
 
     with patch("sharkiqpy.AylaApi.async_sign_in", return_value=True), patch(
-        "homeassistant.components.sharkiq.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.sharkiq.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -41,7 +39,6 @@ async def test_form(hass):
         "password": TEST_PASSWORD,
     }
     await hass.async_block_till_done()
-    mock_setup.assert_called_once()
     mock_setup_entry.assert_called_once()
 
 

--- a/tests/components/srp_energy/test_config_flow.py
+++ b/tests/components/srp_energy/test_config_flow.py
@@ -21,8 +21,6 @@ async def test_form(hass):
     with patch(
         "homeassistant.components.srp_energy.config_flow.SrpEnergyClient"
     ), patch(
-        "homeassistant.components.srp_energy.async_setup", return_value=True
-    ) as mock_setup, patch(
         "homeassistant.components.srp_energy.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -36,7 +34,6 @@ async def test_form(hass):
         assert result["title"] == "Test"
         assert result["data"][CONF_IS_TOU] is False
 
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
 

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -27,7 +27,6 @@ from .conftest import (
 
 from tests.common import MockConfigEntry
 
-ASYNC_SETUP = "homeassistant.components.subaru.async_setup"
 ASYNC_SETUP_ENTRY = "homeassistant.components.subaru.async_setup_entry"
 
 
@@ -96,8 +95,6 @@ async def test_user_form_pin_not_required(hass, user_form):
         MOCK_API_IS_PIN_REQUIRED,
         return_value=False,
     ) as mock_is_pin_required, patch(
-        ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         ASYNC_SETUP_ENTRY, return_value=True
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
@@ -106,7 +103,6 @@ async def test_user_form_pin_not_required(hass, user_form):
         )
     assert len(mock_connect.mock_calls) == 1
     assert len(mock_is_pin_required.mock_calls) == 1
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
 
     expected = {
@@ -160,8 +156,6 @@ async def test_pin_form_success(hass, pin_form):
         MOCK_API_UPDATE_SAVED_PIN,
         return_value=True,
     ) as mock_update_saved_pin, patch(
-        ASYNC_SETUP, return_value=True
-    ) as mock_setup, patch(
         ASYNC_SETUP_ENTRY, return_value=True
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
@@ -170,7 +164,6 @@ async def test_pin_form_success(hass, pin_form):
 
     assert len(mock_test_pin.mock_calls) == 1
     assert len(mock_update_saved_pin.mock_calls) == 1
-    assert len(mock_setup.mock_calls) == 1
     assert len(mock_setup_entry.mock_calls) == 1
     expected = {
         "title": TEST_USERNAME,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#48381 remove the need for an integration `setup` or `async_setup` in case the integration provides a `async_setup_entry`. For example:

```py
async def async_setup(hass, config):
    """Component setup, do nothing."""
    return True
```

This PR is cleanup for those (or similar).

TODO:
- [x] Cleanup tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
