### PR TITLE
Add technicolor platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -978,6 +978,7 @@ omit =
     homeassistant/components/tankerkoenig/*
     homeassistant/components/tapsaff/binary_sensor.py
     homeassistant/components/tautulli/sensor.py
+    homeassistant/components/technicolor/*
     homeassistant/components/ted5000/sensor.py
     homeassistant/components/telegram/notify.py
     homeassistant/components/telegram_bot/*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -485,6 +485,7 @@ homeassistant/components/tankerkoenig/* @guillempages
 homeassistant/components/tapsaff/* @bazwilliams
 homeassistant/components/tasmota/* @emontnemery
 homeassistant/components/tautulli/* @ludeeus
+homeassistant/components/technicolor/* @shaiu
 homeassistant/components/tellduslive/* @fredrike
 homeassistant/components/template/* @PhracturedBlue @tetienne
 homeassistant/components/tesla/* @zabuldon @alandtse

--- a/homeassistant/components/technicolor/__init__.py
+++ b/homeassistant/components/technicolor/__init__.py
@@ -1,0 +1,1 @@
+"""The technicolor integration."""

--- a/homeassistant/components/technicolor/device_tracker.py
+++ b/homeassistant/components/technicolor/device_tracker.py
@@ -1,0 +1,130 @@
+"""Support for Technicolor routers."""
+import logging
+from pprint import pformat
+
+from technicolorgateway import TechnicolorGateway
+import voluptuous as vol
+
+from homeassistant.components.device_tracker import (
+    DOMAIN,
+    PLATFORM_SCHEMA,
+    DeviceScanner,
+)
+from homeassistant.const import (
+    CONF_DEVICES,
+    CONF_EXCLUDE,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+)
+import homeassistant.helpers.config_validation as cv
+
+_LOGGER = logging.getLogger(__name__)
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Optional(CONF_HOST, default=""): cv.string,
+        vol.Optional(CONF_USERNAME, default=""): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_DEVICES, default=[]): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXCLUDE, default=[]): vol.All(cv.ensure_list, [cv.string]),
+    }
+)
+
+
+def get_scanner(hass, config):
+    """Validate the configuration and returns a Technicolor scanner."""
+    info = config[DOMAIN]
+    devices = info[CONF_DEVICES]
+    excluded_devices = info[CONF_EXCLUDE]
+
+    gateway = TechnicolorGateway(
+        info.get(CONF_HOST), "80", info.get(CONF_USERNAME), info.get(CONF_PASSWORD)
+    )
+    gateway.srp6authenticate()
+    scanner = TechnicolorDeviceScanner(gateway, devices, excluded_devices)
+
+    _LOGGER.debug("Logging in")
+
+    results = scanner._get_attached_devices()
+
+    if results is not None:
+        scanner.last_results = results
+    else:
+        _LOGGER.error("Failed to Login")
+        return None
+
+    return scanner
+
+
+class TechnicolorDeviceScanner(DeviceScanner):
+    """Queries a Technicolor wireless router using web."""
+
+    def __init__(
+        self,
+        gateway,
+        devices,
+        excluded_devices,
+    ):
+        """Initialize the scanner."""
+        self.gateway = gateway
+        self.tracked_devices = devices
+        self.excluded_devices = excluded_devices
+        self.last_results = []
+
+    def get_device_name(self, device: str) -> str:
+        """Return the name of the given device or the MAC if we don't know."""
+        name = None
+        for dev in self.last_results:
+            if dev["mac"] == device:
+                name = dev["name"]
+                break
+
+        if not name or name == "--":
+            name = device
+
+        return name
+
+    def get_extra_attributes(self, device: str) -> dict:
+        """Get the extra attributes of a device."""
+        return {}
+
+    def scan_devices(self):
+        """Scan for new devices and return a list with found device IDs."""
+        self._update_info()
+
+        devices = []
+
+        for dev in self.last_results:
+            tracked = (
+                not self.tracked_devices
+                or dev["mac"] in self.tracked_devices
+                or dev["name"] in self.tracked_devices
+            )
+            tracked = tracked and (
+                not self.excluded_devices
+                or not (
+                    dev["mac"] in self.excluded_devices
+                    or dev["name"] in self.excluded_devices
+                )
+            )
+            if tracked:
+                devices.append(dev["mac"])
+
+        return devices
+
+    def _update_info(self):
+        _LOGGER.debug("Scanning")
+
+        results = self._get_attached_devices()
+
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug("Scan result: \n%s", pformat(results))
+
+        if results is None:
+            _LOGGER.warning("Error scanning devices")
+
+        self.last_results = results or []
+
+    def _get_attached_devices(self):
+        return self.gateway.get_device_modal()

--- a/homeassistant/components/technicolor/manifest.json
+++ b/homeassistant/components/technicolor/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "technicolor",
+  "name": "Technicolor",
+  "documentation": "https://www.home-assistant.io/integrations/technicolor",
+  "requirements": ["pytechnicolor==1.0.2"],
+  "dependencies": [],
+  "codeowners": [
+    "@shaiu"
+  ],
+  "iot_class": "local_polling"
+}

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1761,6 +1761,9 @@ pytankerkoenig==0.0.6
 # homeassistant.components.tautulli
 pytautulli==0.5.0
 
+# homeassistant.components.technicolor
+pytechnicolor==1.0.2
+
 # homeassistant.components.tfiac
 pytfiac==0.4
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This changes adds an integration for a Technicolor Gateway (Router).
It's a device_tracker component.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml
device_tracker:
  - platform: technicolor
    host: 192.168.1.1
    username: "admin"
    password: "password"
    new_device_defaults:
      track_new_devices: true
```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
