### PR TITLE
Do not wait for websocket response to be delivered before shutdown

### DIFF
--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -21,7 +21,6 @@ from homeassistant.const import (
 import homeassistant.core as ha
 from homeassistant.exceptions import HomeAssistantError, Unauthorized, UnknownUser
 from homeassistant.helpers import config_validation as cv, recorder
-from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.service import (
     async_extract_config_entry_ids,
     async_extract_referenced_entity_ids,
@@ -49,7 +48,6 @@ SCHEMA_RELOAD_CONFIG_ENTRY = vol.All(
 
 
 SHUTDOWN_SERVICES = (SERVICE_HOMEASSISTANT_STOP, SERVICE_HOMEASSISTANT_RESTART)
-WEBSOCKET_RECEIVE_DELAY = 1
 
 
 async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
@@ -143,15 +141,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             )
 
         if call.service == SERVICE_HOMEASSISTANT_STOP:
-            # We delay the stop by WEBSOCKET_RECEIVE_DELAY to ensure the frontend
-            # can receive the response before the webserver shuts down
-            @ha.callback
-            def _async_stop(_):
-                # This must not be a tracked task otherwise
-                # the task itself will block stop
-                asyncio.create_task(hass.async_stop())
-
-            async_call_later(hass, WEBSOCKET_RECEIVE_DELAY, _async_stop)
+            asyncio.create_task(hass.async_stop())
             return
 
         errors = await conf_util.async_check_ha_config_file(hass)
@@ -172,19 +162,7 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:
             )
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:
-            # We delay the restart by WEBSOCKET_RECEIVE_DELAY to ensure the frontend
-            # can receive the response before the webserver shuts down
-            @ha.callback
-            def _async_stop_with_code(_):
-                # This must not be a tracked task otherwise
-                # the task itself will block restart
-                asyncio.create_task(hass.async_stop(RESTART_EXIT_CODE))
-
-            async_call_later(
-                hass,
-                WEBSOCKET_RECEIVE_DELAY,
-                _async_stop_with_code,
-            )
+            asyncio.create_task(hass.async_stop(RESTART_EXIT_CODE))
 
     async def async_handle_update_service(call):
         """Service handler for updating an entity."""

--- a/tests/components/homeassistant/test_init.py
+++ b/tests/components/homeassistant/test_init.py
@@ -1,7 +1,6 @@
 """The tests for Core components."""
 # pylint: disable=protected-access
 import asyncio
-from datetime import timedelta
 import unittest
 from unittest.mock import Mock, patch
 
@@ -34,12 +33,10 @@ import homeassistant.core as ha
 from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers import entity
 from homeassistant.setup import async_setup_component
-import homeassistant.util.dt as dt_util
 
 from tests.common import (
     MockConfigEntry,
     async_capture_events,
-    async_fire_time_changed,
     async_mock_service,
     get_test_home_assistant,
     mock_registry,
@@ -526,7 +523,6 @@ async def test_restart_homeassistant(hass):
             blocking=True,
         )
         assert mock_check.called
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
         await hass.async_block_till_done()
         assert mock_restart.called
 
@@ -545,6 +541,5 @@ async def test_stop_homeassistant(hass):
             blocking=True,
         )
         assert not mock_check.called
-        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=2))
         await hass.async_block_till_done()
         assert mock_restart.called


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Waiting was unreliable since the websocket response could take a few seconds to get delivered when mobile/remote
- Alternate frontend fix is https://github.com/home-assistant/frontend/pull/8932


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
