### PR TITLE
Better ZHA device reconfiguration

### DIFF
--- a/homeassistant/components/zha/core/channels/__init__.py
+++ b/homeassistant/components/zha/core/channels/__init__.py
@@ -130,6 +130,13 @@ class Channels:
         await self.zdo_channel.async_configure()
         self.zdo_channel.debug("'async_configure' stage succeeded")
         await asyncio.gather(*(pool.async_configure() for pool in self.pools))
+        async_dispatcher_send(
+            self.zha_device.hass,
+            const.ZHA_CHANNEL_MSG,
+            {
+                const.ATTR_TYPE: const.ZHA_CHANNEL_CFG_DONE,
+            },
+        )
 
     @callback
     def async_new_entity(

--- a/homeassistant/components/zha/core/channels/base.py
+++ b/homeassistant/components/zha/core/channels/base.py
@@ -11,6 +11,7 @@ import zigpy.exceptions
 
 from homeassistant.const import ATTR_COMMAND
 from homeassistant.core import callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .. import typing as zha_typing
 from ..const import (
@@ -18,10 +19,15 @@ from ..const import (
     ATTR_ATTRIBUTE_ID,
     ATTR_ATTRIBUTE_NAME,
     ATTR_CLUSTER_ID,
+    ATTR_TYPE,
     ATTR_UNIQUE_ID,
     ATTR_VALUE,
     CHANNEL_ZDO,
     SIGNAL_ATTR_UPDATED,
+    ZHA_CHANNEL_MSG,
+    ZHA_CHANNEL_MSG_BIND,
+    ZHA_CHANNEL_MSG_CFG_RPT,
+    ZHA_CHANNEL_MSG_DATA,
 )
 from ..helpers import LogMixin, safe_read
 
@@ -148,9 +154,33 @@ class ZigbeeChannel(LogMixin):
         try:
             res = await self.cluster.bind()
             self.debug("bound '%s' cluster: %s", self.cluster.ep_attribute, res[0])
+            async_dispatcher_send(
+                self._ch_pool.hass,
+                ZHA_CHANNEL_MSG,
+                {
+                    ATTR_TYPE: ZHA_CHANNEL_MSG_BIND,
+                    ZHA_CHANNEL_MSG_DATA: {
+                        "cluster_name": self.cluster.name,
+                        "cluster_id": self.cluster.cluster_id,
+                        "success": res[0] == 0,
+                    },
+                },
+            )
         except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
             self.debug(
                 "Failed to bind '%s' cluster: %s", self.cluster.ep_attribute, str(ex)
+            )
+            async_dispatcher_send(
+                self._ch_pool.hass,
+                ZHA_CHANNEL_MSG,
+                {
+                    ATTR_TYPE: ZHA_CHANNEL_MSG_BIND,
+                    ZHA_CHANNEL_MSG_DATA: {
+                        "cluster_name": self.cluster.name,
+                        "cluster_id": self.cluster.cluster_id,
+                        "success": False,
+                    },
+                },
             )
 
     async def configure_reporting(self) -> None:
@@ -159,6 +189,7 @@ class ZigbeeChannel(LogMixin):
         This also swallows ZigbeeException exceptions that are thrown when
         devices are unreachable.
         """
+        event_data = {}
         kwargs = {}
         if self.cluster.cluster_id >= 0xFC00 and self._ch_pool.manufacturer_code:
             kwargs["manufacturer"] = self._ch_pool.manufacturer_code
@@ -180,6 +211,12 @@ class ZigbeeChannel(LogMixin):
                     reportable_change,
                     res,
                 )
+                event_data[attr_name] = {
+                    "min": min_report_int,
+                    "max": max_report_int,
+                    "change": reportable_change,
+                    "success": res[0][0].status == 0 or res[0][0].status == 134,
+                }
             except (zigpy.exceptions.ZigbeeException, asyncio.TimeoutError) as ex:
                 self.debug(
                     "failed to set reporting for '%s' attr on '%s' cluster: %s",
@@ -187,6 +224,24 @@ class ZigbeeChannel(LogMixin):
                     self.cluster.ep_attribute,
                     str(ex),
                 )
+                event_data[attr_name] = {
+                    "min": min_report_int,
+                    "max": max_report_int,
+                    "change": reportable_change,
+                    "success": False,
+                }
+        async_dispatcher_send(
+            self._ch_pool.hass,
+            ZHA_CHANNEL_MSG,
+            {
+                ATTR_TYPE: ZHA_CHANNEL_MSG_CFG_RPT,
+                ZHA_CHANNEL_MSG_DATA: {
+                    "cluster_name": self.cluster.name,
+                    "cluster_id": self.cluster.cluster_id,
+                    "attributes": event_data,
+                },
+            },
+        )
 
     async def async_configure(self) -> None:
         """Set cluster binding and attribute reporting."""

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -339,6 +339,11 @@ WARNING_DEVICE_SQUAWK_MODE_ARMED = 0
 WARNING_DEVICE_SQUAWK_MODE_DISARMED = 1
 
 ZHA_DISCOVERY_NEW = "zha_discovery_new_{}"
+ZHA_CHANNEL_MSG = "zha_channel_message"
+ZHA_CHANNEL_MSG_BIND = "zha_channel_bind"
+ZHA_CHANNEL_MSG_CFG_RPT = "zha_channel_configure_reporting"
+ZHA_CHANNEL_MSG_DATA = "zha_channel_msg_data"
+ZHA_CHANNEL_CFG_DONE = "zha_channel_cfg_done"
 ZHA_GW_MSG = "zha_gateway_message"
 ZHA_GW_MSG_DEVICE_FULL_INIT = "device_fully_initialized"
 ZHA_GW_MSG_DEVICE_INFO = "device_info"

--- a/tests/components/zha/common.py
+++ b/tests/components/zha/common.py
@@ -93,7 +93,11 @@ def patch_cluster(cluster):
         return (result,)
 
     cluster.bind = AsyncMock(return_value=[0])
-    cluster.configure_reporting = AsyncMock(return_value=[0])
+    cluster.configure_reporting = AsyncMock(
+        return_value=[
+            [zcl_f.ConfigureReportingResponseRecord(zcl_f.Status.SUCCESS, 0x00, 0xAABB)]
+        ]
+    )
     cluster.deserialize = Mock()
     cluster.handle_cluster_request = Mock()
     cluster.read_attributes = AsyncMock(wraps=cluster.read_attributes)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR continues the work on the reconfiguration dialog for ZHA devices. The log relaying has been replaced by events that the UI uses to provide a more user friendly visual representation for the reconfiguration process.


https://user-images.githubusercontent.com/1335687/116005321-6a4ccd00-a5d4-11eb-86d6-08b7d8cb80c3.mov

**RELATED UI PR** https://github.com/home-assistant/frontend/pull/8990

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49124
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
