### PR TITLE
Rename HomeAssistantType to HomeAssistant, integrations w* - z*

### DIFF
--- a/homeassistant/components/water_heater/group.py
+++ b/homeassistant/components/water_heater/group.py
@@ -3,8 +3,7 @@
 
 from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OFF
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 
 from . import (
     STATE_ECO,
@@ -18,7 +17,7 @@ from . import (
 
 @callback
 def async_describe_on_off_states(
-    hass: HomeAssistantType, registry: GroupIntegrationRegistry
+    hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(

--- a/homeassistant/components/water_heater/reproduce_state.py
+++ b/homeassistant/components/water_heater/reproduce_state.py
@@ -13,8 +13,7 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
-from homeassistant.core import Context, State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import Context, HomeAssistant, State
 
 from . import (
     ATTR_AWAY_MODE,
@@ -47,7 +46,7 @@ VALID_STATES = {
 
 
 async def _async_reproduce_state(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     state: State,
     *,
     context: Context | None = None,
@@ -124,7 +123,7 @@ async def _async_reproduce_state(
 
 
 async def async_reproduce_states(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     states: Iterable[State],
     *,
     context: Context | None = None,

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -22,13 +22,12 @@ from homeassistant.components.light import (
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_registry import (
     async_get_registry as async_get_entity_registry,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
 
 from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity, wled_exception_handler
@@ -51,7 +50,7 @@ PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[list[Entity], bool], None],
 ) -> None:

--- a/homeassistant/components/wled/sensor.py
+++ b/homeassistant/components/wled/sensor.py
@@ -13,8 +13,8 @@ from homeassistant.const import (
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.util.dt import utcnow
 
 from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity
@@ -22,7 +22,7 @@ from .const import ATTR_LED_COUNT, ATTR_MAX_POWER, CURRENT_MA, DOMAIN
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[list[Entity], bool], None],
 ) -> None:

--- a/homeassistant/components/wled/switch.py
+++ b/homeassistant/components/wled/switch.py
@@ -5,8 +5,8 @@ from typing import Any, Callable
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import WLEDDataUpdateCoordinator, WLEDDeviceEntity, wled_exception_handler
 from .const import (
@@ -21,7 +21,7 @@ PARALLEL_UPDATES = 1
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     entry: ConfigEntry,
     async_add_entities: Callable[[list[Entity], bool], None],
 ) -> None:

--- a/homeassistant/components/wunderground/sensor.py
+++ b/homeassistant/components/wunderground/sensor.py
@@ -33,10 +33,11 @@ from homeassistant.const import (
     TEMP_CELSIUS,
     TEMP_FAHRENHEIT,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.typing import ConfigType, HomeAssistantType
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import Throttle
 
 _RESOURCE = "http://api.wunderground.com/api/{}/{}/{}/q/"
@@ -1084,7 +1085,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 
 
 async def async_setup_platform(
-    hass: HomeAssistantType, config: ConfigType, async_add_entities, discovery_info=None
+    hass: HomeAssistant, config: ConfigType, async_add_entities, discovery_info=None
 ):
     """Set up the WUnderground sensor."""
     latitude = config.get(CONF_LATITUDE, hass.config.latitude)
@@ -1119,7 +1120,7 @@ async def async_setup_platform(
 class WUndergroundSensor(SensorEntity):
     """Implementing the WUnderground sensor."""
 
-    def __init__(self, hass: HomeAssistantType, rest, condition, unique_id_base: str):
+    def __init__(self, hass: HomeAssistant, rest, condition, unique_id_base: str):
         """Initialize the sensor."""
         self.rest = rest
         self._condition = condition

--- a/homeassistant/components/xbox/__init__.py
+++ b/homeassistant/components/xbox/__init__.py
@@ -29,7 +29,6 @@ from homeassistant.helpers import (
     config_entry_oauth2_flow,
     config_validation as cv,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import api, config_flow
@@ -168,7 +167,7 @@ class XboxUpdateCoordinator(DataUpdateCoordinator):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         client: XboxLiveClient,
         consoles: SmartglassConsoleList,
     ) -> None:

--- a/homeassistant/components/xbox/binary_sensor.py
+++ b/homeassistant/components/xbox/binary_sensor.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 from functools import partial
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_registry import (
     async_get_registry as async_get_entity_registry,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import XboxUpdateCoordinator
 from .base_sensor import XboxBaseSensorEntity
@@ -17,7 +16,7 @@ from .const import DOMAIN
 PRESENCE_ATTRIBUTES = ["online", "in_party", "in_game", "in_multiplayer"]
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     """Set up Xbox Live friends."""
     coordinator: XboxUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
         "coordinator"

--- a/homeassistant/components/xbox/media_source.py
+++ b/homeassistant/components/xbox/media_source.py
@@ -24,8 +24,7 @@ from homeassistant.components.media_source.models import (
     MediaSourceItem,
     PlayMedia,
 )
-from homeassistant.core import callback
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.util import dt as dt_util
 
 from .browse_media import _find_media_image
@@ -42,7 +41,7 @@ MEDIA_CLASS_MAP = {
 }
 
 
-async def async_get_media_source(hass: HomeAssistantType):
+async def async_get_media_source(hass: HomeAssistant):
     """Set up Xbox media source."""
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     client = hass.data[DOMAIN][entry.entry_id]["client"]
@@ -75,11 +74,11 @@ class XboxSource(MediaSource):
 
     name: str = "Xbox Game Media"
 
-    def __init__(self, hass: HomeAssistantType, client: XboxLiveClient):
+    def __init__(self, hass: HomeAssistant, client: XboxLiveClient):
         """Initialize Xbox source."""
         super().__init__(DOMAIN)
 
-        self.hass: HomeAssistantType = hass
+        self.hass: HomeAssistant = hass
         self.client: XboxLiveClient = client
 
     async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:

--- a/homeassistant/components/xbox/sensor.py
+++ b/homeassistant/components/xbox/sensor.py
@@ -4,11 +4,10 @@ from __future__ import annotations
 from functools import partial
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_registry import (
     async_get_registry as async_get_entity_registry,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import XboxUpdateCoordinator
 from .base_sensor import XboxBaseSensorEntity
@@ -17,7 +16,7 @@ from .const import DOMAIN
 SENSOR_ATTRIBUTES = ["status", "gamer_score", "account_tier", "gold_tenure"]
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry, async_add_entities):
+async def async_setup_entry(hass: HomeAssistant, config_entry, async_add_entities):
     """Set up Xbox Live friends."""
     coordinator: XboxUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id][
         "coordinator"

--- a/homeassistant/components/zerproc/light.py
+++ b/homeassistant/components/zerproc/light.py
@@ -19,7 +19,6 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import HomeAssistantType
 import homeassistant.util.color as color_util
 
 from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
@@ -51,7 +50,7 @@ async def discover_entities(hass: HomeAssistant) -> list[Entity]:
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     config_entry: ConfigEntry,
     async_add_entities: Callable[[list[Entity], bool], None],
 ) -> None:

--- a/homeassistant/components/zha/__init__.py
+++ b/homeassistant/components/zha/__init__.py
@@ -8,10 +8,10 @@ from zhaquirks import setup as setup_quirks
 from zigpy.config import CONF_DEVICE, CONF_DEVICE_PATH
 
 from homeassistant import config_entries, const as ha_const
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.device_registry import CONNECTION_ZIGBEE
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import api
 from .core import ZHAGateway
@@ -156,7 +156,7 @@ async def async_unload_entry(hass, config_entry):
     return True
 
 
-async def async_load_entities(hass: HomeAssistantType) -> None:
+async def async_load_entities(hass: HomeAssistant) -> None:
     """Load entities after integration was setup."""
     await hass.data[DATA_ZHA][DATA_ZHA_GATEWAY].async_initialize_devices_and_entities()
     to_setup = hass.data[DATA_ZHA][DATA_ZHA_PLATFORM_LOADED]
@@ -168,7 +168,7 @@ async def async_load_entities(hass: HomeAssistantType) -> None:
 
 
 async def async_migrate_entry(
-    hass: HomeAssistantType, config_entry: config_entries.ConfigEntry
+    hass: HomeAssistant, config_entry: config_entries.ConfigEntry
 ):
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", config_entry.version)

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -17,13 +17,12 @@ from zigpy.zcl.clusters.general import Groups
 import zigpy.zdo.types as zdo_types
 
 from homeassistant.const import ATTR_COMMAND, ATTR_NAME
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import channels, typing as zha_typing
 from .const import (
@@ -88,7 +87,7 @@ class ZHADevice(LogMixin):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         zigpy_device: zha_typing.ZigpyDeviceType,
         zha_gateway: zha_typing.ZhaGatewayType,
     ):
@@ -288,7 +287,7 @@ class ZHADevice(LogMixin):
     @classmethod
     def new(
         cls,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         zigpy_dev: zha_typing.ZigpyDeviceType,
         gateway: zha_typing.ZhaGatewayType,
         restored: bool = False,

--- a/homeassistant/components/zha/core/discovery.py
+++ b/homeassistant/components/zha/core/discovery.py
@@ -6,13 +6,12 @@ import logging
 from typing import Callable
 
 from homeassistant import const as ha_const
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
 from homeassistant.helpers.entity_registry import async_entries_for_device
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import const as zha_const, registries as zha_regs, typing as zha_typing
 from .. import (  # noqa: F401 pylint: disable=unused-import,
@@ -159,7 +158,7 @@ class ProbeEndpoint:
             channel = channel_class(cluster, ep_channels)
             self.probe_single_cluster(component, channel, ep_channels)
 
-    def initialize(self, hass: HomeAssistantType) -> None:
+    def initialize(self, hass: HomeAssistant) -> None:
         """Update device overrides config."""
         zha_config = hass.data[zha_const.DATA_ZHA].get(zha_const.DATA_ZHA_CONFIG, {})
         overrides = zha_config.get(zha_const.CONF_DEVICE_CONFIG)
@@ -175,7 +174,7 @@ class GroupProbe:
         self._hass = None
         self._unsubs = []
 
-    def initialize(self, hass: HomeAssistantType) -> None:
+    def initialize(self, hass: HomeAssistant) -> None:
         """Initialize the group probe."""
         self._hass = hass
         self._unsubs.append(
@@ -235,7 +234,7 @@ class GroupProbe:
 
     @staticmethod
     def determine_entity_domains(
-        hass: HomeAssistantType, group: zha_typing.ZhaGroupType
+        hass: HomeAssistant, group: zha_typing.ZhaGroupType
     ) -> list[str]:
         """Determine the entity domains for this group."""
         entity_domains: list[str] = []

--- a/homeassistant/components/zha/core/group.py
+++ b/homeassistant/components/zha/core/group.py
@@ -8,8 +8,8 @@ from typing import Any
 
 import zigpy.exceptions
 
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_registry import async_entries_for_device
-from homeassistant.helpers.typing import HomeAssistantType
 
 from .helpers import LogMixin
 from .typing import (
@@ -113,12 +113,12 @@ class ZHAGroup(LogMixin):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         zha_gateway: ZhaGatewayType,
         zigpy_group: ZigpyGroupType,
     ):
         """Initialize the group."""
-        self.hass: HomeAssistantType = hass
+        self.hass: HomeAssistant = hass
         self._zigpy_group: ZigpyGroupType = zigpy_group
         self._zha_gateway: ZhaGatewayType = zha_gateway
 

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -26,9 +26,9 @@ from homeassistant.const import (
     PRESSURE_HPA,
     TEMP_CELSIUS,
 )
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.typing import HomeAssistantType, StateType
+from homeassistant.helpers.typing import StateType
 
 from .core import discovery
 from .core.const import (
@@ -72,7 +72,7 @@ STRICT_MATCH = functools.partial(ZHA_ENTITIES.strict_match, DOMAIN)
 
 
 async def async_setup_entry(
-    hass: HomeAssistantType, config_entry: ConfigEntry, async_add_entities: Callable
+    hass: HomeAssistant, config_entry: ConfigEntry, async_add_entities: Callable
 ) -> None:
     """Set up the Zigbee Home Automation sensor from config entry."""
     entities_to_create = hass.data[DATA_ZHA][DOMAIN]

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -14,11 +14,10 @@ from homeassistant.components.websocket_api.auth import (
     TYPE_AUTH_REQUIRED,
 )
 from homeassistant.components.websocket_api.const import URL
-from homeassistant.core import Context, callback
+from homeassistant.core import Context, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.loader import async_get_integration
 from homeassistant.setup import DATA_SETUP_TIME, async_setup_component
 
@@ -233,7 +232,7 @@ async def test_call_service_child_not_found(hass, websocket_client):
 
 
 async def test_call_service_schema_validation_error(
-    hass: HomeAssistantType, websocket_client
+    hass: HomeAssistant, websocket_client
 ):
     """Test call service command with invalid service data."""
 

--- a/tests/components/wilight/__init__.py
+++ b/tests/components/wilight/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.components.wilight.config_flow import (
     CONF_SERIAL_NUMBER,
 )
 from homeassistant.const import CONF_HOST
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
@@ -58,7 +58,7 @@ MOCK_SSDP_DISCOVERY_INFO_MISSING_MANUFACTORER = {
 
 
 async def setup_integration(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
 ) -> MockConfigEntry:
     """Mock ConfigEntry in Home Assistant."""
 

--- a/tests/components/wilight/test_config_flow.py
+++ b/tests/components/wilight/test_config_flow.py
@@ -10,12 +10,12 @@ from homeassistant.components.wilight.config_flow import (
 )
 from homeassistant.config_entries import SOURCE_SSDP
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_SOURCE
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
     RESULT_TYPE_CREATE_ENTRY,
     RESULT_TYPE_FORM,
 )
-from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.common import MockConfigEntry
 from tests.components.wilight import (
@@ -52,7 +52,7 @@ def mock_dummy_get_components_from_model_wrong():
         yield components
 
 
-async def test_show_ssdp_form(hass: HomeAssistantType) -> None:
+async def test_show_ssdp_form(hass: HomeAssistant) -> None:
     """Test that the ssdp confirmation form is served."""
 
     discovery_info = MOCK_SSDP_DISCOVERY_INFO_P_B.copy()
@@ -68,7 +68,7 @@ async def test_show_ssdp_form(hass: HomeAssistantType) -> None:
     }
 
 
-async def test_ssdp_not_wilight_abort_1(hass: HomeAssistantType) -> None:
+async def test_ssdp_not_wilight_abort_1(hass: HomeAssistant) -> None:
     """Test that the ssdp aborts not_wilight."""
 
     discovery_info = MOCK_SSDP_DISCOVERY_INFO_WRONG_MANUFACTORER.copy()
@@ -80,7 +80,7 @@ async def test_ssdp_not_wilight_abort_1(hass: HomeAssistantType) -> None:
     assert result["reason"] == "not_wilight_device"
 
 
-async def test_ssdp_not_wilight_abort_2(hass: HomeAssistantType) -> None:
+async def test_ssdp_not_wilight_abort_2(hass: HomeAssistant) -> None:
     """Test that the ssdp aborts not_wilight."""
 
     discovery_info = MOCK_SSDP_DISCOVERY_INFO_MISSING_MANUFACTORER.copy()
@@ -93,7 +93,7 @@ async def test_ssdp_not_wilight_abort_2(hass: HomeAssistantType) -> None:
 
 
 async def test_ssdp_not_wilight_abort_3(
-    hass: HomeAssistantType, dummy_get_components_from_model_clear
+    hass: HomeAssistant, dummy_get_components_from_model_clear
 ) -> None:
     """Test that the ssdp aborts not_wilight."""
 
@@ -107,7 +107,7 @@ async def test_ssdp_not_wilight_abort_3(
 
 
 async def test_ssdp_not_supported_abort(
-    hass: HomeAssistantType, dummy_get_components_from_model_wrong
+    hass: HomeAssistant, dummy_get_components_from_model_wrong
 ) -> None:
     """Test that the ssdp aborts not_supported."""
 
@@ -120,7 +120,7 @@ async def test_ssdp_not_supported_abort(
     assert result["reason"] == "not_supported_device"
 
 
-async def test_ssdp_device_exists_abort(hass: HomeAssistantType) -> None:
+async def test_ssdp_device_exists_abort(hass: HomeAssistant) -> None:
     """Test abort SSDP flow if WiLight already configured."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -145,7 +145,7 @@ async def test_ssdp_device_exists_abort(hass: HomeAssistantType) -> None:
     assert result["reason"] == "already_configured"
 
 
-async def test_full_ssdp_flow_implementation(hass: HomeAssistantType) -> None:
+async def test_full_ssdp_flow_implementation(hass: HomeAssistant) -> None:
     """Test the full SSDP flow from start to finish."""
 
     discovery_info = MOCK_SSDP_DISCOVERY_INFO_P_B.copy()

--- a/tests/components/wilight/test_cover.py
+++ b/tests/components/wilight/test_cover.py
@@ -20,8 +20,8 @@ from homeassistant.const import (
     STATE_OPEN,
     STATE_OPENING,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
     HOST,
@@ -56,7 +56,7 @@ def mock_dummy_device_from_host_light_fan():
 
 
 async def test_loading_cover(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     dummy_device_from_host_cover,
 ) -> None:
     """Test the WiLight configuration entry loading."""
@@ -78,7 +78,7 @@ async def test_loading_cover(
 
 
 async def test_open_close_cover_state(
-    hass: HomeAssistantType, dummy_device_from_host_cover
+    hass: HomeAssistant, dummy_device_from_host_cover
 ) -> None:
     """Test the change of state of the cover."""
     await setup_integration(hass)

--- a/tests/components/wilight/test_fan.py
+++ b/tests/components/wilight/test_fan.py
@@ -20,8 +20,8 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.typing import HomeAssistantType
 
 from . import (
     HOST,
@@ -56,7 +56,7 @@ def mock_dummy_device_from_host_light_fan():
 
 
 async def test_loading_light_fan(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     dummy_device_from_host_light_fan,
 ) -> None:
     """Test the WiLight configuration entry loading."""
@@ -78,7 +78,7 @@ async def test_loading_light_fan(
 
 
 async def test_on_off_fan_state(
-    hass: HomeAssistantType, dummy_device_from_host_light_fan
+    hass: HomeAssistant, dummy_device_from_host_light_fan
 ) -> None:
     """Test the change of state of the fan switches."""
     await setup_integration(hass)
@@ -125,7 +125,7 @@ async def test_on_off_fan_state(
 
 
 async def test_speed_fan_state(
-    hass: HomeAssistantType, dummy_device_from_host_light_fan
+    hass: HomeAssistant, dummy_device_from_host_light_fan
 ) -> None:
     """Test the change of speed of the fan switches."""
     await setup_integration(hass)
@@ -171,7 +171,7 @@ async def test_speed_fan_state(
 
 
 async def test_direction_fan_state(
-    hass: HomeAssistantType, dummy_device_from_host_light_fan
+    hass: HomeAssistant, dummy_device_from_host_light_fan
 ) -> None:
     """Test the change of direction of the fan switches."""
     await setup_integration(hass)

--- a/tests/components/wilight/test_init.py
+++ b/tests/components/wilight/test_init.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import (
     ENTRY_STATE_NOT_LOADED,
     ENTRY_STATE_SETUP_RETRY,
 )
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from tests.components.wilight import (
     HOST,
@@ -43,16 +43,14 @@ def mock_dummy_device_from_host():
         yield device
 
 
-async def test_config_entry_not_ready(hass: HomeAssistantType) -> None:
+async def test_config_entry_not_ready(hass: HomeAssistant) -> None:
     """Test the WiLight configuration entry not ready."""
     entry = await setup_integration(hass)
 
     assert entry.state == ENTRY_STATE_SETUP_RETRY
 
 
-async def test_unload_config_entry(
-    hass: HomeAssistantType, dummy_device_from_host
-) -> None:
+async def test_unload_config_entry(hass: HomeAssistant, dummy_device_from_host) -> None:
     """Test the WiLight configuration entry unloading."""
     entry = await setup_integration(hass)
 

--- a/tests/components/wilight/test_light.py
+++ b/tests/components/wilight/test_light.py
@@ -16,8 +16,8 @@ from homeassistant.const import (
     STATE_OFF,
     STATE_ON,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.typing import HomeAssistantType
 
 from tests.components.wilight import (
     HOST,
@@ -129,7 +129,7 @@ def mock_dummy_device_from_host_color():
 
 
 async def test_loading_light(
-    hass: HomeAssistantType,
+    hass: HomeAssistant,
     dummy_device_from_host_light_fan,
     dummy_get_components_from_model_light,
 ) -> None:
@@ -154,7 +154,7 @@ async def test_loading_light(
 
 
 async def test_on_off_light_state(
-    hass: HomeAssistantType, dummy_device_from_host_pb
+    hass: HomeAssistant, dummy_device_from_host_pb
 ) -> None:
     """Test the change of state of the light switches."""
     await setup_integration(hass)
@@ -187,7 +187,7 @@ async def test_on_off_light_state(
 
 
 async def test_dimmer_light_state(
-    hass: HomeAssistantType, dummy_device_from_host_dimmer
+    hass: HomeAssistant, dummy_device_from_host_dimmer
 ) -> None:
     """Test the change of state of the light switches."""
     await setup_integration(hass)
@@ -257,7 +257,7 @@ async def test_dimmer_light_state(
 
 
 async def test_color_light_state(
-    hass: HomeAssistantType, dummy_device_from_host_color
+    hass: HomeAssistant, dummy_device_from_host_color
 ) -> None:
     """Test the change of state of the light switches."""
     await setup_integration(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Change HomeAssistantType to HomeAssistant and import from core.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
