### PR TITLE
Accept both value and position cover templates

### DIFF
--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -62,7 +62,6 @@ POSITION_ACTION = "set_cover_position"
 TILT_ACTION = "set_cover_tilt_position"
 CONF_TILT_OPTIMISTIC = "tilt_optimistic"
 
-CONF_VALUE_OR_POSITION_TEMPLATE = "value_or_position"
 CONF_OPEN_OR_CLOSE = "open_or_close"
 
 TILT_FEATURES = (
@@ -79,12 +78,8 @@ COVER_SCHEMA = vol.All(
             vol.Inclusive(OPEN_ACTION, CONF_OPEN_OR_CLOSE): cv.SCRIPT_SCHEMA,
             vol.Inclusive(CLOSE_ACTION, CONF_OPEN_OR_CLOSE): cv.SCRIPT_SCHEMA,
             vol.Optional(STOP_ACTION): cv.SCRIPT_SCHEMA,
-            vol.Exclusive(
-                CONF_POSITION_TEMPLATE, CONF_VALUE_OR_POSITION_TEMPLATE
-            ): cv.template,
-            vol.Exclusive(
-                CONF_VALUE_TEMPLATE, CONF_VALUE_OR_POSITION_TEMPLATE
-            ): cv.template,
+            vol.Optional(CONF_POSITION_TEMPLATE): cv.template,
+            vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
             vol.Optional(CONF_POSITION_TEMPLATE): cv.template,
             vol.Optional(CONF_TILT_TEMPLATE): cv.template,
@@ -258,10 +253,11 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         state = str(result).lower()
 
         if state in _VALID_STATES:
-            if state in ("true", STATE_OPEN):
-                self._position = 100
-            else:
-                self._position = 0
+            if not self._position_template:
+                if state in ("true", STATE_OPEN):
+                    self._position = 100
+                else:
+                    self._position = 0
 
             self._is_opening = state == STATE_OPENING
             self._is_closing = state == STATE_CLOSING

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -251,8 +251,8 @@ async def test_template_out_of_bounds(hass, calls):
 
 
 async def test_template_mutex(hass, calls):
-    """Test that only value or position template can be used."""
-    with assert_setup_component(0, "cover"):
+    """Test that value and position template can be used."""
+    with assert_setup_component(1, "cover"):
         assert await setup.async_setup_component(
             hass,
             "cover",
@@ -261,7 +261,7 @@ async def test_template_mutex(hass, calls):
                     "platform": "template",
                     "covers": {
                         "test_template_cover": {
-                            "value_template": "{{ 1 == 1 }}",
+                            "value_template": "{{ 'opening' }}",
                             "position_template": "{{ 42 }}",
                             "open_cover": {
                                 "service": "cover.open_cover",
@@ -284,7 +284,9 @@ async def test_template_mutex(hass, calls):
     await hass.async_start()
     await hass.async_block_till_done()
 
-    assert hass.states.async_all() == []
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_OPENING
+    assert state.attributes.get("current_position") == 42.0
 
 
 async def test_template_open_or_position(hass, caplog):


### PR DESCRIPTION
## Proposed change

Instead of making `value_template` and `position_template` exclusive to
each other, accept that they are both given. In that case, only
`opening` and `closing` are taken into account, and `position_template`
takes precedence on all other state values.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:

```yaml
cover:
  - platform: template
    covers:
      garage_door:
        device_class: garage
        friendly_name: "Garage Door"
        value_template: >-
            {% if is_state('switch.garage_up', 'on') %}
                opening
            {% elif if state('switch.garage_down', 'on') %}
                closing
            {% elif is_state('sensor.garage_door_position', '0') %}
                closed
            {% else %}
                open
            {% endif %}
        position_template: "{{ states('sensor.garage_door_position') }}"
        open_cover:
          - service: switch.turn_off
            target:
              entity_id: switch.garage_down
          - service: switch.turn_on
            target:
              entity_id: switch.garage_up
        close_cover:
          - service: switch.turn_off
            target:
              entity_id: switch.garage_up
          - service: switch.turn_on
            target:
              entity_id: switch.garage_down
        stop_cover:
          - service: switch.turn_off
            target:
              entity_id: switch.garage_up
          - service: switch.turn_off
            target:
              entity_id: switch.garage_down
```
## Additional information

- This PR fixes or closes issue: fixes #38610
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17519

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
