### PR TITLE
Fix charging error in Roomba integration

### DIFF
--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 import async_timeout
-from roombapy import Roomba, RoombaConnectionError
+from roombapy import RoombaFactory, RoombaConnectionError
 
 from homeassistant import exceptions
 from homeassistant.const import (
@@ -40,7 +40,7 @@ async def async_setup_entry(hass, config_entry):
             },
         )
 
-    roomba = Roomba(
+    roomba = RoombaFactory.create_roomba(
         address=config_entry.data[CONF_HOST],
         blid=config_entry.data[CONF_BLID],
         password=config_entry.data[CONF_PASSWORD],

--- a/homeassistant/components/roomba/__init__.py
+++ b/homeassistant/components/roomba/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 
 import async_timeout
-from roombapy import RoombaFactory, RoombaConnectionError
+from roombapy import RoombaConnectionError, RoombaFactory
 
 from homeassistant import exceptions
 from homeassistant.const import (

--- a/homeassistant/components/roomba/config_flow.py
+++ b/homeassistant/components/roomba/config_flow.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from roombapy import Roomba
+from roombapy import RoombaFactory
 from roombapy.discovery import RoombaDiscovery
 from roombapy.getpassword import RoombaPassword
 import voluptuous as vol
@@ -40,7 +40,7 @@ async def validate_input(hass: core.HomeAssistant, data):
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
-    roomba = Roomba(
+    roomba = RoombaFactory.create_roomba(
         address=data[CONF_HOST],
         blid=data[CONF_BLID],
         password=data[CONF_PASSWORD],

--- a/homeassistant/components/roomba/manifest.json
+++ b/homeassistant/components/roomba/manifest.json
@@ -3,7 +3,7 @@
   "name": "iRobot Roomba and Braava",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roomba",
-  "requirements": ["roombapy==1.6.2"],
+  "requirements": ["roombapy==1.6.3"],
   "codeowners": ["@pschmitt", "@cyr-ius", "@shenxn"],
   "dhcp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1991,7 +1991,7 @@ rocketchat-API==0.6.1
 rokuecp==0.8.1
 
 # homeassistant.components.roomba
-roombapy==1.6.2
+roombapy==1.6.3
 
 # homeassistant.components.roon
 roonapi==0.0.32

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1058,7 +1058,7 @@ ring_doorbell==0.6.2
 rokuecp==0.8.1
 
 # homeassistant.components.roomba
-roombapy==1.6.2
+roombapy==1.6.3
 
 # homeassistant.components.roon
 roonapi==0.0.32

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -2,8 +2,7 @@
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
-from roombapy import RoombaConnectionError
-from roombapy.roomba import RoombaInfo
+from roombapy import RoombaConnectionError, RoombaInfo
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS

--- a/tests/components/roomba/test_config_flow.py
+++ b/tests/components/roomba/test_config_flow.py
@@ -143,7 +143,7 @@ async def test_form_user_discovery_and_password_fetch(hass):
     assert result2["step_id"] == "link"
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",
@@ -259,7 +259,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch(hass):
     assert result3["errors"] is None
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",
@@ -358,7 +358,7 @@ async def test_form_user_discovery_manual_and_auto_password_fetch_but_cannot_con
     assert result3["errors"] is None
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",
@@ -409,7 +409,7 @@ async def test_form_user_discovery_no_devices_found_and_auto_password_fetch(hass
     assert result2["errors"] is None
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",
@@ -478,7 +478,7 @@ async def test_form_user_discovery_no_devices_found_and_password_fetch_fails(has
         await hass.async_block_till_done()
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.async_setup_entry",
@@ -547,7 +547,7 @@ async def test_form_user_discovery_not_devices_found_and_password_fetch_fails_an
         await hass.async_block_till_done()
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.async_setup_entry",
@@ -605,7 +605,7 @@ async def test_form_user_discovery_and_password_fetch_gets_connection_refused(ha
         await hass.async_block_till_done()
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.async_setup_entry",
@@ -656,7 +656,7 @@ async def test_dhcp_discovery_and_roomba_discovery_finds(hass, discovery_data):
     assert result["description_placeholders"] == {"name": "robot_name"}
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",
@@ -726,7 +726,7 @@ async def test_dhcp_discovery_falls_back_to_manual(hass, discovery_data):
     assert result3["errors"] is None
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",
@@ -788,7 +788,7 @@ async def test_dhcp_discovery_no_devices_falls_back_to_manual(hass, discovery_da
     assert result2["errors"] is None
 
     with patch(
-        "homeassistant.components.roomba.config_flow.Roomba",
+        "homeassistant.components.roomba.config_flow.RoombaFactory.create_roomba",
         return_value=mocked_roomba,
     ), patch(
         "homeassistant.components.roomba.config_flow.RoombaPassword",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes #46132, which was caused by missing 'chargingerror' value in `ROOMBA_STATES`. This needed to be fixed in roombapy package first (https://github.com/pschmitt/roombapy/issues/67) and now since it's done, it's time to update the integration to use the new release of this dependency.

Changelog: https://github.com/pschmitt/roombapy/compare/pschmitt:1.6.2...1.6.3

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46132
- This PR is related to issue: https://github.com/pschmitt/roombapy/issues/67

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
