### PR TITLE
zwave_js: cover: Fibaro FGR-222 venetian blind tilt support

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -5,14 +5,22 @@ import logging
 from typing import Any, Callable
 
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.model.value import Value as ZwaveValue
+from zwave_js_server.const import CommandClass
+from zwave_js_server.model.node import Node as ZwaveNode
+from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
+    ATTR_TILT_POSITION,
     DEVICE_CLASS_GARAGE,
     DOMAIN as COVER_DOMAIN,
     SUPPORT_CLOSE,
+    SUPPORT_CLOSE_TILT,
     SUPPORT_OPEN,
+    SUPPORT_OPEN_TILT,
+    SUPPORT_SET_POSITION,
+    SUPPORT_SET_TILT_POSITION,
+    SUPPORT_STOP,
     CoverEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -34,6 +42,61 @@ BARRIER_STATE_STOPPED = 253
 BARRIER_STATE_OPENING = 254
 BARRIER_STATE_OPEN = 255
 
+FIBARO_FGR222_CONFIGURATION_REPORTS_TYPE_PROPERTY = 3
+FIBARO_FGR222_CONFIGURATION_REPORTS_TYPE_MANUFAC_PROP = 1
+FIBARO_FGR222_CONFIGURATION_OPERATING_MODE_PROPERTY = 10
+FIBARO_FGR222_CONFIGURATION_OPERATING_MODE_VENETIAN_WITH_POSITION = 2
+FIBARO_FGR222_MANUFACTURER_PROPRIETARY_BLINDS_POSITION_PROPERTY = (
+    "fibaro-venetianBlindsPosition"
+)
+FIBARO_FGR222_MANUFACTURER_PROPRIETARY_BLINDS_TILT_PROPERTY = (
+    "fibaro-venetianBlindsTilt"
+)
+
+
+def get_node_configuration_value(node: ZwaveNode, property_: int) -> Any | None:
+    """Return a node's configuration value, if any."""
+    config_values = node.get_configuration_values()
+
+    value_id = get_value_id(
+        node,
+        CommandClass.CONFIGURATION,
+        property_,
+        endpoint=0,
+    )
+    if value_id not in config_values:
+        return None
+
+    return config_values[value_id].value
+
+
+def is_fgr222_in_venetian_config(info: ZwaveDiscoveryInfo) -> bool:
+    """Check if node is an FGR222 in sane venetian blinds configuration."""
+    if info.platform_hint != "fibaro_fgr222":
+        return False
+
+    # Is the node reporting through the "Manufacturer Proprietary" value?
+    if (
+        get_node_configuration_value(
+            info.node, FIBARO_FGR222_CONFIGURATION_REPORTS_TYPE_PROPERTY
+        )
+        is not FIBARO_FGR222_CONFIGURATION_REPORTS_TYPE_MANUFAC_PROP
+    ):
+        return False
+
+    # Is the node configured as "venetian blind mode with positioning"?
+    if (
+        get_node_configuration_value(
+            info.node, FIBARO_FGR222_CONFIGURATION_OPERATING_MODE_PROPERTY
+        )
+        is not FIBARO_FGR222_CONFIGURATION_OPERATING_MODE_VENETIAN_WITH_POSITION
+    ):
+        return False
+
+    LOGGER.debug("Node %u detected as FGR222 in venetian config", info.node.node_id)
+
+    return True
+
 
 async def async_setup_entry(
     hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
@@ -47,6 +110,8 @@ async def async_setup_entry(
         entities: list[ZWaveBaseEntity] = []
         if info.platform_hint == "motorized_barrier":
             entities.append(ZwaveMotorizedBarrier(config_entry, client, info))
+        elif is_fgr222_in_venetian_config(info):
+            entities.append(FGR222Venetian(config_entry, client, info))
         else:
             entities.append(ZWaveCover(config_entry, client, info))
         async_add_entities(entities)
@@ -70,12 +135,20 @@ def percent_to_zwave_position(value: int) -> int:
     return 0
 
 
+def zwave_position_to_percent(value: int) -> int:
+    """Convert position in 0-99 scale to 0-100 scale.
+
+    `value` -- (int) Position byte value from 0-99.
+    """
+    return round((value / 99) * 100)
+
+
 class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     """Representation of a Z-Wave Cover device."""
 
     @property
     def is_closed(self) -> bool | None:
-        """Return true if cover is closed."""
+        """Return if the cover is closed or not."""
         if self.info.primary_value.value is None:
             # guard missing value
             return None
@@ -83,11 +156,14 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 
     @property
     def current_cover_position(self) -> int | None:
-        """Return the current position of cover where 0 means closed and 100 is fully open."""
+        """Return current position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
         if self.info.primary_value.value is None:
             # guard missing value
             return None
-        return round((self.info.primary_value.value / 99) * 100)
+        return zwave_position_to_percent(self.info.primary_value.value)
 
     async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
@@ -114,6 +190,117 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
         target_value = self.get_zwave_value("Close") or self.get_zwave_value("Down")
         if target_value:
             await self.info.node.async_set_value(target_value, False)
+
+
+class FGR222Venetian(ZWaveCover):
+    """Implementation of the FGR-222 in proprietary venetian configuration.
+
+    This adds support for the tilt feature for the ventian blind mode.
+
+    To enable this, the following node configuration values must be set:
+      * Set "3: Reports type to Blind position reports sent"
+          to value "the main controller using Fibaro Command Class"
+      * Set "10: Roller Shutter operating modes"
+          to  value "2 - Venetian Blind Mode, with positioning"
+    """
+
+    def __init__(
+        self, config_entry: ConfigEntry, client: ZwaveClient, info: ZwaveDiscoveryInfo
+    ) -> None:
+        """Initialize the FGR-222."""
+        super().__init__(config_entry, client, info)
+
+        self._blinds_position = self.get_zwave_value(
+            FIBARO_FGR222_MANUFACTURER_PROPRIETARY_BLINDS_POSITION_PROPERTY,
+            command_class=CommandClass.MANUFACTURER_PROPRIETARY,
+            add_to_watched_value_ids=True,
+        )
+
+        self._tilt_position = self.get_zwave_value(
+            FIBARO_FGR222_MANUFACTURER_PROPRIETARY_BLINDS_TILT_PROPERTY,
+            command_class=CommandClass.MANUFACTURER_PROPRIETARY,
+            add_to_watched_value_ids=True,
+        )
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return if the cover is closed or not."""
+        pos = self.current_cover_position
+        if pos is None:
+            return None
+
+        return bool(pos == 0)
+
+    @property
+    def current_cover_position(self) -> int | None:
+        """Return current position of cover.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        if self._blinds_position is None:
+            return None
+        if self._blinds_position.value is None:
+            return None
+
+        # On the FGR-222, when it is controlling venetian blinds, it can happen that the cover
+        # position can't reach 0 or 99. On top of that, the tilt position can influence the reported
+        # cover position as well. That is, fully open or fully closed blinds can shift the blinds
+        # position value.
+        #
+        # Hence, saturate a bit earlier in each direction.
+        pos = self._blinds_position.value  # This is a Zwave value, so range is: 0-99
+        if pos < 4:
+            pos = 0
+        if pos > 95:
+            pos = 99
+
+        return zwave_position_to_percent(pos)
+
+    @property
+    def current_cover_tilt_position(self) -> int | None:
+        """Return current position of cover tilt.
+
+        None is unknown, 0 is closed, 100 is fully open.
+        """
+        if self._tilt_position is None:
+            return None
+        if self._tilt_position.value is None:
+            return None
+
+        return zwave_position_to_percent(self._tilt_position.value)
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features."""
+        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+
+        if self.current_cover_position is not None:
+            supported_features |= SUPPORT_SET_POSITION
+
+        if self.current_cover_tilt_position is not None:
+            supported_features |= (
+                SUPPORT_OPEN_TILT | SUPPORT_CLOSE_TILT | SUPPORT_SET_TILT_POSITION
+            )
+
+        return supported_features
+
+    async def async_open_cover_tilt(self, **kwargs: Any) -> None:
+        """Open the cover tilt."""
+        if self._tilt_position:
+            await self.info.node.async_set_value(self._tilt_position, 99)
+
+    async def async_close_cover_tilt(self, **kwargs: Any) -> None:
+        """Close the cover tilt."""
+        if self._tilt_position:
+            await self.info.node.async_set_value(self._tilt_position, 0)
+
+    async def async_set_cover_tilt_position(self, **kwargs: Any) -> None:
+        """Move the cover tilt to a specific position."""
+        if self._tilt_position:
+            await self.info.node.async_set_value(
+                self._tilt_position,
+                percent_to_zwave_position(kwargs[ATTR_TILT_POSITION]),
+            )
 
 
 class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -164,9 +164,10 @@ DISCOVERY_SCHEMAS = [
             type={"number"},
         ),
     ),
-    # Fibaro Shutter Fibaro FGS222
+    # Fibaro Shutter Fibaro FGR-222
     ZWaveDiscoverySchema(
         platform="cover",
+        hint="fibaro_fgr222",
         manufacturer_id={0x010F},
         product_id={0x1000},
         product_type={0x0302},


### PR DESCRIPTION
## Proposed change

This PR adds home-assistant native tilt support for FGR-222 devices.

The functionality will be enabled dynamically during discovery. Each Zwave
node's configuration parameters are checked, and if the node is reporting using
the `Manufacturer Proprietary` command class, AND `venetian blind mode with
positioning` is set as well, the `FGR222Venetian` class introduced by this patch
will be instantiated. In any other case, the generic implementation will be use as before.

Props to @AlCalzone et al. for zwave_js and the people integrating it in HA. It is a blast to use :fist_oncoming: 

CC @ChristianKuehnel for the giggles.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

We've tried this in the past with Open ZWave already (https://github.com/home-assistant/core/pull/29701), but got quickly shot down again and reverted because one user reported a breakage (https://github.com/home-assistant/core/issues/30674).

One likely cause for this could have been that his FGR-222 were erroneously detected as being configured with tilt support when they weren't in reality. The Open ZWave implementation had (still has?) the shortcoming that it couldn't query a ZWave node's configuration values, because this was broken in Open ZWave itself or its python bindings. So a heuristic was used to detect the venetian mode, and maybe that heuristic failed for this user.

ZWave_js correctly supports querying node config values, making discovery of FGR-222 devices in venetian configuration straight forward. So the confidence in the detection in this PR is much higher.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
