### PR TITLE
Entities for secondary temperature values created by certain Xiaomi devices in deCONZ

### DIFF
--- a/homeassistant/components/deconz/sensor.py
+++ b/homeassistant/components/deconz/sensor.py
@@ -209,7 +209,7 @@ class DeconzTemperature(DeconzDevice, SensorEntity):
     @property
     def unique_id(self):
         """Return a unique identifier for this device."""
-        return f"{super().serial}-temperature"
+        return f"{self.serial}-temperature"
 
     @callback
     def async_update_callback(self, force_update=False):
@@ -226,7 +226,7 @@ class DeconzTemperature(DeconzDevice, SensorEntity):
     @property
     def name(self):
         """Return the name of the temperature sensor."""
-        return f"{self._device.name} Temperature Sensor"
+        return f"{self._device.name} Temperature"
 
     @property
     def device_class(self):

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -82,7 +82,7 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
     assert presence_sensor.state == STATE_OFF
     assert presence_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_MOTION
-    presence_temp = hass.states.get("sensor.presence_sensor_temperature_sensor")
+    presence_temp = hass.states.get("sensor.presence_sensor_temperature")
     assert presence_temp.state == "0.1"
     assert presence_temp.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TEMPERATURE
     assert hass.states.get("binary_sensor.temperature_sensor") is None
@@ -90,7 +90,7 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
     vibration_sensor = hass.states.get("binary_sensor.vibration_sensor")
     assert vibration_sensor.state == STATE_ON
     assert vibration_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_VIBRATION
-    vibration_temp = hass.states.get("sensor.vibration_sensor_temperature_sensor")
+    vibration_temp = hass.states.get("sensor.vibration_sensor_temperature")
     assert vibration_temp.state == "0.1"
     assert vibration_temp.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TEMPERATURE
 

--- a/tests/components/deconz/test_binary_sensor.py
+++ b/tests/components/deconz/test_binary_sensor.py
@@ -13,7 +13,13 @@ from homeassistant.components.deconz.const import (
     DOMAIN as DECONZ_DOMAIN,
 )
 from homeassistant.components.deconz.services import SERVICE_DEVICE_REFRESH
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import async_entries_for_config_entry
 
@@ -72,15 +78,21 @@ async def test_binary_sensors(hass, aioclient_mock, mock_deconz_websocket):
     with patch.dict(DECONZ_WEB_REQUEST, data):
         config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
-    assert len(hass.states.async_all()) == 3
+    assert len(hass.states.async_all()) == 5
     presence_sensor = hass.states.get("binary_sensor.presence_sensor")
     assert presence_sensor.state == STATE_OFF
-    assert presence_sensor.attributes["device_class"] == DEVICE_CLASS_MOTION
+    assert presence_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_MOTION
+    presence_temp = hass.states.get("sensor.presence_sensor_temperature_sensor")
+    assert presence_temp.state == "0.1"
+    assert presence_temp.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TEMPERATURE
     assert hass.states.get("binary_sensor.temperature_sensor") is None
     assert hass.states.get("binary_sensor.clip_presence_sensor") is None
     vibration_sensor = hass.states.get("binary_sensor.vibration_sensor")
     assert vibration_sensor.state == STATE_ON
-    assert vibration_sensor.attributes["device_class"] == DEVICE_CLASS_VIBRATION
+    assert vibration_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_VIBRATION
+    vibration_temp = hass.states.get("sensor.vibration_sensor_temperature_sensor")
+    assert vibration_temp.state == "0.1"
+    assert vibration_temp.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TEMPERATURE
 
     event_changed_sensor = {
         "t": "event",

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -97,7 +97,7 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
     assert light_level_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ILLUMINANCE
     assert light_level_sensor.attributes[ATTR_DAYLIGHT] == 6955
 
-    light_level_temp = hass.states.get("sensor.light_level_sensor_temperature_sensor")
+    light_level_temp = hass.states.get("sensor.light_level_sensor_temperature")
     assert light_level_temp.state == "0.1"
     assert light_level_temp.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TEMPERATURE
 
@@ -146,9 +146,7 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
     }
     await mock_deconz_websocket(data=event_changed_sensor)
 
-    assert (
-        hass.states.get("sensor.light_level_sensor_temperature_sensor").state == "1.0"
-    )
+    assert hass.states.get("sensor.light_level_sensor_temperature").state == "1.0"
 
     # Event signals new battery level
 

--- a/tests/components/deconz/test_sensor.py
+++ b/tests/components/deconz/test_sensor.py
@@ -12,6 +12,7 @@ from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
@@ -89,12 +90,16 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
     with patch.dict(DECONZ_WEB_REQUEST, data):
         config_entry = await setup_deconz_integration(hass, aioclient_mock)
 
-    assert len(hass.states.async_all()) == 5
+    assert len(hass.states.async_all()) == 6
 
     light_level_sensor = hass.states.get("sensor.light_level_sensor")
     assert light_level_sensor.state == "999.8"
     assert light_level_sensor.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_ILLUMINANCE
     assert light_level_sensor.attributes[ATTR_DAYLIGHT] == 6955
+
+    light_level_temp = hass.states.get("sensor.light_level_sensor_temperature_sensor")
+    assert light_level_temp.state == "0.1"
+    assert light_level_temp.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_TEMPERATURE
 
     assert not hass.states.get("sensor.presence_sensor")
     assert not hass.states.get("sensor.switch_1")
@@ -130,6 +135,21 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
 
     assert hass.states.get("sensor.light_level_sensor").state == "1.6"
 
+    # Event signals new temperature value
+
+    event_changed_sensor = {
+        "t": "event",
+        "e": "changed",
+        "r": "sensors",
+        "id": "1",
+        "config": {"temperature": 100},
+    }
+    await mock_deconz_websocket(data=event_changed_sensor)
+
+    assert (
+        hass.states.get("sensor.light_level_sensor_temperature_sensor").state == "1.0"
+    )
+
     # Event signals new battery level
 
     event_changed_sensor = {
@@ -148,7 +168,7 @@ async def test_sensors(hass, aioclient_mock, mock_deconz_websocket):
     await hass.config_entries.async_unload(config_entry.entry_id)
 
     states = hass.states.async_all()
-    assert len(states) == 5
+    assert len(states) == 6
     for state in states:
         assert state.state == STATE_UNAVAILABLE
 
@@ -187,7 +207,7 @@ async def test_allow_clip_sensors(hass, aioclient_mock):
             options={CONF_ALLOW_CLIP_SENSOR: True},
         )
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 3
     assert hass.states.get("sensor.clip_light_level_sensor").state == "999.8"
 
     # Disallow clip sensors
@@ -197,7 +217,7 @@ async def test_allow_clip_sensors(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 2
     assert not hass.states.get("sensor.clip_light_level_sensor")
 
     # Allow clip sensors
@@ -207,7 +227,7 @@ async def test_allow_clip_sensors(hass, aioclient_mock):
     )
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 2
+    assert len(hass.states.async_all()) == 3
     assert hass.states.get("sensor.clip_light_level_sensor").state == "999.8"
 
 
@@ -235,7 +255,7 @@ async def test_add_new_sensor(hass, aioclient_mock, mock_deconz_websocket):
     await mock_deconz_websocket(data=event_added_sensor)
     await hass.async_block_till_done()
 
-    assert len(hass.states.async_all()) == 1
+    assert len(hass.states.async_all()) == 2
     assert hass.states.get("sensor.light_level_sensor").state == "999.8"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create proper entities for secondary temperature values reported by certain Xiaomi devices

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #32620
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
