### PR TITLE
Autodetect zeroconf interface selection when not set

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -122,6 +122,7 @@ def _get_ip_route(ip: str) -> Any:
 
 def _first_ip_nexthop_from_route(routes: Iterable) -> None | str:
     """Find the first RTA_PREFSRC in the routes."""
+    _LOGGER.debug("Routes: %s", routes)
     for route in routes:
         for attr in route["attrs"]:
             if "RTA_PREFSRC" in attr:

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -113,9 +113,9 @@ async def _async_get_instance(hass: HomeAssistant, **zcargs: Any) -> HaZeroconf:
     return zeroconf
 
 
-def _get_ip_route(ip: str) -> Any:
+def _get_ip_route(dst_ip: str) -> Any:
     """Get ip next hop."""
-    return IPRoute().route("get", dst=ip)
+    return IPRoute().route("get", dst=dst_ip)
 
 
 def _first_ip_nexthop_from_route(routes: Iterable) -> None | str:

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -71,9 +71,7 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
-                vol.Optional(
-                    CONF_DEFAULT_INTERFACE, default=DEFAULT_DEFAULT_INTERFACE
-                ): cv.boolean,
+                vol.Optional(CONF_DEFAULT_INTERFACE): cv.boolean,
                 vol.Optional(CONF_IPV6, default=DEFAULT_IPV6): cv.boolean,
             }
         )
@@ -124,9 +122,9 @@ def _first_ip_nexthop_from_route(routes: Iterable) -> None | str:
     """Find the first RTA_PREFSRC in the routes."""
     _LOGGER.debug("Routes: %s", routes)
     for route in routes:
-        for attr in route["attrs"]:
-            if "RTA_PREFSRC" in attr:
-                return cast(str, attr["RTA_PREFSRC"])
+        for key, value in route["attrs"]:
+            if key == "RTA_PREFSRC":
+                return cast(str, value)
     return None
 
 

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.29.0"],
+  "requirements": ["zeroconf==0.29.0","pyroute2==0.5.18"],
   "dependencies": ["api"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -23,6 +23,7 @@ netdisco==2.8.2
 paho-mqtt==1.5.1
 pillow==8.1.2
 pip>=8.0.3,<20.3
+pyroute2==0.5.18
 python-slugify==4.0.1
 pytz>=2021.1
 pyyaml==5.4.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1672,6 +1672,9 @@ pyrisco==0.3.1
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.2
 
+# homeassistant.components.zeroconf
+pyroute2==0.5.18
+
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -920,6 +920,9 @@ pyrisco==0.3.1
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.2
 
+# homeassistant.components.zeroconf
+pyroute2==0.5.18
+
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12
 

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -31,6 +31,27 @@ PROPERTIES = {
 HOMEKIT_STATUS_UNPAIRED = b"1"
 HOMEKIT_STATUS_PAIRED = b"0"
 
+_ROUTE_NO_LOOPBACK = (
+    {
+        "attrs": [
+            ("RTA_TABLE", 254),
+            ("RTA_DST", "224.0.0.251"),
+            ("RTA_OIF", 4),
+            ("RTA_PREFSRC", "192.168.1.5"),
+        ],
+    },
+)
+_ROUTE_LOOPBACK = (
+    {
+        "attrs": [
+            ("RTA_TABLE", 254),
+            ("RTA_DST", "224.0.0.251"),
+            ("RTA_OIF", 4),
+            ("RTA_PREFSRC", "127.0.0.1"),
+        ],
+    },
+)
+
 
 def service_update_mock(zeroconf, services, handlers, *, limit_service=None):
     """Call service update handler."""
@@ -611,3 +632,62 @@ async def test_removed_ignored(hass, mock_zeroconf):
     assert len(mock_zeroconf.get_service_info.mock_calls) == 2
     assert mock_zeroconf.get_service_info.mock_calls[0][1][0] == "_service.added"
     assert mock_zeroconf.get_service_info.mock_calls[1][1][0] == "_service.updated"
+
+
+async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zeroconf):
+    """Test without default interface config and the route returns a non-loopback address."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.IPRoute.route",
+        return_value=_ROUTE_NO_LOOPBACK,
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
+
+
+async def test_async_detect_interfaces_setting_loopback_route(hass, mock_zeroconf):
+    """Test without default interface config and the route returns a loopback address."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.IPRoute.route", return_value=_ROUTE_LOOPBACK
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.All)
+
+
+async def test_async_detect_interfaces_setting_empty_route(hass, mock_zeroconf):
+    """Test without default interface config and the route returns nothing."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch("homeassistant.components.zeroconf.IPRoute.route", return_value=[]):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.All)
+
+
+async def test_async_detect_interfaces_setting_exception(hass, mock_zeroconf):
+    """Test without default interface config and the route throws an exception."""
+    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.IPRoute.route", side_effect=AttributeError
+    ):
+        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.All)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
If the `default_interface` is unset, the value is auto-detected based on the system routing next hop for the mDNS broadcast address (`224.0.0.251`).

If the next-hop cannot be detected or is a loopback address, `zeroconf` will broadcast on all interfaces. If the next hop is a non-loopback address, `zeroconf` will only broadcast on the default interface.

Setting the `default_interface` to `true` or `false` will override the auto detection.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49479
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17546

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
