### PR TITLE
Bump zwave_js dependency to 0.24.0

### DIFF
--- a/homeassistant/components/zwave_js/manifest.json
+++ b/homeassistant/components/zwave_js/manifest.json
@@ -3,7 +3,7 @@
   "name": "Z-Wave JS",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/zwave_js",
-  "requirements": ["zwave-js-server-python==0.23.1"],
+  "requirements": ["zwave-js-server-python==0.24.0"],
   "codeowners": ["@home-assistant/z-wave"],
   "dependencies": ["http", "websocket_api"],
   "iot_class": "local_push"

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -94,9 +94,7 @@ class ZWaveServices:
                 {
                     vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
                     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-                    vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Any(
-                        vol.Coerce(int), cv.string
-                    ),
+                    vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Coerce(int),
                     vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
                         vol.Coerce(int),
                         {

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -100,9 +100,9 @@ class ZWaveServices:
                     vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
                         vol.Coerce(int),
                         {
-                            vol.Any(vol.Coerce(int), BITMASK_SCHEMA): vol.Any(
-                                vol.Coerce(int), cv.string
-                            )
+                            vol.Any(
+                                vol.Coerce(int), BITMASK_SCHEMA, cv.string
+                            ): vol.Any(vol.Coerce(int), cv.string)
                         },
                     ),
                 },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2411,4 +2411,4 @@ zigpy==0.33.0
 zm-py==0.5.2
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.23.1
+zwave-js-server-python==0.24.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1278,4 +1278,4 @@ zigpy-znp==0.4.0
 zigpy==0.33.0
 
 # homeassistant.components.zwave_js
-zwave-js-server-python==0.23.1
+zwave-js-server-python==0.24.0

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -419,7 +419,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
 
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "update_log_config"
+    assert args["command"] == "driver.update_log_config"
     assert args["config"] == {"level": "error"}
 
     client.async_send_command.reset_mock()
@@ -439,7 +439,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
 
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "update_log_config"
+    assert args["command"] == "driver.update_log_config"
     assert args["config"] == {"logToFile": True, "filename": "/test"}
 
     client.async_send_command.reset_mock()
@@ -465,7 +465,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
 
     assert len(client.async_send_command.call_args_list) == 1
     args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "update_log_config"
+    assert args["command"] == "driver.update_log_config"
     assert args["config"] == {
         "level": "error",
         "logToFile": True,


### PR DESCRIPTION
## Proposed change
Changelog: https://github.com/home-assistant-libs/zwave-js-server-python/releases/tag/0.24.0

Because of this line (`Support property names in bulk_set_partial_config_parameters (@raman325)`) and the last line of the description of the PR (https://github.com/home-assistant-libs/zwave-js-server-python/pull/188#issue-611738815), I also updated the schema for the `bulk_set_partial_config_parameters` service.

Finally, while reviewing this change, I realized that the schema is currently wrong and will cause the utility function call to fail. Updating the schema will help prevent the user from making a mistake.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17527

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
