### PR TITLE
Fix Shelly button first trigger

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -33,6 +33,7 @@ from .const import (
     POLLING_TIMEOUT_SEC,
     REST,
     REST_SENSORS_UPDATE_INTERVAL,
+    SHBTN_MODELS,
     SLEEP_PERIOD_MULTIPLIER,
     UPDATE_PERIOD_MULTIPLIER,
 )
@@ -180,6 +181,17 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         """Handle device updates."""
         if not self.device.initialized:
             return
+
+        # For buttons which are battery powered - set initial value for last_event_count
+        if self.model in SHBTN_MODELS and self._last_input_events_count.get(1) is None:
+            for block in self.device.blocks:
+                if block.type != "device":
+                    continue
+
+                if block.wakeupEvent[0] == "button":
+                    self._last_input_events_count[1] = -1
+
+                break
 
         # Check for input events
         for block in self.device.blocks:

--- a/homeassistant/components/shelly/const.py
+++ b/homeassistant/components/shelly/const.py
@@ -49,7 +49,7 @@ BASIC_INPUTS_EVENTS_TYPES = {
     "long",
 }
 
-SHBTN_1_INPUTS_EVENTS_TYPES = {
+SHBTN_INPUTS_EVENTS_TYPES = {
     "single",
     "double",
     "triple",
@@ -71,6 +71,8 @@ INPUTS_EVENTS_SUBTYPES = {
     "button2": 2,
     "button3": 3,
 }
+
+SHBTN_MODELS = ["SHBTN-1", "SHBTN-2"]
 
 # Kelvin value for colorTemp
 KELVIN_MAX_VALUE = 6500

--- a/homeassistant/components/shelly/device_trigger.py
+++ b/homeassistant/components/shelly/device_trigger.py
@@ -27,7 +27,8 @@ from .const import (
     DOMAIN,
     EVENT_SHELLY_CLICK,
     INPUTS_EVENTS_SUBTYPES,
-    SHBTN_1_INPUTS_EVENTS_TYPES,
+    SHBTN_INPUTS_EVENTS_TYPES,
+    SHBTN_MODELS,
     SUPPORTED_INPUTS_EVENTS_TYPES,
 )
 from .utils import get_device_wrapper, get_input_triggers
@@ -69,8 +70,8 @@ async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
     if not wrapper:
         raise InvalidDeviceAutomationConfig(f"Device not found: {device_id}")
 
-    if wrapper.model in ("SHBTN-1", "SHBTN-2"):
-        for trigger in SHBTN_1_INPUTS_EVENTS_TYPES:
+    if wrapper.model in SHBTN_MODELS:
+        for trigger in SHBTN_INPUTS_EVENTS_TYPES:
             triggers.append(
                 {
                     CONF_PLATFORM: "device",

--- a/homeassistant/components/shelly/utils.py
+++ b/homeassistant/components/shelly/utils.py
@@ -16,7 +16,8 @@ from .const import (
     COAP,
     DATA_CONFIG_ENTRY,
     DOMAIN,
-    SHBTN_1_INPUTS_EVENTS_TYPES,
+    SHBTN_INPUTS_EVENTS_TYPES,
+    SHBTN_MODELS,
     SHIX3_1_INPUTS_EVENTS_TYPES,
 )
 
@@ -111,7 +112,7 @@ def get_device_channel_name(
 def is_momentary_input(settings: dict, block: aioshelly.Block) -> bool:
     """Return true if input button settings is set to a momentary type."""
     # Shelly Button type is fixed to momentary and no btn_type
-    if settings["device"]["type"] in ("SHBTN-1", "SHBTN-2"):
+    if settings["device"]["type"] in SHBTN_MODELS:
         return True
 
     button = settings.get("relays") or settings.get("lights") or settings.get("inputs")
@@ -158,8 +159,8 @@ def get_input_triggers(
     else:
         subtype = f"button{int(block.channel)+1}"
 
-    if device.settings["device"]["type"] in ("SHBTN-1", "SHBTN-2"):
-        trigger_types = SHBTN_1_INPUTS_EVENTS_TYPES
+    if device.settings["device"]["type"] in SHBTN_MODELS:
+        trigger_types = SHBTN_INPUTS_EVENTS_TYPES
     elif device.settings["device"]["type"] == "SHIX3-1":
         trigger_types = SHIX3_1_INPUTS_EVENTS_TYPES
     else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Shelly button is a battery operated button. This device sleeps and is not initialized until first event from device which only happens every 12 hours or when a button is pressed. This cause the device to miss the first button event after HA restart since the integration tracks the device `inputEventCnt` to filter duplicate events. 
This bugfix initialize the `last_event_count` to be -1 so it is not None only in case the wakeup event is `button` and the counter is not initialized yet so that first trigger is not missed. This is needed since this button can also run on USB power and in this case events are sent every 15 seconds but with a wakeup event of `ext_power`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/49204
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
