### PR TITLE
[rework-tahoma] Remove OptionsFlow and use a default update interval

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import timedelta
 from enum import Enum
 import logging
+from typing import List
 
 from aiohttp import ClientError, ServerDisconnectedError
 from pyhoma.client import TahomaClient
@@ -12,6 +13,7 @@ from pyhoma.exceptions import (
     MaintenanceException,
     TooManyRequestsException,
 )
+from pyhoma.models import Device
 
 from homeassistant.components.scene import DOMAIN as SCENE
 from homeassistant.config_entries import ConfigEntry
@@ -23,9 +25,9 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     CONF_HUB,
-    CONF_UPDATE_INTERVAL,
     DEFAULT_HUB,
     DEFAULT_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL_RTS,
     DOMAIN,
     HUB_MANUFACTURER,
     IGNORED_OVERKIZ_DEVICES,
@@ -76,9 +78,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         _LOGGER.exception(exception)
         return False
 
-    update_interval = timedelta(
-        seconds=entry.options.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
-    )
+    if is_stateless(devices):
+        update_interval = timedelta(seconds=DEFAULT_UPDATE_INTERVAL_RTS)
+    else:
+        update_interval = timedelta(seconds=DEFAULT_UPDATE_INTERVAL)
 
     overkiz_coordinator = OverkizDataUpdateCoordinator(
         hass,
@@ -102,7 +105,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     hass.data[DOMAIN][entry.entry_id] = {
         "platforms": platforms,
         "coordinator": overkiz_coordinator,
-        "update_listener": entry.add_update_listener(update_listener),
     }
 
     for device in overkiz_coordinator.data.values():
@@ -182,23 +184,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     if unload_ok:
-        hass.data[DOMAIN][entry.entry_id]["update_listener"]()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok
 
 
-async def update_listener(hass: HomeAssistant, entry: ConfigEntry):
-    """Update when config_entry options update."""
-    if entry.options[CONF_UPDATE_INTERVAL]:
-        coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-        new_update_interval = timedelta(seconds=entry.options[CONF_UPDATE_INTERVAL])
-        coordinator.update_interval = new_update_interval
-        coordinator.original_update_interval = new_update_interval
-
-        await coordinator.async_refresh()
-
-
 def beautify_name(name: str):
     """Return human readable string."""
     return name.replace("_", " ").title()
+
+
+async def is_stateless(devices: List[Device]) -> bool:
+    """Return true if all the devices are stateless."""
+    return all(device.states is None or len(device.states) == 0 for device in devices)

--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -194,6 +194,6 @@ def beautify_name(name: str):
     return name.replace("_", " ").title()
 
 
-async def is_stateless(devices: List[Device]) -> bool:
+def is_stateless(devices: List[Device]) -> bool:
     """Return true if all the devices are stateless."""
     return all(device.states is None or len(device.states) == 0 for device in devices)

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -13,18 +13,10 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.dhcp import HOSTNAME
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.core import callback
 from homeassistant.data_entry_flow import AbortFlow
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import device_registry as dr
 
-from .const import (
-    CONF_HUB,
-    CONF_UPDATE_INTERVAL,
-    DEFAULT_HUB,
-    DEFAULT_UPDATE_INTERVAL,
-    MIN_UPDATE_INTERVAL,
-    SUPPORTED_ENDPOINTS,
-)
+from .const import CONF_HUB, DEFAULT_HUB, SUPPORTED_ENDPOINTS
 from .const import DOMAIN  # pylint: disable=unused-import
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,12 +33,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._reauth_entry = None
         self._default_username = None
         self._default_hub = DEFAULT_HUB
-
-    @staticmethod
-    @callback
-    def async_get_options_flow(config_entry):
-        """Handle the flow."""
-        return OptionsFlowHandler(config_entry)
 
     async def async_validate_input(self, user_input):
         """Validate user credentials."""
@@ -147,35 +133,4 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             device_registry.async_get_device(
                 identifiers={(DOMAIN, gateway_id)}, connections=set()
             )
-        )
-
-
-class OptionsFlowHandler(config_entries.OptionsFlow):
-    """Handle a option flow for Overkiz."""
-
-    def __init__(self, config_entry):
-        """Initialize options flow."""
-        self.config_entry = config_entry
-
-    async def async_step_init(self, user_input=None):
-        """Manage the Overkiz options."""
-        return await self.async_step_update_interval()
-
-    async def async_step_update_interval(self, user_input=None):
-        """Manage the options regarding interval updates."""
-        if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
-
-        return self.async_show_form(
-            step_id="update_interval",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(
-                        CONF_UPDATE_INTERVAL,
-                        default=self.config_entry.options.get(
-                            CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL
-                        ),
-                    ): vol.All(cv.positive_int, vol.Clamp(min=MIN_UPDATE_INTERVAL))
-                }
-            ),
         )

--- a/homeassistant/components/overkiz/const.py
+++ b/homeassistant/components/overkiz/const.py
@@ -9,8 +9,8 @@ DOMAIN = "overkiz"
 CONF_HUB = "hub"
 DEFAULT_HUB = "Somfy (Europe)"
 
-MIN_UPDATE_INTERVAL = 30
 DEFAULT_UPDATE_INTERVAL = 30
+DEFAULT_UPDATE_INTERVAL_RTS = 3600
 
 SUPPORTED_ENDPOINTS = {
     "Atlantic Cozytouch": "https://ha110-1.overkiz.com/enduser-mobile-web/enduserAPI/",

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -20,16 +20,5 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]"
     }
-  },
-  "options": {
-    "step": {
-      "update_interval": {
-        "title": "Update Interval",
-        "description": "The Overkiz integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
-        "data": {
-          "update_interval": "Update interval (in seconds)"
-        }
-      }
-    }
   }
 }

--- a/homeassistant/components/overkiz/translations/en.json
+++ b/homeassistant/components/overkiz/translations/en.json
@@ -20,16 +20,5 @@
                 "description": "The Overkiz platform is used by various vendors like Somfy (Connexoon / TaHoma), Hitachi (Hi Kumo), Rexel (Energeasy Connect) and Atlantic (Cozytouch). Enter your application credentials and select your vendor."
             }
         }
-    },
-    "options": {
-        "step": {
-            "update_interval": {
-                "data": {
-                    "update_interval": "Update interval (in seconds)"
-                },
-                "description": "The Overkiz integration periodically retrieves new events. Change the update interval to a lower value if you want more frequent updates, for example when you also control your devices outside Home Assistant.",
-                "title": "Update Interval"
-            }
-        }
     }
 }

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -13,7 +13,6 @@ from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.dhcp import HOSTNAME, IP_ADDRESS, MAC_ADDRESS
 from homeassistant.components.overkiz import config_flow
 from homeassistant.components.overkiz.const import DOMAIN
-from homeassistant.config_entries import ENTRY_STATE_LOADED
 
 from tests.common import MockConfigEntry, mock_device_registry
 
@@ -139,43 +138,6 @@ async def test_allow_multiple_unique_entries(hass):
         "password": TEST_PASSWORD,
         "hub": TEST_HUB,
     }
-
-
-async def test_options_flow(hass):
-    """Test options flow."""
-
-    entry = MockConfigEntry(
-        domain=config_flow.DOMAIN,
-        unique_id=TEST_EMAIL,
-        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
-    )
-
-    with patch("pyhoma.client.TahomaClient.login", return_value=True), patch(
-        "pyhoma.client.TahomaClient.get_gateways", return_value=MOCK_GATEWAY_RESPONSE
-    ), patch("homeassistant.components.overkiz.async_setup_entry", return_value=True):
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-    assert entry.state == ENTRY_STATE_LOADED
-
-    result = await hass.config_entries.options.async_init(
-        entry.entry_id, context={"source": "test"}, data=None
-    )
-    assert result["type"] == "form"
-    assert result["step_id"] == "update_interval"
-
-    assert entry.options == {}
-
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "update_interval": 12000,
-        },
-    )
-
-    assert entry.options == {"update_interval": 12000}
 
 
 async def test_dhcp_flow(hass):


### PR DESCRIPTION
## Proposed change
As suggested in https://github.com/home-assistant/core/pull/49413#discussion_r616057566, the configurable update interval is removed to simplify the integration. If people really miss this feature, we will hear soon enough after the release and it is just a simple PR to add it back.

Default is set to 30 seconds as agreed with Somfy, however for stateless (RTS) device we will set it to an hour.

Part of the Overkiz / TaHoma integration rewrite, target branch is `rework-tahoma`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
