### PR TITLE
Add support for RGBW color to blebox light

### DIFF
--- a/homeassistant/components/blebox/light.py
+++ b/homeassistant/components/blebox/light.py
@@ -5,19 +5,13 @@ from blebox_uniapi.error import BadOnValueError
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_WHITE_VALUE,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
+    ATTR_RGBW_COLOR,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_ONOFF,
+    COLOR_MODE_RGBW,
     LightEntity,
 )
-from homeassistant.util.color import (
-    color_hs_to_RGB,
-    color_rgb_to_hex,
-    color_RGB_to_hs,
-    rgb_hex_to_rgb_list,
-)
+from homeassistant.util.color import color_rgb_to_hex, rgb_hex_to_rgb_list
 
 from . import BleBoxEntity, create_blebox_entities
 
@@ -36,12 +30,9 @@ class BleBoxLightEntity(BleBoxEntity, LightEntity):
     """Representation of BleBox lights."""
 
     @property
-    def supported_features(self):
-        """Return supported features."""
-        white = SUPPORT_WHITE_VALUE if self._feature.supports_white else 0
-        color = SUPPORT_COLOR if self._feature.supports_color else 0
-        brightness = SUPPORT_BRIGHTNESS if self._feature.supports_brightness else 0
-        return white | color | brightness
+    def supported_color_modes(self):
+        """Return supported color modes."""
+        return {self.color_mode}
 
     @property
     def is_on(self):
@@ -54,25 +45,27 @@ class BleBoxLightEntity(BleBoxEntity, LightEntity):
         return self._feature.brightness
 
     @property
-    def white_value(self):
-        """Return the white value."""
-        return self._feature.white_value
+    def color_mode(self):
+        """Return the color mode."""
+        if self._feature.supports_white and self._feature.supports_color:
+            return COLOR_MODE_RGBW
+        if self._feature.supports_brightness:
+            return COLOR_MODE_BRIGHTNESS
+        return COLOR_MODE_ONOFF
 
     @property
-    def hs_color(self):
+    def rgbw_color(self):
         """Return the hue and saturation."""
         rgbw_hex = self._feature.rgbw_hex
         if rgbw_hex is None:
             return None
 
-        rgb = rgb_hex_to_rgb_list(rgbw_hex)[0:3]
-        return color_RGB_to_hs(*rgb)
+        return tuple(rgb_hex_to_rgb_list(rgbw_hex)[0:4])
 
     async def async_turn_on(self, **kwargs):
         """Turn the light on."""
 
-        white = kwargs.get(ATTR_WHITE_VALUE)
-        hs_color = kwargs.get(ATTR_HS_COLOR)
+        rgbw = kwargs.get(ATTR_RGBW_COLOR)
         brightness = kwargs.get(ATTR_BRIGHTNESS)
 
         feature = self._feature
@@ -81,12 +74,9 @@ class BleBoxLightEntity(BleBoxEntity, LightEntity):
         if brightness is not None:
             value = feature.apply_brightness(value, brightness)
 
-        if white is not None:
-            value = feature.apply_white(value, white)
-
-        if hs_color is not None:
-            raw_rgb = color_rgb_to_hex(*color_hs_to_RGB(*hs_color))
-            value = feature.apply_color(value, raw_rgb)
+        if rgbw is not None:
+            value = feature.apply_white(value, rgbw[3])
+            value = feature.apply_color(value, color_rgb_to_hex(*rgbw[0:3]))
 
         try:
             await self._feature.async_on(value)

--- a/tests/components/blebox/test_light.py
+++ b/tests/components/blebox/test_light.py
@@ -7,21 +7,13 @@ import pytest
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_WHITE_VALUE,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
+    ATTR_RGBW_COLOR,
+    ATTR_SUPPORTED_COLOR_MODES,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_RGBW,
 )
-from homeassistant.const import (
-    ATTR_SUPPORTED_FEATURES,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    STATE_OFF,
-    STATE_ON,
-)
+from homeassistant.const import SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_ON
 from homeassistant.helpers import device_registry as dr
-from homeassistant.util import color
 
 from .conftest import async_setup_entity, mock_feature
 
@@ -59,8 +51,8 @@ async def test_dimmer_init(dimmer, hass, config):
     state = hass.states.get(entity_id)
     assert state.name == "dimmerBox-brightness"
 
-    supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_BRIGHTNESS
+    color_modes = state.attributes[ATTR_SUPPORTED_COLOR_MODES]
+    assert color_modes == [COLOR_MODE_BRIGHTNESS]
 
     assert state.attributes[ATTR_BRIGHTNESS] == 65
     assert state.state == STATE_ON
@@ -230,8 +222,8 @@ async def test_wlightbox_s_init(wlightbox_s, hass, config):
     state = hass.states.get(entity_id)
     assert state.name == "wLightBoxS-color"
 
-    supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_BRIGHTNESS
+    color_modes = state.attributes[ATTR_SUPPORTED_COLOR_MODES]
+    assert color_modes == [COLOR_MODE_BRIGHTNESS]
 
     assert ATTR_BRIGHTNESS not in state.attributes
     assert state.state == STATE_OFF
@@ -330,13 +322,11 @@ async def test_wlightbox_init(wlightbox, hass, config):
     state = hass.states.get(entity_id)
     assert state.name == "wLightBox-color"
 
-    supported_features = state.attributes[ATTR_SUPPORTED_FEATURES]
-    assert supported_features & SUPPORT_WHITE_VALUE
-    assert supported_features & SUPPORT_COLOR
+    color_modes = state.attributes[ATTR_SUPPORTED_COLOR_MODES]
+    assert color_modes == [COLOR_MODE_RGBW]
 
-    assert ATTR_WHITE_VALUE not in state.attributes
-    assert ATTR_HS_COLOR not in state.attributes
     assert ATTR_BRIGHTNESS not in state.attributes
+    assert ATTR_RGBW_COLOR not in state.attributes
     assert state.state == STATE_OFF
 
     device_registry = dr.async_get(hass)
@@ -363,12 +353,11 @@ async def test_wlightbox_update(wlightbox, hass, config):
     await async_setup_entity(hass, config, entity_id)
 
     state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_HS_COLOR] == (352.32, 100.0)
-    assert state.attributes[ATTR_WHITE_VALUE] == 0x3A
+    assert state.attributes[ATTR_RGBW_COLOR] == (0xFA, 0x00, 0x20, 0x3A)
     assert state.state == STATE_ON
 
 
-async def test_wlightbox_on_via_just_whiteness(wlightbox, hass, config):
+async def test_wlightbox_on_rgbw(wlightbox, hass, config):
     """Test light on."""
 
     feature_mock, entity_id = wlightbox
@@ -385,125 +374,37 @@ async def test_wlightbox_on_via_just_whiteness(wlightbox, hass, config):
 
     def turn_on(value):
         feature_mock.is_on = True
-        assert value == "f1e2d3c7"
+        assert value == "c1d2f3c7"
         feature_mock.white_value = 0xC7  # on
-        feature_mock.rgbw_hex = "f1e2d3c7"
+        feature_mock.rgbw_hex = "c1d2f3c7"
 
     feature_mock.async_on = AsyncMock(side_effect=turn_on)
 
     def apply_white(value, white):
-        assert value == "f1e2d305"
+        assert value == "00010203"
         assert white == 0xC7
-        return "f1e2d3c7"
+        return "000102c7"
 
     feature_mock.apply_white = apply_white
-
-    feature_mock.sensible_on_value = "f1e2d305"
-
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_ON,
-        {"entity_id": entity_id, ATTR_WHITE_VALUE: 0xC7},
-        blocking=True,
-    )
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_WHITE_VALUE] == 0xC7
-
-    assert state.attributes[ATTR_HS_COLOR] == color.color_RGB_to_hs(0xF1, 0xE2, 0xD3)
-
-
-async def test_wlightbox_on_via_reset_whiteness(wlightbox, hass, config):
-    """Test light on."""
-
-    feature_mock, entity_id = wlightbox
-
-    def initial_update():
-        feature_mock.is_on = False
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-    await async_setup_entity(hass, config, entity_id)
-    feature_mock.async_update = AsyncMock()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    def turn_on(value):
-        feature_mock.is_on = True
-        feature_mock.white_value = 0x0
-        assert value == "f1e2d300"
-        feature_mock.rgbw_hex = "f1e2d300"
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
-
-    def apply_white(value, white):
-        assert value == "f1e2d305"
-        assert white == 0x0
-        return "f1e2d300"
-
-    feature_mock.apply_white = apply_white
-
-    feature_mock.sensible_on_value = "f1e2d305"
-
-    await hass.services.async_call(
-        "light",
-        SERVICE_TURN_ON,
-        {"entity_id": entity_id, ATTR_WHITE_VALUE: 0x0},
-        blocking=True,
-    )
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_ON
-    assert state.attributes[ATTR_WHITE_VALUE] == 0x0
-    assert state.attributes[ATTR_HS_COLOR] == color.color_RGB_to_hs(0xF1, 0xE2, 0xD3)
-
-
-async def test_wlightbox_on_via_just_hsl_color(wlightbox, hass, config):
-    """Test light on."""
-
-    feature_mock, entity_id = wlightbox
-
-    def initial_update():
-        feature_mock.is_on = False
-        feature_mock.rgbw_hex = "00000000"
-
-    feature_mock.async_update = AsyncMock(side_effect=initial_update)
-    await async_setup_entity(hass, config, entity_id)
-    feature_mock.async_update = AsyncMock()
-
-    state = hass.states.get(entity_id)
-    assert state.state == STATE_OFF
-
-    hs_color = color.color_RGB_to_hs(0xFF, 0xA1, 0xB2)
-
-    def turn_on(value):
-        feature_mock.is_on = True
-        assert value == "ffa1b2e4"
-        feature_mock.white_value = 0xE4
-        feature_mock.rgbw_hex = value
-
-    feature_mock.async_on = AsyncMock(side_effect=turn_on)
 
     def apply_color(value, color_value):
-        assert value == "c1a2e3e4"
-        assert color_value == "ffa0b1"
-        return "ffa1b2e4"
+        assert value == "000102c7"
+        assert color_value == "c1d2f3"
+        return "c1d2f3c7"
 
     feature_mock.apply_color = apply_color
-    feature_mock.sensible_on_value = "c1a2e3e4"
+    feature_mock.sensible_on_value = "00010203"
 
     await hass.services.async_call(
         "light",
         SERVICE_TURN_ON,
-        {"entity_id": entity_id, ATTR_HS_COLOR: hs_color},
+        {"entity_id": entity_id, ATTR_RGBW_COLOR: (0xC1, 0xD2, 0xF3, 0xC7)},
         blocking=True,
     )
 
     state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_HS_COLOR] == hs_color
-    assert state.attributes[ATTR_WHITE_VALUE] == 0xE4
     assert state.state == STATE_ON
+    assert state.attributes[ATTR_RGBW_COLOR] == (0xC1, 0xD2, 0xF3, 0xC7)
 
 
 async def test_wlightbox_on_to_last_color(wlightbox, hass, config):
@@ -538,8 +439,7 @@ async def test_wlightbox_on_to_last_color(wlightbox, hass, config):
     )
 
     state = hass.states.get(entity_id)
-    assert state.attributes[ATTR_WHITE_VALUE] == 0xE4
-    assert state.attributes[ATTR_HS_COLOR] == color.color_RGB_to_hs(0xF1, 0xE2, 0xD3)
+    assert state.attributes[ATTR_RGBW_COLOR] == (0xF1, 0xE2, 0xD3, 0xE4)
     assert state.state == STATE_ON
 
 
@@ -573,8 +473,7 @@ async def test_wlightbox_off(wlightbox, hass, config):
     )
 
     state = hass.states.get(entity_id)
-    assert ATTR_WHITE_VALUE not in state.attributes
-    assert ATTR_HS_COLOR not in state.attributes
+    assert ATTR_RGBW_COLOR not in state.attributes
     assert state.state == STATE_OFF
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Blebox light no longer supports deprecated `white_value`, use `rgbw_color` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add explicit support for color_modes to blebox light:
- wLightBox will report `supported_color_modes = {"rgbw"}`
- wLightBoxS and dimmerBox will report `supported_color_modes = {"brightness"}`

Remove support for deprecated `white_value`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
