### PR TITLE
Improve Waze Travel Time import and naming logic

### DIFF
--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -103,31 +103,36 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
-        if user_input is not None:
-            if await self.hass.async_add_executor_job(
-                is_valid_config_entry,
-                self.hass,
-                _LOGGER,
-                user_input[CONF_ORIGIN],
-                user_input[CONF_DESTINATION],
-                user_input[CONF_REGION],
-            ):
-                await self.async_set_unique_id(
-                    slugify(
-                        f"{DOMAIN}_{user_input[CONF_ORIGIN]}_{user_input[CONF_DESTINATION]}"
-                    )
+        user_input = user_input or {}
+
+        if CONF_ORIGIN in user_input:
+            default_name = (
+                f"{DEFAULT_NAME}: {user_input[CONF_ORIGIN]} -> "
+                f"{user_input[CONF_DESTINATION]}"
+            )
+        else:
+            default_name = DEFAULT_NAME
+
+        if user_input:
+            await self.async_set_unique_id(
+                slugify(
+                    f"{DOMAIN}_{user_input[CONF_ORIGIN]}_{user_input[CONF_DESTINATION]}"
                 )
-                self._abort_if_unique_id_configured()
+            )
+            self._abort_if_unique_id_configured()
+            if (
+                self.source == config_entries.SOURCE_IMPORT
+                or await self.hass.async_add_executor_job(
+                    is_valid_config_entry,
+                    self.hass,
+                    _LOGGER,
+                    user_input[CONF_ORIGIN],
+                    user_input[CONF_DESTINATION],
+                    user_input[CONF_REGION],
+                )
+            ):
                 return self.async_create_entry(
-                    title=(
-                        user_input.get(
-                            CONF_NAME,
-                            (
-                                f"{DEFAULT_NAME}: {user_input[CONF_ORIGIN]} -> "
-                                f"{user_input[CONF_DESTINATION]}"
-                            ),
-                        )
-                    ),
+                    title=user_input.get(CONF_NAME, default_name),
                     data=user_input,
                 )
 
@@ -138,6 +143,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
+                    vol.Required(
+                        CONF_NAME, default=user_input.get(CONF_NAME, default_name)
+                    ): cv.string,
                     vol.Required(CONF_ORIGIN): cv.string,
                     vol.Required(CONF_DESTINATION): cv.string,
                     vol.Required(CONF_REGION): vol.In(REGIONS),

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -105,14 +105,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
         user_input = user_input or {}
 
-        if CONF_ORIGIN in user_input:
-            default_name = (
-                f"{DEFAULT_NAME}: {user_input[CONF_ORIGIN]} -> "
-                f"{user_input[CONF_DESTINATION]}"
-            )
-        else:
-            default_name = DEFAULT_NAME
-
         if user_input:
             await self.async_set_unique_id(
                 slugify(
@@ -132,7 +124,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             ):
                 return self.async_create_entry(
-                    title=user_input.get(CONF_NAME, default_name),
+                    title=user_input.get(CONF_NAME, DEFAULT_NAME),
                     data=user_input,
                 )
 
@@ -144,7 +136,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_NAME, default=user_input.get(CONF_NAME, default_name)
+                        CONF_NAME, default=user_input.get(CONF_NAME, DEFAULT_NAME)
                     ): cv.string,
                     vol.Required(CONF_ORIGIN): cv.string,
                     vol.Required(CONF_DESTINATION): cv.string,

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -43,7 +43,6 @@ from .const import (
     DEFAULT_AVOID_FERRIES,
     DEFAULT_AVOID_SUBSCRIPTION_ROADS,
     DEFAULT_AVOID_TOLL_ROADS,
-    DEFAULT_NAME,
     DEFAULT_REALTIME,
     DEFAULT_VEHICLE_TYPE,
     DOMAIN,
@@ -117,10 +116,9 @@ async def async_setup_entry(
         CONF_AVOID_SUBSCRIPTION_ROADS: DEFAULT_AVOID_SUBSCRIPTION_ROADS,
         CONF_AVOID_TOLL_ROADS: DEFAULT_AVOID_TOLL_ROADS,
     }
-    name = None
+
     if not config_entry.options:
         new_data = config_entry.data.copy()
-        name = new_data.pop(CONF_NAME, None)
         options = {}
         for key in [
             CONF_INCL_FILTER,
@@ -144,7 +142,7 @@ async def async_setup_entry(
     destination = config_entry.data[CONF_DESTINATION]
     origin = config_entry.data[CONF_ORIGIN]
     region = config_entry.data[CONF_REGION]
-    name = name or f"{DEFAULT_NAME}: {origin} -> {destination}"
+    name = config_entry.data[CONF_NAME]
 
     if not await hass.async_add_executor_job(
         is_valid_config_entry, hass, _LOGGER, origin, destination, region

--- a/homeassistant/components/waze_travel_time/strings.json
+++ b/homeassistant/components/waze_travel_time/strings.json
@@ -5,6 +5,7 @@
       "user": {
         "description": "For Origin and Destination, enter the address or the GPS coordinates of the location (GPS coordinates has to be separated by a comma). You can also enter an entity id which provides this information in its state, an entity id with latitude and longitude attributes, or zone friendly name.",
         "data": {
+          "name": "[%key:common::config_flow::data::name%]",
           "origin": "Origin",
           "destination": "Destination",
           "region": "Region"

--- a/tests/components/waze_travel_time/test_config_flow.py
+++ b/tests/components/waze_travel_time/test_config_flow.py
@@ -14,7 +14,7 @@ from homeassistant.components.waze_travel_time.const import (
     DEFAULT_NAME,
     DOMAIN,
 )
-from homeassistant.const import CONF_REGION, CONF_UNIT_SYSTEM_IMPERIAL
+from homeassistant.const import CONF_NAME, CONF_REGION, CONF_UNIT_SYSTEM_IMPERIAL
 
 from tests.common import MockConfigEntry
 
@@ -38,8 +38,9 @@ async def test_minimum_fields(hass, validate_config_entry, bypass_setup):
     await hass.async_block_till_done()
 
     assert result2["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result2["title"] == f"{DEFAULT_NAME}: location1 -> location2"
+    assert result2["title"] == DEFAULT_NAME
     assert result2["data"] == {
+        CONF_NAME: DEFAULT_NAME,
         CONF_ORIGIN: "location1",
         CONF_DESTINATION: "location2",
         CONF_REGION: "US",


### PR DESCRIPTION
## Proposed change
There were a couple of problems with the implementation of https://github.com/home-assistant/core/pull/43419 that were quickly discovered by beta testers:
1. Sometimes config import would fail because the component isn't able to validate the origin and destination correctly before HA has started up.
2. We were setting the config entry unique ID too late, and because of 1, that could result in multiple flows/entries for a single imported config
3. The naming strategy was a mess and the default was way too long

Now we skip validation when doing a config import since we can presume that it is correct, and we set the unique ID as early as we can so that we can avoid creating multiple flows/entries. Finally,  we still have a default name, but the user can input a different name as part of the config flow, and that will get passed down to the sensor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Example entry for `configuration.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example configuration.yaml

```

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/49839
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
