### PR TITLE
Add group/join status attributes to roon player

### DIFF
--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -3,7 +3,7 @@
   "name": "RoonLabs music player",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
-  "requirements": ["roonapi==0.0.32"],
+  "requirements": ["roonapi==0.0.35"],
   "codeowners": ["@pavoni"],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -66,6 +66,9 @@ SERVICE_TRANSFER = "transfer"
 ATTR_JOIN = "join_ids"
 ATTR_UNJOIN = "unjoin_ids"
 ATTR_TRANSFER = "transfer_id"
+ATTR_IS_JOINED = "is_joined"
+ATTR_IS_JOINED_LEAD = "is_joined_lead"
+ATTR_JOINED_PLAYER = "joined_lead_player"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -163,6 +166,19 @@ class RoonDevice(MediaPlayerEntity):
     def supported_features(self):
         """Flag media player features that are supported."""
         return SUPPORT_ROON
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the device."""
+        attr = {}
+
+        attr[ATTR_IS_JOINED] = self._server.roonapi.is_grouped(self._output_id)
+        attr[ATTR_IS_JOINED_LEAD] = self._server.roonapi.is_group_main(self._output_id)
+        group_main_roon_name = self._server.roonapi.group_main_zone_name(
+            self._output_id
+        )
+        attr[ATTR_JOINED_PLAYER] = self._server.entity_id(group_main_roon_name)
+        return attr
 
     @property
     def device_info(self):

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -28,6 +28,7 @@ class RoonServer:
         self.offline_devices = set()
         self._exit = False
         self._roon_name_by_id = {}
+        self._id_by_roon_name = {}
 
     async def async_setup(self, tries=0):
         """Set up a roon server based on config parameters."""
@@ -78,10 +79,15 @@ class RoonServer:
     def add_player_id(self, entity_id, roon_name):
         """Register a roon player."""
         self._roon_name_by_id[entity_id] = roon_name
+        self._id_by_roon_name[roon_name] = entity_id
 
     def roon_name(self, entity_id):
         """Get the name of the roon player from entity_id."""
         return self._roon_name_by_id.get(entity_id)
+
+    def entity_id(self, roon_name):
+        """Get the id of the roon player from the roon name."""
+        return self._id_by_roon_name.get(roon_name)
 
     def stop_roon(self):
         """Stop background worker."""

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1994,7 +1994,7 @@ rokuecp==0.8.1
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.32
+roonapi==0.0.35
 
 # homeassistant.components.rova
 rova==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1061,7 +1061,7 @@ rokuecp==0.8.1
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.32
+roonapi==0.0.35
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Roon media players can be joined together using services, but it's currently tricky to use this full in automations because HA doesn't know whether players are joined together.

This PR adds three attributes to the player that will make join/unjoin integrations easier to use

![Screenshot 2021-04-23 at 13 18 39](https://user-images.githubusercontent.com/4487313/115879039-1d84bd00-a441-11eb-8d50-dd34af20a791.png)
 
This requires an updated pyroon library (from 0.0.32 to 0.0.35). Apart from the group/join code changes - most other changes are cosmetic.

https://github.com/pavoni/pyroon/compare/0.0.32...0.0.35

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
