### PR TITLE
SMA code quality improvement and bugfix

### DIFF
--- a/homeassistant/components/sma/__init__.py
+++ b/homeassistant/components/sma/__init__.py
@@ -61,7 +61,7 @@ def _parse_legacy_options(entry: ConfigEntry, sensor_def: pysma.Sensors) -> List
         return []
 
     # Support import of legacy config that should have been removed from 0.99, but was still functional
-    # See also #25880 and #26306. Function support was dropped in #48003
+    # See also #25880 and #26306. Functional support was dropped in #48003
     if isinstance(config_sensors, dict):
         config_sensors_list = []
 

--- a/homeassistant/components/sma/config_flow.py
+++ b/homeassistant/components/sma/config_flow.py
@@ -19,8 +19,7 @@ from homeassistant.const import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
-from .const import CONF_CUSTOM, CONF_GROUP, DEVICE_INFO, GROUPS
-from .const import DOMAIN  # pylint: disable=unused-import
+from .const import CONF_CUSTOM, CONF_GROUP, DEVICE_INFO, DOMAIN, GROUPS
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/components/sma/__init__.py
+++ b/tests/components/sma/__init__.py
@@ -38,6 +38,25 @@ MOCK_IMPORT = {
     },
 }
 
+MOCK_IMPORT_DICT = {
+    "platform": "sma",
+    "host": "1.1.1.1",
+    "ssl": True,
+    "verify_ssl": False,
+    "group": "user",
+    "password": "password",
+    "sensors": {
+        "pv_power": [],
+        "pv_gen_meter": [],
+        "solar_daily": ["daily_yield", "total_yield"],
+        "status": ["grid_power", "frequency", "voltage_l1", "operating_time"],
+    },
+    "custom": {
+        "operating_time": {"key": "6400_00462E00", "unit": "uur", "factor": 3600},
+        "solar_daily": {"key": "6400_00262200", "unit": "kWh", "factor": 1000},
+    },
+}
+
 MOCK_CUSTOM_SENSOR = {
     "name": "yesterday_consumption",
     "key": "6400_00543A01",
@@ -103,9 +122,7 @@ async def init_integration(hass):
     )
     entry.add_to_hass(hass)
 
-    with patch(
-        "homeassistant.helpers.update_coordinator.DataUpdateCoordinator.async_config_entry_first_refresh"
-    ):
+    with patch("pysma.SMA.read"):
         await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry

--- a/tests/components/sma/__init__.py
+++ b/tests/components/sma/__init__.py
@@ -110,30 +110,23 @@ MOCK_LEGACY_ENTRY = er.RegistryEntry(
     original_name="pv_power",
 )
 
+MOCK_CONFIG_ENTRY = MockConfigEntry(
+    domain=DOMAIN,
+    title=MOCK_DEVICE["name"],
+    unique_id=MOCK_DEVICE["serial"],
+    data=MOCK_CUSTOM_SETUP_DATA,
+    source="import",
+)
+
 
 async def init_integration(hass):
     """Create a fake SMA Config Entry."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        title=MOCK_DEVICE["name"],
-        unique_id=MOCK_DEVICE["serial"],
-        data=MOCK_CUSTOM_SETUP_DATA,
-        source="import",
-    )
-    entry.add_to_hass(hass)
+    MOCK_CONFIG_ENTRY.add_to_hass(hass)
 
     with patch("pysma.SMA.read"):
-        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.config_entries.async_setup(MOCK_CONFIG_ENTRY.entry_id)
     await hass.async_block_till_done()
-    return entry
-
-
-def _patch_validate_input(return_value=MOCK_DEVICE, side_effect=None):
-    return patch(
-        "homeassistant.components.sma.config_flow.validate_input",
-        return_value=return_value,
-        side_effect=side_effect,
-    )
+    return MOCK_CONFIG_ENTRY
 
 
 def _patch_async_setup_entry(return_value=True):

--- a/tests/components/sma/__init__.py
+++ b/tests/components/sma/__init__.py
@@ -1,11 +1,6 @@
 """Tests for the sma integration."""
 from unittest.mock import patch
 
-from homeassistant.components.sma.const import DOMAIN
-from homeassistant.helpers import entity_registry as er
-
-from tests.common import MockConfigEntry
-
 MOCK_DEVICE = {
     "manufacturer": "SMA",
     "name": "SMA Device Name",
@@ -101,32 +96,6 @@ MOCK_CUSTOM_SETUP_DATA = dict(
     },
     **MOCK_USER_INPUT,
 )
-
-MOCK_LEGACY_ENTRY = er.RegistryEntry(
-    entity_id="sensor.pv_power",
-    unique_id="sma-6100_0046C200-pv_power",
-    platform="sma",
-    unit_of_measurement="W",
-    original_name="pv_power",
-)
-
-MOCK_CONFIG_ENTRY = MockConfigEntry(
-    domain=DOMAIN,
-    title=MOCK_DEVICE["name"],
-    unique_id=MOCK_DEVICE["serial"],
-    data=MOCK_CUSTOM_SETUP_DATA,
-    source="import",
-)
-
-
-async def init_integration(hass):
-    """Create a fake SMA Config Entry."""
-    MOCK_CONFIG_ENTRY.add_to_hass(hass)
-
-    with patch("pysma.SMA.read"):
-        await hass.config_entries.async_setup(MOCK_CONFIG_ENTRY.entry_id)
-    await hass.async_block_till_done()
-    return MOCK_CONFIG_ENTRY
 
 
 def _patch_async_setup_entry(return_value=True):

--- a/tests/components/sma/conftest.py
+++ b/tests/components/sma/conftest.py
@@ -1,0 +1,33 @@
+"""Fixtures for sma tests."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.sma.const import DOMAIN
+
+from . import MOCK_CUSTOM_SETUP_DATA, MOCK_DEVICE
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry():
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title=MOCK_DEVICE["name"],
+        unique_id=MOCK_DEVICE["serial"],
+        data=MOCK_CUSTOM_SETUP_DATA,
+        source="import",
+    )
+
+
+@pytest.fixture
+async def init_integration(hass, mock_config_entry):
+    """Create a fake SMA Config Entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("pysma.SMA.read"):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -16,11 +16,13 @@ from homeassistant.helpers import entity_registry as er
 from . import (
     MOCK_DEVICE,
     MOCK_IMPORT,
+    MOCK_IMPORT_DICT,
     MOCK_LEGACY_ENTRY,
     MOCK_SETUP_DATA,
     MOCK_USER_INPUT,
     _patch_async_setup_entry,
     _patch_validate_input,
+    init_integration,
 )
 
 
@@ -118,18 +120,7 @@ async def test_form_unexpected_exception(hass):
 
 async def test_form_already_configured(hass):
     """Test starting a flow by user when already configured."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_USER}
-    )
-
-    with _patch_validate_input():
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            MOCK_USER_INPUT,
-        )
-
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["result"].unique_id == MOCK_DEVICE["serial"]
+    await init_integration(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -165,6 +156,28 @@ async def test_import(hass):
 
     assert MOCK_LEGACY_ENTRY.original_name not in result["data"]["sensors"]
     assert "pv_power_a" in result["data"]["sensors"]
+
+    entity = entity_registry.async_get(MOCK_LEGACY_ENTRY.entity_id)
+    assert entity.unique_id == f"{MOCK_DEVICE['serial']}-6380_40251E00_0"
+
+
+async def test_import_sensor_dict(hass):
+    """Test we can import."""
+    entity_registry = er.async_get(hass)
+    entity_registry._register_entry(MOCK_LEGACY_ENTRY)
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with _patch_validate_input():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data=MOCK_IMPORT_DICT,
+        )
+
+    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == MOCK_USER_INPUT["host"]
+    assert result["data"] == MOCK_IMPORT_DICT
 
     entity = entity_registry.async_get(MOCK_LEGACY_ENTRY.entity_id)
     assert entity.unique_id == f"{MOCK_DEVICE['serial']}-6380_40251E00_0"

--- a/tests/components/sma/test_sensor.py
+++ b/tests/components/sma/test_sensor.py
@@ -5,13 +5,11 @@ from homeassistant.const import (
     POWER_WATT,
 )
 
-from . import MOCK_CUSTOM_SENSOR, init_integration
+from . import MOCK_CUSTOM_SENSOR
 
 
-async def test_sensors(hass):
+async def test_sensors(hass, init_integration):
     """Test states of the sensors."""
-    await init_integration(hass)
-
     state = hass.states.get("sensor.current_consumption")
     assert state
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == POWER_WATT


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change will:

- Improve code quality. Based on reviews after merge of #48003
- Fix bug reported by @bramkragten.
Support for dict in yaml sensor config should have been dropped in #25880 and #26306
Unfortunately the code that made it work (https://github.com/home-assistant/core/blob/master/homeassistant/components/sma/sensor.py#L107-L123) was not removed untill #48003.
This fix supports import of this legacy config using dict and:
  - Makes sure we always have a List and code does not raise an exception at https://github.com/rklomp/home-assistant-core/blob/e15030394d9ef3e6e926f9fde4a72c7add10e89e/homeassistant/components/sma/__init__.py#L78
  - Makes #48003 less breaking for users still using this yaml config.
  - Adds a test to validate a dict can be supplied to the import flow


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->
Configuration used by @bramkragten
```
sensor:
  - platform: sma
    host: *******
    password: *******
    sensors:
      pv_power:
      pv_gen_meter:
      solar_daily: [daily_yield, total_yield]
      status: [grid_power, frequency, voltage_l1, operating_time]
    custom:
      operating_time:
        key: '6400_00462E00'
        unit: uur
        factor: 3600
      solar_daily:
        key: '6400_00262200'
        unit: kWh
        factor: 1000
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
