### PR TITLE
Consider Continuous Mode on Nuki Opener to be "unlocked"

### DIFF
--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -2,12 +2,12 @@
 from abc import ABC, abstractmethod
 import logging
 
+from pynuki import MODE_OPENER_CONTINUOUS
 import voluptuous as vol
 
 from homeassistant.components.lock import PLATFORM_SCHEMA, SUPPORT_OPEN, LockEntity
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.helpers import config_validation as cv, entity_platform
-from pynuki import MODE_OPENER_CONTINUOUS
 
 from . import NukiEntity
 from .const import (
@@ -146,7 +146,10 @@ class NukiOpenerEntity(NukiDeviceEntity):
     @property
     def is_locked(self):
         """Return true if either ring-to-open or continuous mode is enabled."""
-        return not (self._nuki_device.is_rto_activated or self._nuki_device.mode == MODE_OPENER_CONTINUOUS)
+        return not (
+            self._nuki_device.is_rto_activated
+            or self._nuki_device.mode == MODE_OPENER_CONTINUOUS
+        )
 
     def lock(self, **kwargs):
         """Disable ring-to-open."""

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -145,7 +145,7 @@ class NukiOpenerEntity(NukiDeviceEntity):
 
     @property
     def is_locked(self):
-        """Return true if ring-to-open is enabled."""
+        """Return true if either ring-to-open or continuous mode is enabled."""
         return not (self._nuki_device.is_rto_activated or self._nuki_device.mode == MODE_OPENER_CONTINUOUS)
 
     def lock(self, **kwargs):

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from homeassistant.components.lock import PLATFORM_SCHEMA, SUPPORT_OPEN, LockEntity
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TOKEN
 from homeassistant.helpers import config_validation as cv, entity_platform
+from pynuki import MODE_OPENER_CONTINUOUS
 
 from . import NukiEntity
 from .const import (
@@ -145,7 +146,7 @@ class NukiOpenerEntity(NukiDeviceEntity):
     @property
     def is_locked(self):
         """Return true if ring-to-open is enabled."""
-        return not self._nuki_device.is_rto_activated
+        return not (self._nuki_device.is_rto_activated or self._nuki_device.mode == MODE_OPENER_CONTINUOUS)
 
     def lock(self, **kwargs):
         """Disable ring-to-open."""


### PR DESCRIPTION
## Breaking change

This PR starts to enable Continuous Mode on the Nuki Opener by considering Continuous Mode to be an "unlocked" state, versus solely considering the "Ring To Open (rto)" state

## Proposed change

This PR starts to enable Continuous Mode on the Nuki Opener by considering Continuous Mode to be an "unlocked" state. Since this mode permanently enables the gate to be opened whenever anyone buzzes it, this is more Accurate than to consider Continuous Mode to still be "locked"


## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests


## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
