### PR TITLE
Make number of stored traces configurable

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -74,6 +74,7 @@ from .config import PLATFORM_SCHEMA  # noqa: F401
 from .const import (
     CONF_ACTION,
     CONF_INITIAL_STATE,
+    CONF_STORED_TRACES,
     CONF_TRIGGER,
     CONF_TRIGGER_VARIABLES,
     DEFAULT_INITIAL_STATE,
@@ -274,6 +275,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         trigger_variables,
         raw_config,
         blueprint_inputs,
+        stored_traces,
     ):
         """Initialize an automation entity."""
         self._id = automation_id
@@ -292,6 +294,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         self._trigger_variables: ScriptVariables = trigger_variables
         self._raw_config = raw_config
         self._blueprint_inputs = blueprint_inputs
+        self._stored_traces = stored_traces
 
     @property
     def name(self):
@@ -444,6 +447,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             self._raw_config,
             self._blueprint_inputs,
             trigger_context,
+            self._stored_traces,
         ) as automation_trace:
             if self._variables:
                 try:
@@ -684,6 +688,7 @@ async def _async_process_config(
                 config_block.get(CONF_TRIGGER_VARIABLES),
                 raw_config,
                 raw_blueprint_inputs,
+                config_block[CONF_STORED_TRACES],
             )
 
             entities.append(entity)

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -74,7 +74,7 @@ from .config import PLATFORM_SCHEMA  # noqa: F401
 from .const import (
     CONF_ACTION,
     CONF_INITIAL_STATE,
-    CONF_STORED_TRACES,
+    CONF_TRACE,
     CONF_TRIGGER,
     CONF_TRIGGER_VARIABLES,
     DEFAULT_INITIAL_STATE,
@@ -275,7 +275,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         trigger_variables,
         raw_config,
         blueprint_inputs,
-        stored_traces,
+        trace_config,
     ):
         """Initialize an automation entity."""
         self._id = automation_id
@@ -294,7 +294,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         self._trigger_variables: ScriptVariables = trigger_variables
         self._raw_config = raw_config
         self._blueprint_inputs = blueprint_inputs
-        self._stored_traces = stored_traces
+        self._trace_config = trace_config
 
     @property
     def name(self):
@@ -447,7 +447,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
             self._raw_config,
             self._blueprint_inputs,
             trigger_context,
-            self._stored_traces,
+            self._trace_config,
         ) as automation_trace:
             if self._variables:
                 try:
@@ -688,7 +688,7 @@ async def _async_process_config(
                 config_block.get(CONF_TRIGGER_VARIABLES),
                 raw_config,
                 raw_blueprint_inputs,
-                config_block[CONF_STORED_TRACES],
+                config_block[CONF_TRACE],
             )
 
             entities.append(entity)

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -8,7 +8,7 @@ from homeassistant.components import blueprint
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
-from homeassistant.components.trace.const import STORED_TRACES
+from homeassistant.components.trace import TRACE_CONFIG_SCHEMA
 from homeassistant.config import async_log_exception, config_without_domain
 from homeassistant.const import (
     CONF_ALIAS,
@@ -27,7 +27,7 @@ from .const import (
     CONF_ACTION,
     CONF_HIDE_ENTITY,
     CONF_INITIAL_STATE,
-    CONF_STORED_TRACES,
+    CONF_TRACE,
     CONF_TRIGGER,
     CONF_TRIGGER_VARIABLES,
     DOMAIN,
@@ -47,7 +47,7 @@ PLATFORM_SCHEMA = vol.All(
             CONF_ID: str,
             CONF_ALIAS: cv.string,
             vol.Optional(CONF_DESCRIPTION): cv.string,
-            vol.Optional(CONF_STORED_TRACES, default=STORED_TRACES): cv.positive_int,
+            vol.Optional(CONF_TRACE, default={}): TRACE_CONFIG_SCHEMA,
             vol.Optional(CONF_INITIAL_STATE): cv.boolean,
             vol.Optional(CONF_HIDE_ENTITY): cv.boolean,
             vol.Required(CONF_TRIGGER): cv.TRIGGER_SCHEMA,

--- a/homeassistant/components/automation/config.py
+++ b/homeassistant/components/automation/config.py
@@ -8,6 +8,7 @@ from homeassistant.components import blueprint
 from homeassistant.components.device_automation.exceptions import (
     InvalidDeviceAutomationConfig,
 )
+from homeassistant.components.trace.const import STORED_TRACES
 from homeassistant.config import async_log_exception, config_without_domain
 from homeassistant.const import (
     CONF_ALIAS,
@@ -26,6 +27,7 @@ from .const import (
     CONF_ACTION,
     CONF_HIDE_ENTITY,
     CONF_INITIAL_STATE,
+    CONF_STORED_TRACES,
     CONF_TRIGGER,
     CONF_TRIGGER_VARIABLES,
     DOMAIN,
@@ -45,6 +47,7 @@ PLATFORM_SCHEMA = vol.All(
             CONF_ID: str,
             CONF_ALIAS: cv.string,
             vol.Optional(CONF_DESCRIPTION): cv.string,
+            vol.Optional(CONF_STORED_TRACES, default=STORED_TRACES): cv.positive_int,
             vol.Optional(CONF_INITIAL_STATE): cv.boolean,
             vol.Optional(CONF_HIDE_ENTITY): cv.boolean,
             vol.Required(CONF_TRIGGER): cv.TRIGGER_SCHEMA,

--- a/homeassistant/components/automation/const.py
+++ b/homeassistant/components/automation/const.py
@@ -12,7 +12,7 @@ CONF_CONDITION_TYPE = "condition_type"
 CONF_INITIAL_STATE = "initial_state"
 CONF_BLUEPRINT = "blueprint"
 CONF_INPUT = "input"
-CONF_STORED_TRACES = "stored_traces"
+CONF_TRACE = "trace"
 
 DEFAULT_INITIAL_STATE = True
 

--- a/homeassistant/components/automation/const.py
+++ b/homeassistant/components/automation/const.py
@@ -12,6 +12,7 @@ CONF_CONDITION_TYPE = "condition_type"
 CONF_INITIAL_STATE = "initial_state"
 CONF_BLUEPRINT = "blueprint"
 CONF_INPUT = "input"
+CONF_STORED_TRACES = "stored_traces"
 
 DEFAULT_INITIAL_STATE = True
 

--- a/homeassistant/components/automation/trace.py
+++ b/homeassistant/components/automation/trace.py
@@ -38,10 +38,12 @@ class AutomationTrace(ActionTrace):
 
 
 @contextmanager
-def trace_automation(hass, automation_id, config, blueprint_inputs, context):
+def trace_automation(
+    hass, automation_id, config, blueprint_inputs, context, stored_traces
+):
     """Trace action execution of automation with automation_id."""
     trace = AutomationTrace(automation_id, config, blueprint_inputs, context)
-    async_store_trace(hass, trace)
+    async_store_trace(hass, trace, stored_traces)
 
     try:
         yield trace

--- a/homeassistant/components/automation/trace.py
+++ b/homeassistant/components/automation/trace.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Any
 
 from homeassistant.components.trace import ActionTrace, async_store_trace
+from homeassistant.components.trace.const import CONF_STORED_TRACES
 from homeassistant.core import Context
 
 # mypy: allow-untyped-calls, allow-untyped-defs
@@ -39,11 +40,11 @@ class AutomationTrace(ActionTrace):
 
 @contextmanager
 def trace_automation(
-    hass, automation_id, config, blueprint_inputs, context, stored_traces
+    hass, automation_id, config, blueprint_inputs, context, trace_config
 ):
     """Trace action execution of automation with automation_id."""
     trace = AutomationTrace(automation_id, config, blueprint_inputs, context)
-    async_store_trace(hass, trace, stored_traces)
+    async_store_trace(hass, trace, trace_config[CONF_STORED_TRACES])
 
     try:
         yield trace

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -6,7 +6,7 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.components.trace.const import STORED_TRACES
+from homeassistant.components.trace import TRACE_CONFIG_SCHEMA
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_MODE,
@@ -59,7 +59,7 @@ CONF_ADVANCED = "advanced"
 CONF_EXAMPLE = "example"
 CONF_FIELDS = "fields"
 CONF_REQUIRED = "required"
-CONF_STORED_TRACES = "stored_traces"
+CONF_TRACE = "trace"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -69,7 +69,7 @@ EVENT_SCRIPT_STARTED = "script_started"
 SCRIPT_ENTRY_SCHEMA = make_script_schema(
     {
         vol.Optional(CONF_ALIAS): cv.string,
-        vol.Optional(CONF_STORED_TRACES, default=STORED_TRACES): cv.positive_int,
+        vol.Optional(CONF_TRACE, default={}): TRACE_CONFIG_SCHEMA,
         vol.Optional(CONF_ICON): cv.icon,
         vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_DESCRIPTION, default=""): cv.string,
@@ -322,7 +322,7 @@ class ScriptEntity(ToggleEntity):
         )
         self._changed = asyncio.Event()
         self._raw_config = raw_config
-        self._stored_traces = cfg[CONF_STORED_TRACES]
+        self._trace_config = cfg[CONF_TRACE]
 
     @property
     def should_poll(self):
@@ -388,7 +388,7 @@ class ScriptEntity(ToggleEntity):
 
     async def _async_run(self, variables, context):
         with trace_script(
-            self.hass, self.object_id, self._raw_config, context, self._stored_traces
+            self.hass, self.object_id, self._raw_config, context, self._trace_config
         ) as script_trace:
             # Prepare tracing the execution of the script's sequence
             script_trace.set_trace(trace_get())

--- a/homeassistant/components/script/__init__.py
+++ b/homeassistant/components/script/__init__.py
@@ -6,6 +6,7 @@ import logging
 
 import voluptuous as vol
 
+from homeassistant.components.trace.const import STORED_TRACES
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_MODE,
@@ -58,6 +59,7 @@ CONF_ADVANCED = "advanced"
 CONF_EXAMPLE = "example"
 CONF_FIELDS = "fields"
 CONF_REQUIRED = "required"
+CONF_STORED_TRACES = "stored_traces"
 
 ENTITY_ID_FORMAT = DOMAIN + ".{}"
 
@@ -67,6 +69,7 @@ EVENT_SCRIPT_STARTED = "script_started"
 SCRIPT_ENTRY_SCHEMA = make_script_schema(
     {
         vol.Optional(CONF_ALIAS): cv.string,
+        vol.Optional(CONF_STORED_TRACES, default=STORED_TRACES): cv.positive_int,
         vol.Optional(CONF_ICON): cv.icon,
         vol.Required(CONF_SEQUENCE): cv.SCRIPT_SCHEMA,
         vol.Optional(CONF_DESCRIPTION, default=""): cv.string,
@@ -319,6 +322,7 @@ class ScriptEntity(ToggleEntity):
         )
         self._changed = asyncio.Event()
         self._raw_config = raw_config
+        self._stored_traces = cfg[CONF_STORED_TRACES]
 
     @property
     def should_poll(self):
@@ -384,7 +388,7 @@ class ScriptEntity(ToggleEntity):
 
     async def _async_run(self, variables, context):
         with trace_script(
-            self.hass, self.object_id, self._raw_config, context
+            self.hass, self.object_id, self._raw_config, context, self._stored_traces
         ) as script_trace:
             # Prepare tracing the execution of the script's sequence
             script_trace.set_trace(trace_get())

--- a/homeassistant/components/script/trace.py
+++ b/homeassistant/components/script/trace.py
@@ -23,10 +23,10 @@ class ScriptTrace(ActionTrace):
 
 
 @contextmanager
-def trace_script(hass, item_id, config, context):
+def trace_script(hass, item_id, config, context, stored_traces):
     """Trace execution of a script."""
     trace = ScriptTrace(item_id, config, context)
-    async_store_trace(hass, trace)
+    async_store_trace(hass, trace, stored_traces)
 
     try:
         yield trace

--- a/homeassistant/components/script/trace.py
+++ b/homeassistant/components/script/trace.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Any
 
 from homeassistant.components.trace import ActionTrace, async_store_trace
+from homeassistant.components.trace.const import CONF_STORED_TRACES
 from homeassistant.core import Context
 
 
@@ -23,10 +24,10 @@ class ScriptTrace(ActionTrace):
 
 
 @contextmanager
-def trace_script(hass, item_id, config, context, stored_traces):
+def trace_script(hass, item_id, config, context, trace_config):
     """Trace execution of a script."""
     trace = ScriptTrace(item_id, config, context)
-    async_store_trace(hass, trace, stored_traces)
+    async_store_trace(hass, trace, trace_config[CONF_STORED_TRACES])
 
     try:
         yield trace

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -30,18 +30,20 @@ async def async_setup(hass, config):
     return True
 
 
-def async_store_trace(hass, trace):
+def async_store_trace(hass, trace, stored_traces):
     """Store a trace if its item_id is valid."""
     key = trace.key
     if key[1]:
         traces = hass.data[DATA_TRACE]
         if key not in traces:
             traces[key] = LimitedSizeDict(size_limit=STORED_TRACES)
+        else:
+            traces[key].size_limit = stored_traces
         traces[key][trace.run_id] = trace
 
 
 class ActionTrace:
-    """Base container for an script or automation trace."""
+    """Base container for a script or automation trace."""
 
     _run_ids = count(0)
 

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -6,7 +6,10 @@ import datetime as dt
 from itertools import count
 from typing import Any
 
+import voluptuous as vol
+
 from homeassistant.core import Context
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.trace import (
     TraceElement,
     script_execution_get,
@@ -17,10 +20,14 @@ from homeassistant.helpers.trace import (
 import homeassistant.util.dt as dt_util
 
 from . import websocket_api
-from .const import DATA_TRACE
+from .const import CONF_STORED_TRACES, DATA_TRACE, DEFAULT_STORED_TRACES
 from .utils import LimitedSizeDict
 
 DOMAIN = "trace"
+
+TRACE_CONFIG_SCHEMA = {
+    vol.Optional(CONF_STORED_TRACES, default=DEFAULT_STORED_TRACES): cv.positive_int
+}
 
 
 async def async_setup(hass, config):

--- a/homeassistant/components/trace/__init__.py
+++ b/homeassistant/components/trace/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.trace import (
 import homeassistant.util.dt as dt_util
 
 from . import websocket_api
-from .const import DATA_TRACE, STORED_TRACES
+from .const import DATA_TRACE
 from .utils import LimitedSizeDict
 
 DOMAIN = "trace"
@@ -36,7 +36,7 @@ def async_store_trace(hass, trace, stored_traces):
     if key[1]:
         traces = hass.data[DATA_TRACE]
         if key not in traces:
-            traces[key] = LimitedSizeDict(size_limit=STORED_TRACES)
+            traces[key] = LimitedSizeDict(size_limit=stored_traces)
         else:
             traces[key].size_limit = stored_traces
         traces[key][trace.run_id] = trace

--- a/homeassistant/components/trace/const.py
+++ b/homeassistant/components/trace/const.py
@@ -1,4 +1,5 @@
 """Shared constants for script and automation tracing and debugging."""
 
+CONF_STORED_TRACES = "stored_traces"
 DATA_TRACE = "trace"
-STORED_TRACES = 5  # Stored traces per script or automation
+DEFAULT_STORED_TRACES = 5  # Stored traces per script or automation

--- a/homeassistant/components/trace/websocket_api.py
+++ b/homeassistant/components/trace/websocket_api.py
@@ -57,7 +57,7 @@ def async_setup(hass: HomeAssistant) -> None:
     }
 )
 def websocket_trace_get(hass, connection, msg):
-    """Get an script or automation trace."""
+    """Get a script or automation trace."""
     key = (msg["domain"], msg["item_id"])
     run_id = msg["run_id"]
 
@@ -77,7 +77,7 @@ def websocket_trace_get(hass, connection, msg):
 
 
 def get_debug_traces(hass, key):
-    """Return a serializable list of debug traces for an script or automation."""
+    """Return a serializable list of debug traces for a script or automation."""
     traces = []
 
     for trace in hass.data[DATA_TRACE].get(key, {}).values():

--- a/tests/components/trace/test_websocket_api.py
+++ b/tests/components/trace/test_websocket_api.py
@@ -12,7 +12,7 @@ from tests.common import assert_lists_same
 
 
 def _find_run_id(traces, trace_type, item_id):
-    """Find newest run_id for an script or automation."""
+    """Find newest run_id for a script or automation."""
     for trace in reversed(traces):
         if trace["domain"] == trace_type and trace["item_id"] == item_id:
             return trace["run_id"]
@@ -21,7 +21,7 @@ def _find_run_id(traces, trace_type, item_id):
 
 
 def _find_traces(traces, trace_type, item_id):
-    """Find traces for an script or automation."""
+    """Find traces for a script or automation."""
     return [
         trace
         for trace in traces
@@ -29,7 +29,9 @@ def _find_traces(traces, trace_type, item_id):
     ]
 
 
-async def _setup_automation_or_script(hass, domain, configs, script_config=None):
+async def _setup_automation_or_script(
+    hass, domain, configs, script_config=None, stored_traces=None
+):
     """Set up automations or scripts from automation config."""
     if domain == "script":
         configs = {config["id"]: {"sequence": config["action"]} for config in configs}
@@ -41,6 +43,14 @@ async def _setup_automation_or_script(hass, domain, configs, script_config=None)
             )
         else:
             configs = {**configs, **script_config}
+
+    if stored_traces is not None:
+        if domain == "script":
+            for config in configs.values():
+                config["stored_traces"] = stored_traces
+        else:
+            for config in configs:
+                config["stored_traces"] = stored_traces
 
     assert await async_setup_component(hass, domain, {domain: configs})
 
@@ -97,7 +107,7 @@ async def test_get_trace(
     context_key,
     condition_results,
 ):
-    """Test tracing an script or automation."""
+    """Test tracing a script or automation."""
     id = 1
 
     def next_id():
@@ -347,8 +357,11 @@ async def test_get_invalid_trace(hass, hass_ws_client, domain):
     assert response["error"]["code"] == "not_found"
 
 
-@pytest.mark.parametrize("domain", ["automation", "script"])
-async def test_trace_overflow(hass, hass_ws_client, domain):
+@pytest.mark.parametrize(
+    "domain,stored_traces",
+    [("automation", None), ("automation", 10), ("script", None), ("script", 10)],
+)
+async def test_trace_overflow(hass, hass_ws_client, domain, stored_traces):
     """Test the number of stored traces per script or automation is limited."""
     id = 1
 
@@ -367,7 +380,9 @@ async def test_trace_overflow(hass, hass_ws_client, domain):
         "trigger": {"platform": "event", "event_type": "test_event2"},
         "action": {"event": "another_event"},
     }
-    await _setup_automation_or_script(hass, domain, [sun_config, moon_config])
+    await _setup_automation_or_script(
+        hass, domain, [sun_config, moon_config], stored_traces=stored_traces
+    )
 
     client = await hass_ws_client()
 
@@ -390,7 +405,7 @@ async def test_trace_overflow(hass, hass_ws_client, domain):
     assert len(_find_traces(response["result"], domain, "sun")) == 1
 
     # Trigger "moon" enough times to overflow the max number of stored traces
-    for _ in range(STORED_TRACES):
+    for _ in range(stored_traces or STORED_TRACES):
         await _run_automation_or_script(hass, domain, moon_config, "test_event2")
         await hass.async_block_till_done()
 
@@ -398,10 +413,12 @@ async def test_trace_overflow(hass, hass_ws_client, domain):
     response = await client.receive_json()
     assert response["success"]
     moon_traces = _find_traces(response["result"], domain, "moon")
-    assert len(moon_traces) == STORED_TRACES
+    assert len(moon_traces) == stored_traces or STORED_TRACES
     assert moon_traces[0]
     assert int(moon_traces[0]["run_id"]) == int(moon_run_id) + 1
-    assert int(moon_traces[-1]["run_id"]) == int(moon_run_id) + STORED_TRACES
+    assert int(moon_traces[-1]["run_id"]) == int(moon_run_id) + (
+        stored_traces or STORED_TRACES
+    )
     assert len(_find_traces(response["result"], domain, "sun")) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make the number of traces stored per automation or script configurable through configuation variables.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
automation:
  # Change the light in the kitchen and living room to 150 brightness and color red.
  trace:
      # Store 30 traces for this automation
      stored_traces: 30
  trigger:
    - platform: sun
      event: sunset
  action:
    - service: light.turn_on
      target:
        entity_id:
          - light.kitchen
          - light.living_room
      data:
        brightness: 150
        rgb_color: [255, 0, 0]

script:
  trace:
    # Don't store any trace for this script
    stored_traces: 0
  example_script:
    sequence:
      # This is written using the Script Syntax
      - alias: "Turn on ceiling light"
        service: light.turn_on
        target:
          entity_id: light.ceiling
      - alias: "Notify that ceiling light is turned on"
        service: notify.notify
        data:
          message: "Turned on the ceiling light!"
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
