### PR TITLE
Fix opening cover via emulated_hue without specifying a position

### DIFF
--- a/homeassistant/components/emulated_hue/hue_api.py
+++ b/homeassistant/components/emulated_hue/hue_api.py
@@ -526,9 +526,10 @@ class HueOneLightChangeView(HomeAssistantView):
         # If the requested entity is a cover, convert to open_cover/close_cover
         elif entity.domain == cover.DOMAIN:
             domain = entity.domain
-            service = SERVICE_CLOSE_COVER
             if service == SERVICE_TURN_ON:
                 service = SERVICE_OPEN_COVER
+            else:
+                service = SERVICE_CLOSE_COVER
 
             if (
                 entity_features & SUPPORT_SET_POSITION

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -884,10 +884,10 @@ async def test_put_light_state_media_player(hass_hue, hue_client):
     assert walkman.attributes[media_player.ATTR_MEDIA_VOLUME_LEVEL] == level
 
 
-async def test_close_cover(hass_hue, hue_client):
+async def test_open_cover_without_position(hass_hue, hue_client):
     """Test opening cover ."""
     cover_id = "cover.living_room_window"
-    # Turn the office light off first
+    # Close cover first
     await hass_hue.services.async_call(
         cover.DOMAIN,
         const.SERVICE_CLOSE_COVER,
@@ -907,25 +907,24 @@ async def test_close_cover(hass_hue, hue_client):
     assert cover_test.state == "closed"
 
     # Go through the API to turn it on
-    cover_result = await perform_put_light_state(
-        hass_hue, hue_client, cover_id, True, 100
-    )
+    cover_result = await perform_put_light_state(hass_hue, hue_client, cover_id, True)
 
     assert cover_result.status == HTTP_OK
     assert CONTENT_TYPE_JSON in cover_result.headers["content-type"]
 
-    for _ in range(7):
+    for _ in range(11):
         future = dt_util.utcnow() + timedelta(seconds=1)
         async_fire_time_changed(hass_hue, future)
         await hass_hue.async_block_till_done()
 
     cover_result_json = await cover_result.json()
 
-    assert len(cover_result_json) == 2
+    assert len(cover_result_json) == 1
 
     # Check to make sure the state changed
     cover_test_2 = hass_hue.states.get(cover_id)
     assert cover_test_2.state == "open"
+    assert cover_test_2.attributes.get("current_position") == 100
 
 
 async def test_set_position_cover(hass_hue, hue_client):

--- a/tests/components/emulated_hue/test_hue_api.py
+++ b/tests/components/emulated_hue/test_hue_api.py
@@ -926,6 +926,26 @@ async def test_open_cover_without_position(hass_hue, hue_client):
     assert cover_test_2.state == "open"
     assert cover_test_2.attributes.get("current_position") == 100
 
+    # Go through the API to turn it off
+    cover_result = await perform_put_light_state(hass_hue, hue_client, cover_id, False)
+
+    assert cover_result.status == HTTP_OK
+    assert CONTENT_TYPE_JSON in cover_result.headers["content-type"]
+
+    for _ in range(11):
+        future = dt_util.utcnow() + timedelta(seconds=1)
+        async_fire_time_changed(hass_hue, future)
+        await hass_hue.async_block_till_done()
+
+    cover_result_json = await cover_result.json()
+
+    assert len(cover_result_json) == 1
+
+    # Check to make sure the state changed
+    cover_test_2 = hass_hue.states.get(cover_id)
+    assert cover_test_2.state == "closed"
+    assert cover_test_2.attributes.get("current_position") == 0
+
 
 async def test_set_position_cover(hass_hue, hue_client):
     """Test setting position cover ."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Fix opening cover through `emulated_hue` without specifying position / brightness, i.e. with payload `{"on":true}`

#48367 introduced a bug in a code path that was not tested properly. The `service` variable would be overwritten in line 529, immediately before checking against it in line 530. So the statement following the `if` clause in line 531 would  be unreachable. This PR reverts the change.

Regarding the tests: The two existing tests `test_close_cover` and `test_set_position_cover` would _both_ supply a brightness / position to the API, so the modified code path was essentially untested and the bug would go unnoticed. I reused the first test to test the code path without a specified position.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #48367
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
