### PR TITLE
Add support for deCONZ alarm events in logbook

### DIFF
--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -22,7 +22,6 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
-    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 from homeassistant.helpers import entity_platform
@@ -154,7 +153,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str:
         """Return the state of the control panel."""
-        return DECONZ_TO_ALARM_STATE.get(self._device.state, STATE_UNKNOWN)
+        return DECONZ_TO_ALARM_STATE.get(self._device.state, None)
 
     async def async_alarm_arm_away(self, code: None = None) -> None:
         """Send arm away command."""

--- a/homeassistant/components/deconz/alarm_control_panel.py
+++ b/homeassistant/components/deconz/alarm_control_panel.py
@@ -153,7 +153,7 @@ class DeconzAlarmControlPanel(DeconzDevice, AlarmControlPanelEntity):
     @property
     def state(self) -> str:
         """Return the state of the control panel."""
-        return DECONZ_TO_ALARM_STATE.get(self._device.state, None)
+        return DECONZ_TO_ALARM_STATE.get(self._device.state)
 
     async def async_alarm_arm_away(self, code: None = None) -> None:
         """Send arm away command."""

--- a/homeassistant/components/deconz/deconz_event.py
+++ b/homeassistant/components/deconz/deconz_event.py
@@ -19,7 +19,6 @@ from homeassistant.const import (
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
     STATE_ALARM_DISARMED,
-    STATE_UNKNOWN,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -169,11 +168,14 @@ class DeconzAlarmEvent(DeconzEvent):
 
         state, code, _area = self._device.action.split(",")
 
+        if state not in DECONZ_TO_ALARM_STATE:
+            return
+
         data = {
             CONF_ID: self.event_id,
             CONF_UNIQUE_ID: self.serial,
             CONF_DEVICE_ID: self.device_id,
-            CONF_EVENT: DECONZ_TO_ALARM_STATE.get(state, STATE_UNKNOWN),
+            CONF_EVENT: DECONZ_TO_ALARM_STATE[state],
             CONF_CODE: code,
         }
 

--- a/homeassistant/components/deconz/logbook.py
+++ b/homeassistant/components/deconz/logbook.py
@@ -8,7 +8,12 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.event import Event
 
 from .const import CONF_GESTURE, DOMAIN as DECONZ_DOMAIN
-from .deconz_event import CONF_DECONZ_EVENT, DeconzEvent
+from .deconz_event import (
+    CONF_DECONZ_ALARM_EVENT,
+    CONF_DECONZ_EVENT,
+    DeconzAlarmEvent,
+    DeconzEvent,
+)
 from .device_trigger import (
     CONF_BOTH_BUTTONS,
     CONF_BOTTOM_BUTTONS,
@@ -124,6 +129,20 @@ def async_describe_events(
     """Describe logbook events."""
 
     @callback
+    def async_describe_deconz_alarm_event(event: Event) -> dict:
+        """Describe deCONZ logbook alarm event."""
+        deconz_alarm_event: DeconzAlarmEvent | None = _get_deconz_event_from_device_id(
+            hass, event.data[ATTR_DEVICE_ID]
+        )
+
+        data = event.data[CONF_EVENT]
+
+        return {
+            "name": f"{deconz_alarm_event.device.name}",
+            "message": f"fired event '{data}'.",
+        }
+
+    @callback
     def async_describe_deconz_event(event: Event) -> dict:
         """Describe deCONZ logbook event."""
         deconz_event: DeconzEvent | None = _get_deconz_event_from_device_id(
@@ -165,4 +184,7 @@ def async_describe_events(
             "message": f"'{ACTIONS[action]}' event for '{INTERFACES[interface]}' was fired.",
         }
 
+    async_describe_event(
+        DECONZ_DOMAIN, CONF_DECONZ_ALARM_EVENT, async_describe_deconz_alarm_event
+    )
     async_describe_event(DECONZ_DOMAIN, CONF_DECONZ_EVENT, async_describe_deconz_event)

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -265,7 +265,19 @@ async def test_deconz_alarm_events(hass, aioclient_mock, mock_deconz_websocket):
         CONF_CODE: "1234",
     }
 
-    # Unsupported event
+    # Unsupported events
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "state": {"action": "unsupported,1234,1"},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+    await hass.async_block_till_done()
+
+    assert len(captured_events) == 1
 
     event_changed_sensor = {
         "t": "event",

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -4,14 +4,94 @@ from unittest.mock import patch
 
 from homeassistant.components import logbook
 from homeassistant.components.deconz.const import CONF_GESTURE, DOMAIN as DECONZ_DOMAIN
-from homeassistant.components.deconz.deconz_event import CONF_DECONZ_EVENT
-from homeassistant.const import CONF_DEVICE_ID, CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
+from homeassistant.components.deconz.deconz_event import (
+    CONF_DECONZ_ALARM_EVENT,
+    CONF_DECONZ_EVENT,
+)
+from homeassistant.const import (
+    CONF_CODE,
+    CONF_DEVICE_ID,
+    CONF_EVENT,
+    CONF_ID,
+    CONF_UNIQUE_ID,
+    STATE_ALARM_ARMED_AWAY,
+)
 from homeassistant.setup import async_setup_component
 from homeassistant.util import slugify
 
 from .test_gateway import DECONZ_WEB_REQUEST, setup_deconz_integration
 
 from tests.components.logbook.test_init import MockLazyEventPartialState
+
+
+async def test_humanifying_deconz_alarm_event(hass, aioclient_mock):
+    """Test humanifying deCONZ event."""
+    data = {
+        "sensors": {
+            "1": {
+                "config": {
+                    "armed": "disarmed",
+                    "enrolled": 0,
+                    "on": True,
+                    "panel": "disarmed",
+                    "pending": [],
+                    "reachable": True,
+                },
+                "ep": 1,
+                "etag": "3c4008d74035dfaa1f0bb30d24468b12",
+                "lastseen": "2021-04-02T13:07Z",
+                "manufacturername": "Universal Electronics Inc",
+                "modelid": "URC4450BC0-X-R",
+                "name": "Keypad",
+                "state": {
+                    "action": "armed_away,1111,55",
+                    "lastupdated": "2021-04-02T13:08:18.937",
+                    "lowbattery": False,
+                    "tampered": True,
+                },
+                "type": "ZHAAncillaryControl",
+                "uniqueid": "00:0d:6f:00:13:4f:61:39-01-0501",
+            }
+        }
+    }
+    with patch.dict(DECONZ_WEB_REQUEST, data):
+        await setup_deconz_integration(hass, aioclient_mock)
+
+    device_registry = await hass.helpers.device_registry.async_get_registry()
+
+    keypad_event_id = slugify(data["sensors"]["1"]["name"])
+    keypad_serial = data["sensors"]["1"]["uniqueid"].split("-", 1)[0]
+    keypad_entry = device_registry.async_get_device(
+        identifiers={(DECONZ_DOMAIN, keypad_serial)}
+    )
+
+    hass.config.components.add("recorder")
+    assert await async_setup_component(hass, "logbook", {})
+    entity_attr_cache = logbook.EntityAttributeCache(hass)
+
+    events = list(
+        logbook.humanify(
+            hass,
+            [
+                MockLazyEventPartialState(
+                    CONF_DECONZ_ALARM_EVENT,
+                    {
+                        CONF_CODE: 1234,
+                        CONF_DEVICE_ID: keypad_entry.id,
+                        CONF_EVENT: STATE_ALARM_ARMED_AWAY,
+                        CONF_ID: keypad_event_id,
+                        CONF_UNIQUE_ID: keypad_serial,
+                    },
+                ),
+            ],
+            entity_attr_cache,
+            {},
+        )
+    )
+
+    assert events[0]["name"] == "Keypad"
+    assert events[0]["domain"] == "deconz"
+    assert events[0]["message"] == "fired event 'armed_away'."
 
 
 async def test_humanifying_deconz_event(hass, aioclient_mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add logbook support for alarm events, will not print out user code

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
