### PR TITLE
Ensure harmony callbacks run in the event loop

### DIFF
--- a/homeassistant/components/harmony/connection_state.py
+++ b/homeassistant/components/harmony/connection_state.py
@@ -16,14 +16,14 @@ class ConnectionStateMixin:
         super().__init__()
         self._unsub_mark_disconnected = None
 
-    async def got_connected(self, _=None):
+    async def async_got_connected(self, _=None):
         """Notification that we're connected to the HUB."""
         _LOGGER.debug("%s: connected to the HUB", self._name)
         self.async_write_ha_state()
 
         self._clear_disconnection_delay()
 
-    async def got_disconnected(self, _=None):
+    async def async_got_disconnected(self, _=None):
         """Notification that we're disconnected from the HUB."""
         _LOGGER.debug("%s: disconnected from the HUB", self._name)
         # We're going to wait for 10 seconds before announcing we're

--- a/homeassistant/components/harmony/remote.py
+++ b/homeassistant/components/harmony/remote.py
@@ -16,7 +16,7 @@ from homeassistant.components.remote import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_platform
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -115,16 +115,17 @@ class HarmonyRemote(ConnectionStateMixin, remote.RemoteEntity, RestoreEntity):
 
     def _setup_callbacks(self):
         callbacks = {
-            "connected": self.got_connected,
-            "disconnected": self.got_disconnected,
-            "config_updated": self.new_config,
-            "activity_starting": self.new_activity,
-            "activity_started": self._new_activity_finished,
+            "connected": self.async_got_connected,
+            "disconnected": self.async_got_disconnected,
+            "config_updated": self.async_new_config,
+            "activity_starting": self.async_new_activity,
+            "activity_started": self.async_new_activity_finished,
         }
 
         self.async_on_remove(self._data.async_subscribe(HarmonyCallback(**callbacks)))
 
-    def _new_activity_finished(self, activity_info: tuple) -> None:
+    @callback
+    def async_new_activity_finished(self, activity_info: tuple) -> None:
         """Call for finished updated current activity."""
         self._activity_starting = None
         self.async_write_ha_state()
@@ -148,7 +149,7 @@ class HarmonyRemote(ConnectionStateMixin, remote.RemoteEntity, RestoreEntity):
 
         # Store Harmony HUB config, this will also update our current
         # activity
-        await self.new_config()
+        await self.async_new_config()
 
         # Restore the last activity so we know
         # how what to turn on if nothing
@@ -212,7 +213,8 @@ class HarmonyRemote(ConnectionStateMixin, remote.RemoteEntity, RestoreEntity):
         """Return True if connected to Hub, otherwise False."""
         return self._data.available
 
-    def new_activity(self, activity_info: tuple) -> None:
+    @callback
+    def async_new_activity(self, activity_info: tuple) -> None:
         """Call for updating the current activity."""
         activity_id, activity_name = activity_info
         _LOGGER.debug("%s: activity reported as: %s", self._name, activity_name)
@@ -229,10 +231,10 @@ class HarmonyRemote(ConnectionStateMixin, remote.RemoteEntity, RestoreEntity):
         self._state = bool(activity_id != -1)
         self.async_write_ha_state()
 
-    async def new_config(self, _=None):
+    async def async_new_config(self, _=None):
         """Call for updating the current activity."""
         _LOGGER.debug("%s: configuration has been updated", self._name)
-        self.new_activity(self._data.current_activity)
+        self.async_new_activity(self._data.current_activity)
         await self.hass.async_add_executor_job(self.write_config_file)
 
     async def async_turn_on(self, **kwargs):

--- a/homeassistant/components/harmony/switch.py
+++ b/homeassistant/components/harmony/switch.py
@@ -3,6 +3,7 @@ import logging
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import CONF_NAME
+from homeassistant.core import callback
 
 from .connection_state import ConnectionStateMixin
 from .const import DOMAIN, HARMONY_DATA
@@ -80,14 +81,15 @@ class HarmonyActivitySwitch(ConnectionStateMixin, SwitchEntity):
         """Call when entity is added to hass."""
 
         callbacks = {
-            "connected": self.got_connected,
-            "disconnected": self.got_disconnected,
-            "activity_starting": self._activity_update,
-            "activity_started": self._activity_update,
+            "connected": self.async_got_connected,
+            "disconnected": self.async_got_disconnected,
+            "activity_starting": self._async_activity_update,
+            "activity_started": self._async_activity_update,
             "config_updated": None,
         }
 
         self.async_on_remove(self._data.async_subscribe(HarmonyCallback(**callbacks)))
 
-    def _activity_update(self, activity_info: tuple):
+    @callback
+    def _async_activity_update(self, activity_info: tuple):
         self.async_write_ha_state()


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure harmony callbacks run in the event loop

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
