### PR TITLE
Add support for color_mode to ESPHome light

### DIFF
--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -1,6 +1,8 @@
 """Support for ESPHome lights."""
 from __future__ import annotations
 
+import logging
+
 from aioesphomeapi import LightInfo, LightState
 
 from homeassistant.components.light import (
@@ -8,27 +10,31 @@ from homeassistant.components.light import (
     ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_FLASH,
-    ATTR_HS_COLOR,
+    ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
-    ATTR_WHITE_VALUE,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_COLOR_TEMP,
+    COLOR_MODE_ONOFF,
+    COLOR_MODE_RGB,
+    COLOR_MODE_RGBW,
+    COLOR_MODE_RGBWW,
     FLASH_LONG,
     FLASH_SHORT,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_COLOR_TEMP,
     SUPPORT_EFFECT,
     SUPPORT_FLASH,
     SUPPORT_TRANSITION,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-import homeassistant.util.color as color_util
 
 from . import EsphomeEntity, esphome_state_property, platform_async_setup_entry
 
 FLASH_LENGTHS = {FLASH_SHORT: 2, FLASH_LONG: 10}
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -68,22 +74,38 @@ class EsphomeLight(EsphomeEntity, LightEntity):
     async def async_turn_on(self, **kwargs) -> None:
         """Turn the entity on."""
         data = {"key": self._static_info.key, "state": True}
-        if ATTR_HS_COLOR in kwargs:
-            hue, sat = kwargs[ATTR_HS_COLOR]
-            red, green, blue = color_util.color_hsv_to_RGB(hue, sat, 100)
-            data["rgb"] = (red / 255, green / 255, blue / 255)
-        if ATTR_FLASH in kwargs:
-            data["flash_length"] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
-        if ATTR_TRANSITION in kwargs:
-            data["transition_length"] = kwargs[ATTR_TRANSITION]
         if ATTR_BRIGHTNESS in kwargs:
             data["brightness"] = kwargs[ATTR_BRIGHTNESS] / 255
         if ATTR_COLOR_TEMP in kwargs:
             data["color_temperature"] = kwargs[ATTR_COLOR_TEMP]
+            data["rgb"] = (0, 0, 0)
+        if ATTR_RGB_COLOR in kwargs:
+            red, green, blue = kwargs[ATTR_RGB_COLOR]
+            data["rgb"] = (red / 255, green / 255, blue / 255)
+            data["white"] = 0
+        if ATTR_RGBW_COLOR in kwargs:
+            red, green, blue, white = kwargs[ATTR_RGBW_COLOR]
+            data["rgb"] = (red / 255, green / 255, blue / 255)
+            data["white"] = white / 255
+        if ATTR_RGBWW_COLOR in kwargs:
+            red, green, blue, cold_white, warm_white = kwargs[ATTR_RGBWW_COLOR]
+            max_mireds = self._static_info.max_mireds
+            min_mireds = self._static_info.min_mireds
+            mired_range = max_mireds - min_mireds
+            try:
+                ct_ratio = warm_white / (cold_white + warm_white)
+            except ZeroDivisionError:
+                ct_ratio = 0.5
+            data["color_temperature"] = min_mireds + ct_ratio * mired_range
+            data["rgb"] = (red / 255, green / 255, blue / 255)
+            data["white"] = max(cold_white, warm_white) / 255
+            _LOGGER.debug("async_turn_on: %s -> %s (%s)", {**kwargs}, data, ct_ratio)
+        if ATTR_FLASH in kwargs:
+            data["flash_length"] = FLASH_LENGTHS[kwargs[ATTR_FLASH]]
+        if ATTR_TRANSITION in kwargs:
+            data["transition_length"] = kwargs[ATTR_TRANSITION]
         if ATTR_EFFECT in kwargs:
             data["effect"] = kwargs[ATTR_EFFECT]
-        if ATTR_WHITE_VALUE in kwargs:
-            data["white"] = kwargs[ATTR_WHITE_VALUE] / 255
         await self._client.light_command(**data)
 
     async def async_turn_off(self, **kwargs) -> None:
@@ -100,12 +122,18 @@ class EsphomeLight(EsphomeEntity, LightEntity):
         """Return the brightness of this light between 0..255."""
         return round(self._state.brightness * 255)
 
-    @esphome_state_property
-    def hs_color(self) -> tuple[float, float] | None:
-        """Return the hue and saturation color value [float, float]."""
-        return color_util.color_RGB_to_hs(
-            self._state.red * 255, self._state.green * 255, self._state.blue * 255
-        )
+    @property
+    def color_mode(self) -> int | None:
+        """Return the brightness of this light between 0..255."""
+        color_modes = self.supported_color_modes
+        # RGBWW light may be in color_temp mode or rgbww mode
+        if COLOR_MODE_RGBWW in color_modes:
+            rgbww = self.rgbww_color
+            if not rgbww or rgbww[0] == 0 and rgbww[1] == 0 and rgbww[2] == 0:
+                return COLOR_MODE_COLOR_TEMP
+            return COLOR_MODE_RGBWW
+        # Other light supports a single mode only, return it
+        return next(iter(color_modes))
 
     @esphome_state_property
     def color_temp(self) -> float | None:
@@ -113,9 +141,46 @@ class EsphomeLight(EsphomeEntity, LightEntity):
         return self._state.color_temperature
 
     @esphome_state_property
-    def white_value(self) -> int | None:
-        """Return the white value of this light between 0..255."""
-        return round(self._state.white * 255)
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the RGB color value."""
+        red = int(self._state.red * 255)
+        green = int(self._state.green * 255)
+        blue = int(self._state.blue * 255)
+        return (red, green, blue)
+
+    @esphome_state_property
+    def rgbw_color(self) -> tuple[int, int, int, int] | None:
+        """Return the RGB color value."""
+        red = int(self._state.red * 255)
+        green = int(self._state.green * 255)
+        blue = int(self._state.blue * 255)
+        white = int(self._state.white * 255)
+        return (red, green, blue, white)
+
+    @esphome_state_property
+    def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
+        """Return the RGB color value."""
+        red = int(self._state.red * 255)
+        green = int(self._state.green * 255)
+        blue = int(self._state.blue * 255)
+        white = self._state.white
+        color_temp = self._state.color_temperature
+
+        max_mireds = self._static_info.max_mireds
+        min_mireds = self._static_info.min_mireds
+        mired_range = max_mireds - min_mireds
+        warm_white_fraction = (color_temp - min_mireds) / mired_range
+        cold_white_fraction = 1 - warm_white_fraction
+        max_cw_ww = max(cold_white_fraction, warm_white_fraction)
+        warm_white = int(min(white * warm_white_fraction / max_cw_ww * 255, 255))
+        cold_white = int(min(white * cold_white_fraction / max_cw_ww * 255, 255))
+        _LOGGER.debug(
+            "rgbww_color: %s -> %s (%s)",
+            {"r": red, "g": green, "b": blue, "w": white, "ct": color_temp},
+            (red, green, blue, cold_white, warm_white),
+            warm_white_fraction,
+        )
+        return (red, green, blue, cold_white, warm_white)
 
     @esphome_state_property
     def effect(self) -> str | None:
@@ -123,18 +188,32 @@ class EsphomeLight(EsphomeEntity, LightEntity):
         return self._state.effect
 
     @property
+    def supported_color_modes(self) -> int:
+        """Flag supported color_modes."""
+        supported_color_modes = set()
+        supports_color_temp = self._static_info.supports_color_temperature
+        supports_rgb = self._static_info.supports_rgb
+        supports_white = self._static_info.supports_white_value
+        if supports_rgb and not supports_white and not supports_color_temp:
+            supported_color_modes.add(COLOR_MODE_RGB)
+        if supports_rgb and supports_white and not supports_color_temp:
+            supported_color_modes.add(COLOR_MODE_RGBW)
+        if supports_rgb and supports_white and supports_color_temp:
+            supported_color_modes.add(COLOR_MODE_RGBWW)
+        if self._static_info.supports_color_temperature:
+            supported_color_modes.add(COLOR_MODE_COLOR_TEMP)
+        if not supported_color_modes and self._static_info.supports_brightness:
+            supported_color_modes.add(COLOR_MODE_BRIGHTNESS)
+        if not supported_color_modes:
+            supported_color_modes.add(COLOR_MODE_ONOFF)
+        return supported_color_modes
+
+    @property
     def supported_features(self) -> int:
         """Flag supported features."""
         flags = SUPPORT_FLASH
         if self._static_info.supports_brightness:
-            flags |= SUPPORT_BRIGHTNESS
             flags |= SUPPORT_TRANSITION
-        if self._static_info.supports_rgb:
-            flags |= SUPPORT_COLOR
-        if self._static_info.supports_white_value:
-            flags |= SUPPORT_WHITE_VALUE
-        if self._static_info.supports_color_temperature:
-            flags |= SUPPORT_COLOR_TEMP
         if self._static_info.effects:
             flags |= SUPPORT_EFFECT
         return flags

--- a/homeassistant/components/esphome/light.py
+++ b/homeassistant/components/esphome/light.py
@@ -123,8 +123,8 @@ class EsphomeLight(EsphomeEntity, LightEntity):
         return round(self._state.brightness * 255)
 
     @property
-    def color_mode(self) -> int | None:
-        """Return the brightness of this light between 0..255."""
+    def color_mode(self) -> str | None:
+        """Return the color mode of the light."""
         color_modes = self.supported_color_modes
         # RGBWW light may be in color_temp mode or rgbww mode
         if COLOR_MODE_RGBWW in color_modes:
@@ -143,26 +143,26 @@ class EsphomeLight(EsphomeEntity, LightEntity):
     @esphome_state_property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the RGB color value."""
-        red = int(self._state.red * 255)
-        green = int(self._state.green * 255)
-        blue = int(self._state.blue * 255)
+        red = round(self._state.red * 255)
+        green = round(self._state.green * 255)
+        blue = round(self._state.blue * 255)
         return (red, green, blue)
 
     @esphome_state_property
     def rgbw_color(self) -> tuple[int, int, int, int] | None:
-        """Return the RGB color value."""
-        red = int(self._state.red * 255)
-        green = int(self._state.green * 255)
-        blue = int(self._state.blue * 255)
-        white = int(self._state.white * 255)
+        """Return the RGBW color value."""
+        red = round(self._state.red * 255)
+        green = round(self._state.green * 255)
+        blue = round(self._state.blue * 255)
+        white = round(self._state.white * 255)
         return (red, green, blue, white)
 
     @esphome_state_property
     def rgbww_color(self) -> tuple[int, int, int, int, int] | None:
-        """Return the RGB color value."""
-        red = int(self._state.red * 255)
-        green = int(self._state.green * 255)
-        blue = int(self._state.blue * 255)
+        """Return the RGBWW color value."""
+        red = round(self._state.red * 255)
+        green = round(self._state.green * 255)
+        blue = round(self._state.blue * 255)
         white = self._state.white
         color_temp = self._state.color_temperature
 
@@ -174,12 +174,6 @@ class EsphomeLight(EsphomeEntity, LightEntity):
         max_cw_ww = max(cold_white_fraction, warm_white_fraction)
         warm_white = int(min(white * warm_white_fraction / max_cw_ww * 255, 255))
         cold_white = int(min(white * cold_white_fraction / max_cw_ww * 255, 255))
-        _LOGGER.debug(
-            "rgbww_color: %s -> %s (%s)",
-            {"r": red, "g": green, "b": blue, "w": white, "ct": color_temp},
-            (red, green, blue, cold_white, warm_white),
-            warm_white_fraction,
-        )
         return (red, green, blue, cold_white, warm_white)
 
     @esphome_state_property
@@ -188,7 +182,7 @@ class EsphomeLight(EsphomeEntity, LightEntity):
         return self._state.effect
 
     @property
-    def supported_color_modes(self) -> int:
+    def supported_color_modes(self) -> set | None:
         """Flag supported color_modes."""
         supported_color_modes = set()
         supports_color_temp = self._static_info.supports_color_temperature
@@ -200,7 +194,7 @@ class EsphomeLight(EsphomeEntity, LightEntity):
             supported_color_modes.add(COLOR_MODE_RGBW)
         if supports_rgb and supports_white and supports_color_temp:
             supported_color_modes.add(COLOR_MODE_RGBWW)
-        if self._static_info.supports_color_temperature:
+        if supports_color_temp:
             supported_color_modes.add(COLOR_MODE_COLOR_TEMP)
         if not supported_color_modes and self._static_info.supports_brightness:
             supported_color_modes.add(COLOR_MODE_BRIGHTNESS)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
ESPHome lights no longer supports deprecated white_value, use rgbw_color instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color_mode support to ESPHome light.
Flag support for rgbw instead of white_value for lights with red, green, blue and a single white channel
Flag support for rgbww instead of white_value for lights with red, green, blue and two white channels

Supported color modes is calculated as follows:
- Light supports RGB but not white_value or color_temperature: `[COLOR_MODE_RGB]`
- Light supports RGB and white_value but not color_temperature: `[COLOR_MODE_RGBW]`
- Light supports RGB and white_value and color_temperature: `[COLOR_MODE_RGBWW]`
- Light supports color_temperature: `[COLOR_MODE_COLOR_TEMP]`
- Light supports none of the above and supports brightness: `[COLOR_MODE_BRIGHTNESS]`
- Light supports none of the above: `[COLOR_MODE_ONOFF]`

TODO:
- When setting rgbww, this is translated to rgb + white + color_temperature. It would be better if the API supported setting rgbww directly.
- When the light reports state, rgb + white + color_temperature is translated to an rgbww tuple. It would be better if the state report from the light had the rgbww tuple.
- Light can be configured with `color_interlock` where rgb and white channels are exclusive, this should preferably be exposed in `LightInfo` in the aioesphomeapi
- Light can be configured with `constant_brightness` which limits brightness of the white channels to a sum is 1.0, this should preferably be exposed in `LightInfo` in the aioesphomeapi
- The light seems to do some kind of normalizing of the brightness across all channels, we probably don't want this when setting rgbww /  rgbw directly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
