### PR TITLE
Catch missing/unavailable response from modbus

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -620,6 +620,7 @@ omit =
     homeassistant/components/mochad/*
     homeassistant/components/modbus/climate.py
     homeassistant/components/modbus/cover.py
+    homeassistant/components/modbus/modbus.py
     homeassistant/components/modbus/switch.py
     homeassistant/components/modem_callerid/sensor.py
     homeassistant/components/motion_blinds/__init__.py

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -253,7 +253,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -268,7 +268,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -283,7 +283,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -298,7 +298,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return False
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -313,7 +313,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return False
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -328,7 +328,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return False
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -343,7 +343,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return False
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return False
             self._in_error = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -162,10 +162,11 @@ class ModbusHub:
         return self._config_name
 
     def _log_error(self, exception_error: ModbusException, error_state=True):
+        log_text = "Pymodbus: " + str(exception_error)
         if self._in_error:
-            _LOGGER.debug("Pymodbus: " + str(exception_error))
+            _LOGGER.debug(log_text)
         else:
-            _LOGGER.error("Pymodbus: " + str(exception_error))
+            _LOGGER.error(log_text)
             self._in_error = error_state
 
     def setup(self):

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -238,7 +238,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
-            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
                 self._log_error(result)
                 return None
             self._in_error = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -5,6 +5,7 @@ import threading
 from pymodbus.client.sync import ModbusSerialClient, ModbusTcpClient, ModbusUdpClient
 from pymodbus.constants import Defaults
 from pymodbus.exceptions import ModbusException
+from pymodbus.pdu import ExceptionResponse, IllegalFunctionRequest
 from pymodbus.transaction import ModbusRtuFramer
 
 from homeassistant.const import (
@@ -162,9 +163,9 @@ class ModbusHub:
 
     def _log_error(self, exception_error: ModbusException, error_state=True):
         if self._in_error:
-            _LOGGER.debug(str(exception_error))
+            _LOGGER.debug("Pymodbus: " + str(exception_error))
         else:
-            _LOGGER.error(str(exception_error))
+            _LOGGER.error("Pymodbus: " + str(exception_error))
             self._in_error = error_state
 
     def setup(self):
@@ -236,6 +237,9 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
+                return None
             self._in_error = False
             return result
 
@@ -247,6 +251,9 @@ class ModbusHub:
                 result = self._client.read_discrete_inputs(address, count, **kwargs)
             except ModbusException as exception_error:
                 self._log_error(exception_error)
+                return None
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
                 return None
             self._in_error = False
             return result
@@ -260,6 +267,9 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
+                return None
             self._in_error = False
             return result
 
@@ -272,6 +282,9 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 return None
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
+                return None
             self._in_error = False
             return result
 
@@ -280,9 +293,12 @@ class ModbusHub:
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
             try:
-                self._client.write_coil(address, value, **kwargs)
+                result = self._client.write_coil(address, value, **kwargs)
             except ModbusException as exception_error:
                 self._log_error(exception_error)
+                return False
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
                 return False
             self._in_error = False
             return True
@@ -292,9 +308,12 @@ class ModbusHub:
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
             try:
-                self._client.write_coils(address, values, **kwargs)
+                result = self._client.write_coils(address, values, **kwargs)
             except ModbusException as exception_error:
                 self._log_error(exception_error)
+                return False
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
                 return False
             self._in_error = False
             return True
@@ -304,9 +323,12 @@ class ModbusHub:
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
             try:
-                self._client.write_register(address, value, **kwargs)
+                result = self._client.write_register(address, value, **kwargs)
             except ModbusException as exception_error:
                 self._log_error(exception_error)
+                return False
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
                 return False
             self._in_error = False
             return True
@@ -316,9 +338,12 @@ class ModbusHub:
         with self._lock:
             kwargs = {"unit": unit} if unit else {}
             try:
-                self._client.write_registers(address, values, **kwargs)
+                result = self._client.write_registers(address, values, **kwargs)
             except ModbusException as exception_error:
                 self._log_error(exception_error)
+                return False
+            if type(result) in [ExceptionResponse, IllegalFunctionRequest]:
+                self._log_error(result)
                 return False
             self._in_error = False
             return True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
pymodbus 2.5.1 returns IllegalResponse, ExceptionResponse in case a function
is not implemented or not available in a device. This can e.g. happen when the user
configures a wrong address (which is the cause of this PR).

All read/write functions have been guarded against this. It is handled like an exception, and
class modbusHub returns None to the platform functions. 

.coveragerc was updated not to include modbus.py. This is done because the tests added caused
other changes in the test harness (and in "Type of change" I may only select 1 box).

Tests are submitted in PR #49633 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
