### PR TITLE
Use StaticPool for recorder and NullPool for all other threads with sqlite3

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -43,6 +43,7 @@ import homeassistant.util.dt as dt_util
 from . import migration, purge
 from .const import CONF_DB_INTEGRITY_CHECK, DATA_INSTANCE, DOMAIN, SQLITE_URL_PREFIX
 from .models import Base, Events, RecorderRuns, States
+from .pool import RecorderPool
 from .util import (
     dburl_to_path,
     end_incomplete_runs,
@@ -783,6 +784,8 @@ class Recorder(threading.Thread):
             kwargs["connect_args"] = {"check_same_thread": False}
             kwargs["poolclass"] = StaticPool
             kwargs["pool_reset_on_return"] = None
+        elif self.db_url.startswith(SQLITE_URL_PREFIX):
+            kwargs["poolclass"] = RecorderPool
         else:
             kwargs["echo"] = False
 

--- a/homeassistant/components/recorder/pool.py
+++ b/homeassistant/components/recorder/pool.py
@@ -1,0 +1,34 @@
+"""A pool for sqlite connections."""
+import threading
+
+from sqlalchemy.pool import NullPool, StaticPool
+
+
+class RecorderPool(StaticPool, NullPool):
+    """A hybird of NullPool and StaticPool.
+
+    When called from the creating thread acts like StaticPool
+    When called from any other thread, acts like NullPool
+    """
+
+    def __init__(self, *args, **kw):  # pylint: disable=super-init-not-called
+        """Create the pool."""
+        self._tid = threading.current_thread().ident
+        StaticPool.__init__(self, *args, **kw)
+
+    def _do_return_conn(self, conn):
+        if threading.current_thread().ident == self._tid:
+            return super()._do_return_conn(conn)
+        conn.close()
+
+    def dispose(self):
+        """Dispose of the connection."""
+        if threading.current_thread().ident == self._tid:
+            return super().dispose()
+
+    def _do_get(self):
+        if threading.current_thread().ident == self._tid:
+            return super()._do_get()
+        return super(  # pylint: disable=bad-super-call
+            NullPool, self
+        )._create_connection()

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -13,24 +13,22 @@ def test_recorder_pool():
     engine = create_engine("sqlite://", poolclass=RecorderPool)
     get_session = sessionmaker(bind=engine)
 
+    connections = []
+
     def _get_connection_twice():
         session = get_session()
-        original_connection = session.connection().connection.connection
+        connections.append(session.connection().connection.connection)
         session.close()
 
         session = get_session()
-        second_connection = session.connection().connection.connection
+        connections.append(session.connection().connection.connection)
         session.close()
 
-        return original_connection, second_connection
-
-    connections = _get_connection_twice()
+    _get_connection_twice()
     assert connections[0] == connections[1]
 
-    def _test_in_new_thread():
-        connections = _get_connection_twice()
-        assert connections[0] != connections[1]
-
-    new_thread = threading.Thread(target=_test_in_new_thread)
+    new_thread = threading.Thread(target=_get_connection_twice)
     new_thread.start()
     new_thread.join()
+    
+    assert connections[2] != connections[3]

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -1,0 +1,36 @@
+"""Test pool."""
+import threading
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from homeassistant.components.recorder.pool import RecorderPool
+
+
+def test_recorder_pool():
+    """Test RecorderPool gives the same connection in the creating thread."""
+
+    engine = create_engine("sqlite://", poolclass=RecorderPool)
+    get_session = sessionmaker(bind=engine)
+
+    def _get_conection_twice():
+        session = get_session()
+        original_connection = session.connection().connection.connection
+        session.close()
+
+        session = get_session()
+        second_connection = session.connection().connection.connection
+        session.close()
+
+        return original_connection, second_connection
+
+    connections = _get_conection_twice()
+    assert connections[0] == connections[1]
+
+    def _test_in_new_thread():
+        connections = _get_conection_twice()
+        assert connections[0] != connections[1]
+
+    new_thread = threading.Thread(target=_test_in_new_thread)
+    new_thread.start()
+    new_thread.join()

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -13,7 +13,7 @@ def test_recorder_pool():
     engine = create_engine("sqlite://", poolclass=RecorderPool)
     get_session = sessionmaker(bind=engine)
 
-    def _get_conection_twice():
+    def _get_connection_twice():
         session = get_session()
         original_connection = session.connection().connection.connection
         session.close()
@@ -24,11 +24,11 @@ def test_recorder_pool():
 
         return original_connection, second_connection
 
-    connections = _get_conection_twice()
+    connections = _get_connection_twice()
     assert connections[0] == connections[1]
 
     def _test_in_new_thread():
-        connections = _get_conection_twice()
+        connections = _get_connection_twice()
         assert connections[0] != connections[1]
 
     new_thread = threading.Thread(target=_test_in_new_thread)

--- a/tests/components/recorder/test_pool.py
+++ b/tests/components/recorder/test_pool.py
@@ -30,5 +30,5 @@ def test_recorder_pool():
     new_thread = threading.Thread(target=_get_connection_twice)
     new_thread.start()
     new_thread.join()
-    
+
     assert connections[2] != connections[3]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the recorder is constantly writing to the database it
should keep the sqlite3 connection open for the life of the
thread.  The default NullPool closes the database after
each commit.  This is an expensive operation.  To solve this
performance issue, RecorderPool has been created.  RecorderPool
acts like StaticPool, maintaining a single connection to the
database in the recorder thread, and NullPool in all other threads (current behavior).
This behavior ensures that threads do not share sqlite3
connections for thread safety but still allows the recorder
to use a single connection to the database that it does
not close for the life of the run unless there is a problem.

<img width="569" alt="Screen_Shot_2021-04-25_at_9_27_25_PM" src="https://user-images.githubusercontent.com/663432/116044960-3f329f80-a60d-11eb-8b8c-687ab6c78b3c.png">

The previous behavior resulted in a WAL checkpoint happening at almost
every commit because the connection was closed by `NullPool` after each commit (usually once per second) `SQLite will automatically checkpoint whenever a COMMIT occurs that causes the WAL file to be 1000 pages or more in size, or when the last database connection on a database file closes.` (https://sqlite.org/wal.html#3.1) 

Since checkpoints ran almost every time there was data to be written (frequently every 1s), checkpoints were frequently happening every one second.  This behavior was not particularly friendly to SD cards lifetimes (checkpoints require sync operations!) or write performance (although good for reads if the disk can do the writes fast enough). `To maximize write performance, one wants to amortize the cost of each checkpoint over as many writes as possible, meaning that one wants to run checkpoints infrequently and let the WAL grow as large as possible before each checkpoint.` (https://sqlite.org/wal.html#2.3).  

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
