### PR TITLE
Fix exception in roomba discovery when the device does not respond on the first try

### DIFF
--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -328,9 +328,8 @@ async def _async_discover_roombas(hass, host):
             discovery = _async_get_roomba_discovery()
             try:
                 if host:
-                    discovered = [
-                        await hass.async_add_executor_job(discovery.get, host)
-                    ]
+                    device = await hass.async_add_executor_job(discovery.get, host)
+                    discovered = [device] if device else []
                 else:
                     discovered = await hass.async_add_executor_job(discovery.get_all)
             except OSError:

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -687,7 +687,7 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
 
 @pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP)
 async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
-    """Test we can process the discovery from dhcp but roomba discovery cannot find the device."""
+    """Test we can process the discovery from dhcp but roomba discovery cannot find the specific device."""
     await setup.async_setup_component(hass, "persistent_notification", {})
 
     mocked_roomba = _create_mocked_roomba(
@@ -746,6 +746,68 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
     assert result4["title"] == "myroomba"
     assert result4["result"].unique_id == "BLID"
     assert result4["data"] == {
+        CONF_BLID: "BLID",
+        CONF_CONTINUOUS: True,
+        CONF_DELAY: 1,
+        CONF_HOST: MOCK_IP,
+        CONF_PASSWORD: "password",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize("discovery_data", DHCP_DISCOVERY_DEVICES_WITHOUT_MATCHING_IP)
+async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_data):
+    """Test we can process the discovery from dhcp but roomba discovery cannot find any devices."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    mocked_roomba = _create_mocked_roomba(
+        roomba_connected=True,
+        master_state={"state": {"reported": {"name": "myroomba"}}},
+    )
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.RoombaDiscovery",
+        _mocked_no_devices_found_discovery,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=discovery_data,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] is None
+    assert result["step_id"] == "manual"
+
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_IP, CONF_BLID: "blid"},
+    )
+    await hass.async_block_till_done()
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result2["errors"] is None
+
+    with patch(
+        "homeassistant.components.roomba.config_flow.Roomba",
+        return_value=mocked_roomba,
+    ), patch(
+        "homeassistant.components.roomba.config_flow.RoombaPassword",
+        _mocked_getpassword,
+    ), patch(
+        "homeassistant.components.roomba.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            {},
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result3["title"] == "myroomba"
+    assert result3["result"].unique_id == "BLID"
+    assert result3["data"] == {
         CONF_BLID: "BLID",
         CONF_CONTINUOUS: True,
         CONF_DELAY: 1,


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix exception in roomba discovery when the device does not respond on the first try

Fixes
```
2021-04-17 11:25:11 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved                                                
Traceback (most recent call last):                                                                                                                         
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 151, in async_init                                                                
    flow, result = await task                                                                                                                             
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 177, in _async_init                                                                  
    result = await self._async_handle_step(flow, flow.init_step, data, init_done)                                                                                    
  File "/usr/src/homeassistant/homeassistant/data_entry_flow.py", line 258, in _async_handle_step                                                               
    result: FlowResultDict = await getattr(flow, method)(user_input)                                                                                       
  File "/usr/src/homeassistant/homeassistant/components/roomba/config_flow.py", line 107, in async_step_dhcp                                               
    return await self.async_step_user()                                                                                                                        
  File "/usr/src/homeassistant/homeassistant/components/roomba/config_flow.py", line 134, in async_step_user                                                
    devices = await _async_discover_roombas(self.hass, self.host)                                                                                               
  File "/usr/src/homeassistant/homeassistant/components/roomba/config_flow.py", line 342, in _async_discover_roombas                                       
    if device.ip in discovered_hosts:                                                                                                                             
AttributeError: 'NoneType' object has no attribute 'ip' 
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
