### PR TITLE
Supplementary fixes to new motionEye integration

### DIFF
--- a/homeassistant/components/motioneye/camera.py
+++ b/homeassistant/components/motioneye/camera.py
@@ -59,7 +59,7 @@ PLATFORMS = ["camera"]
 
 async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: Callable
-) -> bool:
+) -> None:
     """Set up motionEye from a config entry."""
     entry_data = hass.data[DOMAIN][entry.entry_id]
 
@@ -82,7 +82,6 @@ async def async_setup_entry(
         )
 
     listen_for_new_cameras(hass, entry, camera_add)
-    return True
 
 
 class MotionEyeMjpegCamera(MjpegCamera, CoordinatorEntity):
@@ -96,7 +95,7 @@ class MotionEyeMjpegCamera(MjpegCamera, CoordinatorEntity):
         camera: dict[str, Any],
         client: MotionEyeClient,
         coordinator: DataUpdateCoordinator,
-    ):
+    ) -> None:
         """Initialize a MJPEG camera."""
         self._surveillance_username = username
         self._surveillance_password = password
@@ -109,7 +108,7 @@ class MotionEyeMjpegCamera(MjpegCamera, CoordinatorEntity):
             config_entry_id, self._camera_id, TYPE_MOTIONEYE_MJPEG_CAMERA
         )
         self._motion_detection_enabled: bool = camera.get(KEY_MOTION_DETECTION, False)
-        self._available = MotionEyeMjpegCamera._is_acceptable_streaming_camera(camera)
+        self._available = self._is_acceptable_streaming_camera(camera)
 
         # motionEye cameras are always streaming or unavailable.
         self.is_streaming = True
@@ -184,7 +183,7 @@ class MotionEyeMjpegCamera(MjpegCamera, CoordinatorEntity):
         available = False
         if self.coordinator.last_update_success:
             camera = get_camera_from_cameras(self._camera_id, self.coordinator.data)
-            if MotionEyeMjpegCamera._is_acceptable_streaming_camera(camera):
+            if self._is_acceptable_streaming_camera(camera):
                 assert camera
                 self._set_mjpeg_camera_state_for_camera(camera)
                 self._motion_detection_enabled = camera.get(KEY_MOTION_DETECTION, False)

--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -44,10 +44,10 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
 
         def _get_form(
-            user_input: ConfigType | None, errors: dict[str, str] | None = None
+            user_input: ConfigType, errors: dict[str, str] | None = None
         ) -> dict[str, Any]:
             """Show the form to the user."""
-            out = self.async_show_form(
+            out: dict[str, Any] = self.async_show_form(
                 step_id="user",
                 data_schema=vol.Schema(
                     {
@@ -125,7 +125,8 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
         # at least prevent entries with the same motionEye URL.
         for existing_entry in self.hass.config_entries.async_entries(DOMAIN):
             if existing_entry.data.get(CONF_URL) == user_input[CONF_URL]:
-                return self.async_abort(reason="already_configured")
+                out = self.async_abort(reason="already_configured")
+                return out
 
         out = self.async_create_entry(
             title=f"{user_input[CONF_URL]}",

--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -47,7 +47,7 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
             user_input: ConfigType, errors: dict[str, str] | None = None
         ) -> dict[str, Any]:
             """Show the form to the user."""
-            out: dict[str, Any] = self.async_show_form(
+            return self.async_show_form(
                 step_id="user",
                 data_schema=vol.Schema(
                     {
@@ -74,7 +74,6 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
                 ),
                 errors=errors,
             )
-            return out
 
         reauth_entry = None
         if self.context.get("entry_id"):
@@ -82,7 +81,6 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
                 self.context["entry_id"]
             )
 
-        out: dict[str, Any] = {}
         if user_input is None:
             return _get_form(reauth_entry.data if reauth_entry else {})
 
@@ -101,16 +99,20 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
             surveillance_password=user_input.get(CONF_SURVEILLANCE_PASSWORD),
         )
 
+        errors = {}
         try:
             await client.async_client_login()
         except MotionEyeClientConnectionError:
-            return _get_form(user_input, {"base": "cannot_connect"})
+            errors["base"] = "cannot_connect"
         except MotionEyeClientInvalidAuthError:
-            return _get_form(user_input, {"base": "invalid_auth"})
+            errors["base"] = "invalid_auth"
         except MotionEyeClientRequestError:
-            return _get_form(user_input, {"base": "unknown"})
+            errors["base"] = "unknown"
         finally:
             await client.async_client_close()
+
+        if errors:
+            return _get_form(user_input, errors)
 
         if self.context.get(CONF_SOURCE) == SOURCE_REAUTH and reauth_entry is not None:
             self.hass.config_entries.async_update_entry(reauth_entry, data=user_input)
@@ -118,21 +120,18 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
             # installed because the initial load did not succeed (the reauth
             # flow will not be initiated if the load succeeds).
             await self.hass.config_entries.async_reload(reauth_entry.entry_id)
-            out = self.async_abort(reason="reauth_successful")
-            return out
+            return self.async_abort(reason="reauth_successful")
 
         # Search for duplicates: there isn't a useful unique_id, but
         # at least prevent entries with the same motionEye URL.
-        for existing_entry in self.hass.config_entries.async_entries(DOMAIN):
+        for existing_entry in self._async_current_entries(include_ignore=False):
             if existing_entry.data.get(CONF_URL) == user_input[CONF_URL]:
-                out = self.async_abort(reason="already_configured")
-                return out
+                return self.async_abort(reason="already_configured")
 
-        out = self.async_create_entry(
+        return self.async_create_entry(
             title=f"{user_input[CONF_URL]}",
             data=user_input,
         )
-        return out
 
     async def async_step_reauth(
         self,

--- a/homeassistant/components/motioneye/config_flow.py
+++ b/homeassistant/components/motioneye/config_flow.py
@@ -43,79 +43,93 @@ class MotionEyeConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: ConfigType | None = None
     ) -> dict[str, Any]:
         """Handle the initial step."""
+
+        def _get_form(
+            user_input: ConfigType | None, errors: dict[str, str] | None = None
+        ) -> dict[str, Any]:
+            """Show the form to the user."""
+            out = self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_URL, default=user_input.get(CONF_URL, "")
+                        ): str,
+                        vol.Optional(
+                            CONF_ADMIN_USERNAME,
+                            default=user_input.get(CONF_ADMIN_USERNAME),
+                        ): str,
+                        vol.Optional(
+                            CONF_ADMIN_PASSWORD,
+                            default=user_input.get(CONF_ADMIN_PASSWORD),
+                        ): str,
+                        vol.Optional(
+                            CONF_SURVEILLANCE_USERNAME,
+                            default=user_input.get(CONF_SURVEILLANCE_USERNAME),
+                        ): str,
+                        vol.Optional(
+                            CONF_SURVEILLANCE_PASSWORD,
+                            default=user_input.get(CONF_SURVEILLANCE_PASSWORD),
+                        ): str,
+                    }
+                ),
+                errors=errors,
+            )
+            return out
+
         out: dict[str, Any] = {}
-        errors = {}
         if user_input is None:
             entry = self.context.get(CONF_CONFIG_ENTRY)
-            user_input = entry.data if entry else {}
-        else:
-            try:
-                # Cannot use cv.url validation in the schema itself, so
-                # apply extra validation here.
-                cv.url(user_input[CONF_URL])
-            except vol.Invalid:
-                errors["base"] = "invalid_url"
-            else:
-                client = create_motioneye_client(
-                    user_input[CONF_URL],
-                    admin_username=user_input.get(CONF_ADMIN_USERNAME),
-                    admin_password=user_input.get(CONF_ADMIN_PASSWORD),
-                    surveillance_username=user_input.get(CONF_SURVEILLANCE_USERNAME),
-                    surveillance_password=user_input.get(CONF_SURVEILLANCE_PASSWORD),
-                )
+            return _get_form(entry.data if entry else {})
 
-                try:
-                    await client.async_client_login()
-                except MotionEyeClientConnectionError:
-                    errors["base"] = "cannot_connect"
-                except MotionEyeClientInvalidAuthError:
-                    errors["base"] = "invalid_auth"
-                except MotionEyeClientRequestError:
-                    errors["base"] = "unknown"
-                else:
-                    entry = self.context.get(CONF_CONFIG_ENTRY)
-                    if (
-                        self.context.get(CONF_SOURCE) == SOURCE_REAUTH
-                        and entry is not None
-                    ):
-                        self.hass.config_entries.async_update_entry(
-                            entry, data=user_input
-                        )
-                        # Need to manually reload, as the listener won't have been
-                        # installed because the initial load did not succeed (the reauth
-                        # flow will not be initiated if the load succeeds).
-                        await self.hass.config_entries.async_reload(entry.entry_id)
-                        out = self.async_abort(reason="reauth_successful")
-                        return out
+        try:
+            # Cannot use cv.url validation in the schema itself, so
+            # apply extra validation here.
+            cv.url(user_input[CONF_URL])
+        except vol.Invalid:
+            return _get_form(user_input, {"base": "invalid_url"})
 
-                    out = self.async_create_entry(
-                        title=f"{user_input[CONF_URL]}",
-                        data=user_input,
-                    )
-                    return out
+        client = create_motioneye_client(
+            user_input[CONF_URL],
+            admin_username=user_input.get(CONF_ADMIN_USERNAME),
+            admin_password=user_input.get(CONF_ADMIN_PASSWORD),
+            surveillance_username=user_input.get(CONF_SURVEILLANCE_USERNAME),
+            surveillance_password=user_input.get(CONF_SURVEILLANCE_PASSWORD),
+        )
 
-        out = self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_URL, default=user_input.get(CONF_URL, "")): str,
-                    vol.Optional(
-                        CONF_ADMIN_USERNAME, default=user_input.get(CONF_ADMIN_USERNAME)
-                    ): str,
-                    vol.Optional(
-                        CONF_ADMIN_PASSWORD, default=user_input.get(CONF_ADMIN_PASSWORD)
-                    ): str,
-                    vol.Optional(
-                        CONF_SURVEILLANCE_USERNAME,
-                        default=user_input.get(CONF_SURVEILLANCE_USERNAME),
-                    ): str,
-                    vol.Optional(
-                        CONF_SURVEILLANCE_PASSWORD,
-                        default=user_input.get(CONF_SURVEILLANCE_PASSWORD),
-                    ): str,
-                }
-            ),
-            errors=errors,
+        try:
+            await client.async_client_login()
+        except MotionEyeClientConnectionError:
+            return _get_form(user_input, {"base": "cannot_connect"})
+        except MotionEyeClientInvalidAuthError:
+            return _get_form(user_input, {"base": "invalid_auth"})
+        except MotionEyeClientRequestError:
+            return _get_form(user_input, {"base": "unknown"})
+        finally:
+            await client.async_client_close()
+
+        if (
+            self.context.get(CONF_SOURCE) == SOURCE_REAUTH
+            and self.context.get(CONF_CONFIG_ENTRY) is not None
+        ):
+            entry = self.context[CONF_CONFIG_ENTRY]
+            self.hass.config_entries.async_update_entry(entry, data=user_input)
+            # Need to manually reload, as the listener won't have been
+            # installed because the initial load did not succeed (the reauth
+            # flow will not be initiated if the load succeeds).
+            await self.hass.config_entries.async_reload(entry.entry_id)
+            out = self.async_abort(reason="reauth_successful")
+            return out
+
+        # Search for duplicates: there isn't a useful unique_id, but
+        # at least prevent entries with the same motionEye URL.
+        for existing_entry in self.hass.config_entries.async_entries(DOMAIN):
+            if existing_entry.data.get(CONF_URL) == user_input[CONF_URL]:
+                return self.async_abort(reason="already_configured")
+
+        out = self.async_create_entry(
+            title=f"{user_input[CONF_URL]}",
+            data=user_input,
         )
         return out
 

--- a/homeassistant/components/motioneye/const.py
+++ b/homeassistant/components/motioneye/const.py
@@ -3,7 +3,6 @@ from datetime import timedelta
 
 DOMAIN = "motioneye"
 
-CONF_CONFIG_ENTRY = "config_entry"
 CONF_CLIENT = "client"
 CONF_COORDINATOR = "coordinator"
 CONF_ADMIN_PASSWORD = "admin_password"

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -22,6 +22,8 @@ from homeassistant.core import HomeAssistant
 
 from . import TEST_URL, create_mock_motioneye_client, create_mock_motioneye_config_entry
 
+from tests.common import MockConfigEntry
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -32,7 +34,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert result["type"] == "form"
-    assert result["errors"] == {}
+    assert not result["errors"]
 
     mock_client = create_mock_motioneye_client()
 
@@ -65,6 +67,7 @@ async def test_user_success(hass: HomeAssistant) -> None:
         CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
     }
     assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_client.async_client_close.called
 
 
 async def test_user_invalid_auth(hass: HomeAssistant) -> None:
@@ -92,10 +95,11 @@ async def test_user_invalid_auth(hass: HomeAssistant) -> None:
                 CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
             },
         )
-        await mock_client.async_client_close()
+        await hass.async_block_till_done()
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_auth"}
+    assert mock_client.async_client_close.called
 
 
 async def test_user_invalid_url(hass: HomeAssistant) -> None:
@@ -105,9 +109,10 @@ async def test_user_invalid_url(hass: HomeAssistant) -> None:
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
+    mock_client = create_mock_motioneye_client()
     with patch(
         "homeassistant.components.motioneye.MotionEyeClient",
-        return_value=create_mock_motioneye_client(),
+        return_value=mock_client,
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -119,6 +124,7 @@ async def test_user_invalid_url(hass: HomeAssistant) -> None:
                 CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
             },
         )
+        await hass.async_block_till_done()
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "invalid_url"}
@@ -149,10 +155,11 @@ async def test_user_cannot_connect(hass: HomeAssistant) -> None:
                 CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
             },
         )
-        await mock_client.async_client_close()
+        await hass.async_block_till_done()
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "cannot_connect"}
+    assert mock_client.async_client_close.called
 
 
 async def test_user_request_error(hass: HomeAssistant) -> None:
@@ -178,10 +185,11 @@ async def test_user_request_error(hass: HomeAssistant) -> None:
                 CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
             },
         )
-        await mock_client.async_client_close()
+        await hass.async_block_till_done()
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "unknown"}
+    assert mock_client.async_client_close.called
 
 
 async def test_reauth(hass: HomeAssistant) -> None:
@@ -201,7 +209,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
         },
     )
     assert result["type"] == "form"
-    assert result["errors"] == {}
+    assert not result["errors"]
 
     mock_client = create_mock_motioneye_client()
 
@@ -226,8 +234,57 @@ async def test_reauth(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "reauth_successful"
-        assert config_entry.data == new_data
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "reauth_successful"
+    assert config_entry.data == new_data
 
     assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_client.async_client_close.called
+
+
+async def test_duplicate(hass: HomeAssistant) -> None:
+    """Test that a duplicate entry (same URL) is rejected."""
+    config_data = {
+        CONF_URL: TEST_URL,
+    }
+
+    # Add an existing entry with the same URL.
+    existing_entry: MockConfigEntry = MockConfigEntry(  # type: ignore[no-untyped-call]
+        domain=DOMAIN,
+        data=config_data,
+    )
+    existing_entry.add_to_hass(hass)  # type: ignore[no-untyped-call]
+
+    # Now do the usual config entry process, and verify it is rejected.
+    create_mock_motioneye_config_entry(hass, data=config_data)
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert not result["errors"]
+    mock_client = create_mock_motioneye_client()
+
+    new_data = {
+        CONF_URL: TEST_URL,
+        CONF_ADMIN_USERNAME: "admin-username",
+        CONF_ADMIN_PASSWORD: "admin-password",
+        CONF_SURVEILLANCE_USERNAME: "surveillance-username",
+        CONF_SURVEILLANCE_PASSWORD: "surveillance-password",
+    }
+
+    with patch(
+        "homeassistant.components.motioneye.MotionEyeClient",
+        return_value=mock_client,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            new_data,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+    assert mock_client.async_client_close.called

--- a/tests/components/motioneye/test_config_flow.py
+++ b/tests/components/motioneye/test_config_flow.py
@@ -12,7 +12,6 @@ from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.motioneye.const import (
     CONF_ADMIN_PASSWORD,
     CONF_ADMIN_USERNAME,
-    CONF_CONFIG_ENTRY,
     CONF_SURVEILLANCE_PASSWORD,
     CONF_SURVEILLANCE_USERNAME,
     DOMAIN,
@@ -205,7 +204,7 @@ async def test_reauth(hass: HomeAssistant) -> None:
         DOMAIN,
         context={
             "source": config_entries.SOURCE_REAUTH,
-            CONF_CONFIG_ENTRY: config_entry,
+            "entry_id": config_entry.entry_id,
         },
     )
     assert result["type"] == "form"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

   * Minor fixes as requested (post-merge) on https://github.com/home-assistant/core/pull/48239 .
      * Primary change: Duplicate checking to prevent the same motionEye URL being used in subsequent config entries.
      * Needed to reactor async_step_user to be significantly less indented for this to be readable.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

None.

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/48239 .
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
