### PR TITLE
Use dev endpoint for dev installations

### DIFF
--- a/homeassistant/components/analytics/const.py
+++ b/homeassistant/components/analytics/const.py
@@ -5,6 +5,7 @@ import logging
 import voluptuous as vol
 
 ANALYTICS_ENDPOINT_URL = "https://analytics-api.home-assistant.io/v1"
+ANALYTICS_ENDPOINT_URL_DEV = "https://analytics-api-dev.home-assistant.io/v1"
 DOMAIN = "analytics"
 INTERVAL = timedelta(days=1)
 STORAGE_KEY = "core.analytics"

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -27,7 +27,6 @@ MOCK_VERSION_NIGHTLY = "1970.1.0.dev19700101"
 
 async def test_no_send(hass, caplog, aioclient_mock):
     """Test send when no prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     with patch(
         "homeassistant.components.hassio.is_hassio",
@@ -77,51 +76,47 @@ async def test_load_with_supervisor_without_diagnostics(hass):
 
 async def test_failed_to_send(hass, caplog, aioclient_mock):
     """Test failed to send payload."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=400)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=400)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
     assert analytics.preferences[ATTR_BASE]
 
-    with patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
     assert (
-        f"Sending analytics failed with statuscode 400 from {ANALYTICS_ENDPOINT_URL_DEV}"
+        f"Sending analytics failed with statuscode 400 from {ANALYTICS_ENDPOINT_URL}"
         in caplog.text
     )
 
 
 async def test_failed_to_send_raises(hass, caplog, aioclient_mock):
     """Test raises when failed to send payload."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, exc=aiohttp.ClientError())
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, exc=aiohttp.ClientError())
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
     assert analytics.preferences[ATTR_BASE]
 
-    with patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
     assert "Error sending analytics" in caplog.text
 
 
 async def test_send_base(hass, caplog, aioclient_mock):
     """Test send base prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
 
     await analytics.save_preferences({ATTR_BASE: True})
     assert analytics.preferences[ATTR_BASE]
 
     with patch("uuid.UUID.hex", new_callable=PropertyMock) as hex, patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
     ):
         hex.return_value = MOCK_UUID
         await analytics.send_analytics()
 
     assert f"'uuid': '{MOCK_UUID}'" in caplog.text
-    assert f"'version': '{MOCK_VERSION_DEV}'" in caplog.text
+    assert f"'version': '{MOCK_VERSION}'" in caplog.text
     assert "'installation_type':" in caplog.text
     assert "'integration_count':" not in caplog.text
     assert "'integrations':" not in caplog.text
@@ -129,7 +124,7 @@ async def test_send_base(hass, caplog, aioclient_mock):
 
 async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
     """Test send base prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
 
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
@@ -150,7 +145,7 @@ async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
     ), patch(
         "uuid.UUID.hex", new_callable=PropertyMock
     ) as hex, patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
     ):
         hex.return_value = MOCK_UUID
         await analytics.load()
@@ -158,7 +153,7 @@ async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
         await analytics.send_analytics()
 
     assert f"'uuid': '{MOCK_UUID}'" in caplog.text
-    assert f"'version': '{MOCK_VERSION_DEV}'" in caplog.text
+    assert f"'version': '{MOCK_VERSION}'" in caplog.text
     assert "'supervisor': {'healthy': True, 'supported': True}}" in caplog.text
     assert "'installation_type':" in caplog.text
     assert "'integration_count':" not in caplog.text
@@ -167,7 +162,7 @@ async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
 
 async def test_send_usage(hass, caplog, aioclient_mock):
     """Test send usage prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
@@ -175,9 +170,7 @@ async def test_send_usage(hass, caplog, aioclient_mock):
     assert analytics.preferences[ATTR_USAGE]
     hass.config.components = ["default_config"]
 
-    with patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
 
     assert "'integrations': ['default_config']" in caplog.text
@@ -186,7 +179,7 @@ async def test_send_usage(hass, caplog, aioclient_mock):
 
 async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
     """Test send usage with supervisor prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
 
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
@@ -223,7 +216,7 @@ async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
     ), patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
     ):
         await analytics.send_analytics()
     assert (
@@ -235,16 +228,14 @@ async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
 
 async def test_send_statistics(hass, caplog, aioclient_mock):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
     assert analytics.preferences[ATTR_STATISTICS]
     hass.config.components = ["default_config"]
 
-    with patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
     assert (
         "'state_count': 0, 'automation_count': 0, 'integration_count': 1, 'user_count': 0"
@@ -255,7 +246,7 @@ async def test_send_statistics(hass, caplog, aioclient_mock):
 
 async def test_send_statistics_one_integration_fails(hass, caplog, aioclient_mock):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -265,9 +256,7 @@ async def test_send_statistics_one_integration_fails(hass, caplog, aioclient_moc
     with patch(
         "homeassistant.components.analytics.analytics.async_get_integration",
         side_effect=IntegrationNotFound("any"),
-    ), patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
 
     post_call = aioclient_mock.mock_calls[0]
@@ -279,7 +268,7 @@ async def test_send_statistics_async_get_integration_unknown_exception(
     hass, caplog, aioclient_mock
 ):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -289,13 +278,13 @@ async def test_send_statistics_async_get_integration_unknown_exception(
     with pytest.raises(ValueError), patch(
         "homeassistant.components.analytics.analytics.async_get_integration",
         side_effect=ValueError,
-    ):
+    ), patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
 
 
 async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -330,7 +319,7 @@ async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
         "homeassistant.components.hassio.is_hassio",
         side_effect=Mock(return_value=True),
     ), patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
     ):
         await analytics.send_analytics()
     assert "'addon_count': 1" in caplog.text
@@ -339,14 +328,14 @@ async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
 
 async def test_reusing_uuid(hass, aioclient_mock):
     """Test reusing the stored UUID."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     analytics._data[ATTR_UUID] = "NOT_MOCK_UUID"
 
     await analytics.save_preferences({ATTR_BASE: True})
 
     with patch("uuid.UUID.hex", new_callable=PropertyMock) as hex, patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION
     ):
         # This is not actually called but that in itself prove the test
         hex.return_value = MOCK_UUID
@@ -357,47 +346,49 @@ async def test_reusing_uuid(hass, aioclient_mock):
 
 async def test_custom_integrations(hass, aioclient_mock):
     """Test sending custom integrations."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     analytics = Analytics(hass)
     assert await async_setup_component(hass, "test_package", {"test_package": {}})
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
-    with patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await analytics.send_analytics()
 
     payload = aioclient_mock.mock_calls[0][2]
     assert payload["custom_integrations"][0][ATTR_DOMAIN] == "test_package"
 
 
-async def test_production_url(hass, aioclient_mock):
-    """Test sending payload to production url."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+async def test_dev_url(hass, aioclient_mock):
+    """Test sending payload to dev url."""
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
 
-    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+    with patch(
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+    ):
         await analytics.send_analytics()
 
     payload = aioclient_mock.mock_calls[0]
-    assert str(payload[1]) == ANALYTICS_ENDPOINT_URL
+    assert str(payload[1]) == ANALYTICS_ENDPOINT_URL_DEV
 
 
-async def test_production_url_error(hass, aioclient_mock, caplog):
-    """Test sending payload to production url that returns error."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=400)
+async def test_dev_url_error(hass, aioclient_mock, caplog):
+    """Test sending payload to dev url that returns error."""
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=400)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
 
-    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+    with patch(
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+    ):
 
         await analytics.send_analytics()
 
     payload = aioclient_mock.mock_calls[0]
-    assert str(payload[1]) == ANALYTICS_ENDPOINT_URL
+    assert str(payload[1]) == ANALYTICS_ENDPOINT_URL_DEV
     assert (
-        f"Sending analytics failed with statuscode 400 from {ANALYTICS_ENDPOINT_URL}"
+        f"Sending analytics failed with statuscode 400 from {ANALYTICS_ENDPOINT_URL_DEV}"
         in caplog.text
     )
 

--- a/tests/components/analytics/test_analytics.py
+++ b/tests/components/analytics/test_analytics.py
@@ -7,6 +7,7 @@ import pytest
 from homeassistant.components.analytics.analytics import Analytics
 from homeassistant.components.analytics.const import (
     ANALYTICS_ENDPOINT_URL,
+    ANALYTICS_ENDPOINT_URL_DEV,
     ATTR_BASE,
     ATTR_DIAGNOSTICS,
     ATTR_PREFERENCES,
@@ -19,11 +20,12 @@ from homeassistant.loader import IntegrationNotFound
 from homeassistant.setup import async_setup_component
 
 MOCK_UUID = "abcdefg"
+MOCK_VERSION = "1970.1.0"
 
 
 async def test_no_send(hass, caplog, aioclient_mock):
     """Test send when no prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     with patch(
         "homeassistant.components.hassio.is_hassio",
@@ -73,17 +75,20 @@ async def test_load_with_supervisor_without_diagnostics(hass):
 
 async def test_failed_to_send(hass, caplog, aioclient_mock):
     """Test failed to send payload."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=400)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=400)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
     assert analytics.preferences[ATTR_BASE]
     await analytics.send_analytics()
-    assert "Sending analytics failed with statuscode 400" in caplog.text
+    assert (
+        f"Sending analytics failed with statuscode 400 from {ANALYTICS_ENDPOINT_URL_DEV}"
+        in caplog.text
+    )
 
 
 async def test_failed_to_send_raises(hass, caplog, aioclient_mock):
     """Test raises when failed to send payload."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, exc=aiohttp.ClientError())
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, exc=aiohttp.ClientError())
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
     assert analytics.preferences[ATTR_BASE]
@@ -93,7 +98,7 @@ async def test_failed_to_send_raises(hass, caplog, aioclient_mock):
 
 async def test_send_base(hass, caplog, aioclient_mock):
     """Test send base prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
 
     await analytics.save_preferences({ATTR_BASE: True})
@@ -112,7 +117,7 @@ async def test_send_base(hass, caplog, aioclient_mock):
 
 async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
     """Test send base prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
 
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True})
@@ -148,7 +153,7 @@ async def test_send_base_with_supervisor(hass, caplog, aioclient_mock):
 
 async def test_send_usage(hass, caplog, aioclient_mock):
     """Test send usage prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
 
@@ -164,7 +169,7 @@ async def test_send_usage(hass, caplog, aioclient_mock):
 
 async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
     """Test send usage with supervisor prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
 
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
@@ -211,7 +216,7 @@ async def test_send_usage_with_supervisor(hass, caplog, aioclient_mock):
 
 async def test_send_statistics(hass, caplog, aioclient_mock):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -228,7 +233,7 @@ async def test_send_statistics(hass, caplog, aioclient_mock):
 
 async def test_send_statistics_one_integration_fails(hass, caplog, aioclient_mock):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -250,7 +255,7 @@ async def test_send_statistics_async_get_integration_unknown_exception(
     hass, caplog, aioclient_mock
 ):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -266,7 +271,7 @@ async def test_send_statistics_async_get_integration_unknown_exception(
 
 async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
     """Test send statistics prefrences are defined."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     await analytics.save_preferences({ATTR_BASE: True, ATTR_STATISTICS: True})
     assert analytics.preferences[ATTR_BASE]
@@ -308,7 +313,7 @@ async def test_send_statistics_with_supervisor(hass, caplog, aioclient_mock):
 
 async def test_reusing_uuid(hass, aioclient_mock):
     """Test reusing the stored UUID."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     analytics._data[ATTR_UUID] = "NOT_MOCK_UUID"
 
@@ -324,7 +329,7 @@ async def test_reusing_uuid(hass, aioclient_mock):
 
 async def test_custom_integrations(hass, aioclient_mock):
     """Test sending custom integrations."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     analytics = Analytics(hass)
     assert await async_setup_component(hass, "test_package", {"test_package": {}})
     await analytics.save_preferences({ATTR_BASE: True, ATTR_USAGE: True})
@@ -333,3 +338,35 @@ async def test_custom_integrations(hass, aioclient_mock):
 
     payload = aioclient_mock.mock_calls[0][2]
     assert payload["custom_integrations"][0][ATTR_DOMAIN] == "test_package"
+
+
+async def test_production_url(hass, aioclient_mock):
+    """Test sending payload to production url integrations."""
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    analytics = Analytics(hass)
+    await analytics.save_preferences({ATTR_BASE: True})
+
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+
+        await analytics.send_analytics()
+
+    payload = aioclient_mock.mock_calls[0]
+    assert str(payload[1]) == ANALYTICS_ENDPOINT_URL
+
+
+async def test_production_url_error(hass, aioclient_mock, caplog):
+    """Test sending payload to production url integrations that returns error."""
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=400)
+    analytics = Analytics(hass)
+    await analytics.save_preferences({ATTR_BASE: True})
+
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
+
+        await analytics.send_analytics()
+
+    payload = aioclient_mock.mock_calls[0]
+    assert str(payload[1]) == ANALYTICS_ENDPOINT_URL
+    assert (
+        f"Sending analytics failed with statuscode 400 from {ANALYTICS_ENDPOINT_URL}"
+        in caplog.text
+    )

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -1,5 +1,5 @@
 """The tests for the analytics ."""
-from homeassistant.components.analytics.const import ANALYTICS_ENDPOINT_URL, DOMAIN
+from homeassistant.components.analytics.const import ANALYTICS_ENDPOINT_URL_DEV, DOMAIN
 from homeassistant.setup import async_setup_component
 
 
@@ -13,7 +13,7 @@ async def test_setup(hass):
 
 async def test_websocket(hass, hass_ws_client, aioclient_mock):
     """Test websocekt commands."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()
 

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -1,6 +1,10 @@
 """The tests for the analytics ."""
+from unittest.mock import patch
+
 from homeassistant.components.analytics.const import ANALYTICS_ENDPOINT_URL_DEV, DOMAIN
 from homeassistant.setup import async_setup_component
+
+MOCK_VERSION_DEV = "1970.1.0.dev0"
 
 
 async def test_setup(hass):
@@ -24,10 +28,13 @@ async def test_websocket(hass, hass_ws_client, aioclient_mock):
 
     assert response["success"]
 
-    await ws_client.send_json(
-        {"id": 2, "type": "analytics/preferences", "preferences": {"base": True}}
-    )
-    response = await ws_client.receive_json()
+    with patch(
+        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
+    ):
+        await ws_client.send_json(
+            {"id": 2, "type": "analytics/preferences", "preferences": {"base": True}}
+        )
+        response = await ws_client.receive_json()
     assert len(aioclient_mock.mock_calls) == 1
     assert response["result"]["preferences"]["base"]
 

--- a/tests/components/analytics/test_init.py
+++ b/tests/components/analytics/test_init.py
@@ -1,10 +1,10 @@
 """The tests for the analytics ."""
 from unittest.mock import patch
 
-from homeassistant.components.analytics.const import ANALYTICS_ENDPOINT_URL_DEV, DOMAIN
+from homeassistant.components.analytics.const import ANALYTICS_ENDPOINT_URL, DOMAIN
 from homeassistant.setup import async_setup_component
 
-MOCK_VERSION_DEV = "1970.1.0.dev0"
+MOCK_VERSION = "1970.1.0"
 
 
 async def test_setup(hass):
@@ -17,7 +17,7 @@ async def test_setup(hass):
 
 async def test_websocket(hass, hass_ws_client, aioclient_mock):
     """Test websocekt commands."""
-    aioclient_mock.post(ANALYTICS_ENDPOINT_URL_DEV, status=200)
+    aioclient_mock.post(ANALYTICS_ENDPOINT_URL, status=200)
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
     await hass.async_block_till_done()
 
@@ -28,9 +28,7 @@ async def test_websocket(hass, hass_ws_client, aioclient_mock):
 
     assert response["success"]
 
-    with patch(
-        "homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION_DEV
-    ):
+    with patch("homeassistant.components.analytics.analytics.HA_VERSION", MOCK_VERSION):
         await ws_client.send_json(
             {"id": 2, "type": "analytics/preferences", "preferences": {"base": True}}
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use the dev analytics environment as the receiver for payloads from dev installations, this does not include nightly builds

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
