### PR TITLE
Make device info a TypedDict

### DIFF
--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -10,9 +10,8 @@ from typing import Any
 from aiohttp import ClientError
 from bond_api import BPUPSubscriptions
 
-from homeassistant.const import ATTR_NAME
 from homeassistant.core import callback
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN
@@ -65,18 +64,24 @@ class BondEntity(Entity):
         return False
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> DeviceInfo:
         """Get a an HA device representing this Bond controlled device."""
-        device_info = {
-            ATTR_NAME: self.name,
+        device_info: DeviceInfo = {
             "manufacturer": self._hub.make,
-            "identifiers": {(DOMAIN, self._hub.bond_id, self._device.device_id)},
-            "suggested_area": self._device.location,
-            "via_device": (DOMAIN, self._hub.bond_id),
+            # type ignore: tuple items should not be Optional
+            "identifiers": {(DOMAIN, self._hub.bond_id, self._device.device_id)},  # type: ignore[arg-type]
         }
+        if self.name is not None:
+            device_info["name"] = self.name
+        if self._hub.bond_id is not None:
+            device_info["via_device"] = (DOMAIN, self._hub.bond_id)
+        if self._device.location is not None:
+            device_info["suggested_area"] = self._device.location
         if not self._hub.is_bridge:
-            device_info["model"] = self._hub.model
-            device_info["sw_version"] = self._hub.fw_ver
+            if self._hub.model is not None:
+                device_info["model"] = self._hub.model
+            if self._hub.fw_ver is not None:
+                device_info["sw_version"] = self._hub.fw_ver
         else:
             model_data = []
             if self._device.branding_profile:

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_CLASS_TIMESTAMP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -32,7 +33,7 @@ async def async_setup_entry(
 
     sensors = []
 
-    device_info = {
+    device_info: DeviceInfo = {
         "identifiers": {(DOMAIN, coordinator.data.serial)},
         "name": coordinator.data.model,
         "manufacturer": ATTR_MANUFACTURER,
@@ -53,7 +54,7 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
         self,
         coordinator: BrotherDataUpdateCoordinator,
         kind: str,
-        device_info: dict[str, Any],
+        device_info: DeviceInfo,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -110,7 +111,7 @@ class BrotherPrinterSensor(CoordinatorEntity, SensorEntity):
         return self._description["unit"]
 
     @property
-    def device_info(self) -> dict[str, Any]:
+    def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return self._device_info
 

--- a/homeassistant/components/heos/media_player.py
+++ b/homeassistant/components/heos/media_player.py
@@ -31,6 +31,7 @@ from homeassistant.components.media_player.const import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_IDLE, STATE_PAUSED, STATE_PLAYING
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util.dt import utcnow
 
 from .const import DATA_SOURCE_MANAGER, DOMAIN as HEOS_DOMAIN, SIGNAL_HEOS_UPDATED
@@ -253,7 +254,7 @@ class HeosMediaPlayer(MediaPlayerEntity):
         return self._player.available
 
     @property
-    def device_info(self) -> dict:
+    def device_info(self) -> DeviceInfo:
         """Get attributes about the device."""
         return {
             "identifiers": {(HEOS_DOMAIN, self._player.player_id)},

--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -49,7 +49,7 @@ from homeassistant.helpers import (
     discovery,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect, dispatcher_send
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 
@@ -600,7 +600,7 @@ class HuaweiLteBaseEntity(Entity):
         return False
 
     @property
-    def device_info(self) -> dict[str, Any]:
+    def device_info(self) -> DeviceInfo:
         """Get info for matching with parent router."""
         return {
             "identifiers": self.router.device_identifiers,

--- a/homeassistant/components/hyperion/light.py
+++ b/homeassistant/components/hyperion/light.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.entity import DeviceInfo
 import homeassistant.util.color as color_util
 
 from . import (
@@ -234,7 +235,7 @@ class HyperionBaseLight(LightEntity):
         return self._unique_id
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> DeviceInfo:
         """Return device information."""
         return {
             "identifiers": {(DOMAIN, self._device_id)},

--- a/homeassistant/components/hyperion/switch.py
+++ b/homeassistant/components/hyperion/switch.py
@@ -31,6 +31,7 @@ from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
     async_dispatcher_send,
 )
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.util import slugify
 
 from . import (
@@ -179,7 +180,7 @@ class HyperionComponentSwitch(SwitchEntity):
         return bool(self._client.has_loaded_state)
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> DeviceInfo:
         """Return device information."""
         return {
             "identifiers": {(DOMAIN, self._device_id)},

--- a/homeassistant/components/twinkly/light.py
+++ b/homeassistant/components/twinkly/light.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
 
 from aiohttp import ClientError
 
@@ -14,6 +13,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
     ATTR_HOST,
@@ -105,7 +105,7 @@ class TwinklyLight(LightEntity):
         return "mdi:string-lights"
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> DeviceInfo | None:
         """Get device specific attributes."""
         return (
             {

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 import logging
 import re
-from typing import Any, Callable
+from typing import Callable
 
 from WazeRouteCalculator import WazeRouteCalculator, WRCError
 import voluptuous as vol
@@ -23,6 +23,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Config, CoreState, HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity import DeviceInfo
 
 from .const import (
     ATTR_DESTINATION,
@@ -263,7 +264,7 @@ class WazeTravelTime(SensorEntity):
         self._waze_data.update()
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
         return {
             "name": "Waze",

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -9,7 +9,7 @@ from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity import DeviceInfo, Entity
 
 from .const import DOMAIN
 from .discovery import ZwaveDiscoveryInfo
@@ -92,7 +92,7 @@ class ZWaveBaseEntity(Entity):
         )
 
     @property
-    def device_info(self) -> dict:
+    def device_info(self) -> DeviceInfo:
         """Return device information for the device registry."""
         # device is precreated in main handler
         return {

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -10,7 +10,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import Any
+from typing import Any, TypedDict
 
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (
@@ -108,6 +108,23 @@ def get_supported_features(hass: HomeAssistant, entity_id: str) -> int:
         raise HomeAssistantError(f"Unknown entity {entity_id}")
 
     return entry.supported_features or 0
+
+
+class DeviceInfo(TypedDict, total=False):
+    """Entity device information for device registry."""
+
+    name: str
+    connections: set[tuple[str, str]]
+    identifiers: set[tuple[str, ...]]
+    manufacturer: str
+    model: str
+    suggested_area: str
+    sw_version: str
+    via_device: tuple[str, str]
+    entry_type: str | None
+    default_name: str
+    default_manufacturer: str
+    default_model: str
 
 
 class Entity(ABC):
@@ -214,7 +231,7 @@ class Entity(ABC):
         return None
 
     @property
-    def device_info(self) -> Mapping[str, Any] | None:
+    def device_info(self) -> DeviceInfo | None:
         """Return device specific attributes.
 
         Implemented by platform classes.


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This makes entity device info a TypedDict, providing for easier coding and better typecheck time validation.

Type defs follow the docs at https://developers.home-assistant.io/docs/device_registry_index/#device-properties as well as in the device registry. In particular, entry_type is the only thing marked as optional here per the docs above.

This contains the bare minimum to implement the change and make tests pass, next step is to fix device_info signatures in the rest of the tree. I have it prepared already, but will submit separately to keep PR size at bay, unless a reviewer here requests it to be included already here.

FYI @prystupa: This exposes a "bug" in the bond component; it uses a three-tuple as device identifier, with one component of it being possibly None, whereas the expected identifiers are declared to be two-tuples of str (no optionals). I've marked it to be ignored here, that'll preserve current status. I guess the bug is currently a typecheck level only, as nothing seems to peek into the contents of those identifiers at runtime, they're just used as-is for lookup. But it would be good to get this properly fixed, preferably IMO after this PR has been merged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
