### PR TITLE
Rework roon media player grouping to use media_player base services

### DIFF
--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -3,7 +3,7 @@
   "name": "RoonLabs music player",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
-  "requirements": ["roonapi==0.0.35"],
+  "requirements": ["roonapi==0.0.36"],
   "codeowners": ["@pavoni"],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/roon/manifest.json
+++ b/homeassistant/components/roon/manifest.json
@@ -3,7 +3,7 @@
   "name": "RoonLabs music player",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/roon",
-  "requirements": ["roonapi==0.0.32"],
+  "requirements": ["roonapi==0.0.35"],
   "codeowners": ["@pavoni"],
   "iot_class": "local_push"
 }

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 from homeassistant.components.media_player import MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     SUPPORT_BROWSE_MEDIA,
+    SUPPORT_GROUPING,
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
     SUPPORT_PLAY,
@@ -42,6 +43,7 @@ from .media_browser import browse_media
 
 SUPPORT_ROON = (
     SUPPORT_BROWSE_MEDIA
+    | SUPPORT_GROUPING
     | SUPPORT_PAUSE
     | SUPPORT_VOLUME_SET
     | SUPPORT_STOP
@@ -59,16 +61,9 @@ SUPPORT_ROON = (
 
 _LOGGER = logging.getLogger(__name__)
 
-SERVICE_JOIN = "join"
-SERVICE_UNJOIN = "unjoin"
 SERVICE_TRANSFER = "transfer"
 
-ATTR_JOIN = "join_ids"
-ATTR_UNJOIN = "unjoin_ids"
 ATTR_TRANSFER = "transfer_id"
-ATTR_IS_JOINED = "is_joined"
-ATTR_IS_JOINED_LEAD = "is_joined_lead"
-ATTR_JOINED_PLAYER = "joined_lead_player"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -78,16 +73,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
     # Register entity services
     platform = entity_platform.current_platform.get()
-    platform.async_register_entity_service(
-        SERVICE_JOIN,
-        {vol.Required(ATTR_JOIN): vol.All(cv.ensure_list, [cv.entity_id])},
-        "join",
-    )
-    platform.async_register_entity_service(
-        SERVICE_UNJOIN,
-        {vol.Optional(ATTR_UNJOIN): vol.All(cv.ensure_list, [cv.entity_id])},
-        "unjoin",
-    )
     platform.async_register_entity_service(
         SERVICE_TRANSFER,
         {vol.Required(ATTR_TRANSFER): cv.entity_id},
@@ -168,17 +153,11 @@ class RoonDevice(MediaPlayerEntity):
         return SUPPORT_ROON
 
     @property
-    def extra_state_attributes(self):
-        """Return the state attributes of the device."""
-        attr = {}
+    def group_members(self):
+        """Return the grouped players."""
 
-        attr[ATTR_IS_JOINED] = self._server.roonapi.is_grouped(self._output_id)
-        attr[ATTR_IS_JOINED_LEAD] = self._server.roonapi.is_group_main(self._output_id)
-        group_main_roon_name = self._server.roonapi.group_main_zone_name(
-            self._output_id
-        )
-        attr[ATTR_JOINED_PLAYER] = self._server.entity_id(group_main_roon_name)
-        return attr
+        roon_names = self._server.roonapi.grouped_zone_names(self._output_id)
+        return [self._server.entity_id(roon_name) for roon_name in roon_names]
 
     @property
     def device_info(self):
@@ -507,8 +486,8 @@ class RoonDevice(MediaPlayerEntity):
                     path_list,
                 )
 
-    def join(self, join_ids):
-        """Add another Roon player to this player's join group."""
+    async def async_join_players(self, group_members):
+        """Join `group_members` as a player group with the current player."""
 
         zone_data = self._server.roonapi.zone_by_output_id(self._output_id)
         if zone_data is None:
@@ -527,7 +506,7 @@ class RoonDevice(MediaPlayerEntity):
                     sync_available[zone["display_name"]] = output["output_id"]
 
         names = []
-        for entity_id in join_ids:
+        for entity_id in group_members:
             name = self._server.roon_name(entity_id)
             if name is None:
                 _LOGGER.error("No roon player found for %s", entity_id)
@@ -547,43 +526,17 @@ class RoonDevice(MediaPlayerEntity):
             [self._output_id] + [sync_available[name] for name in names]
         )
 
-    def unjoin(self, unjoin_ids=None):
-        """Remove a Roon player to this player's join group."""
+    async def async_unjoin_player(self):
+        """Remove this player from any group."""
 
-        zone_data = self._server.roonapi.zone_by_output_id(self._output_id)
-        if zone_data is None:
-            _LOGGER.error("No zone data for %s", self.name)
+        if not self._server.roonapi.is_grouped(self._output_id):
+            _LOGGER.error(
+                "Can't unjoin player %s because it's not in a group",
+                self.name,
+            )
             return
 
-        join_group = {
-            output["display_name"]: output["output_id"]
-            for output in zone_data["outputs"]
-            if output["display_name"] != self.name
-        }
-
-        if unjoin_ids is None:
-            # unjoin everything
-            names = list(join_group)
-        else:
-            names = []
-            for entity_id in unjoin_ids:
-                name = self._server.roon_name(entity_id)
-                if name is None:
-                    _LOGGER.error("No roon player found for %s", entity_id)
-                    return
-
-                if name not in join_group:
-                    _LOGGER.error(
-                        "Can't unjoin player %s from %s because it's not in the joined group %s",
-                        name,
-                        self.name,
-                        list(join_group),
-                    )
-                    return
-                names.append(name)
-
-        _LOGGER.debug("Unjoining %s from %s", names, self.name)
-        self._server.roonapi.ungroup_outputs([join_group[name] for name in names])
+        self._server.roonapi.ungroup_outputs([self._output_id])
 
     async def async_transfer(self, transfer_id):
         """Transfer playback from this roon player to another."""

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -486,7 +486,7 @@ class RoonDevice(MediaPlayerEntity):
                     path_list,
                 )
 
-    async def async_join_players(self, group_members):
+    def join_players(self, group_members):
         """Join `group_members` as a player group with the current player."""
 
         zone_data = self._server.roonapi.zone_by_output_id(self._output_id)
@@ -526,7 +526,7 @@ class RoonDevice(MediaPlayerEntity):
             [self._output_id] + [sync_available[name] for name in names]
         )
 
-    async def async_unjoin_player(self):
+    def unjoin_player(self):
         """Remove this player from any group."""
 
         if not self._server.roonapi.is_grouped(self._output_id):

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -66,6 +66,9 @@ SERVICE_TRANSFER = "transfer"
 ATTR_JOIN = "join_ids"
 ATTR_UNJOIN = "unjoin_ids"
 ATTR_TRANSFER = "transfer_id"
+ATTR_IS_JOINED = "is_joined"
+ATTR_IS_JOINED_LEAD = "is_joined_lead"
+ATTR_JOINED_PLAYER = "joined_lead_player"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -163,6 +166,19 @@ class RoonDevice(MediaPlayerEntity):
     def supported_features(self):
         """Flag media player features that are supported."""
         return SUPPORT_ROON
+
+    @property
+    def extra_state_attributes(self):
+        """Return the state attributes of the device."""
+        attr = {}
+
+        attr[ATTR_IS_JOINED] = self._server.roonapi.is_grouped(self._output_id)
+        attr[ATTR_IS_JOINED_LEAD] = self._server.roonapi.is_group_main(self._output_id)
+        group_main_roon_name = self._server.roonapi.group_main_zone_name(
+            self._output_id
+        )
+        attr[ATTR_JOINED_PLAYER] = self._server.entity_id(group_main_roon_name)
+        return attr
 
     @property
     def device_info(self):

--- a/homeassistant/components/roon/server.py
+++ b/homeassistant/components/roon/server.py
@@ -28,6 +28,7 @@ class RoonServer:
         self.offline_devices = set()
         self._exit = False
         self._roon_name_by_id = {}
+        self._id_by_roon_name = {}
 
     async def async_setup(self, tries=0):
         """Set up a roon server based on config parameters."""
@@ -78,10 +79,15 @@ class RoonServer:
     def add_player_id(self, entity_id, roon_name):
         """Register a roon player."""
         self._roon_name_by_id[entity_id] = roon_name
+        self._id_by_roon_name[roon_name] = entity_id
 
     def roon_name(self, entity_id):
         """Get the name of the roon player from entity_id."""
         return self._roon_name_by_id.get(entity_id)
+
+    def entity_id(self, roon_name):
+        """Get the id of the roon player from the roon name."""
+        return self._id_by_roon_name.get(roon_name)
 
     def stop_roon(self):
         """Stop background worker."""

--- a/homeassistant/components/roon/services.yaml
+++ b/homeassistant/components/roon/services.yaml
@@ -1,23 +1,3 @@
-join:
-  description: Group players together.
-  fields:
-    entity_id:
-      description: id of the player that will be the master of the group.
-      example: "media_player.study"
-    join_ids:
-      description: id(s) of the players that will join the master.
-      example: "['media_player.bedroom', 'media_player.kitchen']"
-
-unjoin:
-  description: Remove players from a group.
-  fields:
-    entity_id:
-      description: id of the player that is the master of the group..
-      example: "media_player.study"
-    unjoin_ids:
-      description: Optional id(s) of the players that will be unjoined from the group. If not specified, all players will be unjoined from the master.
-      example: "['media_player.bedroom', 'media_player.kitchen']"
-
 transfer:
   description: Transfer playback from one player to another.
   fields:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1994,7 +1994,7 @@ rokuecp==0.8.1
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.32
+roonapi==0.0.35
 
 # homeassistant.components.rova
 rova==0.2.1

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1994,7 +1994,7 @@ rokuecp==0.8.1
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.35
+roonapi==0.0.36
 
 # homeassistant.components.rova
 rova==0.2.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1061,7 +1061,7 @@ rokuecp==0.8.1
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.35
+roonapi==0.0.36
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1061,7 +1061,7 @@ rokuecp==0.8.1
 roombapy==1.6.2
 
 # homeassistant.components.roon
-roonapi==0.0.32
+roonapi==0.0.35
 
 # homeassistant.components.rpi_power
 rpi-bad-power==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The roon media_player previous had integration specific services for `join` and `un_join`. This PR removes those services and replaces them with the base `media_player` services. So anyone using the previous `join` / `un_join` services will need to change their automations.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR replaces the roon specific `join` / `un_join` grouping services with the new base `media_player` services. It also supports the `group_members` properly - which will make writing automations around grouping easier.

It requires a revised version of the pyroon library. This has a number of cosmetic changes and some improved error handling - but the main change is to add some functions to get group status and membership.

Full details here:-
https://github.com/pavoni/pyroon/compare/0.0.32...0.0.36

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17600

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
