### PR TITLE
Add support to enable/disable zwave_js data collection

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -50,6 +50,7 @@ from .const import (
     ATTR_TYPE,
     ATTR_VALUE,
     ATTR_VALUE_RAW,
+    CONF_DATA_COLLECTION_OPTED_IN,
     CONF_INTEGRATION_CREATED_ADDON,
     CONF_NETWORK_KEY,
     CONF_USB_PATH,
@@ -64,7 +65,7 @@ from .const import (
     ZWAVE_JS_VALUE_NOTIFICATION_EVENT,
 )
 from .discovery import async_discover_values
-from .helpers import get_device_id
+from .helpers import async_enable_statistics, get_device_id
 from .migrate import async_migrate_discovered_value
 from .services import ZWaveServices
 
@@ -321,6 +322,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             return
 
         LOGGER.info("Connection to Zwave JS Server initialized")
+
+        # If opt in preference hasn't been specified yet, we do nothing, otherwise
+        # we apply the preference
+        if opted_in := entry.data.get(CONF_DATA_COLLECTION_OPTED_IN):
+            await async_enable_statistics(client)
+        elif opted_in is False:
+            await client.driver.async_disable_statistics()
 
         # Check for nodes that no longer exist and remove them
         stored_devices = device_registry.async_entries_for_config_entry(

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -75,14 +75,7 @@ def async_get_entry(orig_func: Callable) -> Callable:
         """Provide user specific data and store to function."""
         entry_id = msg[ENTRY_ID]
         entry = hass.config_entries.async_get_entry(entry_id)
-        if not entry:
-            connection.send_error(
-                msg[ID], ERR_NOT_FOUND, "Specified config entry cannot be found"
-            )
-            return
-
         client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
-
         await orig_func(hass, connection, msg, entry, client)
 
     return async_get_entry_func

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -579,7 +579,7 @@ async def websocket_update_data_collection_preference(
     entry: ConfigEntry,
     client: Client,
 ) -> None:
-    """Opt in to statistics collection."""
+    """Update preference for data collection and enable/disable collection."""
     opted_in = msg[OPTED_IN]
     update_data_collection_preference(hass, entry, opted_in)
 
@@ -609,7 +609,7 @@ async def websocket_data_collection_status(
     entry: ConfigEntry,
     client: Client,
 ) -> None:
-    """Opt out to statistics collection."""
+    """Return data collection preference and status."""
     result = {
         OPTED_IN: entry.data.get(CONF_DATA_COLLECTION_OPTED_IN),
         ENABLED: await client.driver.async_is_statistics_enabled(),

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -8,7 +8,8 @@ from typing import Callable
 
 from aiohttp import hdrs, web, web_exceptions
 import voluptuous as vol
-from zwave_js_server import client, dump
+from zwave_js_server import dump
+from zwave_js_server.client import Client
 from zwave_js_server.const import LogLevel
 from zwave_js_server.exceptions import InvalidNewValue, NotFoundError, SetValueFailed
 from zwave_js_server.model.log_config import LogConfig
@@ -186,7 +187,7 @@ async def websocket_add_node(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Add a node to the Z-Wave network."""
     controller = client.driver.controller
@@ -259,7 +260,7 @@ async def websocket_stop_inclusion(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Cancel adding a node to the Z-Wave network."""
     controller = client.driver.controller
@@ -284,7 +285,7 @@ async def websocket_stop_exclusion(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Cancel removing a node from the Z-Wave network."""
     controller = client.driver.controller
@@ -309,7 +310,7 @@ async def websocket_remove_node(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Remove a node from the Z-Wave network."""
     controller = client.driver.controller
@@ -369,7 +370,7 @@ async def websocket_refresh_node_info(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Re-interview a node."""
     node_id = msg[NODE_ID]
@@ -401,7 +402,7 @@ async def websocket_set_config_parameter(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Set a config parameter value for a Z-Wave node."""
     node_id = msg[NODE_ID]
@@ -528,7 +529,7 @@ async def websocket_update_log_config(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Update the driver log config."""
     await client.driver.async_update_log_config(LogConfig(**msg[CONFIG]))
@@ -551,7 +552,7 @@ async def websocket_get_log_config(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Get log configuration for the Z-Wave JS driver."""
     result = await client.driver.async_get_log_config()
@@ -576,7 +577,7 @@ async def websocket_update_data_collection_preference(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Opt in to statistics collection."""
     opted_in = msg[OPTED_IN]
@@ -606,7 +607,7 @@ async def websocket_data_collection_status(
     connection: ActiveConnection,
     msg: dict,
     entry: ConfigEntry,
-    client: client.Client,
+    client: Client,
 ) -> None:
     """Opt out to statistics collection."""
     result = {

--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -7,6 +7,7 @@ CONF_INTEGRATION_CREATED_ADDON = "integration_created_addon"
 CONF_NETWORK_KEY = "network_key"
 CONF_USB_PATH = "usb_path"
 CONF_USE_ADDON = "use_addon"
+CONF_DATA_COLLECTION_OPTED_IN = "data_collection_opted_in"
 DOMAIN = "zwave_js"
 
 DATA_CLIENT = "client"

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from typing import cast
 
 from zwave_js_server.client import Client as ZwaveClient
-from zwave_js_server.exceptions import NotFoundError
 from zwave_js_server.model.node import Node as ZwaveNode
 
 from homeassistant.config_entries import ConfigEntry
@@ -26,8 +25,6 @@ def update_data_collection_preference(
     hass: HomeAssistant, entry: ConfigEntry, preference: bool
 ) -> None:
     """Update data collection preference on config entry."""
-    if not entry:
-        raise NotFoundError("Config entry cannot be found")
     new_data = entry.data.copy()
     new_data[CONF_DATA_COLLECTION_OPTED_IN] = preference
     hass.config_entries.async_update_entry(entry, data=new_data)

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -23,10 +23,9 @@ async def async_enable_statistics(client: ZwaveClient) -> None:
 
 @callback
 def update_data_collection_preference(
-    hass: HomeAssistant, entry_id: str, preference: bool
+    hass: HomeAssistant, entry: ConfigEntry, preference: bool
 ) -> None:
     """Update data collection preference on config entry."""
-    entry = hass.config_entries.async_get_entry(entry_id)
     if not entry:
         raise NotFoundError("Config entry cannot be found")
     new_data = entry.data.copy()

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -17,12 +17,16 @@ from homeassistant.components.zwave_js.api import (
     LEVEL,
     LOG_TO_FILE,
     NODE_ID,
+    OPTED_IN,
     PROPERTY,
     PROPERTY_KEY,
     TYPE,
     VALUE,
 )
-from homeassistant.components.zwave_js.const import DOMAIN
+from homeassistant.components.zwave_js.const import (
+    CONF_DATA_COLLECTION_OPTED_IN,
+    DOMAIN,
+)
 from homeassistant.helpers import device_registry as dr
 
 
@@ -552,3 +556,96 @@ async def test_get_log_config(hass, client, integration, hass_ws_client):
     assert log_config["log_to_file"] is False
     assert log_config["filename"] == "/test.txt"
     assert log_config["force_console"] is False
+
+
+async def test_data_collection(hass, client, integration, hass_ws_client):
+    """Test that the data collection WS API commands work."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    client.async_send_command.return_value = {"statisticsEnabled": False}
+    await ws_client.send_json(
+        {
+            ID: 1,
+            TYPE: "zwave_js/data_collection_status",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+    assert result == {"opted_in": None, "enabled": False}
+
+    assert len(client.async_send_command.call_args_list) == 1
+    assert client.async_send_command.call_args[0][0] == {
+        "command": "driver.is_statistics_enabled"
+    }
+
+    assert CONF_DATA_COLLECTION_OPTED_IN not in entry.data
+
+    client.async_send_command.reset_mock()
+
+    client.async_send_command.return_value = {}
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "zwave_js/update_data_collection_preference",
+            ENTRY_ID: entry.entry_id,
+            OPTED_IN: True,
+        }
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+    assert result is None
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "driver.enable_statistics"
+    assert args["applicationName"] == "Home Assistant"
+    assert entry.data[CONF_DATA_COLLECTION_OPTED_IN]
+
+    client.async_send_command.reset_mock()
+
+    client.async_send_command.return_value = {}
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/update_data_collection_preference",
+            ENTRY_ID: entry.entry_id,
+            OPTED_IN: False,
+        }
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+    assert result is None
+
+    assert len(client.async_send_command.call_args_list) == 1
+    assert client.async_send_command.call_args[0][0] == {
+        "command": "driver.disable_statistics"
+    }
+    assert not entry.data[CONF_DATA_COLLECTION_OPTED_IN]
+
+    client.async_send_command.reset_mock()
+
+    # Test invalid ID
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/update_data_collection_preference",
+            ENTRY_ID: "invalid_id",
+            OPTED_IN: False,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"
+
+    await ws_client.send_json(
+        {
+            ID: 5,
+            TYPE: "zwave_js/data_collection_status",
+            ENTRY_ID: "invalid_id",
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -625,27 +625,3 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
     assert not entry.data[CONF_DATA_COLLECTION_OPTED_IN]
 
     client.async_send_command.reset_mock()
-
-    # Test invalid ID
-    await ws_client.send_json(
-        {
-            ID: 4,
-            TYPE: "zwave_js/update_data_collection_preference",
-            ENTRY_ID: "invalid_id",
-            OPTED_IN: False,
-        }
-    )
-    msg = await ws_client.receive_json()
-    assert not msg["success"]
-    assert msg["error"]["code"] == "not_found"
-
-    await ws_client.send_json(
-        {
-            ID: 5,
-            TYPE: "zwave_js/data_collection_status",
-            ENTRY_ID: "invalid_id",
-        }
-    )
-    msg = await ws_client.receive_json()
-    assert not msg["success"]
-    assert msg["error"]["code"] == "not_found"

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -99,7 +99,7 @@ async def test_disabled_statistics(hass, client):
 
 
 async def test_noop_statistics(hass, client):
-    """Test that we don't make any statistics calls if user hasn't provided preferencee."""
+    """Test that we don't make any statistics calls if user hasn't provided preference."""
     entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
     entry.add_to_hass(hass)
 

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -66,6 +66,54 @@ async def test_initialized_timeout(hass, client, connect_timeout):
     assert entry.state == ENTRY_STATE_SETUP_RETRY
 
 
+async def test_enabled_statistics(hass, client):
+    """Test that we enabled statistics if the entry is opted in."""
+    entry = MockConfigEntry(
+        domain="zwave_js",
+        data={"url": "ws://test.org", "data_collection_opted_in": True},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_enable_statistics"
+    ) as mock_cmd:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert mock_cmd.called
+
+
+async def test_disabled_statistics(hass, client):
+    """Test that we diisabled statistics if the entry is opted out."""
+    entry = MockConfigEntry(
+        domain="zwave_js",
+        data={"url": "ws://test.org", "data_collection_opted_in": False},
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_disable_statistics"
+    ) as mock_cmd:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert mock_cmd.called
+
+
+async def test_noop_statistics(hass, client):
+    """Test that we don't make any statistics calls if user hasn't provided preferencee."""
+    entry = MockConfigEntry(domain="zwave_js", data={"url": "ws://test.org"})
+    entry.add_to_hass(hass)
+
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_enable_statistics"
+    ) as mock_cmd1, patch(
+        "zwave_js_server.model.driver.Driver.async_disable_statistics"
+    ) as mock_cmd2:
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+        assert not mock_cmd1.called
+        assert not mock_cmd2.called
+
+
 @pytest.mark.parametrize("error", [BaseZwaveJSServerError("Boom"), Exception("Boom")])
 async def test_listen_failure(hass, client, error):
     """Test we handle errors during client listen."""


### PR DESCRIPTION
## Proposed change
With the latest server (unreleased as of now), we can now enable and disable data collection. We need to add the opt in capability to the UI. In the meantime, with this PR, we check for the presence of an opt in or opt out preference, and enable or disable statistics accordingly. This means that if multiple clients connect to the same server, the latest one to connect that has a preference will control the data collection behavior. I've also added WS API commands to opt in, opt out, and get the current status of data collection.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
