### PR TITLE
Apply default light profile only when light is toggled from off to on

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -498,16 +498,15 @@ class Profiles:
         self.data = await self.hass.async_add_executor_job(self._load_profile_data)
 
     @callback
-    def apply_default(self, entity_id: str, is_on: bool, params: dict) -> None:
+    def apply_default(self, entity_id: str, state_on: bool, params: dict) -> None:
         """Return the default profile for the given light."""
         for _entity_id in (entity_id, "group.all_lights"):
             name = f"{_entity_id}.default"
             if name in self.data:
-                if not is_on or (not params and is_on):
+                if not state_on or not params:
                     self.apply_profile(name, params)
                 elif self.data[name].transition is not None:
                     params.setdefault(ATTR_TRANSITION, self.data[name].transition)
-                return
 
     @callback
     def apply_profile(self, name: str, params: dict) -> None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -511,7 +511,7 @@ class Profiles:
 
     @callback
     def apply_default_transition(self, entity_id: str, params: dict) -> None:
-        """Return the transition attribute from the default profile for the given light"""
+        """Return the transition attribute from the default profile for the given light."""
         for _entity_id in (entity_id, "group.all_lights"):
             name = f"{_entity_id}.default"
             if name in self.data and self.data[name].transition is not None:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -287,7 +287,7 @@ async def async_setup(hass, config):
 
             preprocess_turn_on_alternatives(hass, params)
 
-        if ATTR_PROFILE not in params:
+        if not params or not light.is_on:
             profiles.apply_default(light.entity_id, params)
 
         supported_color_modes = light.supported_color_modes

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -651,6 +651,11 @@ async def test_default_profiles_light(
         blocking=True,
     )
 
+    _, data = dev.last_call("turn_off")
+    assert data == {
+        light.ATTR_TRANSITION: 3,
+    }
+
 
 async def test_light_context(hass, hass_admin_user):
     """Test that light context works."""

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -656,6 +656,7 @@ async def test_default_profiles_light(
         light.ATTR_TRANSITION: 3,
     }
 
+
 async def test_light_context(hass, hass_admin_user):
     """Test that light context works."""
     platform = getattr(hass.components, "test.light")

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -560,11 +560,6 @@ async def test_default_profiles_group(hass, mock_light_profiles):
         light.ATTR_TRANSITION: 2,
     }
 
-    _, data = ent.last_call("turn_off")
-    assert data == {
-        light.ATTR_TRANSITION: 2,
-    }
-
 
 @pytest.mark.parametrize(
     "extra_call_params, expected_params",

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -656,11 +656,6 @@ async def test_default_profiles_light(
         blocking=True,
     )
 
-    _, data = dev.last_call("turn_off")
-    assert data == {
-        light.ATTR_TRANSITION: 3,
-    }
-
 
 async def test_light_context(hass, hass_admin_user):
     """Test that light context works."""

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -651,6 +651,10 @@ async def test_default_profiles_light(
         blocking=True,
     )
 
+    _, data = dev.last_call("turn_off")
+    assert data == {
+        light.ATTR_TRANSITION: 3,
+    }
 
 async def test_light_context(hass, hass_admin_user):
     """Test that light context works."""

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -560,6 +560,11 @@ async def test_default_profiles_group(hass, mock_light_profiles):
         light.ATTR_TRANSITION: 2,
     }
 
+    _, data = ent.last_call("turn_off")
+    assert data == {
+        light.ATTR_TRANSITION: 2,
+    }
+
 
 @pytest.mark.parametrize(
     "extra_call_params, expected_params",

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -651,11 +651,6 @@ async def test_default_profiles_light(
         blocking=True,
     )
 
-    _, data = dev.last_call("turn_off")
-    assert data == {
-        light.ATTR_TRANSITION: 3,
-    }
-
 
 async def test_light_context(hass, hass_admin_user):
     """Test that light context works."""


### PR DESCRIPTION
Partially revert #45450.

## Breaking change
When a light entity has a default profile associated, the default profile will only be applied for the `light.turn_on` service call when the light state is off or no data is sent with the service call.
The transition attribute from the default profile in `light_profiles.csv` will also be applied when `light.turn_off` is called.

## Proposed change
A default light profile should only be applied during the service call `light.turn` on in 3 scenarios:

- The light state is changing from off to on
- No data is being sent in the service call
- The default profile is explicity specified in the service call

As there is no seperate service for the light entity to change brightness, the expected result when a service call to `light.turn_on`, for a light that is presently on is to change the brightness. It should not affect the colour. Specific scenarios can be seen in the table. 

My argument against #45450:
- The documentation explicity says the default profile will be applied when the light is turned-on. https://www.home-assistant.io/integrations/light/#default-turn-on-values
- This reverted functionality is intuitive. Referencing the Front-end UI, when I open the light entity lovelace card, I can change the color, brightness or white level individually. Specifically, if a group of lights all have different colours, I expect that if I change the brightness, the colour remains the same while the brightness is adjusted for each light to the new brightness.
- It is likely that a small proportion of users use the light_profiles. Of them, an even smaller portion would likely raise an issue if this functionality was not working as expected. However, there are 3 seperate issues and multiple commenters on each of these issues.
- I was not able to locate any issues where a user identified that they expected the default profile to be applied anytime the light.turn_on service call was issued (prior to the afformentioned PR).

The default transition attribute will continute to be applied for all `light.turn_on` service calls. It will also be expanded to apply to `light.turn_off` service calls, as was intended in #45450. As a result, it will also apply to `light.toggle`. This is believed to be intuitive to the user.

**All of functionality remains the same except for row 7.**
<table>
<tr>
<td>Service Call</td><td>Light Entity State</td><td>Current New State</td><td>Proposed New State</td></tr>
<tr><td rowspan="2">
No data and the light current state matches the default profile

```yaml
service: light.turn_on
target:
  entity_id: light.a
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td></tr>
<tr><td>

```yaml
state: off
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td></tr>
<tr><td rowspan="2">
Including a parameter, with the light current state matching the default profile.

```yaml
service: light.turn_on
target:
  entity_id: light.a
data:
  brightness: 254
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td></tr>
<tr><td>

```yaml
state: off
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td></tr><tr><td rowspan="2">
No data and the light current state does not match the default profile

```yaml
service: light.turn_on
target:
  entity_id: light.a
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td></tr>
<tr><td>

```yaml
state: off
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.362, 0.37
```
</td></tr>
<tr class="highlight"><td rowspan="2">
Including a parameter and the light current state does not match the default profile

```yaml
service: light.turn_on
target:
  entity_id: light.a
data:
  brightness: 254
```
</td><td>

```yaml
state: on
brightness: 255
xy_color: 0.46, 0.409
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.46, 0.409
```
</td></tr>
<tr><td>

```yaml
state: off
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td><td>

```yaml
state: on
brightness: 254
xy_color: 0.362, 0.37
```
</td></tr>
</table>
Default Light Profile

```csv
id,x,y,brightness
light.a,0.36079,0.37000,255
```
Note: The previous state or attributes when the light entity is off is assumed to be the on state referenced in the row above.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #45979 #46053 #46314
- This PR is related to issue: #49002
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17513

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]