### PR TITLE
Send only a single event per incoming Google command

### DIFF
--- a/homeassistant/components/google_assistant/smart_home.py
+++ b/homeassistant/components/google_assistant/smart_home.py
@@ -116,20 +116,22 @@ async def async_devices_query(hass, data, payload):
 
     https://developers.google.com/assistant/smarthome/develop/process-intents#QUERY
     """
+    payload_devices = payload.get("devices", [])
+
+    hass.bus.async_fire(
+        EVENT_QUERY_RECEIVED,
+        {
+            "request_id": data.request_id,
+            ATTR_ENTITY_ID: [device["id"] for device in payload_devices],
+            "source": data.source,
+        },
+        context=data.context,
+    )
+
     devices = {}
-    for device in payload.get("devices", []):
+    for device in payload_devices:
         devid = device["id"]
         state = hass.states.get(devid)
-
-        hass.bus.async_fire(
-            EVENT_QUERY_RECEIVED,
-            {
-                "request_id": data.request_id,
-                ATTR_ENTITY_ID: devid,
-                "source": data.source,
-            },
-            context=data.context,
-        )
 
         if not state:
             # If we can't find a state, the device is offline
@@ -175,19 +177,19 @@ async def handle_devices_execute(hass, data, payload):
     results = {}
 
     for command in payload["commands"]:
+        hass.bus.async_fire(
+            EVENT_COMMAND_RECEIVED,
+            {
+                "request_id": data.request_id,
+                ATTR_ENTITY_ID: [device["id"] for device in command["devices"]],
+                "execution": command["execution"],
+                "source": data.source,
+            },
+            context=data.context,
+        )
+
         for device, execution in product(command["devices"], command["execution"]):
             entity_id = device["id"]
-
-            hass.bus.async_fire(
-                EVENT_COMMAND_RECEIVED,
-                {
-                    "request_id": data.request_id,
-                    ATTR_ENTITY_ID: entity_id,
-                    "execution": execution,
-                    "source": data.source,
-                },
-                context=data.context,
-            )
 
             # Happens if error occurred. Skip entity for further processing
             if entity_id in results:

--- a/tests/components/google_assistant/test_logbook.py
+++ b/tests/components/google_assistant/test_logbook.py
@@ -32,11 +32,13 @@ async def test_humanify_command_received(hass):
                     EVENT_COMMAND_RECEIVED,
                     {
                         "request_id": "abcd",
-                        ATTR_ENTITY_ID: "light.kitchen",
-                        "execution": {
-                            "command": "action.devices.commands.OnOff",
-                            "params": {"on": True},
-                        },
+                        ATTR_ENTITY_ID: ["light.kitchen"],
+                        "execution": [
+                            {
+                                "command": "action.devices.commands.OnOff",
+                                "params": {"on": True},
+                            }
+                        ],
                         "source": SOURCE_LOCAL,
                     },
                 ),
@@ -44,11 +46,13 @@ async def test_humanify_command_received(hass):
                     EVENT_COMMAND_RECEIVED,
                     {
                         "request_id": "abcd",
-                        ATTR_ENTITY_ID: "light.non_existing",
-                        "execution": {
-                            "command": "action.devices.commands.OnOff",
-                            "params": {"on": False},
-                        },
+                        ATTR_ENTITY_ID: ["light.non_existing"],
+                        "execution": [
+                            {
+                                "command": "action.devices.commands.OnOff",
+                                "params": {"on": False},
+                            }
+                        ],
                         "source": SOURCE_CLOUD,
                     },
                 ),
@@ -63,10 +67,8 @@ async def test_humanify_command_received(hass):
 
     assert event1["name"] == "Google Assistant"
     assert event1["domain"] == DOMAIN
-    assert event1["message"] == "sent command OnOff for The Kitchen Lights (via local)"
-    assert event1["entity_id"] == "light.kitchen"
+    assert event1["message"] == "sent command OnOff (via local)"
 
     assert event2["name"] == "Google Assistant"
     assert event2["domain"] == DOMAIN
-    assert event2["message"] == "sent command OnOff for light.non_existing (via cloud)"
-    assert event2["entity_id"] == "light.non_existing"
+    assert event2["message"] == "sent command OnOff"

--- a/tests/components/google_assistant/test_smart_home.py
+++ b/tests/components/google_assistant/test_smart_home.py
@@ -353,29 +353,16 @@ async def test_query_message(hass):
 
     await hass.async_block_till_done()
 
-    assert len(events) == 4
+    assert len(events) == 1
     assert events[0].event_type == EVENT_QUERY_RECEIVED
     assert events[0].data == {
         "request_id": REQ_ID,
-        "entity_id": "light.demo_light",
-        "source": "cloud",
-    }
-    assert events[1].event_type == EVENT_QUERY_RECEIVED
-    assert events[1].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.another_light",
-        "source": "cloud",
-    }
-    assert events[2].event_type == EVENT_QUERY_RECEIVED
-    assert events[2].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.color_temp_light",
-        "source": "cloud",
-    }
-    assert events[3].event_type == EVENT_QUERY_RECEIVED
-    assert events[3].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.non_existing",
+        "entity_id": [
+            "light.demo_light",
+            "light.another_light",
+            "light.color_temp_light",
+            "light.non_existing",
+        ],
         "source": "cloud",
     }
 
@@ -467,65 +454,25 @@ async def test_execute(hass):
         },
     }
 
-    assert len(events) == 6
+    assert len(events) == 1
     assert events[0].event_type == EVENT_COMMAND_RECEIVED
     assert events[0].data == {
         "request_id": REQ_ID,
-        "entity_id": "light.non_existing",
-        "execution": {
-            "command": "action.devices.commands.OnOff",
-            "params": {"on": True},
-        },
-        "source": "cloud",
-    }
-    assert events[1].event_type == EVENT_COMMAND_RECEIVED
-    assert events[1].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.non_existing",
-        "execution": {
-            "command": "action.devices.commands.BrightnessAbsolute",
-            "params": {"brightness": 20},
-        },
-        "source": "cloud",
-    }
-    assert events[2].event_type == EVENT_COMMAND_RECEIVED
-    assert events[2].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.ceiling_lights",
-        "execution": {
-            "command": "action.devices.commands.OnOff",
-            "params": {"on": True},
-        },
-        "source": "cloud",
-    }
-    assert events[3].event_type == EVENT_COMMAND_RECEIVED
-    assert events[3].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.ceiling_lights",
-        "execution": {
-            "command": "action.devices.commands.BrightnessAbsolute",
-            "params": {"brightness": 20},
-        },
-        "source": "cloud",
-    }
-    assert events[4].event_type == EVENT_COMMAND_RECEIVED
-    assert events[4].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.kitchen_lights",
-        "execution": {
-            "command": "action.devices.commands.OnOff",
-            "params": {"on": True},
-        },
-        "source": "cloud",
-    }
-    assert events[5].event_type == EVENT_COMMAND_RECEIVED
-    assert events[5].data == {
-        "request_id": REQ_ID,
-        "entity_id": "light.kitchen_lights",
-        "execution": {
-            "command": "action.devices.commands.BrightnessAbsolute",
-            "params": {"brightness": 20},
-        },
+        "entity_id": [
+            "light.non_existing",
+            "light.ceiling_lights",
+            "light.kitchen_lights",
+        ],
+        "execution": [
+            {
+                "command": "action.devices.commands.OnOff",
+                "params": {"on": True},
+            },
+            {
+                "command": "action.devices.commands.BrightnessAbsolute",
+                "params": {"brightness": 20},
+            },
+        ],
         "source": "cloud",
     }
 
@@ -543,9 +490,8 @@ async def test_execute(hass):
         "service": "turn_on",
         "service_data": {"brightness_pct": 20, "entity_id": "light.ceiling_lights"},
     }
-    assert service_events[0].context == events[2].context
-    assert service_events[1].context == events[2].context
-    assert service_events[1].context == events[3].context
+    assert service_events[0].context == events[0].context
+    assert service_events[1].context == events[0].context
     assert service_events[2].data == {
         "domain": "light",
         "service": "turn_on",
@@ -556,9 +502,8 @@ async def test_execute(hass):
         "service": "turn_on",
         "service_data": {"brightness_pct": 20, "entity_id": "light.kitchen_lights"},
     }
-    assert service_events[2].context == events[4].context
-    assert service_events[3].context == events[4].context
-    assert service_events[3].context == events[5].context
+    assert service_events[2].context == events[0].context
+    assert service_events[3].context == events[0].context
 
 
 async def test_raising_error_trait(hass):
@@ -618,11 +563,13 @@ async def test_raising_error_trait(hass):
     assert events[0].event_type == EVENT_COMMAND_RECEIVED
     assert events[0].data == {
         "request_id": REQ_ID,
-        "entity_id": "climate.bla",
-        "execution": {
-            "command": "action.devices.commands.ThermostatTemperatureSetpoint",
-            "params": {"thermostatTemperatureSetpoint": 10},
-        },
+        "entity_id": ["climate.bla"],
+        "execution": [
+            {
+                "command": "action.devices.commands.ThermostatTemperatureSetpoint",
+                "params": {"thermostatTemperatureSetpoint": 10},
+            }
+        ],
         "source": "cloud",
     }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Google Assistant would fire a command per entity per execution that came in. This was overkill as it caused a lot of events for a single incoming command. We now group the entities just like they came in from Google.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
