### PR TITLE
Move ZHA config panel section translations to the backend

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -29,6 +29,19 @@
       "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]"
     }
   },
+  "config_panel": {
+    "zha_options": {
+      "title": "Global Options",
+      "enable_identify_on_join": "Enable identify effect when devices join the network",
+      "default_light_transition": "Default light transition time (seconds)"
+    },
+    "zha_alarm_options": {
+      "title": "Alarm Control Panel Options",
+      "alarm_master_code": "Master code for the alarm control panel(s)",
+      "alarm_failed_tries": "The number of consecutive failed code entries to trigger an alarm",
+      "alarm_arm_requires_code": "Code required for arming actions"
+    }
+  },
   "device_automation": {
     "action_type": { "squawk": "Squawk", "warn": "Warn" },
     "trigger_type": {

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -33,6 +33,19 @@
             }
         }
     },
+    "config_panel": {
+        "zha_alarm_options": {
+            "alarm_arm_requires_code": "Code required for arming actions",
+            "alarm_failed_tries": "The number of consecutive failed code entries to trigger an alarm",
+            "alarm_master_code": "Master code for the alarm control panel(s)",
+            "title": "Alarm Control Panel Options"
+        },
+        "zha_options": {
+            "default_light_transition": "Default light transition time (seconds)",
+            "enable_identify_on_join": "Enable identify effect when devices join the network",
+            "title": "Global Options"
+        }
+    },
     "device_automation": {
         "action_type": {
             "squawk": "Squawk",

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -142,9 +142,12 @@ def gen_strings_schema(config: Config, integration: Integration):
             vol.Optional("system_health"): {
                 vol.Optional("info"): {str: cv.string_with_no_html}
             },
-            vol.Optional("config_panel"): {
-                vol.Optional("info"): {str: cv.string_with_no_html}
-            },
+            vol.Optional("config_panel"): cv.schema_with_slug_keys(
+                cv.schema_with_slug_keys(
+                    cv.string_with_no_html, slug_validator=lowercase_validator
+                ),
+                slug_validator=vol.Any("_", cv.slug),
+            ),
         }
     )
 

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -142,6 +142,10 @@ def gen_strings_schema(config: Config, integration: Integration):
             vol.Optional("system_health"): {
                 vol.Optional("info"): {str: cv.string_with_no_html}
             },
+            vol.Optional("config_panel"): cv.schema_with_slug_keys(
+                cv.schema_with_slug_keys(str, slug_validator=lowercase_validator),
+                slug_validator=vol.Any("_", cv.slug),
+            ),
         }
     )
 

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -142,10 +142,9 @@ def gen_strings_schema(config: Config, integration: Integration):
             vol.Optional("system_health"): {
                 vol.Optional("info"): {str: cv.string_with_no_html}
             },
-            vol.Optional("config_panel"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(str, slug_validator=lowercase_validator),
-                slug_validator=vol.Any("_", cv.slug),
-            ),
+            vol.Optional("config_panel"): {
+                vol.Optional("info"): {str: cv.string_with_no_html}
+            },
         }
     )
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR moves the translations for the ZHA configuration panel sections to the backend so that PR's don't have to be opened in Both the frontend and backend repos when new configuration panel sections are added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
