### PR TITLE
Improve color conversion for RGBWW lights

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -71,7 +71,13 @@ VALID_COLOR_MODES = {
     COLOR_MODE_RGBWW,
 }
 COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {COLOR_MODE_ONOFF}
-COLOR_MODES_COLOR = {COLOR_MODE_HS, COLOR_MODE_RGB, COLOR_MODE_RGBW, COLOR_MODE_XY}
+COLOR_MODES_COLOR = {
+    COLOR_MODE_HS,
+    COLOR_MODE_RGB,
+    COLOR_MODE_RGBW,
+    COLOR_MODE_RGBWW,
+    COLOR_MODE_XY,
+}
 
 
 def valid_supported_color_modes(color_modes):
@@ -321,10 +327,9 @@ async def async_setup(hass, config):  # noqa: C901
                 rgb_color = color_util.color_hs_to_RGB(*hs_color)
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
             elif COLOR_MODE_RGBWW in supported_color_modes:
-                params[ATTR_RGBWW_COLOR] = (
-                    *color_util.color_hs_to_RGB(*hs_color),
-                    0,
-                    0,
+                rgb_color = color_util.color_hs_to_RGB(*hs_color)
+                params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
+                    *rgb_color, light.min_mireds, light.max_mireds
                 )
             elif COLOR_MODE_XY in supported_color_modes:
                 params[ATTR_XY_COLOR] = color_util.color_hs_to_xy(*hs_color)
@@ -333,7 +338,9 @@ async def async_setup(hass, config):  # noqa: C901
             if COLOR_MODE_RGBW in supported_color_modes:
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
             if COLOR_MODE_RGBWW in supported_color_modes:
-                params[ATTR_RGBWW_COLOR] = (*rgb_color, 0, 0)
+                params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
+                    *rgb_color, light.min_mireds, light.max_mireds
+                )
             elif COLOR_MODE_HS in supported_color_modes:
                 params[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
             elif COLOR_MODE_XY in supported_color_modes:
@@ -348,10 +355,9 @@ async def async_setup(hass, config):  # noqa: C901
                 rgb_color = color_util.color_xy_to_RGB(*xy_color)
                 params[ATTR_RGBW_COLOR] = color_util.color_rgb_to_rgbw(*rgb_color)
             elif COLOR_MODE_RGBWW in supported_color_modes:
-                params[ATTR_RGBWW_COLOR] = (
-                    *color_util.color_xy_to_RGB(*xy_color),
-                    0,
-                    0,
+                rgb_color = color_util.color_xy_to_RGB(*xy_color)
+                params[ATTR_RGBWW_COLOR] = color_util.color_rgb_to_rgbww(
+                    *rgb_color, light.min_mireds, light.max_mireds
                 )
 
         # Remove deprecated white value if the light supports color mode
@@ -694,6 +700,15 @@ class LightEntity(ToggleEntity):
             data[ATTR_RGB_COLOR] = tuple(int(x) for x in rgb_color[0:3])
             data[ATTR_RGBW_COLOR] = tuple(int(x) for x in rgbw_color[0:4])
             data[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
+        elif color_mode == COLOR_MODE_RGBWW and self.rgbww_color:
+            rgbww_color = self.rgbww_color
+            rgb_color = color_util.color_rgbww_to_rgb(
+                *rgbww_color, self.min_mireds, self.max_mireds
+            )
+            data[ATTR_HS_COLOR] = color_util.color_RGB_to_hs(*rgb_color)
+            data[ATTR_RGB_COLOR] = tuple(int(x) for x in rgb_color[0:3])
+            data[ATTR_RGBWW_COLOR] = tuple(int(x) for x in rgbww_color[0:5])
+            data[ATTR_XY_COLOR] = color_util.color_RGB_to_xy(*rgb_color)
         return data
 
     @final
@@ -730,9 +745,6 @@ class LightEntity(ToggleEntity):
 
         if color_mode in COLOR_MODES_COLOR:
             data.update(self._light_internal_convert_color(color_mode))
-
-        if color_mode == COLOR_MODE_RGBWW:
-            data[ATTR_RGBWW_COLOR] = self.rgbww_color
 
         if supported_features & SUPPORT_COLOR_TEMP and not self.supported_color_modes:
             # Backwards compatibility

--- a/tests/components/mqtt/test_light_json.py
+++ b/tests/components/mqtt/test_light_json.py
@@ -480,12 +480,12 @@ async def test_controlling_state_via_topic2(hass, mqtt_mock, caplog):
     assert state.attributes.get("color_mode") == "rgbww"
     assert state.attributes.get("color_temp") is None
     assert state.attributes.get("effect") == "colorloop"
-    assert state.attributes.get("hs_color") is None
-    assert state.attributes.get("rgb_color") is None
+    assert state.attributes.get("hs_color") == (20.552, 70.98)
+    assert state.attributes.get("rgb_color") == (255, 136, 74)
     assert state.attributes.get("rgbw_color") is None
     assert state.attributes.get("rgbww_color") == (255, 128, 64, 32, 16)
     assert state.attributes.get("white_value") is None
-    assert state.attributes.get("xy_color") is None
+    assert state.attributes.get("xy_color") == (0.571, 0.361)
 
     # Light turned off
     async_fire_mqtt_message(hass, "test_light_rgb", '{"state":"OFF"}')
@@ -892,11 +892,11 @@ async def test_sending_mqtt_commands_and_optimistic2(hass, mqtt_mock):
     assert state.attributes["brightness"] == 75
     assert state.attributes["color_mode"] == "rgbww"
     assert state.attributes["rgbww_color"] == (255, 128, 0, 45, 32)
-    assert "hs_color" not in state.attributes
-    assert "rgb_color" not in state.attributes
+    assert state.attributes["hs_color"] == (29.872, 92.157)
+    assert state.attributes["rgb_color"] == (255, 137, 20)
     assert "rgbw_color" not in state.attributes
     assert "white_value" not in state.attributes
-    assert "xy_color" not in state.attributes
+    assert state.attributes["xy_color"] == (0.596, 0.382)
     mqtt_mock.async_publish.assert_called_once_with(
         "test_light_rgb/set",
         JsonValidator(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve color conversion for RGBWW lights:

- When a light only supporting RGBWW is set to a color, the white channels will be used for the white component
  - This is done by calculating the midpoint of color temperatures supported by the light's white channels. As an alternative, the color temperature closest to RGB whitepoint at ~6500K could be used, or try to match the RGB color to the closest color temperature supported by the light.
- HS, RGB and XY colors will be approximated in the light's state by adding the white channels to the color
- RGBWW lights will be supported by alexa, google assistant, homekit + emulated hue as color lights

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #49764 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
