### PR TITLE
Do not log error messages when discovering Broadlink devices

### DIFF
--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -77,7 +77,7 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         supported_types = set.union(*DOMAINS_AND_TYPES.values())
         if device.type not in supported_types:
-            raise data_entry_flow.AbortFlow("not_supported")
+            return self.async_abort("not_supported")
 
         await self.async_set_device(device)
         return await self.async_step_auth()

--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -62,15 +62,22 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         unique_id = discovery_info[MAC_ADDRESS].lower().replace(":", "")
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host})
+
         try:
             hello = partial(blk.discover, discover_ip_address=host)
             device = (await self.hass.async_add_executor_job(hello))[0]
+
         except IndexError:
             return self.async_abort(reason="cannot_connect")
+
         except OSError as err:
             if err.errno == errno.ENETUNREACH:
                 return self.async_abort(reason="cannot_connect")
             return self.async_abort(reason="unknown")
+
+        supported_types = set.union(*DOMAINS_AND_TYPES.values())
+        if device.type not in supported_types:
+            raise data_entry_flow.AbortFlow("not_supported")
 
         await self.async_set_device(device)
         return await self.async_step_auth()

--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -70,9 +70,6 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         except OSError as err:
             if err.errno == errno.ENETUNREACH:
                 return self.async_abort(reason="cannot_connect")
-            return self.async_abort(reason="invalid_host")
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.error("Failed to connect to the device at %s", host, exc_info=ex)
             return self.async_abort(reason="unknown")
 
         await self.async_set_device(device)

--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -77,7 +77,7 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         supported_types = set.union(*DOMAINS_AND_TYPES.values())
         if device.type not in supported_types:
-            return self.async_abort("not_supported")
+            return self.async_abort(reason="not_supported")
 
         await self.async_set_device(device)
         return await self.async_step_auth()

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -900,29 +900,10 @@ async def test_dhcp_unreachable(hass):
     assert result["reason"] == "cannot_connect"
 
 
-async def test_dhcp_connect_einval(hass):
-    """Test DHCP discovery flow that fails to connect with EINVAL."""
-    await setup.async_setup_component(hass, "persistent_notification", {})
-    with patch(DEVICE_DISCOVERY, side_effect=OSError(errno.EINVAL, None)):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": "dhcp"},
-            data={
-                HOSTNAME: "broadlink",
-                IP_ADDRESS: "1.2.3.4",
-                MAC_ADDRESS: "34:ea:34:b4:3b:5a",
-            },
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] == "abort"
-    assert result["reason"] == "invalid_host"
-
-
 async def test_dhcp_connect_unknown_error(hass):
-    """Test DHCP discovery flow that fails to connect with an unknown error."""
+    """Test DHCP discovery flow that fails to connect with an OSError."""
     await setup.async_setup_component(hass, "persistent_notification", {})
-    with patch(DEVICE_DISCOVERY, side_effect=ValueError("Unknown failure")):
+    with patch(DEVICE_DISCOVERY, side_effect=OSError()):
         result = await hass.config_entries.flow.async_init(
             DOMAIN,
             context={"source": "dhcp"},

--- a/tests/components/broadlink/test_config_flow.py
+++ b/tests/components/broadlink/test_config_flow.py
@@ -919,6 +919,27 @@ async def test_dhcp_connect_unknown_error(hass):
     assert result["reason"] == "unknown"
 
 
+async def test_dhcp_device_not_supported(hass):
+    """Test DHCP discovery flow that fails because the device is not supported."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    device = get_device("Kitchen")
+    mock_api = device.get_mock_api()
+
+    with patch(DEVICE_DISCOVERY, return_value=[mock_api]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": "dhcp"},
+            data={
+                HOSTNAME: "broadlink",
+                IP_ADDRESS: device.host,
+                MAC_ADDRESS: device_registry.format_mac(device.mac),
+            },
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_supported"
+
+
 async def test_dhcp_already_exists(hass):
     """Test DHCP discovery flow that fails to connect."""
     await setup.async_setup_component(hass, "persistent_notification", {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The DHCP component is logging an error message for unsupported devices, which is confusing the users. The proposal here is to remove the message. I am taking the opportunity to remove broad-except and errno.EINVAL exception handling. This will never happen.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/49337 fixes https://github.com/home-assistant/core/issues/49163 fixes https://github.com/home-assistant/core/issues/49134

- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
