### PR TITLE
Add color_mode support to zwave_js light

### DIFF
--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -11,14 +11,14 @@ from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP,
     ATTR_HS_COLOR,
+    ATTR_RGBW_COLOR,
     ATTR_TRANSITION,
-    ATTR_WHITE_VALUE,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_COLOR_TEMP,
+    COLOR_MODE_HS,
+    COLOR_MODE_RGBW,
     DOMAIN as LIGHT_DOMAIN,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_COLOR_TEMP,
     SUPPORT_TRANSITION,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -85,14 +85,14 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         """Initialize the light."""
         super().__init__(config_entry, client, info)
         self._supports_color = False
-        self._supports_white_value = False
+        self._supports_rgbw = False
         self._supports_color_temp = False
         self._hs_color: tuple[float, float] | None = None
-        self._white_value: int | None = None
+        self._rgbw_color: tuple[int, int, int, int] | None = None
+        self._color_mode: str | None = None
         self._color_temp: int | None = None
         self._min_mireds = 153  # 6500K as a safe default
         self._max_mireds = 370  # 2700K as a safe default
-        self._supported_features = SUPPORT_BRIGHTNESS
         self._warm_white = self.get_zwave_value(
             "targetColor",
             CommandClass.SWITCH_COLOR,
@@ -103,6 +103,8 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             CommandClass.SWITCH_COLOR,
             value_property_key=ColorComponent.COLD_WHITE,
         )
+        self._supported_color_modes = set()
+        self._supported_features = 0
 
         # get additional (optional) values and set features
         self._target_value = self.get_zwave_value("targetValue")
@@ -110,12 +112,14 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         if self._dimming_duration is not None:
             self._supported_features |= SUPPORT_TRANSITION
         self._calculate_color_values()
-        if self._supports_color:
-            self._supported_features |= SUPPORT_COLOR
+        if self._supports_rgbw:
+            self._supported_color_modes.add(COLOR_MODE_RGBW)
+        elif self._supports_color:
+            self._supported_color_modes.add(COLOR_MODE_HS)
         if self._supports_color_temp:
-            self._supported_features |= SUPPORT_COLOR_TEMP
-        if self._supports_white_value:
-            self._supported_features |= SUPPORT_WHITE_VALUE
+            self._supported_color_modes.add(COLOR_MODE_COLOR_TEMP)
+        if not self._supported_color_modes:
+            self._supported_color_modes.add(COLOR_MODE_BRIGHTNESS)
 
     @callback
     def on_value_update(self) -> None:
@@ -133,6 +137,11 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         return 0
 
     @property
+    def color_mode(self) -> str | None:
+        """Return the color mode of the light."""
+        return self._color_mode
+
+    @property
     def is_on(self) -> bool:
         """Return true if device is on (brightness above 0)."""
         return self.brightness > 0
@@ -143,9 +152,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         return self._hs_color
 
     @property
-    def white_value(self) -> int | None:
-        """Return the white value of this light between 0..255."""
-        return self._white_value
+    def rgbw_color(self) -> tuple[int, int, int, int] | None:
+        """Return the hs color."""
+        return self._rgbw_color
 
     @property
     def color_temp(self) -> int | None:
@@ -161,6 +170,11 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
     def max_mireds(self) -> int:
         """Return the warmest color_temp that this light supports."""
         return self._max_mireds
+
+    @property
+    def supported_color_modes(self) -> set | None:
+        """Flag supported features."""
+        return self._supported_color_modes
 
     @property
     def supported_features(self) -> int:
@@ -211,20 +225,20 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
                 }
             )
 
-        # White value
-        white_value = kwargs.get(ATTR_WHITE_VALUE)
-        if white_value is not None and self._supports_white_value:
-            # white led brightness is controlled by white level
-            # rgb leds (if any) can be on at the same time
-            white_channel = {}
-
+        # RGBW
+        rgbw = kwargs.get(ATTR_RGBW_COLOR)
+        if rgbw is not None and self._supports_rgbw:
+            rgbw_channels = {
+                ColorComponent.RED: rgbw[0],
+                ColorComponent.GREEN: rgbw[1],
+                ColorComponent.BLUE: rgbw[2],
+            }
             if self._warm_white:
-                white_channel[ColorComponent.WARM_WHITE] = white_value
+                rgbw_channels[ColorComponent.WARM_WHITE] = rgbw[3]
 
             if self._cold_white:
-                white_channel[ColorComponent.COLD_WHITE] = white_value
-
-            await self._async_set_colors(white_channel)
+                rgbw_channels[ColorComponent.COLD_WHITE] = rgbw[3]
+            await self._async_set_colors(rgbw_channels)
 
         # set brightness
         await self._async_set_brightness(
@@ -361,6 +375,9 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
         else:
             multi_color = {}
 
+        # Default: Brightness (no color)
+        self._color_mode = COLOR_MODE_BRIGHTNESS
+
         # RGB support
         if red_val and green_val and blue_val:
             # prefer values from the multicolor property
@@ -370,6 +387,8 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             self._supports_color = True
             # convert to HS
             self._hs_color = color_util.color_RGB_to_hs(red, green, blue)
+            # Light supports color, set color mode to hs
+            self._color_mode = COLOR_MODE_HS
 
         # color temperature support
         if ww_val and cw_val:
@@ -382,13 +401,21 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
                     self._max_mireds
                     - ((cold_white / 255) * (self._max_mireds - self._min_mireds))
                 )
+                # White channels turned on, set color mode to color_temp
+                self._color_mode = COLOR_MODE_COLOR_TEMP
             else:
                 self._color_temp = None
-        # only one white channel (warm white) = white_level support
-        elif ww_val:
-            self._supports_white_value = True
-            self._white_value = multi_color.get("warmWhite", ww_val.value)
-        # only one white channel (cool white) = white_level support
+        # only one white channel (warm white) = rgbw support
+        elif red_val and green_val and blue_val and ww_val:
+            self._supports_rgbw = True
+            white = multi_color.get("warmWhite", ww_val.value)
+            self._rgbw_color = (red, green, blue, white)
+            # Light supports rgbw, set color mode to rgbw
+            self._color_mode = COLOR_MODE_RGBW
+        # only one white channel (cool white) = rgbw support
         elif cw_val:
-            self._supports_white_value = True
-            self._white_value = multi_color.get("coldWhite", cw_val.value)
+            self._supports_rgbw = True
+            white = multi_color.get("coldWhite", cw_val.value)
+            self._rgbw_color = (red, green, blue, white)
+            # Light supports rgbw, set color mode to rgbw
+            self._color_mode = COLOR_MODE_RGBW

--- a/tests/components/zwave_js/test_light.py
+++ b/tests/components/zwave_js/test_light.py
@@ -460,7 +460,7 @@ async def test_rgbw_light(hass, client, zen_31, integration):
         },
         "value": {"blue": 70, "green": 159, "red": 255, "warmWhite": 141},
     }
-    assert args["value"] == {'blue': 0, 'green': 0, 'red': 0, "warmWhite": 128}
+    assert args["value"] == {"blue": 0, "green": 0, "red": 0, "warmWhite": 128}
 
     args = client.async_send_command.call_args_list[1][0][0]
     assert args["command"] == "node.set_value"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Zwave JS lights no longer supports deprecated white_value, use rgbw_color instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color_mode support to zwave_js light.
Flag support for rgbw instead of white_value for lights with red, green, blue and a single white channel

#### Note:
The driver for this PR is that `white_value` is deprecated, with a plan to warn when it's used in 2021.6, and a complete removal in 2021.10.
zwave_js is one of the most widely used integrations which supports `white_value`.
If this is not the right way to modify zwave_js, it's perfectly fine to close this PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
