### PR TITLE
Add entity service for deCONZ alarm control panel

### DIFF
--- a/homeassistant/components/deconz/services.yaml
+++ b/homeassistant/components/deconz/services.yaml
@@ -64,3 +64,29 @@ remove_orphaned_entries:
         It can be found as part of the integration name.
         Useful if you run multiple deCONZ integrations.
       example: "00212EFFFF012345"
+
+alarm_panel_state:
+  name: Alarm panel state
+  description: Put keypad panel in an intermediate state, to help with visual and audible cues to the user.
+  target:
+    entity:
+      integration: deconz
+      domain: alarm_control_panel
+  fields:
+    panel_state:
+      name: Panel state
+      description: >-
+        - "arming_away/home/night": set panel in right visual arming state.
+        - "entry_delay": make panel beep until panel is disarmed. Beep interval is short.
+        - "exit_delay": make panel beep until panel is set to armed state. Beep interval is long.
+        - "not_ready_to_arm": turn on yellow status led on the panel. Indicate not all conditions for arming are met.
+      required: true
+      selector:
+        select:
+          options:
+            - "arming_away"
+            - "arming_home"
+            - "arming_night"
+            - "entry_delay"
+            - "exit_delay"
+            - "not_ready_to_arm"

--- a/tests/components/deconz/test_alarm_control_panel.py
+++ b/tests/components/deconz/test_alarm_control_panel.py
@@ -6,12 +6,29 @@ from pydeconz.sensor import (
     ANCILLARY_CONTROL_ARMED_AWAY,
     ANCILLARY_CONTROL_ARMED_NIGHT,
     ANCILLARY_CONTROL_ARMED_STAY,
+    ANCILLARY_CONTROL_ARMING_AWAY,
+    ANCILLARY_CONTROL_ARMING_NIGHT,
+    ANCILLARY_CONTROL_ARMING_STAY,
     ANCILLARY_CONTROL_DISARMED,
+    ANCILLARY_CONTROL_ENTRY_DELAY,
+    ANCILLARY_CONTROL_EXIT_DELAY,
+    ANCILLARY_CONTROL_NOT_READY_TO_ARM,
 )
 
 from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
+from homeassistant.components.deconz.alarm_control_panel import (
+    CONF_ALARM_PANEL_STATE,
+    PANEL_ARMING_AWAY,
+    PANEL_ARMING_HOME,
+    PANEL_ARMING_NIGHT,
+    PANEL_ENTRY_DELAY,
+    PANEL_EXIT_DELAY,
+    PANEL_NOT_READY_TO_ARM,
+    SERVICE_ALARM_PANEL_STATE,
+)
+from homeassistant.components.deconz.const import DOMAIN as DECONZ_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_ALARM_ARM_AWAY,
@@ -202,6 +219,88 @@ async def test_alarm_control_panel(hass, aioclient_mock, mock_deconz_websocket):
     assert aioclient_mock.mock_calls[4][2] == {
         "armed": ANCILLARY_CONTROL_DISARMED,
         "panel": ANCILLARY_CONTROL_DISARMED,
+    }
+
+    # Verify entity service calls
+
+    # Service set panel to arming away
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_PANEL_STATE,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_PANEL_STATE: PANEL_ARMING_AWAY,
+        },
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[5][2] == {"panel": ANCILLARY_CONTROL_ARMING_AWAY}
+
+    # Service set panel to arming home
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_PANEL_STATE,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_PANEL_STATE: PANEL_ARMING_HOME,
+        },
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[6][2] == {"panel": ANCILLARY_CONTROL_ARMING_STAY}
+
+    # Service set panel to arming night
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_PANEL_STATE,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_PANEL_STATE: PANEL_ARMING_NIGHT,
+        },
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[7][2] == {"panel": ANCILLARY_CONTROL_ARMING_NIGHT}
+
+    # Service set panel to entry delay
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_PANEL_STATE,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_PANEL_STATE: PANEL_ENTRY_DELAY,
+        },
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[8][2] == {"panel": ANCILLARY_CONTROL_ENTRY_DELAY}
+
+    # Service set panel to exit delay
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_PANEL_STATE,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_PANEL_STATE: PANEL_EXIT_DELAY,
+        },
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[9][2] == {"panel": ANCILLARY_CONTROL_EXIT_DELAY}
+
+    # Service set panel to not ready to arm
+
+    await hass.services.async_call(
+        DECONZ_DOMAIN,
+        SERVICE_ALARM_PANEL_STATE,
+        {
+            ATTR_ENTITY_ID: "alarm_control_panel.keypad",
+            CONF_ALARM_PANEL_STATE: PANEL_NOT_READY_TO_ARM,
+        },
+        blocking=True,
+    )
+    assert aioclient_mock.mock_calls[10][2] == {
+        "panel": ANCILLARY_CONTROL_NOT_READY_TO_ARM
     }
 
     await hass.config_entries.async_unload(config_entry.entry_id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Expanding on #48736
Depends on https://github.com/dresden-elektronik/deconz-rest-plugin/pull/4758

Entity service which can help guide user to interact with the keypad.
* If user enters house entry_delay can be used to signal the user to disarm the panel
* If user has armed the panel exit_delay can be used to signal the user to exit the house before arming complete
* Arming_away/home/night can be used to visually tell the user the panel is arming the alarm
* not_ready_to_arm can be used to signal something went wrong after trying to arm panel

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
