### PR TITLE
Clean up devolo Home Control config flow

### DIFF
--- a/homeassistant/components/devolo_home_control/config_flow.py
+++ b/homeassistant/components/devolo_home_control/config_flow.py
@@ -1,6 +1,4 @@
 """Config flow to configure the devolo home control integration."""
-import logging
-
 import voluptuous as vol
 
 from homeassistant import config_entries
@@ -16,8 +14,6 @@ from .const import (  # pylint:disable=unused-import
     SUPPORTED_MODEL_TYPES,
 )
 from .exceptions import CredentialsInvalid
-
-_LOGGER = logging.getLogger(__name__)
 
 
 class DevoloHomeControlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
@@ -72,7 +68,6 @@ class DevoloHomeControlFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             mydevolo.credentials_valid
         )
         if not credentials_valid:
-            _LOGGER.debug("Credentials valid")
             raise CredentialsInvalid
         uuid = await self.hass.async_add_executor_job(mydevolo.uuid)
         await self.async_set_unique_id(uuid)

--- a/homeassistant/components/devolo_home_control/exceptions.py
+++ b/homeassistant/components/devolo_home_control/exceptions.py
@@ -1,0 +1,5 @@
+"""Custom exceptions for the devolo_home_control integration."""
+
+
+class CredentialsInvalid(Exception):
+    """Given credentials are invalid."""

--- a/homeassistant/components/devolo_home_control/exceptions.py
+++ b/homeassistant/components/devolo_home_control/exceptions.py
@@ -1,5 +1,6 @@
 """Custom exceptions for the devolo_home_control integration."""
+from homeassistant.exceptions import HomeAssistantError
 
 
-class CredentialsInvalid(Exception):
+class CredentialsInvalid(HomeAssistantError):
     """Given credentials are invalid."""

--- a/tests/components/devolo_home_control/test_config_flow.py
+++ b/tests/components/devolo_home_control/test_config_flow.py
@@ -22,20 +22,22 @@ async def test_form(hass):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     await _setup(hass, result)
 
 
 @pytest.mark.credentials_invalid
-async def test_form_invalid_credentials(hass):
+async def test_form_invalid_credentials_user(hass):
     """Test if we get the error message on invalid credentials."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {}
 
     result = await hass.config_entries.flow.async_configure(
@@ -98,7 +100,7 @@ async def test_form_advanced_options(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_show_zeroconf_form(hass):
+async def test_form_zeroconf(hass):
     """Test that the zeroconf confirmation form is served."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -110,6 +112,27 @@ async def test_show_zeroconf_form(hass):
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
 
     await _setup(hass, result)
+
+
+@pytest.mark.credentials_invalid
+async def test_form_invalid_credentials_zeroconf(hass):
+    """Test if we get the error message on invalid credentials."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=DISCOVERY_INFO,
+    )
+
+    assert result["step_id"] == "zeroconf_confirm"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"username": "test-username", "password": "test-password"},
+    )
+
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_zeroconf_wrong_device(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In #47934 @MartinHjelmare requested a follow up. I must admit, that I did not fully get the issue so I'll rephrase what I understood:

If the integration is setup via Zeroconf, a form with step_id "zeroconf_confirm" is shown. If "credentials_valid" is false then, the step_id unintendedly chances to "user". This PR preserves the step_id.

If that was not the issue, please help me a bit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
