### PR TITLE
Openhome component now uses asyncio and handles unavailability

### DIFF
--- a/homeassistant/components/openhome/manifest.json
+++ b/homeassistant/components/openhome/manifest.json
@@ -2,7 +2,7 @@
   "domain": "openhome",
   "name": "Linn / OpenHome",
   "documentation": "https://www.home-assistant.io/integrations/openhome",
-  "requirements": ["openhomedevice==0.7.2"],
+  "requirements": ["openhomedevice==2.0.1"],
   "codeowners": ["@bazwilliams"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/openhome/media_player.py
+++ b/homeassistant/components/openhome/media_player.py
@@ -1,7 +1,11 @@
 """Support for Openhome Devices."""
+import asyncio
+import functools
 import logging
 
-from openhomedevice.Device import Device
+import aiohttp
+from async_upnp_client.client import UpnpError
+from openhomedevice.device import Device
 import voluptuous as vol
 
 from homeassistant.components.media_player import MediaPlayerEntity
@@ -43,23 +47,43 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 
     _LOGGER.info("Openhome device found: %s", name)
     device = await hass.async_add_executor_job(Device, description)
+    await device.init()
 
     # if device has already been discovered
-    if device.Uuid() in openhome_data:
+    if device.uuid() in openhome_data:
         return True
 
     entity = OpenhomeDevice(hass, device)
 
     async_add_entities([entity])
-    openhome_data.add(device.Uuid())
+    openhome_data.add(device.uuid())
 
     platform = entity_platform.current_platform.get()
 
     platform.async_register_entity_service(
         SERVICE_INVOKE_PIN,
         {vol.Required(ATTR_PIN_INDEX): cv.positive_int},
-        "invoke_pin",
+        "async_invoke_pin",
     )
+
+
+def catch_request_errors():
+    """Catch asyncio.TimeoutError, aiohttp.ClientError, UpnpError errors."""
+
+    def call_wrapper(func):
+        """Call wrapper for decorator."""
+
+        @functools.wraps(func)
+        async def wrapper(self, *args, **kwargs):
+            """Catch asyncio.TimeoutError, aiohttp.ClientError, UpnpError errors."""
+            try:
+                return await func(self, *args, **kwargs)
+            except (asyncio.TimeoutError, aiohttp.ClientError, UpnpError):
+                _LOGGER.error("Error during call %s", func.__name__)
+
+        return wrapper
+
+    return call_wrapper
 
 
 class OpenhomeDevice(MediaPlayerEntity):
@@ -80,64 +104,80 @@ class OpenhomeDevice(MediaPlayerEntity):
         self._source = {}
         self._name = None
         self._state = STATE_PLAYING
+        self._available = True
 
-    def update(self):
+    @property
+    def available(self):
+        """Device is available."""
+        return self._available
+
+    async def async_update(self):
         """Update state of device."""
-        self._in_standby = self._device.IsInStandby()
-        self._transport_state = self._device.TransportState()
-        self._track_information = self._device.TrackInfo()
-        self._source = self._device.Source()
-        self._name = self._device.Room().decode("utf-8")
-        self._supported_features = SUPPORT_OPENHOME
-        source_index = {}
-        source_names = []
+        try:
+            self._in_standby = await self._device.is_in_standby()
+            self._transport_state = await self._device.transport_state()
+            self._track_information = await self._device.track_info()
+            self._source = await self._device.source()
+            self._name = await self._device.room()
+            self._supported_features = SUPPORT_OPENHOME
+            source_index = {}
+            source_names = []
 
-        if self._device.VolumeEnabled():
-            self._supported_features |= (
-                SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET
-            )
-            self._volume_level = self._device.VolumeLevel() / 100.0
-            self._volume_muted = self._device.IsMuted()
+            if self._device.volume_enabled:
+                self._supported_features |= (
+                    SUPPORT_VOLUME_STEP | SUPPORT_VOLUME_MUTE | SUPPORT_VOLUME_SET
+                )
+                self._volume_level = await self._device.volume() / 100.0
+                self._volume_muted = await self._device.is_muted()
 
-        for source in self._device.Sources():
-            source_names.append(source["name"])
-            source_index[source["name"]] = source["index"]
+            for source in await self._device.sources():
+                source_names.append(source["name"])
+                source_index[source["name"]] = source["index"]
 
-        self._source_index = source_index
-        self._source_names = source_names
+            self._source_index = source_index
+            self._source_names = source_names
 
-        if self._source["type"] == "Radio":
-            self._supported_features |= SUPPORT_STOP | SUPPORT_PLAY | SUPPORT_PLAY_MEDIA
-        if self._source["type"] in ("Playlist", "Spotify"):
-            self._supported_features |= (
-                SUPPORT_PREVIOUS_TRACK
-                | SUPPORT_NEXT_TRACK
-                | SUPPORT_PAUSE
-                | SUPPORT_PLAY
-                | SUPPORT_PLAY_MEDIA
-            )
+            if self._source["type"] == "Radio":
+                self._supported_features |= (
+                    SUPPORT_STOP | SUPPORT_PLAY | SUPPORT_PLAY_MEDIA
+                )
+            if self._source["type"] in ("Playlist", "Spotify"):
+                self._supported_features |= (
+                    SUPPORT_PREVIOUS_TRACK
+                    | SUPPORT_NEXT_TRACK
+                    | SUPPORT_PAUSE
+                    | SUPPORT_PLAY
+                    | SUPPORT_PLAY_MEDIA
+                )
 
-        if self._in_standby:
-            self._state = STATE_OFF
-        elif self._transport_state == "Paused":
-            self._state = STATE_PAUSED
-        elif self._transport_state in ("Playing", "Buffering"):
-            self._state = STATE_PLAYING
-        elif self._transport_state == "Stopped":
-            self._state = STATE_IDLE
-        else:
-            # Device is playing an external source with no transport controls
-            self._state = STATE_PLAYING
+            if self._in_standby:
+                self._state = STATE_OFF
+            elif self._transport_state == "Paused":
+                self._state = STATE_PAUSED
+            elif self._transport_state in ("Playing", "Buffering"):
+                self._state = STATE_PLAYING
+            elif self._transport_state == "Stopped":
+                self._state = STATE_IDLE
+            else:
+                # Device is playing an external source with no transport controls
+                self._state = STATE_PLAYING
 
-    def turn_on(self):
+            self._available = True
+        except (asyncio.TimeoutError, aiohttp.ClientError, UpnpError):
+            self._available = False
+
+    @catch_request_errors()
+    async def async_turn_on(self):
         """Bring device out of standby."""
-        self._device.SetStandby(False)
+        await self._device.set_standby(False)
 
-    def turn_off(self):
+    @catch_request_errors()
+    async def async_turn_off(self):
         """Put device in standby."""
-        self._device.SetStandby(True)
+        await self._device.set_standby(True)
 
-    def play_media(self, media_type, media_id, **kwargs):
+    @catch_request_errors()
+    async def async_play_media(self, media_type, media_id, **kwargs):
         """Send the play_media command to the media player."""
         if media_type != MEDIA_TYPE_MUSIC:
             _LOGGER.error(
@@ -147,35 +187,48 @@ class OpenhomeDevice(MediaPlayerEntity):
             )
             return
         track_details = {"title": "Home Assistant", "uri": media_id}
-        self._device.PlayMedia(track_details)
+        await self._device.play_media(track_details)
 
-    def media_pause(self):
+    @catch_request_errors()
+    async def async_media_pause(self):
         """Send pause command."""
-        self._device.Pause()
+        await self._device.pause()
 
-    def media_stop(self):
+    @catch_request_errors()
+    async def async_media_stop(self):
         """Send stop command."""
-        self._device.Stop()
+        await self._device.stop()
 
-    def media_play(self):
+    @catch_request_errors()
+    async def async_media_play(self):
         """Send play command."""
-        self._device.Play()
+        await self._device.play()
 
-    def media_next_track(self):
+    @catch_request_errors()
+    async def async_media_next_track(self):
         """Send next track command."""
-        self._device.Skip(1)
+        await self._device.skip(1)
 
-    def media_previous_track(self):
+    @catch_request_errors()
+    async def async_media_previous_track(self):
         """Send previous track command."""
-        self._device.Skip(-1)
+        await self._device.skip(-1)
 
-    def select_source(self, source):
+    @catch_request_errors()
+    async def async_select_source(self, source):
         """Select input source."""
-        self._device.SetSource(self._source_index[source])
+        await self._device.set_source(self._source_index[source])
 
-    def invoke_pin(self, pin):
+    @catch_request_errors()
+    async def async_invoke_pin(self, pin):
         """Invoke pin."""
-        self._device.InvokePin(pin)
+        try:
+            if self._device.pins_enabled:
+                await self._device.invoke_pin(pin)
+            else:
+                _LOGGER.error("Pins service not supported")
+        except (UpnpError):
+            _LOGGER.error("Error invoking pin %s", pin)
 
     @property
     def name(self):
@@ -190,7 +243,7 @@ class OpenhomeDevice(MediaPlayerEntity):
     @property
     def unique_id(self):
         """Return a unique ID."""
-        return self._device.Uuid()
+        return self._device.uuid()
 
     @property
     def state(self):
@@ -239,18 +292,22 @@ class OpenhomeDevice(MediaPlayerEntity):
         """Return true if volume is muted."""
         return self._volume_muted
 
-    def volume_up(self):
+    @catch_request_errors()
+    async def async_volume_up(self):
         """Volume up media player."""
-        self._device.IncreaseVolume()
+        await self._device.increase_volume()
 
-    def volume_down(self):
+    @catch_request_errors()
+    async def async_volume_down(self):
         """Volume down media player."""
-        self._device.DecreaseVolume()
+        await self._device.decrease_volume()
 
-    def set_volume_level(self, volume):
+    @catch_request_errors()
+    async def async_set_volume_level(self, volume):
         """Set volume level, range 0..1."""
-        self._device.SetVolumeLevel(int(volume * 100))
+        await self._device.set_volume(int(volume * 100))
 
-    def mute_volume(self, mute):
+    @catch_request_errors()
+    async def async_mute_volume(self, mute):
         """Mute (true) or unmute (false) media player."""
-        self._device.SetMute(mute)
+        await self._device.set_mute(mute)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1061,7 +1061,7 @@ openerz-api==0.1.0
 openevsewifi==1.1.0
 
 # homeassistant.components.openhome
-openhomedevice==0.7.2
+openhomedevice==2.0.1
 
 # homeassistant.components.opensensemap
 opensensemap-api==0.1.5


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Upgrades the device library `openhomedevice` to version `2.0.1` which is async.
It also guards against error logs if the device is powered off and attempts to make a guess at _availability_.

Diff: https://github.com/bazwilliams/openhomedevice/compare/0.6.1...2.0.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
discovery:
media_player:
  - platform: openhome
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Before this change if a Linn device is powered off to save energy, the integration would make requests every 10 seconds resulting in a stack trace appearing in the logs. Opted to catch `TimeoutError`,`ClientError` and `UpnpError` and either quietly logging a single error log, or if it occurred during the polling update, don't log anything, just set the availability to `False`. Should a subsequent polling update succeed, the availability is set to `True`.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

(Not applicable)
- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
