### PR TITLE
Make lights supporting rgbw and rgbww accept colors

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -317,11 +317,23 @@ async def async_setup(hass, config):
             hs_color = params.pop(ATTR_HS_COLOR)
             if COLOR_MODE_RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = color_util.color_hs_to_RGB(*hs_color)
+            elif COLOR_MODE_RGBW in supported_color_modes:
+                params[ATTR_RGBW_COLOR] = (*color_util.color_hs_to_RGB(*hs_color), 0)
+            elif COLOR_MODE_RGBWW in supported_color_modes:
+                params[ATTR_RGBWW_COLOR] = (
+                    *color_util.color_hs_to_RGB(*hs_color),
+                    0,
+                    0,
+                )
             elif COLOR_MODE_XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_hs_to_xy(*hs_color)
         elif ATTR_RGB_COLOR in params and COLOR_MODE_RGB not in supported_color_modes:
             rgb_color = params.pop(ATTR_RGB_COLOR)
-            if COLOR_MODE_HS in supported_color_modes:
+            if COLOR_MODE_RGBW in supported_color_modes:
+                params[ATTR_RGBW_COLOR] = (*rgb_color, 0)
+            if COLOR_MODE_RGBWW in supported_color_modes:
+                params[ATTR_RGBWW_COLOR] = (*rgb_color, 0, 0)
+            elif COLOR_MODE_HS in supported_color_modes:
                 params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
             elif COLOR_MODE_XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
@@ -331,6 +343,14 @@ async def async_setup(hass, config):
                 params[ATTR_HS_COLOR] = color_util.color_xy_to_hs(*xy_color)
             elif COLOR_MODE_RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = color_util.color_xy_to_RGB(*xy_color)
+            elif COLOR_MODE_RGBW in supported_color_modes:
+                params[ATTR_RGBW_COLOR] = (*color_util.color_xy_to_RGB(*hs_color), 0)
+            elif COLOR_MODE_RGBWW in supported_color_modes:
+                params[ATTR_RGBWW_COLOR] = (
+                    *color_util.color_xy_to_RGB(*hs_color),
+                    0,
+                    0,
+                )
 
         # Remove deprecated white value if the light supports color mode
         if supported_color_modes:

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -344,10 +344,10 @@ async def async_setup(hass, config):
             elif COLOR_MODE_RGB in supported_color_modes:
                 params[ATTR_RGB_COLOR] = color_util.color_xy_to_RGB(*xy_color)
             elif COLOR_MODE_RGBW in supported_color_modes:
-                params[ATTR_RGBW_COLOR] = (*color_util.color_xy_to_RGB(*hs_color), 0)
+                params[ATTR_RGBW_COLOR] = (*color_util.color_xy_to_RGB(*xy_color), 0)
             elif COLOR_MODE_RGBWW in supported_color_modes:
                 params[ATTR_RGBWW_COLOR] = (
-                    *color_util.color_xy_to_RGB(*hs_color),
+                    *color_util.color_xy_to_RGB(*xy_color),
                     0,
                     0,
                 )

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1209,6 +1209,8 @@ async def test_light_service_call_color_conversion(hass):
     platform.ENTITIES.append(platform.MockLight("Test_xy", STATE_ON))
     platform.ENTITIES.append(platform.MockLight("Test_all", STATE_ON))
     platform.ENTITIES.append(platform.MockLight("Test_legacy", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgbw", STATE_ON))
+    platform.ENTITIES.append(platform.MockLight("Test_rgbww", STATE_ON))
 
     entity0 = platform.ENTITIES[0]
     entity0.supported_color_modes = {light.COLOR_MODE_HS}
@@ -1228,6 +1230,12 @@ async def test_light_service_call_color_conversion(hass):
 
     entity4 = platform.ENTITIES[4]
     entity4.supported_features = light.SUPPORT_COLOR
+
+    entity5 = platform.ENTITIES[5]
+    entity5.supported_color_modes = {light.COLOR_MODE_RGBW}
+
+    entity6 = platform.ENTITIES[6]
+    entity6.supported_color_modes = {light.COLOR_MODE_RGBWW}
 
     assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
     await hass.async_block_till_done()
@@ -1251,6 +1259,12 @@ async def test_light_service_call_color_conversion(hass):
     state = hass.states.get(entity4.entity_id)
     assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_HS]
 
+    state = hass.states.get(entity5.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBW]
+
+    state = hass.states.get(entity6.entity_id)
+    assert state.attributes["supported_color_modes"] == [light.COLOR_MODE_RGBWW]
+
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -1261,6 +1275,8 @@ async def test_light_service_call_color_conversion(hass):
                 entity2.entity_id,
                 entity3.entity_id,
                 entity4.entity_id,
+                entity5.entity_id,
+                entity6.entity_id,
             ],
             "brightness_pct": 100,
             "hs_color": (240, 100),
@@ -1277,6 +1293,10 @@ async def test_light_service_call_color_conversion(hass):
     assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
     _, data = entity4.last_call("turn_on")
     assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
+    _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 255, "rgbw_color": (0, 0, 255, 0)}
+    _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 255, "rgbww_color": (0, 0, 255, 0, 0)}
 
     await hass.services.async_call(
         "light",
@@ -1288,6 +1308,8 @@ async def test_light_service_call_color_conversion(hass):
                 entity2.entity_id,
                 entity3.entity_id,
                 entity4.entity_id,
+                entity5.entity_id,
+                entity6.entity_id,
             ],
             "brightness_pct": 50,
             "rgb_color": (128, 0, 0),
@@ -1304,6 +1326,10 @@ async def test_light_service_call_color_conversion(hass):
     assert data == {"brightness": 128, "rgb_color": (128, 0, 0)}
     _, data = entity4.last_call("turn_on")
     assert data == {"brightness": 128, "hs_color": (0.0, 100.0)}
+    _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (128, 0, 0, 0)}
+    _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (128, 0, 0, 0, 0)}
 
     await hass.services.async_call(
         "light",
@@ -1315,6 +1341,8 @@ async def test_light_service_call_color_conversion(hass):
                 entity2.entity_id,
                 entity3.entity_id,
                 entity4.entity_id,
+                entity5.entity_id,
+                entity6.entity_id,
             ],
             "brightness_pct": 50,
             "xy_color": (0.1, 0.8),
@@ -1331,6 +1359,10 @@ async def test_light_service_call_color_conversion(hass):
     assert data == {"brightness": 128, "xy_color": (0.1, 0.8)}
     _, data = entity4.last_call("turn_on")
     assert data == {"brightness": 128, "hs_color": (125.176, 100.0)}
+    _, data = entity5.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbw_color": (0, 255, 22, 0)}
+    _, data = entity6.last_call("turn_on")
+    assert data == {"brightness": 128, "rgbww_color": (0, 255, 22, 0, 0)}
 
 
 async def test_light_state_color_conversion(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow lights supporting rgbw and rgbww accept `turn_on` service calls with `hs`, `rgb` or `xy` colors by setting the rgb channels to the requested color and white channels  to 0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
