### PR TITLE
Fix zwave_js flow set add-on options

### DIFF
--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -46,7 +46,7 @@ def api_error(error_message: str) -> Callable[[F], F]:
             try:
                 return_value = await func(*args, **kwargs)
             except HassioAPIError as err:
-                raise AddonError(error_message) from err
+                raise AddonError(f"{error_message}: {err}") from err
 
             return return_value
 

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -212,7 +212,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await self.install_task
         except AddonError as err:
-            _LOGGER.error("Failed to install Z-Wave JS add-on: %s", err)
+            _LOGGER.error(err)
             return self.async_show_progress_done(next_step_id="install_failed")
 
         self.integration_created_addon = True
@@ -274,7 +274,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await self.start_task
         except (CannotConnect, AddonError) as err:
-            _LOGGER.error("Failed to start Z-Wave JS add-on: %s", err)
+            _LOGGER.error(err)
             return self.async_show_progress_done(next_step_id="start_failed")
 
         return self.async_show_progress_done(next_step_id="finish_addon_setup")
@@ -309,7 +309,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 else:
                     break
             else:
-                raise CannotConnect("Failed to start add-on: timeout")
+                raise CannotConnect("Failed to start Z-Wave JS add-on: timeout")
         finally:
             # Continue the flow after show progress when the task is done.
             self.hass.async_create_task(
@@ -352,7 +352,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             addon_info: dict = await addon_manager.async_get_addon_info()
         except AddonError as err:
-            _LOGGER.error("Failed to get Z-Wave JS add-on info: %s", err)
+            _LOGGER.error(err)
             raise AbortFlow("addon_info_failed") from err
 
         return addon_info
@@ -378,7 +378,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await addon_manager.async_set_addon_options(config)
         except AddonError as err:
-            _LOGGER.error("Failed to set Z-Wave JS add-on config: %s", err)
+            _LOGGER.error(err)
             raise AbortFlow("addon_set_config_failed") from err
 
     async def _async_install_addon(self) -> None:
@@ -398,7 +398,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             discovery_info_config = await addon_manager.async_get_addon_discovery_info()
         except AddonError as err:
-            _LOGGER.error("Failed to get Z-Wave JS add-on discovery info: %s", err)
+            _LOGGER.error(err)
             raise AbortFlow("addon_get_discovery_info_failed") from err
 
         return discovery_info_config

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -374,10 +374,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_set_addon_config(self, config: dict) -> None:
         """Set Z-Wave JS add-on config."""
-        options = {"options": config}
         addon_manager: AddonManager = get_addon_manager(self.hass)
         try:
-            await addon_manager.async_set_addon_options(options)
+            await addon_manager.async_set_addon_options(config)
         except AddonError as err:
             _LOGGER.error("Failed to set Z-Wave JS add-on config: %s", err)
             raise AbortFlow("addon_set_config_failed") from err

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Z-Wave JS config flow."""
 import asyncio
-from unittest.mock import DEFAULT, patch
+from unittest.mock import DEFAULT, call, patch
 
 import pytest
 from zwave_js_server.version import VersionInfo
@@ -384,6 +384,10 @@ async def test_discovery_addon_not_running(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
     )
 
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
+    )
+
     assert result["type"] == "progress"
     assert result["step_id"] == "start_addon"
 
@@ -396,6 +400,8 @@ async def test_discovery_addon_not_running(
         await hass.async_block_till_done()
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
@@ -441,11 +447,17 @@ async def test_discovery_addon_not_installed(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
+    assert install_addon.call_args == call(hass, "core_zwave_js")
+
     assert result["type"] == "form"
     assert result["step_id"] == "configure_addon"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
+    )
+
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
     )
 
     assert result["type"] == "progress"
@@ -460,6 +472,8 @@ async def test_discovery_addon_not_installed(
         await hass.async_block_till_done()
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
@@ -694,6 +708,10 @@ async def test_addon_installed(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
     )
 
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
+    )
+
     assert result["type"] == "progress"
     assert result["step_id"] == "start_addon"
 
@@ -706,6 +724,8 @@ async def test_addon_installed(
         await hass.async_block_till_done()
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE
@@ -754,11 +774,17 @@ async def test_addon_installed_start_failure(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
     )
 
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
+    )
+
     assert result["type"] == "progress"
     assert result["step_id"] == "start_addon"
 
     await hass.async_block_till_done()
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "abort"
     assert result["reason"] == "addon_start_failed"
@@ -807,11 +833,17 @@ async def test_addon_installed_failures(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
     )
 
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
+    )
+
     assert result["type"] == "progress"
     assert result["step_id"] == "start_addon"
 
     await hass.async_block_till_done()
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "abort"
     assert result["reason"] == "addon_start_failed"
@@ -851,8 +883,14 @@ async def test_addon_installed_set_options_failure(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
     )
 
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
+    )
+
     assert result["type"] == "abort"
     assert result["reason"] == "addon_set_config_failed"
+
+    assert start_addon.call_count == 0
 
 
 @pytest.mark.parametrize("discovery_info", [{"config": ADDON_DISCOVERY_INFO}])
@@ -897,11 +935,19 @@ async def test_addon_installed_already_configured(
         result["flow_id"], {"usb_path": "/test_new", "network_key": "def456"}
     )
 
+    assert set_addon_options.call_args == call(
+        hass,
+        "core_zwave_js",
+        {"options": {"device": "/test_new", "network_key": "def456"}},
+    )
+
     assert result["type"] == "progress"
     assert result["step_id"] == "start_addon"
 
     await hass.async_block_till_done()
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
@@ -944,11 +990,17 @@ async def test_addon_not_installed(
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
+    assert install_addon.call_args == call(hass, "core_zwave_js")
+
     assert result["type"] == "form"
     assert result["step_id"] == "configure_addon"
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"usb_path": "/test", "network_key": "abc123"}
+    )
+
+    assert set_addon_options.call_args == call(
+        hass, "core_zwave_js", {"options": {"device": "/test", "network_key": "abc123"}}
     )
 
     assert result["type"] == "progress"
@@ -963,6 +1015,8 @@ async def test_addon_not_installed(
         await hass.async_block_till_done()
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
         await hass.async_block_till_done()
+
+    assert start_addon.call_args == call(hass, "core_zwave_js")
 
     assert result["type"] == "create_entry"
     assert result["title"] == TITLE

--- a/tests/components/zwave_js/test_config_flow.py
+++ b/tests/components/zwave_js/test_config_flow.py
@@ -1055,5 +1055,7 @@ async def test_install_addon_failure(hass, supervisor, addon_installed, install_
 
     result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
+    assert install_addon.call_args == call(hass, "core_zwave_js")
+
     assert result["type"] == "abort"
     assert result["reason"] == "addon_install_failed"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- The add-on manager already nested the add-on options inside a dict before calling the Supervisor api. The config flow wasn't updated after switching to use the add-on manager.
- Improve error messages.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
