### PR TITLE
Switch screenlogic discovery to use async version

### DIFF
--- a/homeassistant/components/screenlogic/climate.py
+++ b/homeassistant/components/screenlogic/climate.py
@@ -89,7 +89,7 @@ class ScreenLogicClimate(ScreenlogicEntity, ClimateEntity, RestoreEntity):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        if self.config_data["is_celcius"]["value"] == 1:
+        if self.config_data["is_celsius"]["value"] == 1:
             return TEMP_CELSIUS
         return TEMP_FAHRENHEIT
 

--- a/homeassistant/components/screenlogic/config_flow.py
+++ b/homeassistant/components/screenlogic/config_flow.py
@@ -1,7 +1,7 @@
 """Config flow for ScreenLogic."""
 import logging
 
-from screenlogicpy import ScreenLogicError, discover
+from screenlogicpy import ScreenLogicError, discovery
 from screenlogicpy.const import SL_GATEWAY_IP, SL_GATEWAY_NAME, SL_GATEWAY_PORT
 from screenlogicpy.requests import login
 import voluptuous as vol
@@ -27,7 +27,7 @@ async def async_discover_gateways_by_unique_id(hass):
     """Discover gateways and return a dict of them by unique id."""
     discovered_gateways = {}
     try:
-        hosts = await hass.async_add_executor_job(discover)
+        hosts = await discovery.async_discover()
         _LOGGER.debug("Discovered hosts: %s", hosts)
     except ScreenLogicError as ex:
         _LOGGER.debug(ex)

--- a/homeassistant/components/screenlogic/manifest.json
+++ b/homeassistant/components/screenlogic/manifest.json
@@ -3,7 +3,7 @@
   "name": "Pentair ScreenLogic",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/screenlogic",
-  "requirements": ["screenlogicpy==0.3.0"],
+  "requirements": ["screenlogicpy==0.4.1"],
   "codeowners": ["@dieselrabbit"],
   "dhcp": [
     {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2033,7 +2033,7 @@ scapy==2.4.5
 schiene==0.23
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.3.0
+screenlogicpy==0.4.1
 
 # homeassistant.components.scsgate
 scsgate==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1082,7 +1082,7 @@ samsungtvws==1.6.0
 scapy==2.4.5
 
 # homeassistant.components.screenlogic
-screenlogicpy==0.3.0
+screenlogicpy==0.4.1
 
 # homeassistant.components.emulated_kasa
 # homeassistant.components.sense

--- a/tests/components/screenlogic/test_config_flow.py
+++ b/tests/components/screenlogic/test_config_flow.py
@@ -241,9 +241,13 @@ async def test_form_manual_entry(hass):
 
 async def test_form_cannot_connect(hass):
     """Test we handle cannot connect error."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
+    with patch(
+        "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
+        return_value=[],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
 
     with patch(
         "homeassistant.components.screenlogic.config_flow.login.create_socket",

--- a/tests/components/screenlogic/test_config_flow.py
+++ b/tests/components/screenlogic/test_config_flow.py
@@ -30,7 +30,7 @@ async def test_flow_discovery(hass):
     """Test the flow works with basic discovery."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "homeassistant.components.screenlogic.config_flow.discover",
+        "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         return_value=[
             {
                 SL_GATEWAY_IP: "1.1.1.1",
@@ -74,7 +74,7 @@ async def test_flow_discover_none(hass):
     """Test when nothing is discovered."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "homeassistant.components.screenlogic.config_flow.discover",
+        "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         return_value=[],
     ):
         result = await hass.config_entries.flow.async_init(
@@ -90,7 +90,7 @@ async def test_flow_discover_error(hass):
     """Test when discovery errors."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "homeassistant.components.screenlogic.config_flow.discover",
+        "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         side_effect=ScreenLogicError("Fake error"),
     ):
         result = await hass.config_entries.flow.async_init(
@@ -182,7 +182,7 @@ async def test_form_manual_entry(hass):
     """Test we get the form."""
     await setup.async_setup_component(hass, "persistent_notification", {})
     with patch(
-        "homeassistant.components.screenlogic.config_flow.discover",
+        "homeassistant.components.screenlogic.config_flow.discovery.async_discover",
         return_value=[
             {
                 SL_GATEWAY_IP: "1.1.1.1",


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Switch screenlogic discovery to use async version

Changelog: https://github.com/dieselrabbit/screenlogicpy/compare/v0.3.0...v0.4.1

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49129
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
