### PR TITLE
Remove yaml configuration from fritzbox

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -165,6 +165,7 @@ homeassistant/components/fortios/* @kimfrellsen
 homeassistant/components/foscam/* @skgsergio
 homeassistant/components/freebox/* @hacf-fr @Quentame
 homeassistant/components/fritz/* @mammuth @AaronDavidSchneider @chemelli74
+homeassistant/components/fritzbox/* @mib1185
 homeassistant/components/fronius/* @nielstron
 homeassistant/components/frontend/* @home-assistant/frontend
 homeassistant/components/garmin_connect/* @cyberjunky

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -28,11 +28,6 @@ from homeassistant.helpers.update_coordinator import (
 from .const import CONF_CONNECTIONS, CONF_COORDINATOR, DOMAIN, LOGGER, PLATFORMS
 
 
-async def async_setup(hass: HomeAssistant, config: dict[str, str]) -> bool:
-    """Set up the AVM Fritz!Box integration."""
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the AVM Fritz!Box platforms."""
     fritz = Fritzhome(

--- a/homeassistant/components/fritzbox/__init__.py
+++ b/homeassistant/components/fritzbox/__init__.py
@@ -3,19 +3,16 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
-import socket
 
 from pyfritzhome import Fritzhome, FritzhomeDevice, LoginError
 import requests
-import voluptuous as vol
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    CONF_DEVICES,
     CONF_HOST,
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -23,72 +20,16 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
 
-from .const import (
-    CONF_CONNECTIONS,
-    CONF_COORDINATOR,
-    DEFAULT_HOST,
-    DEFAULT_USERNAME,
-    DOMAIN,
-    LOGGER,
-    PLATFORMS,
-)
-
-
-def ensure_unique_hosts(value):
-    """Validate that all configs have a unique host."""
-    vol.Schema(vol.Unique("duplicate host entries found"))(
-        [socket.gethostbyname(entry[CONF_HOST]) for entry in value]
-    )
-    return value
-
-
-CONFIG_SCHEMA = vol.Schema(
-    vol.All(
-        cv.deprecated(DOMAIN),
-        {
-            DOMAIN: vol.Schema(
-                {
-                    vol.Required(CONF_DEVICES): vol.All(
-                        cv.ensure_list,
-                        [
-                            vol.Schema(
-                                {
-                                    vol.Required(
-                                        CONF_HOST, default=DEFAULT_HOST
-                                    ): cv.string,
-                                    vol.Required(CONF_PASSWORD): cv.string,
-                                    vol.Required(
-                                        CONF_USERNAME, default=DEFAULT_USERNAME
-                                    ): cv.string,
-                                }
-                            )
-                        ],
-                        ensure_unique_hosts,
-                    )
-                }
-            )
-        },
-    ),
-    extra=vol.ALLOW_EXTRA,
-)
+from .const import CONF_CONNECTIONS, CONF_COORDINATOR, DOMAIN, LOGGER, PLATFORMS
 
 
 async def async_setup(hass: HomeAssistant, config: dict[str, str]) -> bool:
     """Set up the AVM Fritz!Box integration."""
-    if DOMAIN in config:
-        for entry_config in config[DOMAIN][CONF_DEVICES]:
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN, context={"source": SOURCE_IMPORT}, data=entry_config
-                )
-            )
-
     return True
 
 

--- a/homeassistant/components/fritzbox/config_flow.py
+++ b/homeassistant/components/fritzbox/config_flow.py
@@ -88,10 +88,6 @@ class FritzboxConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except OSError:
             return RESULT_NO_DEVICES_FOUND
 
-    async def async_step_import(self, user_input=None):
-        """Handle configuration by yaml file."""
-        return await self.async_step_user(user_input)
-
     async def async_step_user(self, user_input=None):
         """Handle a flow initialized by the user."""
         errors = {}

--- a/homeassistant/components/fritzbox/manifest.json
+++ b/homeassistant/components/fritzbox/manifest.json
@@ -8,7 +8,7 @@
       "st": "urn:schemas-upnp-org:device:fritzbox:1"
     }
   ],
-  "codeowners": [],
+  "codeowners": ["@mib1185"],
   "config_flow": true,
   "iot_class": "local_polling"
 }

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -1,8 +1,14 @@
 """Tests for the AVM Fritz!Box integration."""
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.components.fritzbox.const import DOMAIN
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 MOCK_CONFIG = {
     DOMAIN: {
@@ -15,6 +21,28 @@ MOCK_CONFIG = {
         ]
     }
 }
+
+
+async def setup_config_entry(
+    hass: HomeAssistant,
+    data: dict[str, Any],
+    unique_id: str = "any",
+    device: Mock = None,
+    fritz: Mock = None,
+) -> bool:
+    """Do setup of a MockConfigEntry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=data,
+        unique_id=unique_id,
+    )
+    entry.add_to_hass(hass)
+    if device is not None and fritz is not None:
+        fritz().get_devices.return_value = [device]
+    result = await hass.config_entries.async_setup(entry.entry_id)
+    if device is not None:
+        await hass.async_block_till_done()
+    return result
 
 
 class FritzDeviceBinarySensorMock(Mock):

--- a/tests/components/fritzbox/conftest.py
+++ b/tests/components/fritzbox/conftest.py
@@ -7,8 +7,7 @@ import pytest
 @pytest.fixture(name="fritz")
 def fritz_fixture() -> Mock:
     """Patch libraries."""
-    with patch("homeassistant.components.fritzbox.socket") as socket, patch(
-        "homeassistant.components.fritzbox.Fritzhome"
-    ) as fritz, patch("homeassistant.components.fritzbox.config_flow.Fritzhome"):
-        socket.gethostbyname.return_value = "FAKE_IP_ADDRESS"
+    with patch("homeassistant.components.fritzbox.Fritzhome") as fritz, patch(
+        "homeassistant.components.fritzbox.config_flow.Fritzhome"
+    ):
         yield fritz

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -10,34 +10,28 @@ from homeassistant.components.fritzbox.const import DOMAIN as FB_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
+    CONF_DEVICES,
     STATE_OFF,
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceBinarySensorMock
+from . import MOCK_CONFIG, FritzDeviceBinarySensorMock, setup_config_entry
 
 from tests.common import async_fire_time_changed
 
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistant, config: dict):
-    """Set up mock AVM Fritz!Box."""
-    assert await async_setup_component(hass, FB_DOMAIN, config)
-    await hass.async_block_till_done()
-
-
 async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceBinarySensorMock()
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
@@ -48,11 +42,11 @@ async def test_is_off(hass: HomeAssistant, fritz: Mock):
     """Test state of platform."""
     device = FritzDeviceBinarySensorMock()
     device.present = False
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.state == STATE_OFF
 
@@ -60,9 +54,9 @@ async def test_is_off(hass: HomeAssistant, fritz: Mock):
 async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update without error."""
     device = FritzDeviceBinarySensorMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1
@@ -79,9 +73,9 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceBinarySensorMock()
     device.update.side_effect = [mock.DEFAULT, HTTPError("Boom")]
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -35,32 +35,26 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_TEMPERATURE,
+    CONF_DEVICES,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceClimateMock
+from . import MOCK_CONFIG, FritzDeviceClimateMock, setup_config_entry
 
 from tests.common import async_fire_time_changed
 
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistant, config: dict):
-    """Set up mock AVM Fritz!Box."""
-    assert await async_setup_component(hass, FB_DOMAIN, config) is True
-    await hass.async_block_till_done()
-
-
 async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.attributes[ATTR_BATTERY_LEVEL] == 23
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 18
@@ -83,10 +77,11 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
 async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock):
     """Test turn device on."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
     device.target_temperature = 127.0
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.attributes[ATTR_TEMPERATURE] == 30
@@ -95,10 +90,11 @@ async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock):
 async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock):
     """Test turn device on."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
     device.target_temperature = 126.5
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.attributes[ATTR_TEMPERATURE] == 0
@@ -107,11 +103,11 @@ async def test_target_temperature_off(hass: HomeAssistant, fritz: Mock):
 async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update without error."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 18
     assert state.attributes[ATTR_MAX_TEMP] == 28
@@ -136,9 +132,10 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceClimateMock()
     device.update.side_effect = HTTPError("Boom")
-    fritz().get_devices.return_value = [device]
+    assert not await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1
 
@@ -153,9 +150,9 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
 async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock):
     """Test setting temperature by temperature."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -169,9 +166,9 @@ async def test_set_temperature_temperature(hass: HomeAssistant, fritz: Mock):
 async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock):
     """Test setting temperature by mode."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -189,9 +186,9 @@ async def test_set_temperature_mode_off(hass: HomeAssistant, fritz: Mock):
 async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock):
     """Test setting temperature by mode."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -209,9 +206,9 @@ async def test_set_temperature_mode_heat(hass: HomeAssistant, fritz: Mock):
 async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock):
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -225,9 +222,9 @@ async def test_set_hvac_mode_off(hass: HomeAssistant, fritz: Mock):
 async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock):
     """Test setting hvac mode."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -241,9 +238,9 @@ async def test_set_hvac_mode_heat(hass: HomeAssistant, fritz: Mock):
 async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock):
     """Test setting preset mode."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -257,9 +254,9 @@ async def test_set_preset_mode_comfort(hass: HomeAssistant, fritz: Mock):
 async def test_set_preset_mode_eco(hass: HomeAssistant, fritz: Mock):
     """Test setting preset mode."""
     device = FritzDeviceClimateMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN,
@@ -275,11 +272,11 @@ async def test_preset_mode_update(hass: HomeAssistant, fritz: Mock):
     device = FritzDeviceClimateMock()
     device.comfort_temperature = 98
     device.eco_temperature = 99
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.attributes[ATTR_PRESET_MODE] is None
 

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -12,12 +12,7 @@ from homeassistant.components.ssdp import (
     ATTR_UPNP_FRIENDLY_NAME,
     ATTR_UPNP_UDN,
 )
-from homeassistant.config_entries import (
-    SOURCE_IMPORT,
-    SOURCE_REAUTH,
-    SOURCE_SSDP,
-    SOURCE_USER,
-)
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_SSDP, SOURCE_USER
 from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import (
@@ -182,19 +177,6 @@ async def test_reauth_not_successful(hass: HomeAssistant, fritz: Mock):
 
     assert result["type"] == RESULT_TYPE_ABORT
     assert result["reason"] == "no_devices_found"
-
-
-async def test_import(hass: HomeAssistant, fritz: Mock):
-    """Test starting a flow by import."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_USER_DATA
-    )
-    assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "fake_host"
-    assert result["data"][CONF_HOST] == "fake_host"
-    assert result["data"][CONF_PASSWORD] == "fake_pass"
-    assert result["data"][CONF_USERNAME] == "fake_user"
-    assert not result["result"].unique_id
 
 
 async def test_ssdp(hass: HomeAssistant, fritz: Mock):

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -13,34 +13,28 @@ from homeassistant.components.sensor import DOMAIN
 from homeassistant.const import (
     ATTR_FRIENDLY_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
+    CONF_DEVICES,
     PERCENTAGE,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceSensorMock
+from . import MOCK_CONFIG, FritzDeviceSensorMock, setup_config_entry
 
 from tests.common import async_fire_time_changed
 
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistant, config: dict):
-    """Set up mock AVM Fritz!Box."""
-    assert await async_setup_component(hass, FB_DOMAIN, config)
-    await hass.async_block_till_done()
-
-
 async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceSensorMock()
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.state == "1.23"
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
@@ -49,7 +43,6 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
 
     state = hass.states.get(f"{ENTITY_ID}_battery")
-
     assert state
     assert state.state == "23"
     assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name Battery"
@@ -59,9 +52,9 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
 async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update without error."""
     device = FritzDeviceSensorMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1
 
@@ -77,9 +70,9 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSensorMock()
     device.update.side_effect = HTTPError("Boom")
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert not await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1
 

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_TEMPERATURE,
+    CONF_DEVICES,
     ENERGY_KILO_WATT_HOUR,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
@@ -24,30 +25,23 @@ from homeassistant.const import (
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceSwitchMock
+from . import MOCK_CONFIG, FritzDeviceSwitchMock, setup_config_entry
 
 from tests.common import async_fire_time_changed
 
 ENTITY_ID = f"{DOMAIN}.fake_name"
 
 
-async def setup_fritzbox(hass: HomeAssistant, config: dict):
-    """Set up mock AVM Fritz!Box."""
-    assert await async_setup_component(hass, FB_DOMAIN, config)
-    await hass.async_block_till_done()
-
-
 async def test_setup(hass: HomeAssistant, fritz: Mock):
     """Test setup of platform."""
     device = FritzDeviceSwitchMock()
-    fritz().get_devices.return_value = [device]
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
-    await setup_fritzbox(hass, MOCK_CONFIG)
     state = hass.states.get(ENTITY_ID)
-
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_CURRENT_POWER_W] == 5.678
@@ -63,9 +57,9 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
 async def test_turn_on(hass: HomeAssistant, fritz: Mock):
     """Test turn device on."""
     device = FritzDeviceSwitchMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_ID}, True
@@ -76,9 +70,9 @@ async def test_turn_on(hass: HomeAssistant, fritz: Mock):
 async def test_turn_off(hass: HomeAssistant, fritz: Mock):
     """Test turn device off."""
     device = FritzDeviceSwitchMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
 
     assert await hass.services.async_call(
         DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: ENTITY_ID}, True
@@ -89,9 +83,9 @@ async def test_turn_off(hass: HomeAssistant, fritz: Mock):
 async def test_update(hass: HomeAssistant, fritz: Mock):
     """Test update without error."""
     device = FritzDeviceSwitchMock()
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1
 
@@ -107,9 +101,9 @@ async def test_update_error(hass: HomeAssistant, fritz: Mock):
     """Test update with error."""
     device = FritzDeviceSwitchMock()
     device.update.side_effect = HTTPError("Boom")
-    fritz().get_devices.return_value = [device]
-
-    await setup_fritzbox(hass, MOCK_CONFIG)
+    assert not await setup_config_entry(
+        hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
+    )
     assert device.update.call_count == 1
     assert fritz().login.call_count == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
YAML configuration is deprecated since 12 months for AVM FRITZ!SmartHome. Configuration via UI is fully integrated. Existing YAML configuration has already been imported automatically in the previous releases and can now safely be removed from your configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR removes deprecated yaml configuration approach from `fritzbox`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
