### PR TITLE
Brunt package update with async, data update coordinator and config flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -137,7 +137,10 @@ omit =
     homeassistant/components/broadlink/updater.py
     homeassistant/components/brottsplatskartan/sensor.py
     homeassistant/components/browser/*
+    homeassistant/components/brunt/__init__.py
     homeassistant/components/brunt/cover.py
+    homeassistant/components/brunt/const.py
+    homeassistant/components/bsblan/__init__.py
     homeassistant/components/bsblan/climate.py
     homeassistant/components/bt_home_hub_5/device_tracker.py
     homeassistant/components/bt_smarthub/device_tracker.py

--- a/.coveragerc
+++ b/.coveragerc
@@ -140,7 +140,6 @@ omit =
     homeassistant/components/brunt/__init__.py
     homeassistant/components/brunt/cover.py
     homeassistant/components/brunt/const.py
-    homeassistant/components/bsblan/__init__.py
     homeassistant/components/bsblan/climate.py
     homeassistant/components/bt_home_hub_5/device_tracker.py
     homeassistant/components/bt_smarthub/device_tracker.py

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,20 +13,6 @@
       "problemMatcher": []
     },
     {
-      "label": "Preview SkipPip",
-      "type": "shell",
-      "command": "hass --skip-pip -c ./config",
-      "group": {
-        "kind": "test",
-        "isDefault": true
-      },
-      "presentation": {
-        "reveal": "always",
-        "panel": "new"
-      },
-      "problemMatcher": []
-    },
-    {
       "label": "Pytest",
       "type": "shell",
       "command": "pytest --timeout=10 tests",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,6 +13,20 @@
       "problemMatcher": []
     },
     {
+      "label": "Preview SkipPip",
+      "type": "shell",
+      "command": "hass --skip-pip -c ./config",
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "new"
+      },
+      "problemMatcher": []
+    },
+    {
       "label": "Pytest",
       "type": "shell",
       "command": "pytest --timeout=10 tests",

--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -46,10 +46,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise ConfigEntryAuthFailed(
             f"Brunt could not connect with username: {entry.data[CONF_USERNAME]}."
         ) from exc
-    # try:
-    #     await bapi.async_get_things(force=True)
-    # except HTTPError as exc:
-    #     raise ConfigEntryNotReady("Brunt could not load things.") from exc
     hass.data[DOMAIN][entry.entry_id] = bapi
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "cover")

--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -1,37 +1,23 @@
 """The brunt component."""
-import asyncio
+from __future__ import annotations
+
 import logging
 
 from aiohttp.client_exceptions import ClientResponseError, ServerDisconnectedError
 from brunt import BruntClientAsync
 
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN
-
-PLATFORMS = ["cover"]
+from .const import DOMAIN, PLATFORMS
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup(hass: HomeAssistant, config: dict):
-    """Component setup, run import config flow for each entry in config."""
-    if DOMAIN not in config:
-        return True
-    hass.data.setdefault(DOMAIN, {})
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
-        )
-    )
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Brunt using config flow."""
     hass.data.setdefault(DOMAIN, {})
     session = async_get_clientsession(hass)
@@ -48,26 +34,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         raise ConfigEntryAuthFailed(
             f"Brunt could not connect with username: {entry.data[CONF_USERNAME]}."
         ) from exc
-    except Exception as exc:  # pylint: disable=broad-except
-        _LOGGER.exception(exc)
-        return False
     hass.data[DOMAIN][entry.entry_id] = bapi
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "cover")
-    )
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok

--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 
 from aiohttp.client_exceptions import ClientResponseError, ServerDisconnectedError
+import async_timeout
 from brunt import BruntClientAsync
 
 from homeassistant.config_entries import ConfigEntry
@@ -11,8 +12,9 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, PLATFORMS
+from .const import DATA_BAPI, DATA_COOR, DOMAIN, PLATFORMS, REGULAR_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,7 +36,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryAuthFailed(
             f"Brunt could not connect with username: {entry.data[CONF_USERNAME]}."
         ) from exc
-    hass.data[DOMAIN][entry.entry_id] = bapi
+
+    async def async_update_data():
+        """Fetch data from the Brunt endpoint for all Things.
+
+        Error 403 is the API response for any kind of authentication error (failed password or email)
+        Error 401 is the API response for things that are not part of the account, could happen when a device is deleted from the account.
+        """
+        try:
+            async with async_timeout.timeout(10):
+                things = await bapi.async_get_things(force=True)
+                return {thing.SERIAL: thing for thing in things}
+        except ServerDisconnectedError as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
+        except ClientResponseError as err:
+            if err.status == 403:
+                raise ConfigEntryAuthFailed() from err
+            if err.status == 401:
+                raise UpdateFailed(
+                    "Device not part of account, please reload Brunt"
+                ) from err
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="brunt",
+        update_method=async_update_data,
+        update_interval=REGULAR_INTERVAL,
+    )
+    await coordinator.async_config_entry_first_refresh()
+
+    hass.data[DOMAIN][entry.entry_id] = {DATA_BAPI: bapi, DATA_COOR: coordinator}
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
 

--- a/homeassistant/components/brunt/__init__.py
+++ b/homeassistant/components/brunt/__init__.py
@@ -1,1 +1,72 @@
 """The brunt component."""
+import asyncio
+import logging
+
+from aiohttp.web_exceptions import HTTPError
+from brunt import BruntClientAsync
+
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+PLATFORMS = ["cover"]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: dict):
+    """Component setup, run import config flow for each entry in config."""
+    if DOMAIN not in config:
+        return True
+    hass.data.setdefault(DOMAIN, {})
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config[DOMAIN]
+        )
+    )
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Set up Brunt using config flow."""
+    hass.data.setdefault(DOMAIN, {})
+    session = async_get_clientsession(hass)
+    bapi = BruntClientAsync(
+        username=entry.data[CONF_USERNAME],
+        password=entry.data[CONF_PASSWORD],
+        session=session,
+    )
+    try:
+        await bapi.async_login()
+    except HTTPError as exc:
+        raise ConfigEntryAuthFailed(
+            f"Brunt could not connect with username: {entry.data[CONF_USERNAME]}."
+        ) from exc
+    # try:
+    #     await bapi.async_get_things(force=True)
+    # except HTTPError as exc:
+    #     raise ConfigEntryNotReady("Brunt could not load things.") from exc
+    hass.data[DOMAIN][entry.entry_id] = bapi
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "cover")
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
+    """Unload a config entry."""
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, component)
+                for component in PLATFORMS
+            ]
+        )
+    )
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+    return unload_ok

--- a/homeassistant/components/brunt/config_flow.py
+++ b/homeassistant/components/brunt/config_flow.py
@@ -83,6 +83,7 @@ class BruntConfigFlow(ConfigFlow, domain=DOMAIN):
         self._reauth_entry = self.hass.config_entries.async_get_entry(
             self.context["entry_id"]
         )
+        assert self._reauth_entry
         if user_input is None:
             return self.async_show_form(step_id="reauth", data_schema=REAUTH_SCHEMA)
         user_input[CONF_USERNAME] = self._reauth_entry.data[CONF_USERNAME]

--- a/homeassistant/components/brunt/config_flow.py
+++ b/homeassistant/components/brunt/config_flow.py
@@ -1,12 +1,15 @@
 """Config flow for brunt integration."""
+from __future__ import annotations
+
 import logging
+from typing import Any
 
 from aiohttp import ClientResponseError
 from aiohttp.client_exceptions import ServerDisconnectedError
 from brunt import BruntClientAsync
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .const import DOMAIN
@@ -16,55 +19,78 @@ _LOGGER = logging.getLogger(__name__)
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
 )
+REAUTH_SCHEMA = vol.Schema({vol.Required(CONF_PASSWORD): str})
 
 
-class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for youless."""
+async def validate_input(
+    user_input: dict[str, Any]
+) -> dict[str, str] | None:  # pragma: no cover
+    """Login to the brunt api and return errors if any."""
+    errors = None
+    bapi = BruntClientAsync(
+        username=user_input[CONF_USERNAME],
+        password=user_input[CONF_PASSWORD],
+    )
+    try:
+        await bapi.async_login()
+    except ClientResponseError as exc:
+        if exc.status == 403:
+            _LOGGER.warning("Brunt Credentials are incorrect")
+            errors = {"base": "invalid_auth"}
+        else:
+            _LOGGER.exception("Unknown error when connecting to Brunt: %s", exc)
+            errors = {"base": "unknown"}
+    except ServerDisconnectedError:
+        _LOGGER.warning("Cannot connect to Brunt")
+        errors = {"base": "cannot_connect"}
+    except Exception as exc:  # pylint: disable=broad-except
+        _LOGGER.exception("Unknown error when connecting to Brunt: %s", exc)
+        errors = {"base": "unknown"}
+    finally:
+        await bapi.async_close()
+    return errors
+
+
+class BruntConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Brunt."""
 
     VERSION = 1
-    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
     def __init__(self):
         """Start the Brunt config flow."""
-        self._reauth_entry = None
+        self._reauth_entry: ConfigEntry | None = None
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
-        errors = None
-        bapi = BruntClientAsync(
-            username=user_input[CONF_USERNAME], password=user_input[CONF_PASSWORD]
-        )
-        try:
-            await bapi.async_login()
-        except ClientResponseError as exc:
-            if exc.status == 403:
-                _LOGGER.warning("Brunt Credentials are incorrect")
-                errors = {"base": "invalid_auth"}
-            else:
-                _LOGGER.warning("Unknown error when connecting to Brunt: %s", exc)
-                errors = {"base": "unknown"}
-        except ServerDisconnectedError:
-            _LOGGER.warning("Cannot connect to Brunt")
-            errors = {"base": "cannot_connect"}
-        except Exception as exc:  # pylint: disable=broad-except
-            _LOGGER.warning("Unknown error when connecting to Brunt: %s", exc)
-            errors = {"base": "unknown"}
-        finally:
-            await bapi.async_close()
+        errors = await validate_input(user_input)
         if errors is not None:
             return self.async_show_form(
                 step_id="user", data_schema=DATA_SCHEMA, errors=errors
             )
 
         await self.async_set_unique_id(user_input[CONF_USERNAME])
-        if self._reauth_entry is None or self._reauth_entry.unique_id != self.unique_id:
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(
-                title=user_input[CONF_USERNAME],
-                data=user_input,
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=user_input[CONF_USERNAME],
+            data=user_input,
+        )
+
+    async def async_step_reauth(self, user_input: dict[str, Any] | None = None):
+        """Handle the reauth step."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        if user_input is None:
+            return self.async_show_form(step_id="reauth", data_schema=REAUTH_SCHEMA)
+        user_input[CONF_USERNAME] = self._reauth_entry.data[CONF_USERNAME]
+
+        errors = await validate_input(user_input)
+        if errors is not None:
+            return self.async_show_form(
+                step_id="reauth", data_schema=REAUTH_SCHEMA, errors=errors
             )
 
         self.hass.config_entries.async_update_entry(self._reauth_entry, data=user_input)
@@ -72,18 +98,11 @@ class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_abort(reason="reauth_successful")
 
-    async def async_step_import(self, import_config):
+    async def async_step_import(self, import_config: dict[str, Any]):
         """Import config from configuration.yaml."""
         entries = self._async_current_entries()
         for entry in entries:
             if entry.data[CONF_USERNAME] == import_config[CONF_USERNAME]:
-                return self.async_abort(reason="already_configured")
+                return self.async_abort(reason="already_configured_account")
 
         return await self.async_step_user(import_config)
-
-    async def async_step_reauth(self, user_input=None):
-        """Perform reauth if the user credentials have changed."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
-        return await self.async_step_user()

--- a/homeassistant/components/brunt/config_flow.py
+++ b/homeassistant/components/brunt/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow for brunt integration."""
+import logging
+
+from aiohttp import ClientResponseError
+from aiohttp.web import HTTPError
+from brunt import BruntClientAsync
+import voluptuous as vol
+
+from homeassistant import config_entries, exceptions
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+DATA_SCHEMA = vol.Schema(
+    {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
+)
+
+
+class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for youless."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if user_input is None:
+            return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
+
+        bapi = BruntClientAsync(
+            username=user_input[CONF_USERNAME], password=user_input[CONF_PASSWORD]
+        )
+        try:
+            await bapi.async_login()
+        except (HTTPError, ClientResponseError):
+            _LOGGER.warning("Cannot connect to Brunt.")
+            return self.async_show_form(
+                step_id="user",
+                data_schema=DATA_SCHEMA,
+                errors={"base": "invalid_auth"},
+            )
+        finally:
+            await bapi.async_close()
+        await self.async_set_unique_id(user_input[CONF_USERNAME])
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(
+            title=user_input[CONF_USERNAME],
+            data=user_input,
+        )
+
+    async def async_step_import(self, import_config):
+        """Import config from configuration.yaml."""
+        entries = self._async_current_entries()
+        for entry in entries:
+            if entry.data[CONF_USERNAME] == import_config[CONF_USERNAME]:
+                return self.async_abort(reason="already_configured")
+
+        return await self.async_step_user(import_config)
+
+
+class CannotConnect(exceptions.HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/brunt/config_flow.py
+++ b/homeassistant/components/brunt/config_flow.py
@@ -81,31 +81,20 @@ class BruntConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Perform reauth upon an API authentication error."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Dialog that informs the user that reauth is required."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="reauth_confirm",
-                data_schema=vol.Schema({}),
-            )
-        return await self.async_step_reauth_input()
-
-    async def async_step_reauth_input(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the reauth input."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
         assert self._reauth_entry
         username = self._reauth_entry.data[CONF_USERNAME]
         if user_input is None:
             return self.async_show_form(
-                step_id="reauth_input",
+                step_id="reauth_confirm",
                 data_schema=REAUTH_SCHEMA,
                 description_placeholders={"username": username},
             )
@@ -113,7 +102,7 @@ class BruntConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = await validate_input(user_input)
         if errors is not None:
             return self.async_show_form(
-                step_id="reauth_input",
+                step_id="reauth_confirm",
                 data_schema=REAUTH_SCHEMA,
                 errors=errors,
                 description_placeholders={"username": username},

--- a/homeassistant/components/brunt/config_flow.py
+++ b/homeassistant/components/brunt/config_flow.py
@@ -6,7 +6,7 @@ from aiohttp.web import HTTPError
 from brunt import BruntClientAsync
 import voluptuous as vol
 
-from homeassistant import config_entries, exceptions
+from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from .const import DOMAIN
@@ -41,6 +41,13 @@ class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 data_schema=DATA_SCHEMA,
                 errors={"base": "invalid_auth"},
             )
+        except Exception as exc:
+            _LOGGER.warning("Unknown error when connecting to Brunt: %s", exc)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=DATA_SCHEMA,
+                errors={"base": "unknown"},
+            )
         finally:
             await bapi.async_close()
         await self.async_set_unique_id(user_input[CONF_USERNAME])
@@ -58,7 +65,3 @@ class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         return await self.async_step_user(import_config)
-
-
-class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""

--- a/homeassistant/components/brunt/config_flow.py
+++ b/homeassistant/components/brunt/config_flow.py
@@ -2,7 +2,7 @@
 import logging
 
 from aiohttp import ClientResponseError
-from aiohttp.web import HTTPError
+from aiohttp.client_exceptions import ServerDisconnectedError
 from brunt import BruntClientAsync
 import voluptuous as vol
 
@@ -24,38 +24,53 @@ class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
+    def __init__(self):
+        """Start the Brunt config flow."""
+        self._reauth_entry = None
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
+        errors = None
         bapi = BruntClientAsync(
             username=user_input[CONF_USERNAME], password=user_input[CONF_PASSWORD]
         )
         try:
             await bapi.async_login()
-        except (HTTPError, ClientResponseError):
-            _LOGGER.warning("Cannot connect to Brunt.")
-            return self.async_show_form(
-                step_id="user",
-                data_schema=DATA_SCHEMA,
-                errors={"base": "invalid_auth"},
-            )
-        except Exception as exc:
+        except ClientResponseError as exc:
+            if exc.status == 403:
+                _LOGGER.warning("Brunt Credentials are incorrect")
+                errors = {"base": "invalid_auth"}
+            else:
+                _LOGGER.warning("Unknown error when connecting to Brunt: %s", exc)
+                errors = {"base": "unknown"}
+        except ServerDisconnectedError:
+            _LOGGER.warning("Cannot connect to Brunt")
+            errors = {"base": "cannot_connect"}
+        except Exception as exc:  # pylint: disable=broad-except
             _LOGGER.warning("Unknown error when connecting to Brunt: %s", exc)
-            return self.async_show_form(
-                step_id="user",
-                data_schema=DATA_SCHEMA,
-                errors={"base": "unknown"},
-            )
+            errors = {"base": "unknown"}
         finally:
             await bapi.async_close()
+        if errors is not None:
+            return self.async_show_form(
+                step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            )
+
         await self.async_set_unique_id(user_input[CONF_USERNAME])
-        self._abort_if_unique_id_configured()
-        return self.async_create_entry(
-            title=user_input[CONF_USERNAME],
-            data=user_input,
-        )
+        if self._reauth_entry is None or self._reauth_entry.unique_id != self.unique_id:
+            self._abort_if_unique_id_configured()
+            return self.async_create_entry(
+                title=user_input[CONF_USERNAME],
+                data=user_input,
+            )
+
+        self.hass.config_entries.async_update_entry(self._reauth_entry, data=user_input)
+        await self.hass.config_entries.async_reload(self._reauth_entry.entry_id)
+
+        return self.async_abort(reason="reauth_successful")
 
     async def async_step_import(self, import_config):
         """Import config from configuration.yaml."""
@@ -65,3 +80,10 @@ class BruntConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         return await self.async_step_user(import_config)
+
+    async def async_step_reauth(self, user_input=None):
+        """Perform reauth if the user credentials have changed."""
+        self._reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+        return await self.async_step_user()

--- a/homeassistant/components/brunt/const.py
+++ b/homeassistant/components/brunt/const.py
@@ -1,0 +1,8 @@
+DOMAIN = "brunt"
+ATTR_REQUEST_POSITION = "request_position"
+NOTIFICATION_ID = "brunt_notification"
+NOTIFICATION_TITLE = "Brunt Cover Setup"
+ATTRIBUTION = "Based on an unofficial Brunt SDK."
+
+CLOSED_POSITION = 0
+OPEN_POSITION = 100

--- a/homeassistant/components/brunt/const.py
+++ b/homeassistant/components/brunt/const.py
@@ -4,6 +4,7 @@ ATTR_REQUEST_POSITION = "request_position"
 NOTIFICATION_ID = "brunt_notification"
 NOTIFICATION_TITLE = "Brunt Cover Setup"
 ATTRIBUTION = "Based on an unofficial Brunt SDK."
+PLATFORMS = ["cover"]
 
 CLOSED_POSITION = 0
 OPEN_POSITION = 100

--- a/homeassistant/components/brunt/const.py
+++ b/homeassistant/components/brunt/const.py
@@ -1,3 +1,4 @@
+"""Constants for Brunt."""
 DOMAIN = "brunt"
 ATTR_REQUEST_POSITION = "request_position"
 NOTIFICATION_ID = "brunt_notification"

--- a/homeassistant/components/brunt/const.py
+++ b/homeassistant/components/brunt/const.py
@@ -1,10 +1,17 @@
 """Constants for Brunt."""
+from datetime import timedelta
+
 DOMAIN = "brunt"
 ATTR_REQUEST_POSITION = "request_position"
 NOTIFICATION_ID = "brunt_notification"
 NOTIFICATION_TITLE = "Brunt Cover Setup"
 ATTRIBUTION = "Based on an unofficial Brunt SDK."
 PLATFORMS = ["cover"]
+DATA_BAPI = "bapi"
+DATA_COOR = "coordinator"
 
 CLOSED_POSITION = 0
 OPEN_POSITION = 100
+
+REGULAR_INTERVAL = timedelta(seconds=20)
+FAST_INTERVAL = timedelta(seconds=5)

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -1,7 +1,10 @@
 """Support for Brunt Blind Engine covers."""
+from __future__ import annotations
 
+from collections.abc import MutableMapping
 from datetime import timedelta
 import logging
+from typing import Any
 
 from aiohttp.client_exceptions import ClientResponseError, ServerDisconnectedError
 import async_timeout
@@ -9,15 +12,18 @@ from brunt import BruntClientAsync, Thing
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
-    DEVICE_CLASS_WINDOW,
+    DEVICE_CLASS_SHADE,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,
     SUPPORT_SET_POSITION,
     CoverEntity,
 )
-from homeassistant.const import ATTR_ATTRIBUTION
-from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -39,7 +45,29 @@ REGULAR_INTERVAL = timedelta(seconds=20)
 FAST_INTERVAL = timedelta(seconds=1)
 
 
-async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None):
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Component setup, run import config flow for each entry in config."""
+    _LOGGER.warning(
+        "Loading brunt via platform config is deprecated; The configuration has been migrated to a config entry and can be safely removed from configuration.yaml"
+    )
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": SOURCE_IMPORT}, data=config
+        )
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
     """Set up the brunt platform."""
     bapi: BruntClientAsync = hass.data[DOMAIN][entry.entry_id]
 
@@ -72,7 +100,6 @@ async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None
         BruntDevice(coordinator, serial, thing, bapi, entry.entry_id)
         for serial, thing in coordinator.data.items()
     )
-    return True
 
 
 class BruntDevice(CoordinatorEntity, CoverEntity):
@@ -89,14 +116,28 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         thing: Thing,
         bapi: BruntClientAsync,
         entry_id: str,
-    ):
+    ) -> None:
         """Init the Brunt device."""
         super().__init__(coordinator)
-        self._unique_id = serial
+        self._attr_unique_id = serial
         self._bapi = bapi
         self._thing = thing
         self._entry_id = entry_id
+
         self._remove_update_listener = None
+
+        self._attr_name = self._thing.NAME
+        self._attr_device_class = DEVICE_CLASS_SHADE
+        self._attr_supported_features = COVER_FEATURES
+        self._attr_attribution = ATTRIBUTION
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._attr_unique_id)},
+            name=self._attr_name,
+            via_device=(DOMAIN, self._entry_id),
+            manufacturer="Brunt",
+            sw_version=self._thing.FW_VERSION,
+            model=self._thing.MODEL,
+        )
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
@@ -106,23 +147,13 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         )
 
     @property
-    def unique_id(self) -> str:
-        """Get unique_id."""
-        return self._unique_id
-
-    @property
-    def name(self):
-        """Return the name of the device as reported by tellcore."""
-        return self._thing.NAME
-
-    @property
-    def current_cover_position(self):
+    def current_cover_position(self) -> int | None:
         """
         Return current position of cover.
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self._unique_id].currentPosition
+        pos = self.coordinator.data[self._attr_unique_id].currentPosition
         return int(pos) if pos else None
 
     @property
@@ -134,8 +165,8 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         to Brunt, at times there is a diff of 1 to current
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self._unique_id].requestPosition
-        return int(pos) if pos else None
+        pos = self.coordinator.data[self._attr_unique_id].requestPosition
+        return int(pos) if pos is not None else None
 
     @property
     def move_state(self) -> int | None:
@@ -144,68 +175,58 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 when stopped, 1 when opening, 2 when closing
         """
-        mov = self.coordinator.data[self._unique_id].moveState
-        return int(mov) if mov else None
+        mov = self.coordinator.data[self._attr_unique_id].moveState
+        return int(mov) if mov is not None else None
 
     @property
-    def is_opening(self):
+    def is_opening(self) -> bool:
         """Return if the cover is opening or not."""
         return self.move_state == 1
 
     @property
-    def is_closing(self):
+    def is_closing(self) -> bool:
         """Return if the cover is closing or not."""
         return self.move_state == 2
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> MutableMapping[str, Any]:
         """Return the detailed device state attributes."""
         return {
-            ATTR_ATTRIBUTION: ATTRIBUTION,
             ATTR_REQUEST_POSITION: self.request_cover_position,
         }
 
     @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_WINDOW
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return COVER_FEATURES
-
-    @property
-    def is_closed(self):
+    def is_closed(self) -> bool:
         """Return true if cover is closed, else False."""
         return self.current_cover_position == CLOSED_POSITION
 
-    async def async_open_cover(self, **kwargs):
+    async def async_open_cover(self, **kwargs) -> None:
         """Set the cover to the open position."""
         await self._async_update_cover(OPEN_POSITION)
 
-    async def async_close_cover(self, **kwargs):
+    async def async_close_cover(self, **kwargs) -> None:
         """Set the cover to the closed position."""
         await self._async_update_cover(CLOSED_POSITION)
 
-    async def async_set_cover_position(self, **kwargs):
+    async def async_set_cover_position(self, **kwargs) -> None:
         """Set the cover to a specific position."""
-        await self._async_update_cover(kwargs[ATTR_POSITION])
+        await self._async_update_cover(int(kwargs[ATTR_POSITION]))
 
-    async def _async_update_cover(self, position):
+    async def _async_update_cover(self, position: int) -> None:
         """Set the cover to the new position and wait for the update to be reflected."""
         try:
             await self._bapi.async_change_request_position(
                 position, thingUri=self._thing.thingUri
             )
-        except ClientResponseError:
-            _LOGGER.warning("Unable to reposition %s", self._thing.NAME)
-            return
+        except ClientResponseError as exc:
+            raise HomeAssistantError(
+                f"Unable to reposition {self._thing.NAME}"
+            ) from exc
         self.coordinator.update_interval = FAST_INTERVAL
         await self.coordinator.async_request_refresh()
 
     @callback
-    def _brunt_update_listener(self):
+    def _brunt_update_listener(self) -> None:
         """Update the update interval after each refresh."""
         if (
             self.request_cover_position
@@ -215,15 +236,3 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
             self.coordinator.update_interval = REGULAR_INTERVAL
         else:
             self.coordinator.update_interval = FAST_INTERVAL
-
-    @property
-    def device_info(self) -> dict:
-        """Return the device_info."""
-        return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
-            "via_device": (DOMAIN, self._entry_id),
-            "manufacturer": "Brunt",
-            "sw_version": self._thing.FW_VERSION,
-            "model": self._thing.MODEL,
-        }

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -42,7 +42,7 @@ _LOGGER = logging.getLogger(__name__)
 
 COVER_FEATURES = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
 REGULAR_INTERVAL = timedelta(seconds=20)
-FAST_INTERVAL = timedelta(seconds=1)
+FAST_INTERVAL = timedelta(seconds=5)
 
 
 async def async_setup_platform(

--- a/homeassistant/components/brunt/cover.py
+++ b/homeassistant/components/brunt/cover.py
@@ -1,10 +1,10 @@
 """Support for Brunt Blind Engine covers."""
-from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from brunt import BruntClientAsync
+
 import async_timeout
+from brunt import BruntClientAsync, Thing
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
@@ -15,6 +15,7 @@ from homeassistant.components.cover import (
     CoverEntity,
 )
 from homeassistant.const import ATTR_ATTRIBUTION
+from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
@@ -32,9 +33,8 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 COVER_FEATURES = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION
-FAST = 1
 REGULAR_INTERVAL = timedelta(seconds=20)
-FAST_INTERVAL = timedelta(seconds=FAST)
+FAST_INTERVAL = timedelta(seconds=1)
 
 
 async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None):
@@ -45,8 +45,8 @@ async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None
         """Fetch data from the Brunt endpoint for all Things."""
         try:
             async with async_timeout.timeout(10):
-                states = await bapi.async_get_things(force=True)
-                return {thing["SERIAL"]: thing for thing in states}
+                things = await bapi.async_get_things(force=True)
+                return {thing.SERIAL: thing for thing in things}
         except (TypeError, KeyError, NameError, ValueError) as err:
             raise UpdateFailed(f"Error communicating with API: {err}") from err
 
@@ -58,6 +58,7 @@ async def async_setup_entry(hass, entry, async_add_entities, discovery_info=None
         update_interval=REGULAR_INTERVAL,
     )
     await coordinator.async_config_entry_first_refresh()
+
     async_add_entities(
         BruntDevice(coordinator, serial, thing, bapi)
         for serial, thing in coordinator.data.items()
@@ -72,16 +73,26 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
     Contains the common logic for all Brunt devices.
     """
 
-    def __init__(self, coordinator, serial, thing, bapi):
+    def __init__(
+        self,
+        coordinator: DataUpdateCoordinator,
+        serial: str,
+        thing: Thing,
+        bapi: BruntClientAsync,
+    ):
         """Init the Brunt device."""
         super().__init__(coordinator)
         self._unique_id = serial
         self._bapi = bapi
         self._thing = thing
-        self._last_requested = None
+        self._remove_update_listener = None
 
-    # TODO: add async_add_to_hass
-    # await coordinator.async_add_listener(self._brunt_update_listener)
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.coordinator.async_add_listener(self._brunt_update_listener)
+        )
 
     @property
     def unique_id(self) -> str:
@@ -91,7 +102,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
     @property
     def name(self):
         """Return the name of the device as reported by tellcore."""
-        return self._thing["NAME"]
+        return self._thing.NAME
 
     @property
     def current_cover_position(self):
@@ -100,7 +111,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self._unique_id].get("currentPosition")
+        pos = self.coordinator.data[self._unique_id].currentPosition
         return int(pos) if pos else None
 
     @property
@@ -112,7 +123,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
         to Brunt, at times there is a diff of 1 to current
         None is unknown, 0 is closed, 100 is fully open.
         """
-        pos = self.coordinator.data[self._unique_id].get("requestPosition")
+        pos = self.coordinator.data[self._unique_id].requestPosition
         return int(pos) if pos else None
 
     @property
@@ -122,7 +133,7 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
 
         None is unknown, 0 when stopped, 1 when opening, 2 when closing
         """
-        mov = self.coordinator.data[self._unique_id].get("moveState")
+        mov = self.coordinator.data[self._unique_id].moveState
         return int(mov) if mov else None
 
     @property
@@ -173,16 +184,22 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
     async def _async_update_cover(self, position):
         """Set the cover to the new position and wait for the update to be reflected."""
         await self._bapi.async_change_request_position(
-            position, thingUri=self._thing["thingUri"]
+            position, thingUri=self._thing.thingUri
         )
-        self._last_requested = position
         self.coordinator.update_interval = FAST_INTERVAL
         await self.coordinator.async_request_refresh()
 
-    async def _brunt_update_listener(self):
-        """update listener for brunt."""
-        if self.request_cover_position != self._last_requested or self.move_state != 0:
+    @callback
+    def _brunt_update_listener(self):
+        """Update the update interval after each refresh."""
+        if (
+            self.request_cover_position
+            == self._bapi.last_requested_positions[self._thing.thingUri]
+            and self.move_state == 0
+        ):
             self.coordinator.update_interval = REGULAR_INTERVAL
+        else:
+            self.coordinator.update_interval = FAST_INTERVAL
 
     @property
     def device_info(self) -> dict:
@@ -192,6 +209,6 @@ class BruntDevice(CoordinatorEntity, CoverEntity):
             "name": self.name,
             "via_device": None,
             "manufacturer": "Brunt",
-            "sw_version": self._thing["FW_VERSION"],
-            "model": self._thing["MODEL"],
+            "sw_version": self._thing.FW_VERSION,
+            "model": self._thing.MODEL,
         }

--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brunt Blind Engine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/brunt",
-  "requirements": ["git+https://github.com/eavanvalkenburg/brunt-api.git@aio#brunt==0.2.0"],
+  "requirements": ["brunt==1.0.0b1"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -3,7 +3,7 @@
   "name": "Brunt Blind Engine",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/brunt",
-  "requirements": ["brunt==1.0.0b1"],
+  "requirements": ["brunt==1.0.0"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/brunt/manifest.json
+++ b/homeassistant/components/brunt/manifest.json
@@ -1,8 +1,9 @@
 {
   "domain": "brunt",
   "name": "Brunt Blind Engine",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/brunt",
-  "requirements": ["brunt==0.1.3"],
+  "requirements": ["git+https://github.com/eavanvalkenburg/brunt-api.git@aio#brunt==0.2.0"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/brunt/strings.json
+++ b/homeassistant/components/brunt/strings.json
@@ -13,6 +13,10 @@
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
         "unknown": "[%key:common::config_flow::error::unknown%]"
+      },
+      "abort": {
+        "already_configured_account": "[%key:common::config_flow::abort::already_configured_account%]",
+        "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
       }
     }
   }

--- a/homeassistant/components/brunt/strings.json
+++ b/homeassistant/components/brunt/strings.json
@@ -7,6 +7,17 @@
             "username": "[%key:common::config_flow::data::username%]",
             "password": "[%key:common::config_flow::data::password%]"
           }
+        },
+        "reauth_confirm": {
+          "title": "[%key:common::config_flow::title::reauth%]",
+          "description": "The Brunt integration needs to re-authenticate your account"
+        },
+        "reauth_input": {
+          "title": "[%key:common::config_flow::title::reauth%]",
+          "description": "Reenter the password for Brunt account: {username}.",
+          "data": {
+            "password": "[%key:common::config_flow::data::password%]"
+          }
         }
       },
       "error": {
@@ -15,7 +26,7 @@
         "unknown": "[%key:common::config_flow::error::unknown%]"
       },
       "abort": {
-        "already_configured_account": "[%key:common::config_flow::abort::already_configured_account%]",
+        "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
         "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
       }
     }

--- a/homeassistant/components/brunt/strings.json
+++ b/homeassistant/components/brunt/strings.json
@@ -1,0 +1,16 @@
+{
+    "config": {
+      "step": {
+        "user": {
+          "title": "Setup your Brunt integration",
+          "data": {
+            "username": "[%key:common::config_flow::data::username%]",
+            "password": "[%key:common::config_flow::data::password%]"
+          }
+        }
+      },
+      "error": {
+        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+      }
+    }
+  }

--- a/homeassistant/components/brunt/strings.json
+++ b/homeassistant/components/brunt/strings.json
@@ -10,11 +10,7 @@
         },
         "reauth_confirm": {
           "title": "[%key:common::config_flow::title::reauth%]",
-          "description": "The Brunt integration needs to re-authenticate your account"
-        },
-        "reauth_input": {
-          "title": "[%key:common::config_flow::title::reauth%]",
-          "description": "Reenter the password for Brunt account: {username}.",
+          "description": "Please reenter the password for: {username}",
           "data": {
             "password": "[%key:common::config_flow::data::password%]"
           }

--- a/homeassistant/components/brunt/strings.json
+++ b/homeassistant/components/brunt/strings.json
@@ -10,7 +10,9 @@
         }
       },
       "error": {
-        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+        "unknown": "[%key:common::config_flow::error::unknown%]"
       }
     }
   }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -43,6 +43,7 @@ FLOWS = [
     "braviatv",
     "broadlink",
     "brother",
+    "brunt",
     "bsblan",
     "buienradar",
     "canary",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -440,7 +440,7 @@ brother==1.1.0
 brottsplatskartan==0.0.1
 
 # homeassistant.components.brunt
-brunt==1.0.0b1
+brunt==1.0.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -440,7 +440,7 @@ brother==1.1.0
 brottsplatskartan==0.0.1
 
 # homeassistant.components.brunt
-brunt==0.1.3
+brunt==1.0.0b1
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -277,6 +277,9 @@ broadlink==0.18.0
 # homeassistant.components.brother
 brother==1.1.0
 
+# homeassistant.components.brunt
+brunt==1.0.0b1
+
 # homeassistant.components.bsblan
 bsblan==0.4.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -278,7 +278,7 @@ broadlink==0.18.0
 brother==1.1.0
 
 # homeassistant.components.brunt
-brunt==1.0.0b1
+brunt==1.0.0
 
 # homeassistant.components.bsblan
 bsblan==0.4.0

--- a/tests/components/brunt/__init__.py
+++ b/tests/components/brunt/__init__.py
@@ -1,0 +1,1 @@
+"""Brunt tests."""

--- a/tests/components/brunt/test_config_flow.py
+++ b/tests/components/brunt/test_config_flow.py
@@ -2,6 +2,7 @@
 from unittest.mock import patch
 
 from aiohttp import ClientResponseError
+from aiohttp.client_exceptions import ServerDisconnectedError
 
 from homeassistant import config_entries, data_entry_flow, setup
 from homeassistant.components.brunt.const import DOMAIN
@@ -74,18 +75,22 @@ async def test_import_duplicate_login(hass):
         title="test-username",
         unique_id="test-username",
     )
-    with patch("brunt.BruntClientAsync.async_login", return_value=True):
+    with patch("brunt.BruntClientAsync.async_login", return_value=True), patch(
+        "homeassistant.components.brunt.async_setup_entry",
+        return_value=True,
+    ):
         entry.add_to_hass(hass)
-        with patch("brunt.BruntClientAsync.async_login", return_value=True), patch(
-            "homeassistant.components.brunt.async_setup_entry",
-            return_value=True,
-        ):
-            result = await hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": config_entries.SOURCE_IMPORT},
-                data=CONF,
-            )
-            await hass.async_block_till_done()
+        # with patch("brunt.BruntClientAsync.async_login", return_value=True)
+        # , patch(
+        #     "homeassistant.components.brunt.async_setup_entry",
+        #     return_value=True,
+        # ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=CONF,
+        )
+        await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
@@ -111,12 +116,39 @@ async def test_form_invalid_auth(hass):
     """Test we handle invalid auth."""
     with patch(
         "brunt.BruntClientAsync.async_login",
-        side_effect=ClientResponseError(None, None),
+        side_effect=ClientResponseError(None, None, status=403),
     ):
         result = await _flow_submit(hass)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_cannot_connect(hass):
+    """Test we handle cannot connect."""
+    with patch(
+        "brunt.BruntClientAsync.async_login",
+        side_effect=ServerDisconnectedError,
+    ):
+        result = await _flow_submit(hass)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_form_client_response_unknown(hass):
+    """Test we handle invalid auth."""
+    with patch(
+        "brunt.BruntClientAsync.async_login",
+        side_effect=ClientResponseError(None, None, status=401),
+    ), patch(
+        "aiohttp.client_exceptions.ClientResponseError.__str__",
+        return_value="ClientResponseError",
+    ):
+        result = await _flow_submit(hass)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "unknown"}
 
 
 async def test_form_generic_exception(hass):
@@ -129,3 +161,41 @@ async def test_form_generic_exception(hass):
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
         assert result["errors"] == {"base": "unknown"}
+
+
+async def test_reauth(hass):
+    """Test uniqueness of username."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=CONF,
+        title="test-username",
+        unique_id="test-username",
+    )
+    with patch(
+        "brunt.BruntClientAsync.async_login",
+        side_effect=ClientResponseError(None, None, status=403),
+    ):
+        entry.add_to_hass(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "unique_id": entry.unique_id,
+                "entry_id": entry.entry_id,
+            },
+            data=entry.data,
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["step_id"] == "user"
+    with patch("brunt.BruntClientAsync.async_login", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={"username": "test-username", "password": "test"},
+        )
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "reauth_successful"
+        assert entry.data["username"] == "test-username"
+        assert entry.data["password"] == "test"

--- a/tests/components/brunt/test_config_flow.py
+++ b/tests/components/brunt/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the Brunt config flow."""
 from unittest.mock import patch
 
+from aiohttp import ClientResponseError
+from aiohttp.client_exceptions import ServerDisconnectedError
 import pytest
 
 from homeassistant import config_entries, data_entry_flow
@@ -9,39 +11,33 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 
 from tests.common import MockConfigEntry
 
-CONF = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}
-
-
-async def _flow_submit(hass, context={"source": config_entries.SOURCE_USER}, data=CONF):
-    """Submit a flow to hass."""
-    return await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context=context,
-        data=data,
-    )
+CONFIG = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}
 
 
 async def test_form(hass):
     """Test we get the form."""
-    result = await _flow_submit(hass, data=None)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}, data=None
+    )
     assert result["type"] == "form"
     assert result["errors"] is None
 
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input", return_value=None
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
+        return_value=None,
     ), patch(
         "homeassistant.components.brunt.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            CONF,
+            CONFIG,
         )
         await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result2["title"] == "test-username"
-    assert result2["data"] == CONF
+    assert result2["data"] == CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -49,17 +45,21 @@ async def test_import(hass):
     """Test we get the form."""
 
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input", return_value=None
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
+        return_value=None,
     ), patch(
         "homeassistant.components.brunt.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
-        result = await _flow_submit(hass, {"source": config_entries.SOURCE_IMPORT})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=CONFIG
+        )
+
         await hass.async_block_till_done()
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["title"] == "test-username"
-    assert result["data"] == CONF
+    assert result["data"] == CONFIG
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -67,91 +67,120 @@ async def test_import_duplicate_login(hass):
     """Test uniqueness of username."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=CONF,
+        data=CONFIG,
         title="test-username",
         unique_id="test-username",
     )
     entry.add_to_hass(hass)
 
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input", return_value=None
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
+        return_value=None,
     ), patch(
         "homeassistant.components.brunt.async_setup_entry",
         return_value=True,
     ):
-        result = await _flow_submit(hass, {"source": config_entries.SOURCE_IMPORT})
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_IMPORT}, data=CONFIG
+        )
         await hass.async_block_till_done()
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured_account"
+        assert result["reason"] == "already_configured"
 
 
 async def test_form_duplicate_login(hass):
     """Test uniqueness of username."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=CONF,
+        data=CONFIG,
         title="test-username",
         unique_id="test-username",
     )
     entry.add_to_hass(hass)
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input", return_value=None
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
+        return_value=None,
     ):
-        result = await _flow_submit(hass)
-
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
+        )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "already_configured"
 
 
-@pytest.mark.parametrize("side_effect", ["cannot_connect", "invalid_auth", "unknown"])
-async def test_form_error(hass, side_effect):
+@pytest.mark.parametrize(
+    "side_effect, error_message",
+    [
+        (ServerDisconnectedError, "cannot_connect"),
+        (ClientResponseError(None, None, status=403), "invalid_auth"),
+        (ClientResponseError(None, None, status=401), "unknown"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_form_error(hass, side_effect, error_message):
     """Test we handle cannot connect."""
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input",
-        return_value={"base": side_effect},
+        "homeassistant.components.brunt.config_flow.ClientResponseError.__str__",
+        return_value="ClientResponseError",
+    ), patch(
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
+        side_effect=side_effect,
     ):
-        result = await _flow_submit(hass)
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}, data=CONFIG
+        )
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["errors"] == {"base": side_effect}
+        assert result["errors"] == {"base": error_message}
 
 
-@pytest.mark.parametrize("user_in", [CONF, None])
-async def test_reauth(hass, user_in):
+@pytest.mark.parametrize("side_effect", [None, Exception])
+async def test_reauth(hass, side_effect):
     """Test uniqueness of username."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data=CONF,
+        data=CONFIG,
         title="test-username",
         unique_id="test-username",
     )
     entry.add_to_hass(hass)
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input",
-        return_value={"errors": "invalid_auth"},
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
+        side_effect=ClientResponseError(None, None, status=403),
     ):
-        result = await _flow_submit(
-            hass,
-            {
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
                 "source": config_entries.SOURCE_REAUTH,
                 "unique_id": entry.unique_id,
                 "entry_id": entry.entry_id,
             },
-            user_in,
+            data=None,
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
-        assert result["step_id"] == "reauth"
+        assert result["step_id"] == "reauth_confirm"
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={},
+        )
+        assert result2["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result2["step_id"] == "reauth_input"
     with patch(
-        "homeassistant.components.brunt.config_flow.validate_input",
+        "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
         return_value=None,
+        side_effect=side_effect,
     ):
-        result = await hass.config_entries.flow.async_configure(
+        result3 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={"password": "test"},
         )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "reauth_successful"
-        assert entry.data["username"] == "test-username"
-        assert entry.data["password"] == "test"
+        if side_effect is None:
+            assert result3["type"] == data_entry_flow.RESULT_TYPE_ABORT
+            assert result3["reason"] == "reauth_successful"
+            assert entry.data["username"] == "test-username"
+            assert entry.data["password"] == "test"
+        else:
+            assert result3["type"] == data_entry_flow.RESULT_TYPE_FORM
+            assert result3["step_id"] == "reauth_input"
+            assert result3["errors"] == {"base": "unknown"}

--- a/tests/components/brunt/test_config_flow.py
+++ b/tests/components/brunt/test_config_flow.py
@@ -1,5 +1,5 @@
 """Test the Brunt config flow."""
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from aiohttp import ClientResponseError
 from aiohttp.client_exceptions import ServerDisconnectedError
@@ -113,17 +113,14 @@ async def test_form_duplicate_login(hass):
     "side_effect, error_message",
     [
         (ServerDisconnectedError, "cannot_connect"),
-        (ClientResponseError(None, None, status=403), "invalid_auth"),
-        (ClientResponseError(None, None, status=401), "unknown"),
+        (ClientResponseError(Mock(), None, status=403), "invalid_auth"),
+        (ClientResponseError(Mock(), None, status=401), "unknown"),
         (Exception, "unknown"),
     ],
 )
 async def test_form_error(hass, side_effect, error_message):
     """Test we handle cannot connect."""
     with patch(
-        "homeassistant.components.brunt.config_flow.ClientResponseError.__str__",
-        return_value="ClientResponseError",
-    ), patch(
         "homeassistant.components.brunt.config_flow.BruntClientAsync.async_login",
         side_effect=side_effect,
     ):

--- a/tests/components/brunt/test_config_flow.py
+++ b/tests/components/brunt/test_config_flow.py
@@ -1,0 +1,131 @@
+"""Test the Brunt config flow."""
+from unittest.mock import patch
+
+from aiohttp import ClientResponseError
+
+from homeassistant import config_entries, data_entry_flow, setup
+from homeassistant.components.brunt.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+CONF = {CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"}
+
+
+async def _flow_submit(hass):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data=CONF,
+    )
+
+
+async def test_form(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+
+    with patch("brunt.BruntClientAsync.async_login", return_value=True), patch(
+        "homeassistant.components.brunt.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            CONF,
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "test-username"
+    assert result2["data"] == CONF
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import(hass):
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    with patch("brunt.BruntClientAsync.async_login", return_value=True), patch(
+        "homeassistant.components.brunt.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data=CONF,
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["title"] == "test-username"
+    assert result["data"] == CONF
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import_duplicate_login(hass):
+    """Test uniqueness of username."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=CONF,
+        title="test-username",
+        unique_id="test-username",
+    )
+    with patch("brunt.BruntClientAsync.async_login", return_value=True):
+        entry.add_to_hass(hass)
+        with patch("brunt.BruntClientAsync.async_login", return_value=True), patch(
+            "homeassistant.components.brunt.async_setup_entry",
+            return_value=True,
+        ):
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": config_entries.SOURCE_IMPORT},
+                data=CONF,
+            )
+            await hass.async_block_till_done()
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "already_configured"
+
+
+async def test_form_duplicate_login(hass):
+    """Test uniqueness of username."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=CONF,
+        title="test-username",
+        unique_id="test-username",
+    )
+    with patch("brunt.BruntClientAsync.async_login", return_value=True):
+        entry.add_to_hass(hass)
+        result = await _flow_submit(hass)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "already_configured"
+
+
+async def test_form_invalid_auth(hass):
+    """Test we handle invalid auth."""
+    with patch(
+        "brunt.BruntClientAsync.async_login",
+        side_effect=ClientResponseError(None, None),
+    ):
+        result = await _flow_submit(hass)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def test_form_generic_exception(hass):
+    """Test we handle cannot connect error."""
+    with patch(
+        "brunt.BruntClientAsync.async_login",
+        side_effect=Exception,
+    ):
+        result = await _flow_submit(hass)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+        assert result["errors"] == {"base": "unknown"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Brunt integration migrated the connection settings to configuration via the UI. Configuring the connection to the Brunt0 api via YAML configuration has been deprecated and will be removed in a future Home Assistant release.

Your existing connection YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

Additionally, the Brunt integration can now be reloaded via the Integrations screen in the frontend and will also reload if a Brunt device is removed from your account.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updates for Brunt integration!
- new package with support for Async and implemented data update coordinator to handle updates. [Release notes](https://github.com/eavanvalkenburg/brunt-api/releases/tag/v1.0.0)
- https://github.com/eavanvalkenburg/brunt-api/compare/c6bae43f56e0fd8f79b7af67d524611dd104dafa...v1.0.0
- added config flow with tests

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/20345

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
