### PR TITLE
Bump httpx to 0.18.0 and respx to 0.17.0

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -17,7 +17,7 @@ distro==1.5.0
 emoji==1.2.0
 hass-nabucasa==0.43.0
 home-assistant-frontend==20210427.0
-httpx==0.17.1
+httpx==0.18.0
 jinja2>=2.11.3
 netdisco==2.8.2
 paho-mqtt==1.5.1
@@ -43,10 +43,6 @@ urllib3>=1.24.3
 
 # Constrain H11 to ensure we get a new enough version to support non-rfc line endings
 h11>=0.12.0
-
-# Constrain httpcore to fix exception when connection dropped
-# https://github.com/encode/httpcore/issues/239
-httpcore>=0.12.3
 
 # Constrain httplib2 to protect against GHSA-93xj-8mrv-444m
 # https://github.com/advisories/GHSA-93xj-8mrv-444m

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ awesomeversion==21.2.3
 bcrypt==3.1.7
 certifi>=2020.12.5
 ciso8601==2.1.3
-httpx==0.17.1
+httpx==0.18.0
 jinja2>=2.11.3
 PyJWT==1.7.1
 cryptography==3.3.2

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -23,6 +23,6 @@ pytest-xdist==2.1.0
 pytest==6.2.3
 requests_mock==1.8.0
 responses==0.12.0
-respx==0.16.2
+respx==0.17.0
 stdlib-list==0.7.0
 tqdm==4.49.0

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -66,10 +66,6 @@ urllib3>=1.24.3
 # Constrain H11 to ensure we get a new enough version to support non-rfc line endings
 h11>=0.12.0
 
-# Constrain httpcore to fix exception when connection dropped
-# https://github.com/encode/httpcore/issues/239
-httpcore>=0.12.3
-
 # Constrain httplib2 to protect against GHSA-93xj-8mrv-444m
 # https://github.com/advisories/GHSA-93xj-8mrv-444m
 httplib2>=0.19.0

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ REQUIRES = [
     "bcrypt==3.1.7",
     "certifi>=2020.12.5",
     "ciso8601==2.1.3",
-    "httpx==0.17.1",
+    "httpx==0.18.0",
     "jinja2>=2.11.3",
     "PyJWT==1.7.1",
     # PyJWT has loose dependency. We want the latest one.

--- a/tests/components/enphase_envoy/test_config_flow.py
+++ b/tests/components/enphase_envoy/test_config_flow.py
@@ -80,7 +80,7 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
 
     with patch(
         "homeassistant.components.enphase_envoy.config_flow.EnvoyReader.getData",
-        side_effect=httpx.HTTPError("any", request=MagicMock()),
+        side_effect=httpx.HTTPError("any"),
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump httpx to 0.18.0 and respx to 0.17.0

Changelog: https://github.com/encode/httpx/compare/0.17.1...0.18.0
https://github.com/lundberg/respx/compare/0.16.3...0.17.0


httpx requires the new version of httpcore (https://github.com/encode/httpcore/compare/0.12.3...0.13.0) which has the long awaited cancel leak fix https://github.com/encode/httpcore/pull/305

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
