### PR TITLE
Add wemo retryable static devices

### DIFF
--- a/homeassistant/components/wemo/__init__.py
+++ b/homeassistant/components/wemo/__init__.py
@@ -99,9 +99,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     # Keep track of WeMo device subscriptions for push updates
     registry = hass.data[DOMAIN]["registry"] = pywemo.SubscriptionRegistry()
     await hass.async_add_executor_job(registry.start)
-
+    static_conf = config.get(CONF_STATIC, [])
     wemo_dispatcher = WemoDispatcher(entry)
-    wemo_discovery = WemoDiscovery(hass, wemo_dispatcher)
+    wemo_discovery = WemoDiscovery(hass, wemo_dispatcher, static_conf)
 
     async def async_stop_wemo(event):
         """Shutdown Wemo subscriptions and subscription thread on exit."""
@@ -111,17 +111,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, async_stop_wemo)
 
-    static_conf = config.get(CONF_STATIC, [])
-    if static_conf:
-        _LOGGER.debug("Adding statically configured WeMo devices")
-        for device in await asyncio.gather(
-            *[
-                hass.async_add_executor_job(validate_static_config, host, port)
-                for host, port in static_conf
-            ]
-        ):
-            if device:
-                wemo_dispatcher.async_add_unique_device(hass, device)
+    # Need to do this at least once in case statics are defined and discovery is disabled
+    await wemo_discovery.discover_statics()
 
     if config.get(CONF_DISCOVERY, DEFAULT_DISCOVERY):
         await wemo_discovery.async_discover_and_schedule()
@@ -181,12 +172,15 @@ class WemoDiscovery:
     ADDITIONAL_SECONDS_BETWEEN_SCANS = 10
     MAX_SECONDS_BETWEEN_SCANS = 300
 
-    def __init__(self, hass: HomeAssistant, wemo_dispatcher: WemoDispatcher) -> None:
+    def __init__(
+        self, hass: HomeAssistant, wemo_dispatcher: WemoDispatcher, staticConfig
+    ) -> None:
         """Initialize the WemoDiscovery."""
         self._hass = hass
         self._wemo_dispatcher = wemo_dispatcher
         self._stop = None
         self._scan_delay = 0
+        self._static_config = staticConfig
 
     async def async_discover_and_schedule(self, *_) -> None:
         """Periodically scan the network looking for WeMo devices."""
@@ -196,6 +190,8 @@ class WemoDiscovery:
                 pywemo.discover_devices
             ):
                 self._wemo_dispatcher.async_add_unique_device(self._hass, device)
+            await self.discover_statics()
+
         finally:
             # Run discovery more frequently after hass has just started.
             self._scan_delay = min(
@@ -214,6 +210,21 @@ class WemoDiscovery:
         if self._stop:
             self._stop()
             self._stop = None
+
+    async def discover_statics(self):
+        """Initialize or Re-Initialize connections to statically configured devices."""
+        if self._static_config:
+            _LOGGER.debug("Adding statically configured WeMo devices")
+            for device in await asyncio.gather(
+                *[
+                    self._hass.async_add_executor_job(
+                        validate_static_config, host, port
+                    )
+                    for host, port in self._static_config
+                ]
+            ):
+                if device:
+                    self._wemo_dispatcher.async_add_unique_device(self._hass, device)
 
 
 def validate_static_config(host, port):

--- a/tests/components/wemo/test_init.py
+++ b/tests/components/wemo/test_init.py
@@ -117,20 +117,26 @@ async def test_discovery(hass, pywemo_registry):
     with patch(
         "pywemo.discover_devices", return_value=pywemo_devices
     ) as mock_discovery:
-        assert await async_setup_component(
-            hass, DOMAIN, {DOMAIN: {CONF_DISCOVERY: True}}
-        )
-        await pywemo_registry.semaphore.acquire()  # Returns after platform setup.
-        mock_discovery.assert_called()
-        pywemo_devices.append(create_device(2))
+        with patch(
+            "homeassistant.components.wemo.WemoDiscovery.discover_statics"
+        ) as mock_discover_statics:
+            assert await async_setup_component(
+                hass, DOMAIN, {DOMAIN: {CONF_DISCOVERY: True}}
+            )
+            await pywemo_registry.semaphore.acquire()  # Returns after platform setup.
+            mock_discovery.assert_called()
+            mock_discover_statics.assert_called()
+            pywemo_devices.append(create_device(2))
 
-        # Test that discovery runs periodically and the async_dispatcher_send code works.
-        async_fire_time_changed(
-            hass,
-            dt.utcnow()
-            + timedelta(seconds=WemoDiscovery.ADDITIONAL_SECONDS_BETWEEN_SCANS + 1),
-        )
-        await hass.async_block_till_done()
+            # Test that discovery runs periodically and the async_dispatcher_send code works.
+            async_fire_time_changed(
+                hass,
+                dt.utcnow()
+                + timedelta(seconds=WemoDiscovery.ADDITIONAL_SECONDS_BETWEEN_SCANS + 1),
+            )
+            await hass.async_block_till_done()
+            # Test that discover_statics runs during discovery
+            assert mock_discover_statics.call_count == 3
 
     # Verify that the expected number of devices were setup.
     entity_reg = er.async_get(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Wemo devices configured with static IPs will now be polled during device discovery. Wemo devices often have trouble maintaining consistent connections. The previous strategy of only trying once at startup to connect to statically configured devices meant some users rarely if ever managed to get all their devices connected at once

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47841
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
