### PR TITLE
Add AsusWrt track_new option

### DIFF
--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -8,7 +8,9 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.device_tracker.const import (
     CONF_CONSIDER_HOME,
+    CONF_TRACK_NEW,
     DEFAULT_CONSIDER_HOME,
+    DEFAULT_TRACK_NEW,
 )
 from homeassistant.const import (
     CONF_HOST,
@@ -201,6 +203,12 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         CONF_CONSIDER_HOME, DEFAULT_CONSIDER_HOME.total_seconds()
                     ),
                 ): vol.All(vol.Coerce(int), vol.Clamp(min=0, max=900)),
+                vol.Optional(
+                    CONF_TRACK_NEW,
+                    default=self.config_entry.options.get(
+                        CONF_TRACK_NEW, DEFAULT_TRACK_NEW
+                    ),
+                ): bool,
                 vol.Optional(
                     CONF_TRACK_UNKNOWN,
                     default=self.config_entry.options.get(

--- a/homeassistant/components/asuswrt/config_flow.py
+++ b/homeassistant/components/asuswrt/config_flow.py
@@ -100,6 +100,7 @@ class AsusWrtFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     vol.Required(CONF_MODE, default=MODE_ROUTER): vol.In(
                         {MODE_ROUTER: "Router", MODE_AP: "Access Point"}
                     ),
+                    vol.Optional(CONF_TRACK_NEW, default=DEFAULT_TRACK_NEW): bool,
                 }
             ),
             errors=errors or {},
@@ -143,6 +144,7 @@ class AsusWrtFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self._host = user_input[CONF_HOST]
         pwd = user_input.get(CONF_PASSWORD)
         ssh = user_input.get(CONF_SSH_KEY)
+        track_new = user_input.get(CONF_TRACK_NEW, DEFAULT_TRACK_NEW)
 
         if not (pwd or ssh):
             errors["base"] = "pwd_or_ssh"
@@ -170,6 +172,7 @@ class AsusWrtFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=self._host,
             data=user_input,
+            options={CONF_TRACK_NEW: False} if not track_new else None,
         )
 
     async def async_step_import(self, user_input=None):

--- a/homeassistant/components/asuswrt/strings.json
+++ b/homeassistant/components/asuswrt/strings.json
@@ -12,7 +12,8 @@
           "ssh_key": "Path to your SSH key file (instead of password)",
           "protocol": "Communication protocol to use",
           "port": "[%key:common::config_flow::data::port%]",
-          "mode": "[%key:common::config_flow::data::mode%]"
+          "mode": "[%key:common::config_flow::data::mode%]",
+          "track_new_devices": "Enable device tracker"
         }
       }
     },

--- a/homeassistant/components/asuswrt/strings.json
+++ b/homeassistant/components/asuswrt/strings.json
@@ -34,6 +34,7 @@
         "title": "AsusWRT Options",
         "data": {
           "consider_home": "Seconds to wait before considering a device away",
+          "track_new_devices": "Track new detected devices",
           "track_unknown": "Track unknown / unamed devices",
           "interface": "The interface that you want statistics from (e.g. eth0,eth1 etc)",
           "dnsmasq": "The location in the router of the dnsmasq.leases files",

--- a/homeassistant/components/asuswrt/translations/en.json
+++ b/homeassistant/components/asuswrt/translations/en.json
@@ -36,6 +36,7 @@
                     "dnsmasq": "The location in the router of the dnsmasq.leases files",
                     "interface": "The interface that you want statistics from (e.g. eth0,eth1 etc)",
                     "require_ip": "Devices must have IP (for access point mode)",
+                    "track_new_devices": "Track new detected devices",
                     "track_unknown": "Track unknown / unamed devices"
                 },
                 "title": "AsusWRT Options"

--- a/homeassistant/components/asuswrt/translations/en.json
+++ b/homeassistant/components/asuswrt/translations/en.json
@@ -21,6 +21,7 @@
                     "port": "Port",
                     "protocol": "Communication protocol to use",
                     "ssh_key": "Path to your SSH key file (instead of password)",
+                    "track_new_devices": "Enable device tracker",
                     "username": "Username"
                 },
                 "description": "Set required parameter to connect to your router",

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -13,7 +13,10 @@ from homeassistant.components.asuswrt.const import (
     CONF_TRACK_UNKNOWN,
     DOMAIN,
 )
-from homeassistant.components.device_tracker.const import CONF_CONSIDER_HOME
+from homeassistant.components.device_tracker.const import (
+    CONF_CONSIDER_HOME,
+    CONF_TRACK_NEW,
+)
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.const import (
     CONF_HOST,
@@ -281,6 +284,7 @@ async def test_options_flow(hass):
             result["flow_id"],
             user_input={
                 CONF_CONSIDER_HOME: 20,
+                CONF_TRACK_NEW: True,
                 CONF_TRACK_UNKNOWN: True,
                 CONF_INTERFACE: "aaa",
                 CONF_DNSMASQ: "bbb",
@@ -290,6 +294,7 @@ async def test_options_flow(hass):
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
         assert config_entry.options[CONF_CONSIDER_HOME] == 20
+        assert config_entry.options[CONF_TRACK_NEW] is True
         assert config_entry.options[CONF_TRACK_UNKNOWN] is True
         assert config_entry.options[CONF_INTERFACE] == "aaa"
         assert config_entry.options[CONF_DNSMASQ] == "bbb"

--- a/tests/components/asuswrt/test_config_flow.py
+++ b/tests/components/asuswrt/test_config_flow.py
@@ -40,6 +40,7 @@ CONFIG_DATA = {
     CONF_USERNAME: "user",
     CONF_PASSWORD: "pwd",
     CONF_MODE: "ap",
+    CONF_TRACK_NEW: True,
 }
 
 

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.dt import utcnow
+from homeassistant.util.dt import now
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -44,6 +44,11 @@ MOCK_BYTES_TOTAL = [60000000000, 50000000000]
 MOCK_CURRENT_TRANSFER_RATES = [20000000, 10000000]
 
 
+def get_devices():
+    """Return mock devices for test."""
+    return MOCK_DEVICES.copy()
+
+
 @pytest.fixture(name="connect")
 def mock_controller_connect():
     """Mock a successful connection."""
@@ -52,7 +57,7 @@ def mock_controller_connect():
         service_mock.return_value.is_connected = True
         service_mock.return_value.connection.disconnect = Mock()
         service_mock.return_value.async_get_connected_devices = AsyncMock(
-            return_value=MOCK_DEVICES
+            side_effect=get_devices
         )
         service_mock.return_value.async_get_bytes_total = AsyncMock(
             return_value=MOCK_BYTES_TOTAL
@@ -122,7 +127,7 @@ async def test_sensors(hass, connect):
     # initial devices setup
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    async_fire_time_changed(hass, now() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     assert hass.states.get(f"{device_tracker.DOMAIN}.test").state == STATE_HOME
@@ -138,7 +143,7 @@ async def test_sensors(hass, connect):
     MOCK_DEVICES["a3:b3:c3:d3:e3:f3"] = Device(
         "a3:b3:c3:d3:e3:f3", "192.168.1.4", "TestThree"
     )
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    async_fire_time_changed(hass, now() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     # consider home option set, all devices still home
@@ -151,7 +156,7 @@ async def test_sensors(hass, connect):
         config_entry, options={CONF_CONSIDER_HOME: 0}
     )
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    async_fire_time_changed(hass, now() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     # consider home option not set, device "test" not home

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -8,7 +8,10 @@ import pytest
 from homeassistant.components import device_tracker, sensor
 from homeassistant.components.asuswrt.const import DOMAIN
 from homeassistant.components.asuswrt.sensor import DEFAULT_PREFIX
-from homeassistant.components.device_tracker.const import CONF_CONSIDER_HOME
+from homeassistant.components.device_tracker.const import (
+    CONF_CONSIDER_HOME,
+    CONF_TRACK_NEW,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_MODE,
@@ -34,6 +37,7 @@ CONFIG_DATA = {
     CONF_USERNAME: "user",
     CONF_PASSWORD: "pwd",
     CONF_MODE: "router",
+    CONF_TRACK_NEW: True,
 }
 
 MOCK_DEVICES = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the only way to avoid tracking new devices is to use the `Enable new added entities` system option. However, this option does not prevent new devices and entities from being created, which however cannot be eliminated in any way except by manually acting on the registry. This new option solves the problem.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
