### PR TITLE
Remove references to hass.data in harmony tests

### DIFF
--- a/tests/components/harmony/test_remote.py
+++ b/tests/components/harmony/test_remote.py
@@ -6,7 +6,6 @@ from aioharmony.const import SendCommandDevice
 
 from homeassistant.components.harmony.const import (
     DOMAIN,
-    HARMONY_DATA,
     SERVICE_CHANGE_CHANNEL,
     SERVICE_SYNC,
 )
@@ -150,7 +149,7 @@ async def test_remote_toggles(mock_hc, hass, mock_write_config):
     assert hass.states.is_state(ENTITY_PLAY_MUSIC, STATE_OFF)
 
 
-async def test_async_send_command(mock_hc, hass, mock_write_config):
+async def test_async_send_command(mock_hc, harmony_client, hass, mock_write_config):
     """Ensure calls to send remote commands properly propagate to devices."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -160,8 +159,7 @@ async def test_async_send_command(mock_hc, hass, mock_write_config):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    data = hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]
-    send_commands_mock = data._client.send_commands
+    send_commands_mock = harmony_client.send_commands
 
     # No device provided
     await _send_commands_and_wait(
@@ -283,7 +281,9 @@ async def test_async_send_command(mock_hc, hass, mock_write_config):
     send_commands_mock.reset_mock()
 
 
-async def test_async_send_command_custom_delay(mock_hc, hass, mock_write_config):
+async def test_async_send_command_custom_delay(
+    mock_hc, harmony_client, hass, mock_write_config
+):
     """Ensure calls to send remote commands properly propagate to devices with custom delays."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -298,8 +298,7 @@ async def test_async_send_command_custom_delay(mock_hc, hass, mock_write_config)
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    data = hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]
-    send_commands_mock = data._client.send_commands
+    send_commands_mock = harmony_client.send_commands
 
     # Tell the TV to play by id
     await _send_commands_and_wait(
@@ -324,7 +323,7 @@ async def test_async_send_command_custom_delay(mock_hc, hass, mock_write_config)
     send_commands_mock.reset_mock()
 
 
-async def test_change_channel(mock_hc, hass, mock_write_config):
+async def test_change_channel(mock_hc, harmony_client, hass, mock_write_config):
     """Test change channel commands."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -334,8 +333,7 @@ async def test_change_channel(mock_hc, hass, mock_write_config):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    data = hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]
-    change_channel_mock = data._client.change_channel
+    change_channel_mock = harmony_client.change_channel
 
     # Tell the remote to change channels
     await hass.services.async_call(
@@ -349,7 +347,7 @@ async def test_change_channel(mock_hc, hass, mock_write_config):
     change_channel_mock.assert_awaited_once_with(100)
 
 
-async def test_sync(mock_hc, mock_write_config, hass):
+async def test_sync(mock_hc, harmony_client, mock_write_config, hass):
     """Test the sync command."""
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_HOST: "192.0.2.0", CONF_NAME: HUB_NAME}
@@ -359,8 +357,7 @@ async def test_sync(mock_hc, mock_write_config, hass):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    data = hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]
-    sync_mock = data._client.sync
+    sync_mock = harmony_client.sync
 
     # Tell the remote to change channels
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This changes the remote tests in the harmony integration to directly inject the mock harmony client instance instead of extracting it from the `HarmonyData` instance inside `hass.data[DOMAIN][entry.entry_id][HARMONY_DATA]`. I missed some of these in #47141.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #47141 (I missed a few spots in the prior PR)
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
