### PR TITLE
Avoid executor jumps in history stats when no update is needed

### DIFF
--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -108,6 +108,7 @@ class HistoryStatsSensor(SensorEntity):
         self, hass, entity_id, entity_states, start, end, duration, sensor_type, name
     ):
         """Initialize the HistoryStats sensor."""
+        self.hass = hass
         self._entity_id = entity_id
         self._entity_states = entity_states
         self._duration = duration

--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import async_track_state_change_event
-from homeassistant.helpers.reload import setup_reload_service
+from homeassistant.helpers.reload import async_setup_reload_service
 import homeassistant.util.dt as dt_util
 
 from . import DOMAIN, PLATFORMS
@@ -74,9 +74,9 @@ PLATFORM_SCHEMA = vol.All(
 
 
 # noinspection PyUnusedLocal
-def setup_platform(hass, config, add_entities, discovery_info=None):
+async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Set up the History Stats sensor."""
-    setup_reload_service(hass, DOMAIN, PLATFORMS)
+    await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
     entity_id = config.get(CONF_ENTITY_ID)
     entity_states = config.get(CONF_STATE)
@@ -90,7 +90,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         if template is not None:
             template.hass = hass
 
-    add_entities(
+    async_add_entities(
         [
             HistoryStatsSensor(
                 hass, entity_id, entity_states, start, end, duration, sensor_type, name
@@ -186,7 +186,7 @@ class HistoryStatsSensor(SensorEntity):
         """Return the icon to use in the frontend, if any."""
         return ICON
 
-    def update(self):
+    async def async_update(self):
         """Get the latest data and updates the states."""
         # Get previous values of start and end
         p_start, p_end = self._period
@@ -218,6 +218,11 @@ class HistoryStatsSensor(SensorEntity):
             # Don't compute anything as the value cannot have changed
             return
 
+        await self.hass.async_add_executor_job(
+            self._update, start, end, now_timestamp, start_timestamp, end_timestamp
+        )
+
+    def _update(self, start, end, now_timestamp, start_timestamp, end_timestamp):
         # Get history between start and end
         history_list = history.state_changes_during_period(
             self.hass, start, end, str(self._entity_id)
@@ -265,7 +270,7 @@ class HistoryStatsSensor(SensorEntity):
         # Parse start
         if self._start is not None:
             try:
-                start_rendered = self._start.render()
+                start_rendered = self._start.async_render()
             except (TemplateError, TypeError) as ex:
                 HistoryStatsHelper.handle_template_exception(ex, "start")
                 return
@@ -285,7 +290,7 @@ class HistoryStatsSensor(SensorEntity):
         # Parse end
         if self._end is not None:
             try:
-                end_rendered = self._end.render()
+                end_rendered = self._end.async_render()
             except (TemplateError, TypeError) as ex:
                 HistoryStatsHelper.handle_template_exception(ex, "end")
                 return

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -118,144 +118,6 @@ class TestHistoryStatsSensor(unittest.TestCase):
         assert sensor2_end.minute == 0
         assert sensor2_end.second == 0
 
-    async def async_test_measure(self):
-        """Test the history statistics sensor measure."""
-        t0 = dt_util.utcnow() - timedelta(minutes=40)
-        t1 = t0 + timedelta(minutes=20)
-        t2 = dt_util.utcnow() - timedelta(minutes=10)
-
-        # Start     t0        t1        t2        End
-        # |--20min--|--20min--|--10min--|--10min--|
-        # |---off---|---on----|---off---|---on----|
-
-        fake_states = {
-            "binary_sensor.test_id": [
-                ha.State("binary_sensor.test_id", "on", last_changed=t0),
-                ha.State("binary_sensor.test_id", "off", last_changed=t1),
-                ha.State("binary_sensor.test_id", "on", last_changed=t2),
-            ]
-        }
-
-        start = Template("{{ as_timestamp(now()) - 3600 }}", self.hass)
-        end = Template("{{ now() }}", self.hass)
-
-        sensor1 = HistoryStatsSensor(
-            self.hass, "binary_sensor.test_id", "on", start, end, None, "time", "Test"
-        )
-
-        sensor2 = HistoryStatsSensor(
-            self.hass, "unknown.id", "on", start, end, None, "time", "Test"
-        )
-
-        sensor3 = HistoryStatsSensor(
-            self.hass, "binary_sensor.test_id", "on", start, end, None, "count", "test"
-        )
-
-        sensor4 = HistoryStatsSensor(
-            self.hass, "binary_sensor.test_id", "on", start, end, None, "ratio", "test"
-        )
-
-        assert sensor1._type == "time"
-        assert sensor3._type == "count"
-        assert sensor4._type == "ratio"
-
-        with patch(
-            "homeassistant.components.history.state_changes_during_period",
-            return_value=fake_states,
-        ), patch("homeassistant.components.history.get_state", return_value=None):
-            await sensor1.async_update()
-            await sensor2.async_update()
-            await sensor3.async_update()
-            await sensor4.async_update()
-
-        assert sensor1.state == 0.5
-        assert sensor2.state is None
-        assert sensor3.state == 2
-        assert sensor4.state == 50
-
-    async def test_measure_multiple(self):
-        """Test the history statistics sensor measure for multiple states."""
-        t0 = dt_util.utcnow() - timedelta(minutes=40)
-        t1 = t0 + timedelta(minutes=20)
-        t2 = dt_util.utcnow() - timedelta(minutes=10)
-
-        # Start     t0        t1        t2        End
-        # |--20min--|--20min--|--10min--|--10min--|
-        # |---------|--orange-|-default-|---blue--|
-
-        fake_states = {
-            "input_select.test_id": [
-                ha.State("input_select.test_id", "orange", last_changed=t0),
-                ha.State("input_select.test_id", "default", last_changed=t1),
-                ha.State("input_select.test_id", "blue", last_changed=t2),
-            ]
-        }
-
-        start = Template("{{ as_timestamp(now()) - 3600 }}", self.hass)
-        end = Template("{{ now() }}", self.hass)
-
-        sensor1 = HistoryStatsSensor(
-            self.hass,
-            "input_select.test_id",
-            ["orange", "blue"],
-            start,
-            end,
-            None,
-            "time",
-            "Test",
-        )
-
-        sensor2 = HistoryStatsSensor(
-            self.hass,
-            "unknown.id",
-            ["orange", "blue"],
-            start,
-            end,
-            None,
-            "time",
-            "Test",
-        )
-
-        sensor3 = HistoryStatsSensor(
-            self.hass,
-            "input_select.test_id",
-            ["orange", "blue"],
-            start,
-            end,
-            None,
-            "count",
-            "test",
-        )
-
-        sensor4 = HistoryStatsSensor(
-            self.hass,
-            "input_select.test_id",
-            ["orange", "blue"],
-            start,
-            end,
-            None,
-            "ratio",
-            "test",
-        )
-
-        assert sensor1._type == "time"
-        assert sensor3._type == "count"
-        assert sensor4._type == "ratio"
-
-        with patch(
-            "homeassistant.components.history.state_changes_during_period",
-            return_value=fake_states,
-        ), patch("homeassistant.components.history.get_state", return_value=None):
-            await sensor1.async_update()
-            await sensor2.async_update()
-            await sensor3.async_update()
-            await sensor4.async_update()
-
-        assert sensor1.state == 0.5
-        assert sensor2.state is None
-        assert sensor3.state == 2
-        assert sensor4.state == 50
-
     def test_wrong_date(self):
         """Test when start or end value is not a timestamp or a date."""
         good = Template("{{ now() }}", self.hass)
@@ -413,6 +275,146 @@ async def test_reload(hass):
 
     assert hass.states.get("sensor.test") is None
     assert hass.states.get("sensor.second_test")
+
+
+async def test_measure_multiple(hass):
+    """Test the history statistics sensor measure for multiple states."""
+    t0 = dt_util.utcnow() - timedelta(minutes=40)
+    t1 = t0 + timedelta(minutes=20)
+    t2 = dt_util.utcnow() - timedelta(minutes=10)
+
+    # Start     t0        t1        t2        End
+    # |--20min--|--20min--|--10min--|--10min--|
+    # |---------|--orange-|-default-|---blue--|
+
+    fake_states = {
+        "input_select.test_id": [
+            ha.State("input_select.test_id", "orange", last_changed=t0),
+            ha.State("input_select.test_id", "default", last_changed=t1),
+            ha.State("input_select.test_id", "blue", last_changed=t2),
+        ]
+    }
+
+    start = Template("{{ as_timestamp(now()) - 3600 }}", hass)
+    end = Template("{{ now() }}", hass)
+
+    sensor1 = HistoryStatsSensor(
+        hass,
+        "input_select.test_id",
+        ["orange", "blue"],
+        start,
+        end,
+        None,
+        "time",
+        "Test",
+    )
+
+    sensor2 = HistoryStatsSensor(
+        hass,
+        "unknown.id",
+        ["orange", "blue"],
+        start,
+        end,
+        None,
+        "time",
+        "Test",
+    )
+
+    sensor3 = HistoryStatsSensor(
+        hass,
+        "input_select.test_id",
+        ["orange", "blue"],
+        start,
+        end,
+        None,
+        "count",
+        "test",
+    )
+
+    sensor4 = HistoryStatsSensor(
+        hass,
+        "input_select.test_id",
+        ["orange", "blue"],
+        start,
+        end,
+        None,
+        "ratio",
+        "test",
+    )
+
+    assert sensor1._type == "time"
+    assert sensor3._type == "count"
+    assert sensor4._type == "ratio"
+
+    with patch(
+        "homeassistant.components.history.state_changes_during_period",
+        return_value=fake_states,
+    ), patch("homeassistant.components.history.get_state", return_value=None):
+        await sensor1.async_update()
+        await sensor2.async_update()
+        await sensor3.async_update()
+        await sensor4.async_update()
+
+    assert sensor1.state == 0.5
+    assert sensor2.state is None
+    assert sensor3.state == 2
+    assert sensor4.state == 50
+
+
+async def async_test_measure(hass):
+    """Test the history statistics sensor measure."""
+    t0 = dt_util.utcnow() - timedelta(minutes=40)
+    t1 = t0 + timedelta(minutes=20)
+    t2 = dt_util.utcnow() - timedelta(minutes=10)
+
+    # Start     t0        t1        t2        End
+    # |--20min--|--20min--|--10min--|--10min--|
+    # |---off---|---on----|---off---|---on----|
+
+    fake_states = {
+        "binary_sensor.test_id": [
+            ha.State("binary_sensor.test_id", "on", last_changed=t0),
+            ha.State("binary_sensor.test_id", "off", last_changed=t1),
+            ha.State("binary_sensor.test_id", "on", last_changed=t2),
+        ]
+    }
+
+    start = Template("{{ as_timestamp(now()) - 3600 }}", hass)
+    end = Template("{{ now() }}", hass)
+
+    sensor1 = HistoryStatsSensor(
+        hass, "binary_sensor.test_id", "on", start, end, None, "time", "Test"
+    )
+
+    sensor2 = HistoryStatsSensor(
+        hass, "unknown.id", "on", start, end, None, "time", "Test"
+    )
+
+    sensor3 = HistoryStatsSensor(
+        hass, "binary_sensor.test_id", "on", start, end, None, "count", "test"
+    )
+
+    sensor4 = HistoryStatsSensor(
+        hass, "binary_sensor.test_id", "on", start, end, None, "ratio", "test"
+    )
+
+    assert sensor1._type == "time"
+    assert sensor3._type == "count"
+    assert sensor4._type == "ratio"
+
+    with patch(
+        "homeassistant.components.history.state_changes_during_period",
+        return_value=fake_states,
+    ), patch("homeassistant.components.history.get_state", return_value=None):
+        await sensor1.async_update()
+        await sensor2.async_update()
+        await sensor3.async_update()
+        await sensor4.async_update()
+
+    assert sensor1.state == 0.5
+    assert sensor2.state is None
+    assert sensor3.state == 2
+    assert sensor4.state == 50
 
 
 def _get_fixtures_base_path():

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -118,7 +118,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
         assert sensor2_end.minute == 0
         assert sensor2_end.second == 0
 
-    def test_measure(self):
+    async def async_test_measure(self):
         """Test the history statistics sensor measure."""
         t0 = dt_util.utcnow() - timedelta(minutes=40)
         t1 = t0 + timedelta(minutes=20)
@@ -163,17 +163,17 @@ class TestHistoryStatsSensor(unittest.TestCase):
             "homeassistant.components.history.state_changes_during_period",
             return_value=fake_states,
         ), patch("homeassistant.components.history.get_state", return_value=None):
-            sensor1.update()
-            sensor2.update()
-            sensor3.update()
-            sensor4.update()
+            await sensor1.async_update()
+            await sensor2.async_update()
+            await sensor3.async_update()
+            await sensor4.async_update()
 
         assert sensor1.state == 0.5
         assert sensor2.state is None
         assert sensor3.state == 2
         assert sensor4.state == 50
 
-    def test_measure_multiple(self):
+    async def test_measure_multiple(self):
         """Test the history statistics sensor measure for multiple states."""
         t0 = dt_util.utcnow() - timedelta(minutes=40)
         t1 = t0 + timedelta(minutes=20)
@@ -246,10 +246,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
             "homeassistant.components.history.state_changes_during_period",
             return_value=fake_states,
         ), patch("homeassistant.components.history.get_state", return_value=None):
-            sensor1.update()
-            sensor2.update()
-            sensor3.update()
-            sensor4.update()
+            await sensor1.async_update()
+            await sensor2.async_update()
+            await sensor3.async_update()
+            await sensor4.async_update()
 
         assert sensor1.state == 0.5
         assert sensor2.state is None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid executor jumps in history stats when no update is needed

Noticed while logging all calls to `run_callback_threadsafe`

Note that the tests are still legacy and need to be updated at some point to not be bare async tests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
