### PR TITLE
Add WS API command to capture zwave_js logs from server

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -498,7 +498,7 @@ def filename_is_present_if_logging_to_file(obj: dict) -> dict:
 @websocket_api.async_response
 @websocket_api.websocket_command(
     {
-        vol.Required(TYPE): "zwave_js/start_listening_logs",
+        vol.Required(TYPE): "zwave_js/subscribe_logs",
         vol.Required(ENTRY_ID): str,
     }
 )

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1,7 +1,6 @@
 """Websocket API for Z-Wave JS."""
 from __future__ import annotations
 
-import asyncio
 import dataclasses
 from functools import wraps
 import json
@@ -514,9 +513,7 @@ async def websocket_start_listening_logs(
     @callback
     def async_cleanup() -> None:
         """Remove signal listeners."""
-        asyncio.run_coroutine_threadsafe(
-            driver.async_stop_listening_logs(), hass.loop
-        ).result()
+        hass.async_create_task(driver.async_stop_listening_logs())
         for unsub in unsubs:
             unsub()
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -498,12 +498,15 @@ def filename_is_present_if_logging_to_file(obj: dict) -> dict:
         vol.Required(ENTRY_ID): str,
     }
 )
+@async_get_entry
 async def websocket_subscribe_logs(
-    hass: HomeAssistant, connection: ActiveConnection, msg: dict
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+    entry: ConfigEntry,
+    client: Client,
 ) -> None:
     """Subscribe to log message events from the server."""
-    entry_id = msg[ENTRY_ID]
-    client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
     driver = client.driver
 
     @callback

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -96,6 +96,8 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_remove_node)
     websocket_api.async_register_command(hass, websocket_stop_exclusion)
     websocket_api.async_register_command(hass, websocket_refresh_node_info)
+    websocket_api.async_register_command(hass, websocket_start_listening_logs)
+    websocket_api.async_register_command(hass, websocket_stop_listening_logs)
     websocket_api.async_register_command(hass, websocket_update_log_config)
     websocket_api.async_register_command(hass, websocket_get_log_config)
     websocket_api.async_register_command(hass, websocket_get_config_parameters)

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -522,7 +522,7 @@ async def websocket_subscribe_logs(
                     "timestamp": log_msg.timestamp,
                     "level": log_msg.level,
                     "primary_tags": log_msg.primary_tags,
-                    "formatted_message": log_msg.formatted_message,
+                    "message": log_msg.formatted_message,
                 },
             )
         )

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -532,13 +532,7 @@ async def websocket_start_listening_logs(
             )
         )
 
-    connection.subscriptions[msg["id"]] = async_cleanup
-    unsubs = [
-        driver.on("logging", forward_event),
-        async_dispatcher_connect(
-            hass, f"{entry_id}_stop_listening_logs", async_cleanup
-        ),
-    ]
+    connection.subscriptions[msg["id"]] = driver.on("logging", forward_event)
 
     await driver.async_start_listening_logs()
     connection.send_result(msg[ID])

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -403,6 +403,48 @@ async def test_dump_view_invalid_entry_id(integration, hass_client):
     assert resp.status == 400
 
 
+async def test_subscribe_logs(hass, integration, client, hass_ws_client):
+    """Test the subscribe_logs websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    client.async_send_command.return_value = {}
+
+    await ws_client.send_json(
+        {ID: 1, TYPE: "zwave_js/subscribe_logs", ENTRY_ID: entry.entry_id}
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    event = Event(
+        type="logging",
+        data={
+            "source": "driver",
+            "event": "logging",
+            "message": "test",
+            "formattedMessage": "test",
+            "direction": ">",
+            "level": "debug",
+            "primaryTags": "tag",
+            "secondaryTags": "tag2",
+            "secondaryTagPadding": 0,
+            "multiline": False,
+            "timestamp": "time",
+            "label": "label",
+        },
+    )
+    client.driver.receive_event(event)
+
+    msg = await ws_client.receive_json()
+    assert msg["event"] == {
+        "message": ["test"],
+        "level": "debug",
+        "primary_tags": "tag",
+        "timestamp": "time",
+    }
+
+
 async def test_update_log_config(hass, client, integration, hass_ws_client):
     """Test that the update_log_config WS API call works and that schema validation works."""
     entry = integration


### PR DESCRIPTION
## Proposed change
We can now receive and listen to logs from zwave-js-server. This PR adds related WS API commands to do that so we can instrument it from the UI.

We should wait until https://github.com/home-assistant/core/pull/49440 is merged to merge this so we can reuse the decorator

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
