### PR TITLE
Rename FlowResultDict to FlowResult

### DIFF
--- a/homeassistant/auth/__init__.py
+++ b/homeassistant/auth/__init__.py
@@ -11,7 +11,7 @@ import jwt
 from homeassistant import data_entry_flow
 from homeassistant.auth.const import ACCESS_TOKEN_EXPIRATION
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.util import dt as dt_util
 
 from . import auth_store, models
@@ -98,8 +98,8 @@ class AuthManagerFlowManager(data_entry_flow.FlowManager):
         return await auth_provider.async_login_flow(context)
 
     async def async_finish_flow(
-        self, flow: data_entry_flow.FlowHandler, result: FlowResultDict
-    ) -> FlowResultDict:
+        self, flow: data_entry_flow.FlowHandler, result: FlowResult
+    ) -> FlowResult:
         """Return a user as result of login flow."""
         flow = cast(LoginFlow, flow)
 

--- a/homeassistant/auth/mfa_modules/__init__.py
+++ b/homeassistant/auth/mfa_modules/__init__.py
@@ -12,7 +12,7 @@ from voluptuous.humanize import humanize_error
 from homeassistant import data_entry_flow, requirements
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util.decorator import Registry
 
@@ -106,7 +106,7 @@ class SetupFlow(data_entry_flow.FlowHandler):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the first step of setup flow.
 
         Return self.async_show_form(step_id='init') if user_input is None.

--- a/homeassistant/auth/mfa_modules/notify.py
+++ b/homeassistant/auth/mfa_modules/notify.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_EXCLUDE, CONF_INCLUDE
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import ServiceNotFound
 from homeassistant.helpers import config_validation as cv
 
@@ -293,7 +293,7 @@ class NotifySetupFlow(SetupFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Let user select available notify services."""
         errors: dict[str, str] = {}
 
@@ -319,7 +319,7 @@ class NotifySetupFlow(SetupFlow):
 
     async def async_step_setup(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Verify user can receive one-time password."""
         errors: dict[str, str] = {}
 

--- a/homeassistant/auth/mfa_modules/totp.py
+++ b/homeassistant/auth/mfa_modules/totp.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant.auth.models import User
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 
 from . import (
     MULTI_FACTOR_AUTH_MODULE_SCHEMA,
@@ -190,7 +190,7 @@ class TotpSetupFlow(SetupFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the first step of setup flow.
 
         Return self.async_show_form(step_id='init') if user_input is None.

--- a/homeassistant/auth/providers/__init__.py
+++ b/homeassistant/auth/providers/__init__.py
@@ -13,7 +13,7 @@ from voluptuous.humanize import humanize_error
 from homeassistant import data_entry_flow, requirements
 from homeassistant.const import CONF_ID, CONF_NAME, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.util import dt as dt_util
 from homeassistant.util.decorator import Registry
@@ -200,7 +200,7 @@ class LoginFlow(data_entry_flow.FlowHandler):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the first step of login flow.
 
         Return self.async_show_form(step_id='init') if user_input is None.
@@ -210,7 +210,7 @@ class LoginFlow(data_entry_flow.FlowHandler):
 
     async def async_step_select_mfa_module(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of select mfa module."""
         errors = {}
 
@@ -235,7 +235,7 @@ class LoginFlow(data_entry_flow.FlowHandler):
 
     async def async_step_mfa(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of mfa validation."""
         assert self.credential
         assert self.user
@@ -287,6 +287,6 @@ class LoginFlow(data_entry_flow.FlowHandler):
             errors=errors,
         )
 
-    async def async_finish(self, flow_result: Any) -> FlowResultDict:
+    async def async_finish(self, flow_result: Any) -> FlowResult:
         """Handle the pass of login flow."""
         return self.async_create_entry(title=self._auth_provider.name, data=flow_result)

--- a/homeassistant/auth/providers/command_line.py
+++ b/homeassistant/auth/providers/command_line.py
@@ -11,7 +11,7 @@ from typing import Any, cast
 import voluptuous as vol
 
 from homeassistant.const import CONF_COMMAND
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
@@ -129,7 +129,7 @@ class CommandLineLoginFlow(LoginFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/auth/providers/homeassistant.py
+++ b/homeassistant/auth/providers/homeassistant.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
@@ -321,7 +321,7 @@ class HassLoginFlow(LoginFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/auth/providers/insecure_example.py
+++ b/homeassistant/auth/providers/insecure_example.py
@@ -9,7 +9,7 @@ from typing import cast
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from . import AUTH_PROVIDER_SCHEMA, AUTH_PROVIDERS, AuthProvider, LoginFlow
@@ -99,7 +99,7 @@ class ExampleLoginFlow(LoginFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/auth/providers/legacy_api_password.py
+++ b/homeassistant/auth/providers/legacy_api_password.py
@@ -12,7 +12,7 @@ from typing import cast
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
@@ -84,7 +84,7 @@ class LegacyLoginFlow(LoginFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of the form."""
         errors = {}
 

--- a/homeassistant/auth/providers/trusted_networks.py
+++ b/homeassistant/auth/providers/trusted_networks.py
@@ -19,7 +19,7 @@ from typing import Any, Dict, List, Union, cast
 import voluptuous as vol
 
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.config_validation as cv
 
@@ -201,7 +201,7 @@ class TrustedNetworksLoginFlow(LoginFlow):
 
     async def async_step_init(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the step of the form."""
         try:
             cast(

--- a/homeassistant/components/adguard/config_flow.py
+++ b/homeassistant/components/adguard/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
@@ -32,7 +32,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _show_setup_form(
         self, errors: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",
@@ -51,7 +51,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _show_hassio_form(
         self, errors: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Show the Hass.io confirmation form to the user."""
         return self.async_show_form(
             step_id="hassio_confirm",
@@ -62,7 +62,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
         if user_input is None:
             return await self._show_setup_form(user_input)
@@ -107,7 +107,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResultDict:
+    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Prepare configuration for a Hass.io AdGuard Home add-on.
 
         This flow is triggered by the discovery component.
@@ -119,7 +119,7 @@ class AdGuardHomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_hassio_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Confirm Supervisor discovery."""
         if user_input is None:
             return await self._show_hassio_form()

--- a/homeassistant/components/bond/config_flow.py
+++ b/homeassistant/components/bond/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     HTTP_UNAUTHORIZED,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import DiscoveryInfoType
 
@@ -94,7 +94,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf(
         self, discovery_info: DiscoveryInfoType
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initialized by zeroconf discovery."""
         name: str = discovery_info[CONF_NAME]
         host: str = discovery_info[CONF_HOST]
@@ -118,7 +118,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle confirmation flow for discovered bond hub."""
         errors = {}
         if user_input is not None:
@@ -159,7 +159,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
         if user_input is not None:

--- a/homeassistant/components/bsblan/config_flow.py
+++ b/homeassistant/components/bsblan/config_flow.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -23,9 +23,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_LOCAL_POLL
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         if user_input is None:
             return self._show_setup_form()
@@ -57,7 +55,7 @@ class BSBLanFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    def _show_setup_form(self, errors: dict | None = None) -> FlowResultDict:
+    def _show_setup_form(self, errors: dict | None = None) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/canary/config_flow.py
+++ b/homeassistant/components/canary/config_flow.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 from homeassistant.config_entries import CONN_CLASS_CLOUD_POLL, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_PASSWORD, CONF_TIMEOUT, CONF_USERNAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -53,13 +53,11 @@ class CanaryConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(
         self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by configuration file."""
         return await self.async_step_user(user_input)
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")

--- a/homeassistant/components/climacell/config_flow.py
+++ b/homeassistant/components/climacell/config_flow.py
@@ -22,7 +22,7 @@ from homeassistant.const import (
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
@@ -88,9 +88,7 @@ class ClimaCellOptionsConfigFlow(config_entries.OptionsFlow):
         """Initialize ClimaCell options flow."""
         self._config_entry = config_entry
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    async def async_step_init(self, user_input: dict[str, Any] = None) -> FlowResult:
         """Manage the ClimaCell options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)
@@ -121,9 +119,7 @@ class ClimaCellConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return ClimaCellOptionsConfigFlow(config_entry)
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
         """Handle the initial step."""
         errors = {}
         if user_input is not None:

--- a/homeassistant/components/coronavirus/config_flow.py
+++ b/homeassistant/components/coronavirus/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 
 from . import get_coordinator
 from .const import DOMAIN, OPTION_WORLDWIDE
@@ -22,7 +22,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 

--- a/homeassistant/components/denonavr/config_flow.py
+++ b/homeassistant/components/denonavr/config_flow.py
@@ -13,7 +13,7 @@ from homeassistant import config_entries
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_TYPE
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.httpx_client import get_async_client
 
 from .receiver import ConnectDenonAVR
@@ -135,7 +135,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_select(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle multiple receivers found."""
         errors = {}
         if user_input is not None:
@@ -156,7 +156,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Allow the user to confirm adding the device."""
         if user_input is not None:
             return await self.async_step_connect()
@@ -166,7 +166,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_connect(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Connect to the receiver."""
         connect_denonavr = ConnectDenonAVR(
             self.host,
@@ -215,7 +215,7 @@ class DenonAvrFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_ssdp(self, discovery_info: dict[str, Any]) -> FlowResultDict:
+    async def async_step_ssdp(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle a discovered Denon AVR.
 
         This flow is triggered by the SSDP component. It will check if the

--- a/homeassistant/components/directv/config_flow.py
+++ b/homeassistant/components/directv/config_flow.py
@@ -12,7 +12,7 @@ from homeassistant.components.ssdp import ATTR_SSDP_LOCATION, ATTR_UPNP_SERIAL
 from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -46,9 +46,7 @@ class DirecTVConfigFlow(ConfigFlow, domain=DOMAIN):
         """Set up the instance."""
         self.discovery_info = {}
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         if user_input is None:
             return self._show_setup_form()
@@ -68,9 +66,7 @@ class DirecTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
 
-    async def async_step_ssdp(
-        self, discovery_info: DiscoveryInfoType
-    ) -> FlowResultDict:
+    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
         """Handle SSDP discovery."""
         host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
         receiver_id = None
@@ -103,7 +99,7 @@ class DirecTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_ssdp_confirm(
         self, user_input: ConfigType = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a confirmation flow initiated by SSDP."""
         if user_input is None:
             return self.async_show_form(
@@ -117,7 +113,7 @@ class DirecTVConfigFlow(ConfigFlow, domain=DOMAIN):
             data=self.discovery_info,
         )
 
-    def _show_setup_form(self, errors: dict | None = None) -> FlowResultDict:
+    def _show_setup_form(self, errors: dict | None = None) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/elgato/config_flow.py
+++ b/homeassistant/components/elgato/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_SERIAL_NUMBER, DOMAIN
@@ -27,7 +27,7 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
         if user_input is None:
             return self._async_show_setup_form()
@@ -42,9 +42,7 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self._async_create_entry()
 
-    async def async_step_zeroconf(
-        self, discovery_info: dict[str, Any]
-    ) -> FlowResultDict:
+    async def async_step_zeroconf(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle zeroconf discovery."""
         self.host = discovery_info[CONF_HOST]
         self.port = discovery_info[CONF_PORT]
@@ -62,14 +60,14 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf_confirm(
         self, _: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by zeroconf."""
         return self._async_create_entry()
 
     @callback
     def _async_show_setup_form(
         self, errors: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",
@@ -83,7 +81,7 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
     @callback
-    def _async_create_entry(self) -> FlowResultDict:
+    def _async_create_entry(self) -> FlowResult:
         return self.async_create_entry(
             title=self.serial_number,
             data={

--- a/homeassistant/components/enphase_envoy/config_flow.py
+++ b/homeassistant/components/enphase_envoy/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.httpx_client import get_async_client
 
@@ -132,7 +132,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the initial step."""
         errors = {}
 

--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     _LOGGER,
@@ -28,11 +28,11 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
         """Initialize HomematicIP Cloud config flow."""
         self.auth = None
 
-    async def async_step_user(self, user_input=None) -> FlowResultDict:
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle a flow initialized by the user."""
         return await self.async_step_init(user_input)
 
-    async def async_step_init(self, user_input=None) -> FlowResultDict:
+    async def async_step_init(self, user_input=None) -> FlowResult:
         """Handle a flow start."""
         errors = {}
 
@@ -63,7 +63,7 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
             errors=errors,
         )
 
-    async def async_step_link(self, user_input=None) -> FlowResultDict:
+    async def async_step_link(self, user_input=None) -> FlowResult:
         """Attempt to link with the HomematicIP Cloud access point."""
         errors = {}
 
@@ -85,7 +85,7 @@ class HomematicipCloudFlowHandler(config_entries.ConfigFlow):
 
         return self.async_show_form(step_id="link", errors=errors)
 
-    async def async_step_import(self, import_info) -> FlowResultDict:
+    async def async_step_import(self, import_info) -> FlowResult:
         """Import a new access point as a config entry."""
         hapid = import_info[HMIPC_HAPID].replace("-", "").upper()
         authtoken = import_info[HMIPC_AUTHTOKEN]

--- a/homeassistant/components/huawei_lte/config_flow.py
+++ b/homeassistant/components/huawei_lte/config_flow.py
@@ -29,7 +29,7 @@ from homeassistant.const import (
     CONF_USERNAME,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 from .const import (
@@ -62,7 +62,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self,
         user_input: dict[str, Any] | None = None,
         errors: dict[str, str] | None = None,
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         if user_input is None:
             user_input = {}
         return self.async_show_form(
@@ -89,7 +89,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle import initiated config flow."""
         return await self.async_step_user(user_input)
 
@@ -103,7 +103,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(  # noqa: C901
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle user initiated config flow."""
         if user_input is None:
             return await self._async_show_user_form()
@@ -215,9 +215,7 @@ class ConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=title, data=user_input)
 
-    async def async_step_ssdp(
-        self, discovery_info: DiscoveryInfoType
-    ) -> FlowResultDict:
+    async def async_step_ssdp(self, discovery_info: DiscoveryInfoType) -> FlowResult:
         """Handle SSDP initiated config flow."""
         await self.async_set_unique_id(discovery_info[ssdp.ATTR_UPNP_UDN])
         self._abort_if_unique_id_configured()
@@ -258,7 +256,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle options flow."""
 
         # Recipients are persisted as a list, but handled as comma separated string in UI

--- a/homeassistant/components/hue/config_flow.py
+++ b/homeassistant/components/hue/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant import config_entries, core
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, CONF_USERNAME
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
 
 from .bridge import authenticate_bridge
@@ -118,7 +118,7 @@ class HueFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_manual(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle manual bridge setup."""
         if user_input is None:
             return self.async_show_form(
@@ -253,7 +253,7 @@ class HueOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Manage Hue options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/hyperion/config_flow.py
+++ b/homeassistant/components/hyperion/config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.const import (
     CONF_TOKEN,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
@@ -131,7 +131,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def _advance_to_auth_step_if_necessary(
         self, hyperion_client: client.HyperionClient
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Determine if auth is required."""
         auth_resp = await hyperion_client.async_is_auth_required()
 
@@ -146,7 +146,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_reauth(
         self,
         config_data: ConfigType,
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a reauthentication flow."""
         self._data = dict(config_data)
         async with self._create_client(raw_connection=True) as hyperion_client:
@@ -154,7 +154,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="cannot_connect")
             return await self._advance_to_auth_step_if_necessary(hyperion_client)
 
-    async def async_step_ssdp(self, discovery_info: dict[str, Any]) -> FlowResultDict:
+    async def async_step_ssdp(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle a flow initiated by SSDP."""
         # Sample data provided by SSDP: {
         #   'ssdp_location': 'http://192.168.0.1:8090/description.xml',
@@ -225,7 +225,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self,
         user_input: ConfigType | None = None,
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
         errors = {}
         if user_input:
@@ -296,7 +296,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_auth(
         self,
         user_input: ConfigType | None = None,
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the auth step of a flow."""
         errors = {}
         if user_input:
@@ -325,7 +325,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_create_token(
         self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Send a request for a new token."""
         if user_input is None:
             self._auth_id = client.generate_random_auth_id()
@@ -351,7 +351,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_create_token_external(
         self, auth_resp: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle completion of the request for a new token."""
         if auth_resp is not None and client.ResponseOK(auth_resp):
             token = auth_resp.get(const.KEY_INFO, {}).get(const.KEY_TOKEN)
@@ -364,7 +364,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_create_token_success(
         self, _: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Create an entry after successful token creation."""
         # Clean-up the request task.
         await self._cancel_request_token_task()
@@ -380,7 +380,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_create_token_fail(
         self, _: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Show an error on the auth form."""
         # Clean-up the request task.
         await self._cancel_request_token_task()
@@ -388,7 +388,7 @@ class HyperionConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_confirm(
         self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Get final confirmation before entry creation."""
         if user_input is None and self._require_confirm:
             return self.async_show_form(
@@ -448,7 +448,7 @@ class HyperionOptionsFlow(OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Manage the options."""
 
         effects = {source: source for source in const.KEY_COMPONENTID_EXTERNAL_SOURCES}

--- a/homeassistant/components/ipp/config_flow.py
+++ b/homeassistant/components/ipp/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -63,9 +63,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
         """Set up the instance."""
         self.discovery_info = {}
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         if user_input is None:
             return self._show_setup_form()
@@ -101,7 +99,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=user_input[CONF_HOST], data=user_input)
 
-    async def async_step_zeroconf(self, discovery_info: ConfigType) -> FlowResultDict:
+    async def async_step_zeroconf(self, discovery_info: ConfigType) -> FlowResult:
         """Handle zeroconf discovery."""
         port = discovery_info[CONF_PORT]
         zctype = discovery_info["type"]
@@ -169,7 +167,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf_confirm(
         self, user_input: ConfigType = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a confirmation flow initiated by zeroconf."""
         if user_input is None:
             return self.async_show_form(
@@ -183,7 +181,7 @@ class IPPFlowHandler(ConfigFlow, domain=DOMAIN):
             data=self.discovery_info,
         )
 
-    def _show_setup_form(self, errors: dict | None = None) -> FlowResultDict:
+    def _show_setup_form(self, errors: dict | None = None) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",

--- a/homeassistant/components/litejet/config_flow.py
+++ b/homeassistant/components/litejet/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PORT
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import DOMAIN
 
@@ -22,7 +22,7 @@ class LiteJetConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Create a LiteJet config entry based upon user input."""
         if self.hass.config_entries.async_entries(DOMAIN):
             return self.async_abort(reason="single_instance_allowed")

--- a/homeassistant/components/met/config_flow.py
+++ b/homeassistant/components/met/config_flow.py
@@ -6,7 +6,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_ELEVATION, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -80,7 +80,7 @@ class MetFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=self._errors,
         )
 
-    async def async_step_import(self, user_input: dict | None = None) -> FlowResultDict:
+    async def async_step_import(self, user_input: dict | None = None) -> FlowResult:
         """Handle configuration by yaml file."""
         return await self.async_step_user(user_input)
 

--- a/homeassistant/components/mutesync/config_flow.py
+++ b/homeassistant/components/mutesync/config_flow.py
@@ -11,7 +11,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.exceptions import HomeAssistantError
 
 from .const import DOMAIN
@@ -46,7 +46,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(

--- a/homeassistant/components/mysensors/config_flow.py
+++ b/homeassistant/components/mysensors/config_flow.py
@@ -27,7 +27,7 @@ from homeassistant.components.mysensors import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 
 from . import CONF_RETAIN, CONF_VERSION, DEFAULT_VERSION
@@ -282,7 +282,7 @@ class MySensorsConfigFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def _async_create_entry(
         self, user_input: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Create the config entry."""
         return self.async_create_entry(
             title=f"{user_input[CONF_DEVICE]}",

--- a/homeassistant/components/nzbget/config_flow.py
+++ b/homeassistant/components/nzbget/config_flow.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -67,7 +67,7 @@ class NZBGetConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(
         self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by configuration file."""
         if CONF_SCAN_INTERVAL in user_input:
             user_input[CONF_SCAN_INTERVAL] = user_input[
@@ -76,9 +76,7 @@ class NZBGetConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user(user_input)
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")

--- a/homeassistant/components/plum_lightpad/config_flow.py
+++ b/homeassistant/components/plum_lightpad/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
@@ -35,9 +35,7 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initialized by the user or redirected to by import."""
         if not user_input:
             return self._show_form()
@@ -59,8 +57,6 @@ class PlumLightpadConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             title=username, data={CONF_USERNAME: username, CONF_PASSWORD: password}
         )
 
-    async def async_step_import(
-        self, import_config: ConfigType | None
-    ) -> FlowResultDict:
+    async def async_step_import(self, import_config: ConfigType | None) -> FlowResult:
         """Import a config entry from configuration.yaml."""
         return await self.async_step_user(import_config)

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -7,7 +7,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import ACCOUNT_HASH, DOMAIN
@@ -28,7 +28,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = config_entries.CONN_CLASS_CLOUD_POLL
 
-    async def async_step_user(self, user_input=None) -> FlowResultDict:
+    async def async_step_user(self, user_input=None) -> FlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)

--- a/homeassistant/components/roku/config_flow.py
+++ b/homeassistant/components/roku/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.components.ssdp import (
 from homeassistant.config_entries import CONN_CLASS_LOCAL_POLL, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import DOMAIN
@@ -54,7 +54,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
         self.discovery_info = {}
 
     @callback
-    def _show_form(self, errors: dict | None = None) -> FlowResultDict:
+    def _show_form(self, errors: dict | None = None) -> FlowResult:
         """Show the form to the user."""
         return self.async_show_form(
             step_id="user",
@@ -62,7 +62,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
-    async def async_step_user(self, user_input: dict | None = None) -> FlowResultDict:
+    async def async_step_user(self, user_input: dict | None = None) -> FlowResult:
         """Handle a flow initialized by the user."""
         if not user_input:
             return self._show_form()
@@ -113,9 +113,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_discovery_confirm()
 
-    async def async_step_ssdp(
-        self, discovery_info: dict | None = None
-    ) -> FlowResultDict:
+    async def async_step_ssdp(self, discovery_info: dict | None = None) -> FlowResult:
         """Handle a flow initialized by discovery."""
         host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
         name = discovery_info[ATTR_UPNP_FRIENDLY_NAME]
@@ -141,7 +139,7 @@ class RokuConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_discovery_confirm(
         self, user_input: dict | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle user-confirmation of discovered device."""
         if user_input is None:
             return self.async_show_form(

--- a/homeassistant/components/rpi_power/config_flow.py
+++ b/homeassistant/components/rpi_power/config_flow.py
@@ -7,7 +7,7 @@ from rpi_bad_power import new_under_voltage
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.config_entry_flow import DiscoveryFlowHandler
 
 from .const import DOMAIN
@@ -35,7 +35,7 @@ class RPiPowerFlow(DiscoveryFlowHandler, domain=DOMAIN):
 
     async def async_step_onboarding(
         self, data: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initialized by onboarding."""
         has_devices = await self._discovery_function(self.hass)
 

--- a/homeassistant/components/sentry/config_flow.py
+++ b/homeassistant/components/sentry/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     CONF_DSN,
@@ -49,7 +49,7 @@ class SentryConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a user config flow."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -80,7 +80,7 @@ class SentryOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Manage Sentry options."""
         if user_input is not None:
             return self.async_create_entry(title="", data=user_input)

--- a/homeassistant/components/sma/config_flow.py
+++ b/homeassistant/components/sma/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_SSL,
     CONF_VERIFY_SSL,
 )
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
@@ -69,7 +69,7 @@ class SmaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """First step in config flow."""
         errors = {}
         if user_input is not None:
@@ -118,7 +118,7 @@ class SmaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(
         self, import_config: dict[str, Any] | None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Import a config flow from configuration."""
         device_info = await validate_input(self.hass, import_config)
         import_config[DEVICE_INFO] = device_info

--- a/homeassistant/components/solaredge/config_flow.py
+++ b/homeassistant/components/solaredge/config_flow.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_API_KEY, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.util import slugify
 
 from .const import CONF_SITE_ID, DEFAULT_NAME, DOMAIN
@@ -57,7 +57,7 @@ class SolarEdgeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Step when user initializes a integration."""
         self._errors = {}
         if user_input is not None:
@@ -93,7 +93,7 @@ class SolarEdgeConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_import(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Import a config entry."""
         if self._site_in_configuration_exists(user_input[CONF_SITE_ID]):
             return self.async_abort(reason="already_configured")

--- a/homeassistant/components/sonarr/config_flow.py
+++ b/homeassistant/components/sonarr/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -76,7 +76,7 @@ class SonarrConfigFlow(ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return SonarrOptionsFlowHandler(config_entry)
 
-    async def async_step_reauth(self, data: ConfigType | None = None) -> FlowResultDict:
+    async def async_step_reauth(self, data: ConfigType | None = None) -> FlowResult:
         """Handle configuration by re-auth."""
         self._reauth = True
         self._entry_data = dict(data)
@@ -87,7 +87,7 @@ class SonarrConfigFlow(ConfigFlow, domain=DOMAIN):
 
     async def async_step_reauth_confirm(
         self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Confirm reauth dialog."""
         if user_input is None:
             return self.async_show_form(
@@ -99,9 +99,7 @@ class SonarrConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return await self.async_step_user()
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         errors = {}
 
@@ -138,9 +136,7 @@ class SonarrConfigFlow(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def _async_reauth_update_entry(
-        self, entry_id: str, data: dict
-    ) -> FlowResultDict:
+    async def _async_reauth_update_entry(self, entry_id: str, data: dict) -> FlowResult:
         """Update existing config entry."""
         entry = self.hass.config_entries.async_get_entry(entry_id)
         self.hass.config_entries.async_update_entry(entry, data=data)

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -9,7 +9,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import persistent_notification
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_entry_oauth2_flow
 
 from .const import DOMAIN, SPOTIFY_SCOPES
@@ -39,7 +39,7 @@ class SpotifyFlowHandler(
         """Extra data that needs to be appended to the authorize url."""
         return {"scope": ",".join(SPOTIFY_SCOPES)}
 
-    async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResultDict:
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResult:
         """Create an entry for Spotify."""
         spotify = Spotify(auth=data["token"]["access_token"])
 
@@ -61,7 +61,7 @@ class SpotifyFlowHandler(
 
         return self.async_create_entry(title=name, data=data)
 
-    async def async_step_reauth(self, entry: dict[str, Any]) -> FlowResultDict:
+    async def async_step_reauth(self, entry: dict[str, Any]) -> FlowResult:
         """Perform reauth upon migration of old entries."""
         if entry:
             self.entry = entry
@@ -77,7 +77,7 @@ class SpotifyFlowHandler(
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Confirm reauth dialog."""
         if user_input is None:
             return self.async_show_form(

--- a/homeassistant/components/toon/config_flow.py
+++ b/homeassistant/components/toon/config_flow.py
@@ -8,7 +8,7 @@ from toonapi import Agreement, Toon, ToonError
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
 
@@ -30,7 +30,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         """Return logger."""
         return logging.getLogger(__name__)
 
-    async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResultDict:
+    async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResult:
         """Test connection and load up agreements."""
         self.data = data
 
@@ -50,7 +50,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     async def async_step_import(
         self, config: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Start a configuration flow based on imported data.
 
         This step is merely here to trigger "discovery" when the `toon`
@@ -67,7 +67,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     async def async_step_agreement(
         self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Select Toon agreement to add."""
         if len(self.agreements) == 1:
             return await self._create_entry(self.agreements[0])
@@ -88,7 +88,7 @@ class ToonFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
         agreement_index = agreements_list.index(user_input[CONF_AGREEMENT])
         return await self._create_entry(self.agreements[agreement_index])
 
-    async def _create_entry(self, agreement: Agreement) -> FlowResultDict:
+    async def _create_entry(self, agreement: Agreement) -> FlowResult:
         if CONF_MIGRATE in self.context:
             await self.hass.config_entries.async_remove(self.context[CONF_MIGRATE])
 

--- a/homeassistant/components/twentemilieu/config_flow.py
+++ b/homeassistant/components/twentemilieu/config_flow.py
@@ -13,7 +13,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigFlow
 from homeassistant.const import CONF_ID
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import CONF_HOUSE_LETTER, CONF_HOUSE_NUMBER, CONF_POST_CODE, DOMAIN
@@ -27,7 +27,7 @@ class TwenteMilieuFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def _show_setup_form(
         self, errors: dict[str, str] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",
@@ -43,7 +43,7 @@ class TwenteMilieuFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by the user."""
         if user_input is None:
             return await self._show_setup_form(user_input)

--- a/homeassistant/components/verisure/config_flow.py
+++ b/homeassistant/components/verisure/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     CONF_GIID,
@@ -58,7 +58,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the initial step."""
         errors: dict[str, str] = {}
 
@@ -97,7 +97,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_installation(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Select Verisure installation to add."""
         if len(self.installations) == 1:
             user_input = {CONF_GIID: list(self.installations)[0]}
@@ -125,14 +125,14 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_reauth(self, data: dict[str, Any]) -> FlowResultDict:
+    async def async_step_reauth(self, data: dict[str, Any]) -> FlowResult:
         """Handle initiation of re-authentication with Verisure."""
         self.entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle re-authentication with Verisure."""
         errors: dict[str, str] = {}
 
@@ -174,7 +174,7 @@ class VerisureConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResultDict:
+    async def async_step_import(self, user_input: dict[str, Any]) -> FlowResult:
         """Import Verisure YAML configuration."""
         if user_input[CONF_GIID]:
             self.giid = user_input[CONF_GIID]
@@ -204,7 +204,7 @@ class VerisureOptionsFlowHandler(OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Manage Verisure options."""
         errors = {}
 

--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -30,7 +30,7 @@ from homeassistant.const import (
     CONF_TYPE,
 )
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import DiscoveryInfoType
@@ -110,9 +110,7 @@ class VizioOptionsConfigFlow(config_entries.OptionsFlow):
         """Initialize vizio options flow."""
         self.config_entry = config_entry
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    async def async_step_init(self, user_input: dict[str, Any] = None) -> FlowResult:
         """Manage the vizio options."""
         if user_input is not None:
             if user_input.get(CONF_APPS_TO_INCLUDE_OR_EXCLUDE):
@@ -194,7 +192,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._data = None
         self._apps = {}
 
-    async def _create_entry(self, input_dict: dict[str, Any]) -> FlowResultDict:
+    async def _create_entry(self, input_dict: dict[str, Any]) -> FlowResult:
         """Create vizio config entry."""
         # Remove extra keys that will not be used by entry setup
         input_dict.pop(CONF_APPS_TO_INCLUDE_OR_EXCLUDE, None)
@@ -205,9 +203,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_create_entry(title=input_dict[CONF_NAME], data=input_dict)
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: dict[str, Any] = None) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
 
@@ -280,7 +276,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
 
-    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResultDict:
+    async def async_step_import(self, import_config: dict[str, Any]) -> FlowResult:
         """Import a config entry from configuration.yaml."""
         # Check if new config entry matches any existing config entries
         for entry in self.hass.config_entries.async_entries(DOMAIN):
@@ -344,7 +340,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf(
         self, discovery_info: DiscoveryInfoType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle zeroconf discovery."""
         # If host already has port, no need to add it again
         if ":" not in discovery_info[CONF_HOST]:
@@ -379,9 +375,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._must_show_form = True
         return await self.async_step_user(user_input=discovery_info)
 
-    async def async_step_pair_tv(
-        self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    async def async_step_pair_tv(self, user_input: dict[str, Any] = None) -> FlowResult:
         """
         Start pairing process for TV.
 
@@ -446,7 +440,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
         )
 
-    async def _pairing_complete(self, step_id: str) -> FlowResultDict:
+    async def _pairing_complete(self, step_id: str) -> FlowResult:
         """Handle config flow completion."""
         if not self._must_show_form:
             return await self._create_entry(self._data)
@@ -460,7 +454,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_pairing_complete(
         self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """
         Complete non-import sourced config flow.
 
@@ -470,7 +464,7 @@ class VizioConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_pairing_complete_import(
         self, user_input: dict[str, Any] = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """
         Complete import sourced config flow.
 

--- a/homeassistant/components/wled/config_flow.py
+++ b/homeassistant/components/wled/config_flow.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import (
     ConfigFlow,
 )
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -23,15 +23,13 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
     VERSION = 1
     CONNECTION_CLASS = CONN_CLASS_LOCAL_POLL
 
-    async def async_step_user(
-        self, user_input: ConfigType | None = None
-    ) -> FlowResultDict:
+    async def async_step_user(self, user_input: ConfigType | None = None) -> FlowResult:
         """Handle a flow initiated by the user."""
         return await self._handle_config_flow(user_input)
 
     async def async_step_zeroconf(
         self, discovery_info: ConfigType | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle zeroconf discovery."""
         if discovery_info is None:
             return self.async_abort(reason="cannot_connect")
@@ -54,13 +52,13 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_zeroconf_confirm(
         self, user_input: ConfigType = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initiated by zeroconf."""
         return await self._handle_config_flow(user_input)
 
     async def _handle_config_flow(
         self, user_input: ConfigType | None = None, prepare: bool = False
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Config flow handler for WLED."""
         source = self.context.get("source")
 
@@ -101,7 +99,7 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
             data={CONF_HOST: user_input[CONF_HOST], CONF_MAC: user_input[CONF_MAC]},
         )
 
-    def _show_setup_form(self, errors: dict | None = None) -> FlowResultDict:
+    def _show_setup_form(self, errors: dict | None = None) -> FlowResult:
         """Show the setup form to the user."""
         return self.async_show_form(
             step_id="user",
@@ -109,7 +107,7 @@ class WLEDFlowHandler(ConfigFlow, domain=DOMAIN):
             errors=errors or {},
         )
 
-    def _show_confirm_dialog(self, errors: dict | None = None) -> FlowResultDict:
+    def _show_confirm_dialog(self, errors: dict | None = None) -> FlowResult:
         """Show the confirm dialog to the user."""
         name = self.context.get(CONF_NAME)
         return self.async_show_form(

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -14,7 +14,7 @@ from homeassistant import config_entries, exceptions
 from homeassistant.components.hassio import is_hassio
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import AbortFlow, FlowResultDict
+from homeassistant.data_entry_flow import AbortFlow, FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .addon import AddonError, AddonManager, get_addon_manager
@@ -89,7 +89,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle the initial step."""
         if is_hassio(self.hass):
             return await self.async_step_on_supervisor()
@@ -98,7 +98,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_manual(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a manual configuration."""
         if user_input is None:
             return self.async_show_form(
@@ -134,7 +134,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="manual", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
 
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResultDict:
+    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Receive configuration from add-on discovery info.
 
         This flow is triggered by the Z-Wave JS add-on.
@@ -152,7 +152,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_hassio_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Confirm the add-on discovery."""
         if user_input is not None:
             return await self.async_step_on_supervisor(
@@ -162,7 +162,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(step_id="hassio_confirm")
 
     @callback
-    def _async_create_entry_from_vars(self) -> FlowResultDict:
+    def _async_create_entry_from_vars(self) -> FlowResult:
         """Return a config entry for the flow."""
         return self.async_create_entry(
             title=TITLE,
@@ -177,7 +177,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_on_supervisor(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle logic when on Supervisor host."""
         if user_input is None:
             return self.async_show_form(
@@ -201,7 +201,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_install_addon(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Install Z-Wave JS add-on."""
         if not self.install_task:
             self.install_task = self.hass.async_create_task(self._async_install_addon())
@@ -221,13 +221,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_install_failed(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Add-on installation failed."""
         return self.async_abort(reason="addon_install_failed")
 
     async def async_step_configure_addon(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Ask for config for Z-Wave JS add-on."""
         addon_config = await self._async_get_addon_config()
 
@@ -263,7 +263,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_start_addon(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Start Z-Wave JS add-on."""
         if not self.start_task:
             self.start_task = self.hass.async_create_task(self._async_start_addon())
@@ -281,7 +281,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_start_failed(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Add-on start failed."""
         return self.async_abort(reason="addon_start_failed")
 
@@ -318,7 +318,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_finish_addon_setup(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Prepare info needed to complete the config entry.
 
         Get add-on discovery info and server version info.

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -579,8 +579,8 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
         self._hass_config = hass_config
 
     async def async_finish_flow(
-        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResultDict
-    ) -> data_entry_flow.FlowResultDict:
+        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResult
+    ) -> data_entry_flow.FlowResult:
         """Finish a config flow and add an entry."""
         flow = cast(ConfigFlow, flow)
 
@@ -688,7 +688,7 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
         return flow
 
     async def async_post_init(
-        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResultDict
+        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResult
     ) -> None:
         """After a flow is initialised trigger new flow notifications."""
         source = flow.context["source"]
@@ -1190,7 +1190,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     @callback
     def _async_in_progress(
         self, include_uninitialized: bool = False
-    ) -> list[data_entry_flow.FlowResultDict]:
+    ) -> list[data_entry_flow.FlowResult]:
         """Return other in progress flows for current domain."""
         return [
             flw
@@ -1202,20 +1202,20 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     async def async_step_ignore(
         self, user_input: dict[str, Any]
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Ignore this config flow."""
         await self.async_set_unique_id(user_input["unique_id"], raise_on_progress=False)
         return self.async_create_entry(title=user_input["title"], data={})
 
     async def async_step_unignore(
         self, user_input: dict[str, Any]
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Rediscover a config entry by it's unique_id."""
         return self.async_abort(reason="not_implemented")
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initiated by the user."""
         return self.async_abort(reason="not_implemented")
 
@@ -1245,7 +1245,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     async def async_step_discovery(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by discovery."""
         await self._async_handle_discovery_without_unique_id()
         return await self.async_step_user()
@@ -1253,7 +1253,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     @callback
     def async_abort(
         self, *, reason: str, description_placeholders: dict | None = None
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Abort the config flow."""
         # Remove reauth notification if no reauth flows are in progress
         if self.source == SOURCE_REAUTH and not any(
@@ -1271,37 +1271,37 @@ class ConfigFlow(data_entry_flow.FlowHandler):
 
     async def async_step_hassio(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by HASS IO discovery."""
         return await self.async_step_discovery(discovery_info)
 
     async def async_step_homekit(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by Homekit discovery."""
         return await self.async_step_discovery(discovery_info)
 
     async def async_step_mqtt(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by MQTT discovery."""
         return await self.async_step_discovery(discovery_info)
 
     async def async_step_ssdp(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by SSDP discovery."""
         return await self.async_step_discovery(discovery_info)
 
     async def async_step_zeroconf(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by Zeroconf discovery."""
         return await self.async_step_discovery(discovery_info)
 
     async def async_step_dhcp(
         self, discovery_info: DiscoveryInfoType
-    ) -> data_entry_flow.FlowResultDict:
+    ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by DHCP discovery."""
         return await self.async_step_discovery(discovery_info)
 
@@ -1330,8 +1330,8 @@ class OptionsFlowManager(data_entry_flow.FlowManager):
         return cast(OptionsFlow, HANDLERS[entry.domain].async_get_options_flow(entry))
 
     async def async_finish_flow(
-        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResultDict
-    ) -> data_entry_flow.FlowResultDict:
+        self, flow: data_entry_flow.FlowHandler, result: data_entry_flow.FlowResult
+    ) -> data_entry_flow.FlowResult:
         """Finish an options flow and update options for configuration entry.
 
         Flow.handler and entry_id is the same thing to map flow with entry.

--- a/homeassistant/helpers/config_entry_flow.py
+++ b/homeassistant/helpers/config_entry_flow.py
@@ -5,7 +5,7 @@ from typing import Any, Awaitable, Callable, Union
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
 DiscoveryFunctionType = Callable[[], Union[Awaitable[bool], bool]]
@@ -31,7 +31,7 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -42,7 +42,7 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Confirm setup."""
         if user_input is None:
             self._set_confirm_only()
@@ -72,7 +72,7 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_discovery(
         self, discovery_info: DiscoveryInfoType
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow initialized by discovery."""
         if self._async_in_progress() or self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -87,7 +87,7 @@ class DiscoveryFlowHandler(config_entries.ConfigFlow):
     async_step_homekit = async_step_discovery
     async_step_dhcp = async_step_discovery
 
-    async def async_step_import(self, _: dict[str, Any] | None) -> FlowResultDict:
+    async def async_step_import(self, _: dict[str, Any] | None) -> FlowResult:
         """Handle a flow initialized by import."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -137,7 +137,7 @@ class WebhookFlowHandler(config_entries.ConfigFlow):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a user initiated set up flow to create a webhook."""
         if not self._allow_multiple and self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")

--- a/homeassistant/helpers/config_entry_oauth2_flow.py
+++ b/homeassistant/helpers/config_entry_oauth2_flow.py
@@ -24,7 +24,7 @@ from yarl import URL
 from homeassistant import config_entries
 from homeassistant.components import http
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import FlowResultDict
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.network import NoURLAvailableError
 
 from .aiohttp_client import async_get_clientsession
@@ -236,7 +236,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
 
     async def async_step_pick_implementation(
         self, user_input: dict | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Handle a flow start."""
         implementations = await async_get_implementations(self.hass, self.DOMAIN)
 
@@ -267,7 +267,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
 
     async def async_step_auth(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Create an entry for auth."""
         # Flow has been triggered by external data
         if user_input:
@@ -293,7 +293,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
 
     async def async_step_creation(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResultDict:
+    ) -> FlowResult:
         """Create config entry from external data."""
         token = await self.flow_impl.async_resolve_external_data(self.external_data)
         # Force int for non-compliant oauth2 providers
@@ -310,7 +310,7 @@ class AbstractOAuth2FlowHandler(config_entries.ConfigFlow, metaclass=ABCMeta):
             {"auth_implementation": self.flow_impl.domain, "token": token}
         )
 
-    async def async_oauth_create_entry(self, data: dict) -> FlowResultDict:
+    async def async_oauth_create_entry(self, data: dict) -> FlowResult:
         """Create an entry for the flow.
 
         Ok to override if you want to fetch extra info or even add another step.

--- a/homeassistant/helpers/data_entry_flow.py
+++ b/homeassistant/helpers/data_entry_flow.py
@@ -22,8 +22,8 @@ class _BaseFlowManagerView(HomeAssistantView):
 
     # pylint: disable=no-self-use
     def _prepare_result_json(
-        self, result: data_entry_flow.FlowResultDict
-    ) -> data_entry_flow.FlowResultDict:
+        self, result: data_entry_flow.FlowResult
+    ) -> data_entry_flow.FlowResult:
         """Convert result to JSON."""
         if result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY:
             data = result.copy()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Two main reasons for that:
1. https://github.com/home-assistant/core/pull/49670 add `DeviceInfo` which is similar `TypedDict` and it doesn't have `Dict` suffix. Let's be consistent with naming of such things.
2. `FlowResult` is just cleaner and more natural than `FlowResultDict`.

`FlowResultDict` was added in https://github.com/home-assistant/core/pull/49260

If if we decide to go with this, can we include it in 2021.5.0 release? Otherwise `FlowResultDict` will be released with it and if custom components start using it, they will have broken import in 2021.6.0.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
