### PR TITLE
Change HomeAssistantType to HomeAssistant

### DIFF
--- a/tests/components/canary/__init__.py
+++ b/tests/components/canary/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.components.canary.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -51,7 +51,7 @@ def _patch_async_setup_entry(return_value=True):
 
 
 async def init_integration(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     *,
     data: dict = ENTRY_CONFIG,
     options: dict = ENTRY_OPTIONS,

--- a/tests/components/cast/test_media_player.py
+++ b/tests/components/cast/test_media_player.py
@@ -28,9 +28,9 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.config import async_process_ha_core_config
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry, assert_setup_component
@@ -158,7 +158,7 @@ async def async_setup_cast_internal_discovery(hass, config=None):
     return discover_chromecast, remove_chromecast, add_entities
 
 
-async def async_setup_media_player_cast(hass: HomeAssistantType, info: ChromecastInfo):
+async def async_setup_media_player_cast(hass: HomeAssistant, info: ChromecastInfo):
     """Set up the cast platform with async_setup_component."""
     browser = MagicMock(devices={}, zc={})
     chromecast = get_fake_chromecast(info)
@@ -549,7 +549,7 @@ async def test_update_cast_chromecasts(hass):
     assert add_dev1.call_count == 1
 
 
-async def test_entity_availability(hass: HomeAssistantType):
+async def test_entity_availability(hass: HomeAssistant):
     """Test handling of connection status."""
     entity_id = "media_player.speaker"
     info = get_fake_chromecast_info()
@@ -575,7 +575,7 @@ async def test_entity_availability(hass: HomeAssistantType):
     assert state.state == "unavailable"
 
 
-async def test_entity_cast_status(hass: HomeAssistantType):
+async def test_entity_cast_status(hass: HomeAssistant):
     """Test handling of cast status."""
     entity_id = "media_player.speaker"
     reg = er.async_get(hass)
@@ -644,7 +644,7 @@ async def test_entity_cast_status(hass: HomeAssistantType):
     )
 
 
-async def test_entity_play_media(hass: HomeAssistantType):
+async def test_entity_play_media(hass: HomeAssistant):
     """Test playing media."""
     entity_id = "media_player.speaker"
     reg = er.async_get(hass)
@@ -673,7 +673,7 @@ async def test_entity_play_media(hass: HomeAssistantType):
     chromecast.media_controller.play_media.assert_called_once_with("best.mp3", "audio")
 
 
-async def test_entity_play_media_cast(hass: HomeAssistantType, quick_play_mock):
+async def test_entity_play_media_cast(hass: HomeAssistant, quick_play_mock):
     """Test playing media with cast special features."""
     entity_id = "media_player.speaker"
     reg = er.async_get(hass)
@@ -752,7 +752,7 @@ async def test_entity_play_media_cast_invalid(hass, caplog, quick_play_mock):
     assert "App unknown not supported" in caplog.text
 
 
-async def test_entity_play_media_sign_URL(hass: HomeAssistantType):
+async def test_entity_play_media_sign_URL(hass: HomeAssistant):
     """Test playing media."""
     entity_id = "media_player.speaker"
 
@@ -779,7 +779,7 @@ async def test_entity_play_media_sign_URL(hass: HomeAssistantType):
     )
 
 
-async def test_entity_media_content_type(hass: HomeAssistantType):
+async def test_entity_media_content_type(hass: HomeAssistant):
     """Test various content types."""
     entity_id = "media_player.speaker"
     reg = er.async_get(hass)
@@ -833,7 +833,7 @@ async def test_entity_media_content_type(hass: HomeAssistantType):
     assert state.attributes.get("media_content_type") == "movie"
 
 
-async def test_entity_control(hass: HomeAssistantType):
+async def test_entity_control(hass: HomeAssistant):
     """Test various device and media controls."""
     entity_id = "media_player.speaker"
     reg = er.async_get(hass)
@@ -942,7 +942,7 @@ async def test_entity_control(hass: HomeAssistantType):
     chromecast.media_controller.seek.assert_called_once_with(123)
 
 
-async def test_entity_media_states(hass: HomeAssistantType):
+async def test_entity_media_states(hass: HomeAssistant):
     """Test various entity media states."""
     entity_id = "media_player.speaker"
     reg = er.async_get(hass)
@@ -1242,7 +1242,7 @@ async def test_failed_cast_tts_base_url(hass, caplog):
     )
 
 
-async def test_disconnect_on_stop(hass: HomeAssistantType):
+async def test_disconnect_on_stop(hass: HomeAssistant):
     """Test cast device disconnects socket on stop."""
     info = get_fake_chromecast_info()
 
@@ -1253,7 +1253,7 @@ async def test_disconnect_on_stop(hass: HomeAssistantType):
     assert chromecast.disconnect.call_count == 1
 
 
-async def test_entry_setup_no_config(hass: HomeAssistantType):
+async def test_entry_setup_no_config(hass: HomeAssistant):
     """Test deprecated empty yaml config.."""
     await async_setup_component(hass, "cast", {})
     await hass.async_block_till_done()
@@ -1261,7 +1261,7 @@ async def test_entry_setup_no_config(hass: HomeAssistantType):
     assert not hass.config_entries.async_entries("cast")
 
 
-async def test_entry_setup_empty_config(hass: HomeAssistantType):
+async def test_entry_setup_empty_config(hass: HomeAssistant):
     """Test deprecated empty yaml config.."""
     await async_setup_component(hass, "cast", {"cast": {}})
     await hass.async_block_till_done()
@@ -1271,7 +1271,7 @@ async def test_entry_setup_empty_config(hass: HomeAssistantType):
     assert config_entry.data["ignore_cec"] == []
 
 
-async def test_entry_setup_single_config(hass: HomeAssistantType, pycast_mock):
+async def test_entry_setup_single_config(hass: HomeAssistant, pycast_mock):
     """Test deprecated yaml config with a single config media_player."""
     await async_setup_component(
         hass, "cast", {"cast": {"media_player": {"uuid": "bla", "ignore_cec": "cast1"}}}
@@ -1285,7 +1285,7 @@ async def test_entry_setup_single_config(hass: HomeAssistantType, pycast_mock):
     assert pycast_mock.IGNORE_CEC == ["cast1"]
 
 
-async def test_entry_setup_list_config(hass: HomeAssistantType, pycast_mock):
+async def test_entry_setup_list_config(hass: HomeAssistant, pycast_mock):
     """Test deprecated yaml config with multiple media_players."""
     await async_setup_component(
         hass,

--- a/tests/components/climacell/test_config_flow.py
+++ b/tests/components/climacell/test_config_flow.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
     CONF_LONGITUDE,
     CONF_NAME,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from .const import API_KEY, MIN_CONFIG
 
@@ -37,7 +37,7 @@ from tests.common import MockConfigEntry
 _LOGGER = logging.getLogger(__name__)
 
 
-async def test_user_flow_minimum_fields(hass: HomeAssistantType) -> None:
+async def test_user_flow_minimum_fields(hass: HomeAssistant) -> None:
     """Test user config flow with minimum fields."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -59,7 +59,7 @@ async def test_user_flow_minimum_fields(hass: HomeAssistantType) -> None:
     assert result["data"][CONF_LONGITUDE] == hass.config.longitude
 
 
-async def test_user_flow_v3(hass: HomeAssistantType) -> None:
+async def test_user_flow_v3(hass: HomeAssistant) -> None:
     """Test user config flow with v3 API."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -84,7 +84,7 @@ async def test_user_flow_v3(hass: HomeAssistantType) -> None:
     assert result["data"][CONF_LONGITUDE] == hass.config.longitude
 
 
-async def test_user_flow_same_unique_ids(hass: HomeAssistantType) -> None:
+async def test_user_flow_same_unique_ids(hass: HomeAssistant) -> None:
     """Test user config flow with the same unique ID as an existing entry."""
     user_input = _get_config_schema(hass, MIN_CONFIG)(MIN_CONFIG)
     MockConfigEntry(
@@ -105,7 +105,7 @@ async def test_user_flow_same_unique_ids(hass: HomeAssistantType) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_user_flow_cannot_connect(hass: HomeAssistantType) -> None:
+async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Test user config flow when ClimaCell can't connect."""
     with patch(
         "homeassistant.components.climacell.config_flow.ClimaCellV4.realtime",
@@ -121,7 +121,7 @@ async def test_user_flow_cannot_connect(hass: HomeAssistantType) -> None:
         assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_user_flow_invalid_api(hass: HomeAssistantType) -> None:
+async def test_user_flow_invalid_api(hass: HomeAssistant) -> None:
     """Test user config flow when API key is invalid."""
     with patch(
         "homeassistant.components.climacell.config_flow.ClimaCellV4.realtime",
@@ -137,7 +137,7 @@ async def test_user_flow_invalid_api(hass: HomeAssistantType) -> None:
         assert result["errors"] == {CONF_API_KEY: "invalid_api_key"}
 
 
-async def test_user_flow_rate_limited(hass: HomeAssistantType) -> None:
+async def test_user_flow_rate_limited(hass: HomeAssistant) -> None:
     """Test user config flow when API key is rate limited."""
     with patch(
         "homeassistant.components.climacell.config_flow.ClimaCellV4.realtime",
@@ -153,7 +153,7 @@ async def test_user_flow_rate_limited(hass: HomeAssistantType) -> None:
         assert result["errors"] == {CONF_API_KEY: "rate_limited"}
 
 
-async def test_user_flow_unknown_exception(hass: HomeAssistantType) -> None:
+async def test_user_flow_unknown_exception(hass: HomeAssistant) -> None:
     """Test user config flow when unknown error occurs."""
     with patch(
         "homeassistant.components.climacell.config_flow.ClimaCellV4.realtime",
@@ -169,7 +169,7 @@ async def test_user_flow_unknown_exception(hass: HomeAssistantType) -> None:
         assert result["errors"] == {"base": "unknown"}
 
 
-async def test_options_flow(hass: HomeAssistantType) -> None:
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options config flow for climacell."""
     user_config = _get_config_schema(hass)(MIN_CONFIG)
     entry = MockConfigEntry(

--- a/tests/components/climacell/test_init.py
+++ b/tests/components/climacell/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.components.climacell.config_flow import (
 from homeassistant.components.climacell.const import CONF_TIMESTEP, DOMAIN
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 from homeassistant.const import CONF_API_VERSION
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from .const import API_V3_ENTRY_DATA, MIN_CONFIG, V1_ENTRY_DATA
 
@@ -20,7 +20,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 async def test_load_and_unload(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test loading and unloading entry."""
@@ -42,7 +42,7 @@ async def test_load_and_unload(
 
 
 async def test_v3_load_and_unload(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test loading and unloading v3 entry."""
@@ -67,7 +67,7 @@ async def test_v3_load_and_unload(
     "old_timestep, new_timestep", [(2, 1), (7, 5), (20, 15), (21, 30)]
 )
 async def test_migrate_timestep(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
     old_timestep: int,
     new_timestep: int,

--- a/tests/components/climacell/test_sensor.py
+++ b/tests/components/climacell/test_sensor.py
@@ -16,9 +16,8 @@ from homeassistant.components.climacell.config_flow import (
 from homeassistant.components.climacell.const import ATTRIBUTION, DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.core import State, callback
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.entity_registry import async_get
-from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import API_V3_ENTRY_DATA, API_V4_ENTRY_DATA
 
@@ -45,7 +44,7 @@ TREE_POLLEN = "tree_pollen_index"
 
 
 @callback
-def _enable_entity(hass: HomeAssistantType, entity_name: str) -> None:
+def _enable_entity(hass: HomeAssistant, entity_name: str) -> None:
     """Enable disabled entity."""
     ent_reg = async_get(hass)
     entry = ent_reg.async_get(entity_name)
@@ -56,7 +55,7 @@ def _enable_entity(hass: HomeAssistantType, entity_name: str) -> None:
     assert updated_entry.disabled is False
 
 
-async def _setup(hass: HomeAssistantType, config: dict[str, Any]) -> State:
+async def _setup(hass: HomeAssistant, config: dict[str, Any]) -> State:
     """Set up entry and return entity state."""
     with patch(
         "homeassistant.util.dt.utcnow",
@@ -94,7 +93,7 @@ async def _setup(hass: HomeAssistantType, config: dict[str, Any]) -> State:
         assert len(hass.states.async_entity_ids(SENSOR_DOMAIN)) == 15
 
 
-def check_sensor_state(hass: HomeAssistantType, entity_name: str, value: str):
+def check_sensor_state(hass: HomeAssistant, entity_name: str, value: str):
     """Check the state of a ClimaCell sensor."""
     state = hass.states.get(CC_SENSOR_ENTITY_ID.format(entity_name))
     assert state
@@ -103,7 +102,7 @@ def check_sensor_state(hass: HomeAssistantType, entity_name: str, value: str):
 
 
 async def test_v3_sensor(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test v3 sensor data."""
@@ -126,7 +125,7 @@ async def test_v3_sensor(
 
 
 async def test_v4_sensor(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test v4 sensor data."""

--- a/tests/components/climacell/test_weather.py
+++ b/tests/components/climacell/test_weather.py
@@ -44,9 +44,8 @@ from homeassistant.components.weather import (
     DOMAIN as WEATHER_DOMAIN,
 )
 from homeassistant.const import ATTR_ATTRIBUTION, ATTR_FRIENDLY_NAME
-from homeassistant.core import State, callback
+from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.entity_registry import async_get
-from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import API_V3_ENTRY_DATA, API_V4_ENTRY_DATA
 
@@ -56,7 +55,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @callback
-def _enable_entity(hass: HomeAssistantType, entity_name: str) -> None:
+def _enable_entity(hass: HomeAssistant, entity_name: str) -> None:
     """Enable disabled entity."""
     ent_reg = async_get(hass)
     entry = ent_reg.async_get(entity_name)
@@ -67,7 +66,7 @@ def _enable_entity(hass: HomeAssistantType, entity_name: str) -> None:
     assert updated_entry.disabled is False
 
 
-async def _setup(hass: HomeAssistantType, config: dict[str, Any]) -> State:
+async def _setup(hass: HomeAssistant, config: dict[str, Any]) -> State:
     """Set up entry and return entity state."""
     with patch(
         "homeassistant.util.dt.utcnow",
@@ -92,7 +91,7 @@ async def _setup(hass: HomeAssistantType, config: dict[str, Any]) -> State:
 
 
 async def test_v3_weather(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test v3 weather data."""
@@ -235,7 +234,7 @@ async def test_v3_weather(
 
 
 async def test_v4_weather(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     climacell_config_entry_update: pytest.fixture,
 ) -> None:
     """Test v4 weather data."""

--- a/tests/components/command_line/test_binary_sensor.py
+++ b/tests/components/command_line/test_binary_sensor.py
@@ -6,12 +6,10 @@ from typing import Any
 from homeassistant import setup
 from homeassistant.components.binary_sensor import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 
-async def setup_test_entity(
-    hass: HomeAssistantType, config_dict: dict[str, Any]
-) -> None:
+async def setup_test_entity(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
     """Set up a test command line binary_sensor entity."""
     assert await setup.async_setup_component(
         hass,
@@ -21,7 +19,7 @@ async def setup_test_entity(
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType) -> None:
+async def test_setup(hass: HomeAssistant) -> None:
     """Test sensor setup."""
     await setup_test_entity(
         hass,
@@ -38,7 +36,7 @@ async def test_setup(hass: HomeAssistantType) -> None:
     assert entity_state.name == "Test"
 
 
-async def test_template(hass: HomeAssistantType) -> None:
+async def test_template(hass: HomeAssistant) -> None:
     """Test setting the state with a template."""
 
     await setup_test_entity(
@@ -55,7 +53,7 @@ async def test_template(hass: HomeAssistantType) -> None:
     assert entity_state.state == STATE_ON
 
 
-async def test_sensor_off(hass: HomeAssistantType) -> None:
+async def test_sensor_off(hass: HomeAssistant) -> None:
     """Test setting the state with a template."""
     await setup_test_entity(
         hass,

--- a/tests/components/command_line/test_cover.py
+++ b/tests/components/command_line/test_cover.py
@@ -15,15 +15,13 @@ from homeassistant.const import (
     SERVICE_RELOAD,
     SERVICE_STOP_COVER,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 
 
-async def setup_test_entity(
-    hass: HomeAssistantType, config_dict: dict[str, Any]
-) -> None:
+async def setup_test_entity(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
     """Set up a test command line notify service."""
     assert await setup.async_setup_component(
         hass,
@@ -37,7 +35,7 @@ async def setup_test_entity(
     await hass.async_block_till_done()
 
 
-async def test_no_covers(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_no_covers(caplog: Any, hass: HomeAssistant) -> None:
     """Test that the cover does not polls when there's no state command."""
 
     with patch(
@@ -48,7 +46,7 @@ async def test_no_covers(caplog: Any, hass: HomeAssistantType) -> None:
         assert "No covers added" in caplog.text
 
 
-async def test_no_poll_when_cover_has_no_command_state(hass: HomeAssistantType) -> None:
+async def test_no_poll_when_cover_has_no_command_state(hass: HomeAssistant) -> None:
     """Test that the cover does not polls when there's no state command."""
 
     with patch(
@@ -61,7 +59,7 @@ async def test_no_poll_when_cover_has_no_command_state(hass: HomeAssistantType) 
         assert not check_output.called
 
 
-async def test_poll_when_cover_has_command_state(hass: HomeAssistantType) -> None:
+async def test_poll_when_cover_has_command_state(hass: HomeAssistant) -> None:
     """Test that the cover polls when there's a state  command."""
 
     with patch(
@@ -76,7 +74,7 @@ async def test_poll_when_cover_has_command_state(hass: HomeAssistantType) -> Non
         )
 
 
-async def test_state_value(hass: HomeAssistantType) -> None:
+async def test_state_value(hass: HomeAssistant) -> None:
     """Test with state value."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "cover_status")
@@ -119,7 +117,7 @@ async def test_state_value(hass: HomeAssistantType) -> None:
         assert entity_state.state == "closed"
 
 
-async def test_reload(hass: HomeAssistantType) -> None:
+async def test_reload(hass: HomeAssistant) -> None:
     """Verify we can reload command_line covers."""
 
     await setup_test_entity(
@@ -155,7 +153,7 @@ async def test_reload(hass: HomeAssistantType) -> None:
     assert hass.states.get("cover.from_yaml")
 
 
-async def test_move_cover_failure(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_move_cover_failure(caplog: Any, hass: HomeAssistant) -> None:
     """Test with state value."""
 
     await setup_test_entity(

--- a/tests/components/command_line/test_notify.py
+++ b/tests/components/command_line/test_notify.py
@@ -9,12 +9,10 @@ from unittest.mock import patch
 
 from homeassistant import setup
 from homeassistant.components.notify import DOMAIN
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 
-async def setup_test_service(
-    hass: HomeAssistantType, config_dict: dict[str, Any]
-) -> None:
+async def setup_test_service(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
     """Set up a test command line notify service."""
     assert await setup.async_setup_component(
         hass,
@@ -28,19 +26,19 @@ async def setup_test_service(
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType) -> None:
+async def test_setup(hass: HomeAssistant) -> None:
     """Test sensor setup."""
     await setup_test_service(hass, {"command": "exit 0"})
     assert hass.services.has_service(DOMAIN, "test")
 
 
-async def test_bad_config(hass: HomeAssistantType) -> None:
+async def test_bad_config(hass: HomeAssistant) -> None:
     """Test set up the platform with bad/missing configuration."""
     await setup_test_service(hass, {})
     assert not hass.services.has_service(DOMAIN, "test")
 
 
-async def test_command_line_output(hass: HomeAssistantType) -> None:
+async def test_command_line_output(hass: HomeAssistant) -> None:
     """Test the command line output."""
     with tempfile.TemporaryDirectory() as tempdirname:
         filename = os.path.join(tempdirname, "message.txt")
@@ -62,9 +60,7 @@ async def test_command_line_output(hass: HomeAssistantType) -> None:
             assert message == handle.read()
 
 
-async def test_error_for_none_zero_exit_code(
-    caplog: Any, hass: HomeAssistantType
-) -> None:
+async def test_error_for_none_zero_exit_code(caplog: Any, hass: HomeAssistant) -> None:
     """Test if an error is logged for non zero exit codes."""
     await setup_test_service(
         hass,
@@ -79,7 +75,7 @@ async def test_error_for_none_zero_exit_code(
     assert "Command failed" in caplog.text
 
 
-async def test_timeout(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_timeout(caplog: Any, hass: HomeAssistant) -> None:
     """Test blocking is not forever."""
     await setup_test_service(
         hass,
@@ -94,7 +90,7 @@ async def test_timeout(caplog: Any, hass: HomeAssistantType) -> None:
     assert "Timeout" in caplog.text
 
 
-async def test_subprocess_exceptions(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_subprocess_exceptions(caplog: Any, hass: HomeAssistant) -> None:
     """Test that notify subprocess exceptions are handled correctly."""
 
     with patch(

--- a/tests/components/command_line/test_sensor.py
+++ b/tests/components/command_line/test_sensor.py
@@ -6,12 +6,10 @@ from unittest.mock import patch
 
 from homeassistant import setup
 from homeassistant.components.sensor import DOMAIN
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 
-async def setup_test_entities(
-    hass: HomeAssistantType, config_dict: dict[str, Any]
-) -> None:
+async def setup_test_entities(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
     """Set up a test command line sensor entity."""
     assert await setup.async_setup_component(
         hass,
@@ -33,7 +31,7 @@ async def setup_test_entities(
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType) -> None:
+async def test_setup(hass: HomeAssistant) -> None:
     """Test sensor setup."""
     await setup_test_entities(
         hass,
@@ -49,7 +47,7 @@ async def test_setup(hass: HomeAssistantType) -> None:
     assert entity_state.attributes["unit_of_measurement"] == "in"
 
 
-async def test_template(hass: HomeAssistantType) -> None:
+async def test_template(hass: HomeAssistant) -> None:
     """Test command sensor with template."""
     await setup_test_entities(
         hass,
@@ -64,7 +62,7 @@ async def test_template(hass: HomeAssistantType) -> None:
     assert float(entity_state.state) == 5
 
 
-async def test_template_render(hass: HomeAssistantType) -> None:
+async def test_template_render(hass: HomeAssistant) -> None:
     """Ensure command with templates get rendered properly."""
 
     await setup_test_entities(
@@ -78,7 +76,7 @@ async def test_template_render(hass: HomeAssistantType) -> None:
     assert entity_state.state == "template_value"
 
 
-async def test_template_render_with_quote(hass: HomeAssistantType) -> None:
+async def test_template_render_with_quote(hass: HomeAssistant) -> None:
     """Ensure command with templates and quotes get rendered properly."""
 
     with patch(
@@ -99,7 +97,7 @@ async def test_template_render_with_quote(hass: HomeAssistantType) -> None:
         )
 
 
-async def test_bad_template_render(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_bad_template_render(caplog: Any, hass: HomeAssistant) -> None:
     """Test rendering a broken template."""
 
     await setup_test_entities(
@@ -112,7 +110,7 @@ async def test_bad_template_render(caplog: Any, hass: HomeAssistantType) -> None
     assert "Error rendering command template" in caplog.text
 
 
-async def test_bad_command(hass: HomeAssistantType) -> None:
+async def test_bad_command(hass: HomeAssistant) -> None:
     """Test bad command."""
     await setup_test_entities(
         hass,
@@ -125,7 +123,7 @@ async def test_bad_command(hass: HomeAssistantType) -> None:
     assert entity_state.state == "unknown"
 
 
-async def test_update_with_json_attrs(hass: HomeAssistantType) -> None:
+async def test_update_with_json_attrs(hass: HomeAssistant) -> None:
     """Test attributes get extracted from a JSON result."""
     await setup_test_entities(
         hass,
@@ -142,7 +140,7 @@ async def test_update_with_json_attrs(hass: HomeAssistantType) -> None:
     assert entity_state.attributes["key_three"] == "value_three"
 
 
-async def test_update_with_json_attrs_no_data(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
+async def test_update_with_json_attrs_no_data(caplog, hass: HomeAssistant) -> None:  # type: ignore[no-untyped-def]
     """Test attributes when no JSON result fetched."""
 
     await setup_test_entities(
@@ -158,7 +156,7 @@ async def test_update_with_json_attrs_no_data(caplog, hass: HomeAssistantType) -
     assert "Empty reply found when expecting JSON data" in caplog.text
 
 
-async def test_update_with_json_attrs_not_dict(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
+async def test_update_with_json_attrs_not_dict(caplog, hass: HomeAssistant) -> None:  # type: ignore[no-untyped-def]
     """Test attributes when the return value not a dict."""
 
     await setup_test_entities(
@@ -174,7 +172,7 @@ async def test_update_with_json_attrs_not_dict(caplog, hass: HomeAssistantType) 
     assert "JSON result was not a dictionary" in caplog.text
 
 
-async def test_update_with_json_attrs_bad_json(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
+async def test_update_with_json_attrs_bad_json(caplog, hass: HomeAssistant) -> None:  # type: ignore[no-untyped-def]
     """Test attributes when the return value is invalid JSON."""
 
     await setup_test_entities(
@@ -190,7 +188,7 @@ async def test_update_with_json_attrs_bad_json(caplog, hass: HomeAssistantType) 
     assert "Unable to parse output as JSON" in caplog.text
 
 
-async def test_update_with_missing_json_attrs(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
+async def test_update_with_missing_json_attrs(caplog, hass: HomeAssistant) -> None:  # type: ignore[no-untyped-def]
     """Test attributes when an expected key is missing."""
 
     await setup_test_entities(
@@ -209,7 +207,7 @@ async def test_update_with_missing_json_attrs(caplog, hass: HomeAssistantType) -
     assert "missing_key" not in entity_state.attributes
 
 
-async def test_update_with_unnecessary_json_attrs(caplog, hass: HomeAssistantType) -> None:  # type: ignore[no-untyped-def]
+async def test_update_with_unnecessary_json_attrs(caplog, hass: HomeAssistant) -> None:  # type: ignore[no-untyped-def]
     """Test attributes when an expected key is missing."""
 
     await setup_test_entities(

--- a/tests/components/command_line/test_switch.py
+++ b/tests/components/command_line/test_switch.py
@@ -17,15 +17,13 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
 from tests.common import async_fire_time_changed
 
 
-async def setup_test_entity(
-    hass: HomeAssistantType, config_dict: dict[str, Any]
-) -> None:
+async def setup_test_entity(hass: HomeAssistant, config_dict: dict[str, Any]) -> None:
     """Set up a test command line switch entity."""
     assert await setup.async_setup_component(
         hass,
@@ -39,7 +37,7 @@ async def setup_test_entity(
     await hass.async_block_till_done()
 
 
-async def test_state_none(hass: HomeAssistantType) -> None:
+async def test_state_none(hass: HomeAssistant) -> None:
     """Test with none state."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "switch_status")
@@ -80,7 +78,7 @@ async def test_state_none(hass: HomeAssistantType) -> None:
         assert entity_state.state == STATE_OFF
 
 
-async def test_state_value(hass: HomeAssistantType) -> None:
+async def test_state_value(hass: HomeAssistant) -> None:
     """Test with state value."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "switch_status")
@@ -123,7 +121,7 @@ async def test_state_value(hass: HomeAssistantType) -> None:
         assert entity_state.state == STATE_OFF
 
 
-async def test_state_json_value(hass: HomeAssistantType) -> None:
+async def test_state_json_value(hass: HomeAssistant) -> None:
     """Test with state JSON value."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "switch_status")
@@ -169,7 +167,7 @@ async def test_state_json_value(hass: HomeAssistantType) -> None:
         assert entity_state.state == STATE_OFF
 
 
-async def test_state_code(hass: HomeAssistantType) -> None:
+async def test_state_code(hass: HomeAssistant) -> None:
     """Test with state code."""
     with tempfile.TemporaryDirectory() as tempdirname:
         path = os.path.join(tempdirname, "switch_status")
@@ -212,7 +210,7 @@ async def test_state_code(hass: HomeAssistantType) -> None:
 
 
 async def test_assumed_state_should_be_true_if_command_state_is_none(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
 ) -> None:
     """Test with state value."""
 
@@ -231,7 +229,7 @@ async def test_assumed_state_should_be_true_if_command_state_is_none(
 
 
 async def test_assumed_state_should_absent_if_command_state_present(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
 ) -> None:
     """Test with state value."""
 
@@ -250,7 +248,7 @@ async def test_assumed_state_should_absent_if_command_state_present(
     assert "assumed_state" not in entity_state.attributes
 
 
-async def test_name_is_set_correctly(hass: HomeAssistantType) -> None:
+async def test_name_is_set_correctly(hass: HomeAssistant) -> None:
     """Test that name is set correctly."""
     await setup_test_entity(
         hass,
@@ -267,7 +265,7 @@ async def test_name_is_set_correctly(hass: HomeAssistantType) -> None:
     assert entity_state.name == "Test friendly name!"
 
 
-async def test_switch_command_state_fail(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_switch_command_state_fail(caplog: Any, hass: HomeAssistant) -> None:
     """Test that switch failures are handled correctly."""
     await setup_test_entity(
         hass,
@@ -301,7 +299,7 @@ async def test_switch_command_state_fail(caplog: Any, hass: HomeAssistantType) -
 
 
 async def test_switch_command_state_code_exceptions(
-    caplog: Any, hass: HomeAssistantType
+    caplog: Any, hass: HomeAssistant
 ) -> None:
     """Test that switch state code exceptions are handled correctly."""
 
@@ -334,7 +332,7 @@ async def test_switch_command_state_code_exceptions(
 
 
 async def test_switch_command_state_value_exceptions(
-    caplog: Any, hass: HomeAssistantType
+    caplog: Any, hass: HomeAssistant
 ) -> None:
     """Test that switch state value exceptions are handled correctly."""
 
@@ -367,7 +365,7 @@ async def test_switch_command_state_value_exceptions(
         assert "Error trying to exec command" in caplog.text
 
 
-async def test_no_switches(caplog: Any, hass: HomeAssistantType) -> None:
+async def test_no_switches(caplog: Any, hass: HomeAssistant) -> None:
     """Test with no switches."""
 
     await setup_test_entity(hass, {})

--- a/tests/components/device_tracker/common.py
+++ b/tests/components/device_tracker/common.py
@@ -15,15 +15,15 @@ from homeassistant.components.device_tracker import (
     DOMAIN,
     SERVICE_SEE,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.typing import GPSType, HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.typing import GPSType
 from homeassistant.loader import bind_hass
 
 
 @callback
 @bind_hass
 def async_see(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     mac: str = None,
     dev_id: str = None,
     host_name: str = None,

--- a/tests/components/directv/__init__.py
+++ b/tests/components/directv/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.const import (
     HTTP_FORBIDDEN,
     HTTP_INTERNAL_SERVER_ERROR,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -99,7 +99,7 @@ def mock_connection(aioclient_mock: AiohttpClientMocker) -> None:
 
 
 async def setup_integration(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     skip_entry_setup: bool = False,
     setup_error: bool = False,

--- a/tests/components/directv/test_config_flow.py
+++ b/tests/components/directv/test_config_flow.py
@@ -7,12 +7,12 @@ from homeassistant.components.directv.const import CONF_RECEIVER_ID, DOMAIN
 from homeassistant.components.ssdp import ATTR_UPNP_SERIAL
 from homeassistant.config_entries import SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SOURCE
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.directv import (
     HOST,
@@ -26,7 +26,7 @@ from tests.components.directv import (
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_show_user_form(hass: HomeAssistantType) -> None:
+async def test_show_user_form(hass: HomeAssistant) -> None:
     """Test that the user set up form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -38,7 +38,7 @@ async def test_show_user_form(hass: HomeAssistantType) -> None:
 
 
 async def test_show_ssdp_form(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test that the ssdp confirmation form is served."""
     mock_connection(aioclient_mock)
@@ -54,7 +54,7 @@ async def test_show_ssdp_form(
 
 
 async def test_cannot_connect(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we show user form on connection error."""
     aioclient_mock.get("http://127.0.0.1:8080/info/getVersion", exc=HTTPClientError)
@@ -72,7 +72,7 @@ async def test_cannot_connect(
 
 
 async def test_ssdp_cannot_connect(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow on connection error."""
     aioclient_mock.get("http://127.0.0.1:8080/info/getVersion", exc=HTTPClientError)
@@ -89,7 +89,7 @@ async def test_ssdp_cannot_connect(
 
 
 async def test_ssdp_confirm_cannot_connect(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow on connection error."""
     aioclient_mock.get("http://127.0.0.1:8080/info/getVersion", exc=HTTPClientError)
@@ -106,7 +106,7 @@ async def test_ssdp_confirm_cannot_connect(
 
 
 async def test_user_device_exists_abort(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort user flow if DirecTV receiver already configured."""
     await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
@@ -123,7 +123,7 @@ async def test_user_device_exists_abort(
 
 
 async def test_ssdp_device_exists_abort(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow if DirecTV receiver already configured."""
     await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
@@ -140,7 +140,7 @@ async def test_ssdp_device_exists_abort(
 
 
 async def test_ssdp_with_receiver_id_device_exists_abort(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow if DirecTV receiver already configured."""
     await setup_integration(hass, aioclient_mock, skip_entry_setup=True)
@@ -158,7 +158,7 @@ async def test_ssdp_with_receiver_id_device_exists_abort(
 
 
 async def test_unknown_error(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we show user form on unknown error."""
     user_input = MOCK_USER_INPUT.copy()
@@ -177,7 +177,7 @@ async def test_unknown_error(
 
 
 async def test_ssdp_unknown_error(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow on unknown error."""
     discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
@@ -196,7 +196,7 @@ async def test_ssdp_unknown_error(
 
 
 async def test_ssdp_confirm_unknown_error(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test we abort SSDP flow on unknown error."""
     discovery_info = MOCK_SSDP_DISCOVERY_INFO.copy()
@@ -215,7 +215,7 @@ async def test_ssdp_confirm_unknown_error(
 
 
 async def test_full_user_flow_implementation(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the full manual user flow from start to finish."""
     mock_connection(aioclient_mock)
@@ -244,7 +244,7 @@ async def test_full_user_flow_implementation(
 
 
 async def test_full_ssdp_flow_implementation(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the full SSDP flow from start to finish."""
     mock_connection(aioclient_mock)

--- a/tests/components/directv/test_init.py
+++ b/tests/components/directv/test_init.py
@@ -5,7 +5,7 @@ from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_RETRY,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from tests.components.directv import setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -14,7 +14,7 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 
 
 async def test_config_entry_not_ready(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the DirecTV configuration entry not ready."""
     entry = await setup_integration(hass, aioclient_mock, setup_error=True)
@@ -23,7 +23,7 @@ async def test_config_entry_not_ready(
 
 
 async def test_unload_config_entry(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the DirecTV configuration entry unloading."""
     entry = await setup_integration(hass, aioclient_mock)

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -54,8 +54,8 @@ from homeassistant.const import (
     STATE_PLAYING,
     STATE_UNAVAILABLE,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util import dt as dt_util
 
 from tests.components.directv import setup_integration
@@ -78,44 +78,38 @@ def mock_now() -> datetime:
     return dt_util.utcnow()
 
 
-async def async_turn_on(hass: HomeAssistantType, entity_id: str | None = None) -> None:
+async def async_turn_on(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Turn on specified media player or all."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     await hass.services.async_call(MP_DOMAIN, SERVICE_TURN_ON, data)
 
 
-async def async_turn_off(hass: HomeAssistantType, entity_id: str | None = None) -> None:
+async def async_turn_off(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Turn off specified media player or all."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     await hass.services.async_call(MP_DOMAIN, SERVICE_TURN_OFF, data)
 
 
-async def async_media_pause(
-    hass: HomeAssistantType, entity_id: str | None = None
-) -> None:
+async def async_media_pause(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Send the media player the command for pause."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     await hass.services.async_call(MP_DOMAIN, SERVICE_MEDIA_PAUSE, data)
 
 
-async def async_media_play(
-    hass: HomeAssistantType, entity_id: str | None = None
-) -> None:
+async def async_media_play(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Send the media player the command for play/pause."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     await hass.services.async_call(MP_DOMAIN, SERVICE_MEDIA_PLAY, data)
 
 
-async def async_media_stop(
-    hass: HomeAssistantType, entity_id: str | None = None
-) -> None:
+async def async_media_stop(hass: HomeAssistant, entity_id: str | None = None) -> None:
     """Send the media player the command for stop."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
     await hass.services.async_call(MP_DOMAIN, SERVICE_MEDIA_STOP, data)
 
 
 async def async_media_next_track(
-    hass: HomeAssistantType, entity_id: str | None = None
+    hass: HomeAssistant, entity_id: str | None = None
 ) -> None:
     """Send the media player the command for next track."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
@@ -123,7 +117,7 @@ async def async_media_next_track(
 
 
 async def async_media_previous_track(
-    hass: HomeAssistantType, entity_id: str | None = None
+    hass: HomeAssistant, entity_id: str | None = None
 ) -> None:
     """Send the media player the command for prev track."""
     data = {ATTR_ENTITY_ID: entity_id} if entity_id else {}
@@ -131,7 +125,7 @@ async def async_media_previous_track(
 
 
 async def async_play_media(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     media_type: str,
     media_id: str,
     entity_id: str | None = None,
@@ -149,9 +143,7 @@ async def async_play_media(
     await hass.services.async_call(MP_DOMAIN, SERVICE_PLAY_MEDIA, data)
 
 
-async def test_setup(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
-) -> None:
+async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with basic config."""
     await setup_integration(hass, aioclient_mock)
     assert hass.states.get(MAIN_ENTITY_ID)
@@ -160,7 +152,7 @@ async def test_setup(
 
 
 async def test_unique_id(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
@@ -181,7 +173,7 @@ async def test_unique_id(
 
 
 async def test_supported_features(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test supported features."""
     await setup_integration(hass, aioclient_mock)
@@ -214,7 +206,7 @@ async def test_supported_features(
 
 
 async def test_check_attributes(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     mock_now: dt_util.dt.datetime,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
@@ -321,7 +313,7 @@ async def test_check_attributes(
 
 
 async def test_attributes_paused(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     mock_now: dt_util.dt.datetime,
     aioclient_mock: AiohttpClientMocker,
 ):
@@ -345,7 +337,7 @@ async def test_attributes_paused(
 
 
 async def test_main_services(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     mock_now: dt_util.dt.datetime,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -7,8 +7,8 @@ from homeassistant.components.remote import (
     SERVICE_SEND_COMMAND,
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.directv import setup_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
@@ -21,9 +21,7 @@ UNAVAILABLE_ENTITY_ID = f"{REMOTE_DOMAIN}.unavailable_client"
 # pylint: disable=redefined-outer-name
 
 
-async def test_setup(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
-) -> None:
+async def test_setup(hass: HomeAssistant, aioclient_mock: AiohttpClientMocker) -> None:
     """Test setup with basic config."""
     await setup_integration(hass, aioclient_mock)
     assert hass.states.get(MAIN_ENTITY_ID)
@@ -32,7 +30,7 @@ async def test_setup(
 
 
 async def test_unique_id(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test unique id."""
     await setup_integration(hass, aioclient_mock)
@@ -50,7 +48,7 @@ async def test_unique_id(
 
 
 async def test_main_services(
-    hass: HomeAssistantType, aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the different services."""
     await setup_integration(hass, aioclient_mock)

--- a/tests/components/ezviz/__init__.py
+++ b/tests/components/ezviz/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
     CONF_URL,
     CONF_USERNAME,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -101,7 +101,7 @@ def _patch_async_setup_entry(return_value=True):
 
 
 async def init_integration(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     *,
     data: dict = ENTRY_CONFIG,
     options: dict = ENTRY_OPTIONS,

--- a/tests/components/freebox/test_config_flow.py
+++ b/tests/components/freebox/test_config_flow.py
@@ -11,7 +11,7 @@ from homeassistant import data_entry_flow
 from homeassistant.components.freebox.const import DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER, SOURCE_ZEROCONF
 from homeassistant.const import CONF_HOST, CONF_PORT
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from .const import MOCK_HOST, MOCK_PORT
 
@@ -37,7 +37,7 @@ MOCK_ZEROCONF_DATA = {
 }
 
 
-async def test_user(hass: HomeAssistantType):
+async def test_user(hass: HomeAssistant):
     """Test user config."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -55,7 +55,7 @@ async def test_user(hass: HomeAssistantType):
     assert result["step_id"] == "link"
 
 
-async def test_import(hass: HomeAssistantType):
+async def test_import(hass: HomeAssistant):
     """Test import step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -66,7 +66,7 @@ async def test_import(hass: HomeAssistantType):
     assert result["step_id"] == "link"
 
 
-async def test_zeroconf(hass: HomeAssistantType):
+async def test_zeroconf(hass: HomeAssistant):
     """Test zeroconf step."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -77,7 +77,7 @@ async def test_zeroconf(hass: HomeAssistantType):
     assert result["step_id"] == "link"
 
 
-async def test_link(hass: HomeAssistantType, router: Mock):
+async def test_link(hass: HomeAssistant, router: Mock):
     """Test linking."""
     with patch(
         "homeassistant.components.freebox.async_setup", return_value=True
@@ -102,7 +102,7 @@ async def test_link(hass: HomeAssistantType, router: Mock):
         assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_abort_if_already_setup(hass: HomeAssistantType):
+async def test_abort_if_already_setup(hass: HomeAssistant):
     """Test we abort if component is already setup."""
     MockConfigEntry(
         domain=DOMAIN,
@@ -129,7 +129,7 @@ async def test_abort_if_already_setup(hass: HomeAssistantType):
     assert result["reason"] == "already_configured"
 
 
-async def test_on_link_failed(hass: HomeAssistantType):
+async def test_on_link_failed(hass: HomeAssistant):
     """Test when we have errors during linking the router."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ENTRY_STATE_LOADED, ENTRY_STATE_NOT_LOADED
 from homeassistant.const import CONF_HOST, CONF_PORT, STATE_UNAVAILABLE
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .const import MOCK_HOST, MOCK_PORT
@@ -15,7 +15,7 @@ from .const import MOCK_HOST, MOCK_PORT
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistantType, router: Mock):
+async def test_setup(hass: HomeAssistant, router: Mock):
     """Test setup of integration."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -44,7 +44,7 @@ async def test_setup(hass: HomeAssistantType, router: Mock):
         mock_service.assert_called_once()
 
 
-async def test_setup_import(hass: HomeAssistantType, router: Mock):
+async def test_setup_import(hass: HomeAssistant, router: Mock):
     """Test setup of integration from import."""
     await async_setup_component(hass, "persistent_notification", {})
 
@@ -66,7 +66,7 @@ async def test_setup_import(hass: HomeAssistantType, router: Mock):
     assert hass.services.has_service(DOMAIN, SERVICE_REBOOT)
 
 
-async def test_unload_remove(hass: HomeAssistantType, router: Mock):
+async def test_unload_remove(hass: HomeAssistant, router: Mock):
     """Test unload and remove of integration."""
     entity_id_dt = f"{DT_DOMAIN}.freebox_server_r2"
     entity_id_sensor = f"{SENSOR_DOMAIN}.freebox_download_speed"

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -13,7 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -24,13 +24,13 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistantType, config: dict):
+async def setup_fritzbox(hass: HomeAssistant, config: dict):
     """Set up mock AVM Fritz!Box."""
     assert await async_setup_component(hass, FB_DOMAIN, config)
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceBinarySensorMock()
     fritz().get_devices.return_value = [device]
@@ -44,7 +44,7 @@ async def test_setup(hass: HomeAssistantType, fritz: Mock):
     assert state.attributes[ATTR_DEVICE_CLASS] == "window"
 
 
-async def test_is_off(hass: HomeAssistantType, fritz: Mock):
+async def test_is_off(hass: HomeAssistant, fritz: Mock):
     """Test state of platform."""
     device = FritzDeviceBinarySensorMock()
     device.present = False
@@ -57,7 +57,7 @@ async def test_is_off(hass: HomeAssistantType, fritz: Mock):
     assert state.state == STATE_OFF
 
 
-async def test_update(hass: HomeAssistantType, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceBinarySensorMock()
     fritz().get_devices.return_value = [device]
@@ -75,7 +75,7 @@ async def test_update(hass: HomeAssistantType, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistantType, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceBinarySensorMock()
     device.update.side_effect = [mock.DEFAULT, HTTPError("Boom")]

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -36,7 +36,7 @@ from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_TEMPERATURE,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -47,13 +47,13 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistantType, config: dict):
+async def setup_fritzbox(hass: HomeAssistant, config: dict):
     """Set up mock AVM Fritz!Box."""
     assert await async_setup_component(hass, FB_DOMAIN, config) is True
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -80,7 +80,7 @@ async def test_setup(hass: HomeAssistantType, fritz: Mock):
     assert state.state == HVAC_MODE_HEAT
 
 
-async def test_target_temperature_on(hass: HomeAssistantType, fritz: Mock):
+async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock):
     """Test turn device on."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -92,7 +92,7 @@ async def test_target_temperature_on(hass: HomeAssistantType, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 30
 
 
-async def test_target_temperature_off(hass: HomeAssistantType, fritz: Mock):
+async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock):
     """Test turn device on."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -104,7 +104,7 @@ async def test_target_temperature_off(hass: HomeAssistantType, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 0
 
 
-async def test_update(hass: HomeAssistantType, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -132,7 +132,7 @@ async def test_update(hass: HomeAssistantType, fritz: Mock):
     assert state.attributes[ATTR_TEMPERATURE] == 20
 
 
-async def test_update_error(hass: HomeAssistantType, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceClimateMock()
     device.update.side_effect = HTTPError("Boom")
@@ -150,7 +150,7 @@ async def test_update_error(hass: HomeAssistantType, fritz: Mock):
     assert fritz().login.call_count == 2
 
 
-async def test_set_temperature_temperature(hass: HomeAssistantType, fritz: Mock):
+async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock):
     """Test setting temperature by temperature."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -166,7 +166,7 @@ async def test_set_temperature_temperature(hass: HomeAssistantType, fritz: Mock)
     assert device.set_target_temperature.call_args_list == [call(123)]
 
 
-async def test_set_temperature_mode_off(hass: HomeAssistantType, fritz: Mock):
+async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock):
     """Test setting temperature by mode."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -186,7 +186,7 @@ async def test_set_temperature_mode_off(hass: HomeAssistantType, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(0)]
 
 
-async def test_set_temperature_mode_heat(hass: HomeAssistantType, fritz: Mock):
+async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock):
     """Test setting temperature by mode."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -206,7 +206,7 @@ async def test_set_temperature_mode_heat(hass: HomeAssistantType, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(22)]
 
 
-async def test_set_hvac_mode_off(hass: HomeAssistantType, fritz: Mock):
+async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock):
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -222,7 +222,7 @@ async def test_set_hvac_mode_off(hass: HomeAssistantType, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(0)]
 
 
-async def test_set_hvac_mode_heat(hass: HomeAssistantType, fritz: Mock):
+async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock):
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -238,7 +238,7 @@ async def test_set_hvac_mode_heat(hass: HomeAssistantType, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(22)]
 
 
-async def test_set_preset_mode_comfort(hass: HomeAssistantType, fritz: Mock):
+async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock):
     """Test setting preset mode."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -254,7 +254,7 @@ async def test_set_preset_mode_comfort(hass: HomeAssistantType, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(22)]
 
 
-async def test_set_preset_mode_eco(hass: HomeAssistantType, fritz: Mock):
+async def test_set_preset_mode_eco(hass: HomeAssistant, fritz: Mock):
     """Test setting preset mode."""
     device = FritzDeviceClimateMock()
     fritz().get_devices.return_value = [device]
@@ -270,7 +270,7 @@ async def test_set_preset_mode_eco(hass: HomeAssistantType, fritz: Mock):
     assert device.set_target_temperature.call_args_list == [call(16)]
 
 
-async def test_preset_mode_update(hass: HomeAssistantType, fritz: Mock):
+async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock):
     """Test preset mode."""
     device = FritzDeviceClimateMock()
     device.comfort_temperature = 98

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -14,12 +14,12 @@ from homeassistant.components.ssdp import (
 )
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import MOCK_CONFIG
 
@@ -40,7 +40,7 @@ def fritz_fixture() -> Mock:
         yield fritz
 
 
-async def test_user(hass: HomeAssistantType, fritz: Mock):
+async def test_user(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow by user."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -59,7 +59,7 @@ async def test_user(hass: HomeAssistantType, fritz: Mock):
     assert not result["result"].unique_id
 
 
-async def test_user_auth_failed(hass: HomeAssistantType, fritz: Mock):
+async def test_user_auth_failed(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow by user with authentication failure."""
     fritz().login.side_effect = [LoginError("Boom"), mock.DEFAULT]
 
@@ -71,7 +71,7 @@ async def test_user_auth_failed(hass: HomeAssistantType, fritz: Mock):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_user_not_successful(hass: HomeAssistantType, fritz: Mock):
+async def test_user_not_successful(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow by user but no connection found."""
     fritz().login.side_effect = OSError("Boom")
 
@@ -82,7 +82,7 @@ async def test_user_not_successful(hass: HomeAssistantType, fritz: Mock):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_user_already_configured(hass: HomeAssistantType, fritz: Mock):
+async def test_user_already_configured(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow by user when already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA
@@ -97,7 +97,7 @@ async def test_user_already_configured(hass: HomeAssistantType, fritz: Mock):
     assert result["reason"] == "already_configured"
 
 
-async def test_reauth_success(hass: HomeAssistantType, fritz: Mock):
+async def test_reauth_success(hass: HomeAssistant, fritz: Mock):
     """Test starting a reauthentication flow."""
     mock_config = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_DATA)
     mock_config.add_to_hass(hass)
@@ -124,7 +124,7 @@ async def test_reauth_success(hass: HomeAssistantType, fritz: Mock):
     assert mock_config.data[CONF_PASSWORD] == "other_fake_password"
 
 
-async def test_reauth_auth_failed(hass: HomeAssistantType, fritz: Mock):
+async def test_reauth_auth_failed(hass: HomeAssistant, fritz: Mock):
     """Test starting a reauthentication flow with authentication failure."""
     fritz().login.side_effect = LoginError("Boom")
 
@@ -152,7 +152,7 @@ async def test_reauth_auth_failed(hass: HomeAssistantType, fritz: Mock):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_reauth_not_successful(hass: HomeAssistantType, fritz: Mock):
+async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock):
     """Test starting a reauthentication flow but no connection found."""
     fritz().login.side_effect = OSError("Boom")
 
@@ -179,7 +179,7 @@ async def test_reauth_not_successful(hass: HomeAssistantType, fritz: Mock):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_import(hass: HomeAssistantType, fritz: Mock):
+async def test_import(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow by import."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "import"}, data=MOCK_USER_DATA
@@ -192,7 +192,7 @@ async def test_import(hass: HomeAssistantType, fritz: Mock):
     assert not result["result"].unique_id
 
 
-async def test_ssdp(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -212,7 +212,7 @@ async def test_ssdp(hass: HomeAssistantType, fritz: Mock):
     assert result["result"].unique_id == "only-a-test"
 
 
-async def test_ssdp_no_friendly_name(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_no_friendly_name(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery without friendly name."""
     MOCK_NO_NAME = MOCK_SSDP_DATA.copy()
     del MOCK_NO_NAME[ATTR_UPNP_FRIENDLY_NAME]
@@ -234,7 +234,7 @@ async def test_ssdp_no_friendly_name(hass: HomeAssistantType, fritz: Mock):
     assert result["result"].unique_id == "only-a-test"
 
 
-async def test_ssdp_auth_failed(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_auth_failed(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery with authentication failure."""
     fritz().login.side_effect = LoginError("Boom")
 
@@ -254,7 +254,7 @@ async def test_ssdp_auth_failed(hass: HomeAssistantType, fritz: Mock):
     assert result["errors"]["base"] == "invalid_auth"
 
 
-async def test_ssdp_not_successful(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_not_successful(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery but no device found."""
     fritz().login.side_effect = OSError("Boom")
 
@@ -272,7 +272,7 @@ async def test_ssdp_not_successful(hass: HomeAssistantType, fritz: Mock):
     assert result["reason"] == "no_devices_found"
 
 
-async def test_ssdp_not_supported(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_not_supported(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery with unsupported device."""
     fritz().get_device_elements.side_effect = HTTPError("Boom")
 
@@ -290,7 +290,7 @@ async def test_ssdp_not_supported(hass: HomeAssistantType, fritz: Mock):
     assert result["reason"] == "not_supported"
 
 
-async def test_ssdp_already_in_progress_unique_id(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_already_in_progress_unique_id(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -305,7 +305,7 @@ async def test_ssdp_already_in_progress_unique_id(hass: HomeAssistantType, fritz
     assert result["reason"] == "already_in_progress"
 
 
-async def test_ssdp_already_in_progress_host(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_already_in_progress_host(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery twice."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_SSDP}, data=MOCK_SSDP_DATA
@@ -322,7 +322,7 @@ async def test_ssdp_already_in_progress_host(hass: HomeAssistantType, fritz: Moc
     assert result["reason"] == "already_in_progress"
 
 
-async def test_ssdp_already_configured(hass: HomeAssistantType, fritz: Mock):
+async def test_ssdp_already_configured(hass: HomeAssistant, fritz: Mock):
     """Test starting a flow from discovery when already configured."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}, data=MOCK_USER_DATA

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     STATE_UNAVAILABLE,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from . import MOCK_CONFIG, FritzDeviceSwitchMock
@@ -25,7 +25,7 @@ from . import MOCK_CONFIG, FritzDeviceSwitchMock
 from tests.common import MockConfigEntry
 
 
-async def test_setup(hass: HomeAssistantType, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of integration."""
     assert await async_setup_component(hass, FB_DOMAIN, MOCK_CONFIG)
     await hass.async_block_till_done()
@@ -40,7 +40,7 @@ async def test_setup(hass: HomeAssistantType, fritz: Mock):
     ]
 
 
-async def test_setup_duplicate_config(hass: HomeAssistantType, fritz: Mock, caplog):
+async def test_setup_duplicate_config(hass: HomeAssistant, fritz: Mock, caplog):
     """Test duplicate config of integration."""
     DUPLICATE = {
         FB_DOMAIN: {
@@ -57,7 +57,7 @@ async def test_setup_duplicate_config(hass: HomeAssistantType, fritz: Mock, capl
     assert "duplicate host entries found" in caplog.text
 
 
-async def test_unload_remove(hass: HomeAssistantType, fritz: Mock):
+async def test_unload_remove(hass: HomeAssistant, fritz: Mock):
     """Test unload and remove of integration."""
     fritz().get_devices.return_value = [FritzDeviceSwitchMock()]
     entity_id = f"{SWITCH_DOMAIN}.fake_name"

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     PERCENTAGE,
     TEMP_CELSIUS,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -27,13 +27,13 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistantType, config: dict):
+async def setup_fritzbox(hass: HomeAssistant, config: dict):
     """Set up mock AVM Fritz!Box."""
     assert await async_setup_component(hass, FB_DOMAIN, config)
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceSensorMock()
     fritz().get_devices.return_value = [device]
@@ -56,7 +56,7 @@ async def test_setup(hass: HomeAssistantType, fritz: Mock):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 
-async def test_update(hass: HomeAssistantType, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSensorMock()
     fritz().get_devices.return_value = [device]
@@ -73,7 +73,7 @@ async def test_update(hass: HomeAssistantType, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistantType, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSensorMock()
     device.update.side_effect = HTTPError("Boom")

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
     STATE_ON,
     TEMP_CELSIUS,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
@@ -34,13 +34,13 @@ from tests.common import async_fire_time_changed
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistantType, config: dict):
+async def setup_fritzbox(hass: HomeAssistant, config: dict):
     """Set up mock AVM Fritz!Box."""
     assert await async_setup_component(hass, FB_DOMAIN, config)
     await hass.async_block_till_done()
 
 
-async def test_setup(hass: HomeAssistantType, fritz: Mock):
+async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceSwitchMock()
     fritz().get_devices.return_value = [device]
@@ -60,7 +60,7 @@ async def test_setup(hass: HomeAssistantType, fritz: Mock):
     assert state.attributes[ATTR_TOTAL_CONSUMPTION_UNIT] == ENERGY_KILO_WATT_HOUR
 
 
-async def test_turn_on(hass: HomeAssistantType, fritz: Mock):
+async def test_turn_on(hass: HomeAssistant, fritz: Mock):
     """Test turn device on."""
     device = FritzDeviceSwitchMock()
     fritz().get_devices.return_value = [device]
@@ -73,7 +73,7 @@ async def test_turn_on(hass: HomeAssistantType, fritz: Mock):
     assert device.set_switch_state_on.call_count == 1
 
 
-async def test_turn_off(hass: HomeAssistantType, fritz: Mock):
+async def test_turn_off(hass: HomeAssistant, fritz: Mock):
     """Test turn device off."""
     device = FritzDeviceSwitchMock()
     fritz().get_devices.return_value = [device]
@@ -86,7 +86,7 @@ async def test_turn_off(hass: HomeAssistantType, fritz: Mock):
     assert device.set_switch_state_off.call_count == 1
 
 
-async def test_update(hass: HomeAssistantType, fritz: Mock):
+async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSwitchMock()
     fritz().get_devices.return_value = [device]
@@ -103,7 +103,7 @@ async def test_update(hass: HomeAssistantType, fritz: Mock):
     assert fritz().login.call_count == 1
 
 
-async def test_update_error(hass: HomeAssistantType, fritz: Mock):
+async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSwitchMock()
     device.update.side_effect = HTTPError("Boom")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I have some spare cycles, so I thought I would continue the work @frenck started. If accepted I should be able to do all this week.

Changing HomeAssistantType to HomeAssistant (including from core and not helpers.typing).

I have on purpose made a commit for each integration (combined homeassistant/components/X and tests/components/X),

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
