### PR TITLE
Allow str 1..n-tuples in device registry identifier type hints

### DIFF
--- a/homeassistant/components/huawei_lte/__init__.py
+++ b/homeassistant/components/huawei_lte/__init__.py
@@ -162,7 +162,7 @@ class Router:
         return DEFAULT_DEVICE_NAME
 
     @property
-    def device_identifiers(self) -> set[tuple[str, str]]:
+    def device_identifiers(self) -> set[tuple[str, ...]]:
         """Get router identifiers for device registry."""
         try:
             return {(DOMAIN, self.data[KEY_DEVICE_INFORMATION]["SerialNumber"])}

--- a/homeassistant/components/syncthru/__init__.py
+++ b/homeassistant/components/syncthru/__init__.py
@@ -60,7 +60,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return unload_ok
 
 
-def device_identifiers(printer: SyncThru) -> set[tuple[str, str]]:
+def device_identifiers(printer: SyncThru) -> set[tuple[str, ...]]:
     """Get device identifiers for device registry."""
     return {(DOMAIN, printer.serial_number())}
 

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -43,7 +43,7 @@ def get_device_id(client: ZwaveClient, node: ZwaveNode) -> tuple[str, str]:
 
 
 @callback
-def get_home_and_node_id_from_device_id(device_id: tuple[str, str]) -> list[str]:
+def get_home_and_node_id_from_device_id(device_id: tuple[str, ...]) -> list[str]:
     """
     Get home ID and node ID for Z-Wave device registry entry.
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -55,7 +55,7 @@ class DeviceEntry:
 
     config_entries: set[str] = attr.ib(converter=set, factory=set)
     connections: set[tuple[str, str]] = attr.ib(converter=set, factory=set)
-    identifiers: set[tuple[str, str]] = attr.ib(converter=set, factory=set)
+    identifiers: set[tuple[str, ...]] = attr.ib(converter=set, factory=set)
     manufacturer: str | None = attr.ib(default=None)
     model: str | None = attr.ib(default=None)
     name: str | None = attr.ib(default=None)
@@ -92,7 +92,7 @@ class DeletedDeviceEntry:
 
     config_entries: set[str] = attr.ib()
     connections: set[tuple[str, str]] = attr.ib()
-    identifiers: set[tuple[str, str]] = attr.ib()
+    identifiers: set[tuple[str, ...]] = attr.ib()
     id: str = attr.ib()
     orphaned_timestamp: float | None = attr.ib()
 
@@ -100,7 +100,7 @@ class DeletedDeviceEntry:
         self,
         config_entry_id: str,
         connections: set[tuple[str, str]],
-        identifiers: set[tuple[str, str]],
+        identifiers: set[tuple[str, ...]],
     ) -> DeviceEntry:
         """Create DeviceEntry from DeletedDeviceEntry."""
         return DeviceEntry(
@@ -138,7 +138,7 @@ class DeviceRegistry:
 
     devices: dict[str, DeviceEntry]
     deleted_devices: dict[str, DeletedDeviceEntry]
-    _devices_index: dict[str, dict[str, dict[tuple[str, str], str]]]
+    _devices_index: dict[str, dict[str, dict[tuple[str, ...], str]]]
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the device registry."""
@@ -154,7 +154,7 @@ class DeviceRegistry:
     @callback
     def async_get_device(
         self,
-        identifiers: set[tuple[str, str]],
+        identifiers: set[tuple[str, ...]],
         connections: set[tuple[str, str]] | None = None,
     ) -> DeviceEntry | None:
         """Check if device is registered."""
@@ -167,7 +167,7 @@ class DeviceRegistry:
 
     def _async_get_deleted_device(
         self,
-        identifiers: set[tuple[str, str]],
+        identifiers: set[tuple[str, ...]],
         connections: set[tuple[str, str]] | None,
     ) -> DeletedDeviceEntry | None:
         """Check if device is deleted."""
@@ -181,7 +181,7 @@ class DeviceRegistry:
     def _async_get_device_id_from_index(
         self,
         index: str,
-        identifiers: set[tuple[str, str]],
+        identifiers: set[tuple[str, ...]],
         connections: set[tuple[str, str]] | None,
     ) -> str | None:
         """Check if device has previously been registered."""
@@ -247,7 +247,7 @@ class DeviceRegistry:
         *,
         config_entry_id: str,
         connections: set[tuple[str, str]] | None = None,
-        identifiers: set[tuple[str, str]] | None = None,
+        identifiers: set[tuple[str, ...]] | None = None,
         manufacturer: str | None | UndefinedType = UNDEFINED,
         model: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
@@ -331,7 +331,7 @@ class DeviceRegistry:
         model: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
         name_by_user: str | None | UndefinedType = UNDEFINED,
-        new_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
+        new_identifiers: set[tuple[str, ...]] | UndefinedType = UNDEFINED,
         sw_version: str | None | UndefinedType = UNDEFINED,
         via_device_id: str | None | UndefinedType = UNDEFINED,
         remove_config_entry_id: str | UndefinedType = UNDEFINED,
@@ -362,8 +362,8 @@ class DeviceRegistry:
         add_config_entry_id: str | UndefinedType = UNDEFINED,
         remove_config_entry_id: str | UndefinedType = UNDEFINED,
         merge_connections: set[tuple[str, str]] | UndefinedType = UNDEFINED,
-        merge_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
-        new_identifiers: set[tuple[str, str]] | UndefinedType = UNDEFINED,
+        merge_identifiers: set[tuple[str, ...]] | UndefinedType = UNDEFINED,
+        new_identifiers: set[tuple[str, ...]] | UndefinedType = UNDEFINED,
         manufacturer: str | None | UndefinedType = UNDEFINED,
         model: str | None | UndefinedType = UNDEFINED,
         name: str | None | UndefinedType = UNDEFINED,
@@ -521,7 +521,7 @@ class DeviceRegistry:
                     config_entries=set(device["config_entries"]),
                     # type ignores (if tuple arg was cast): likely https://github.com/python/mypy/issues/8625
                     connections={tuple(conn) for conn in device["connections"]},  # type: ignore[misc]
-                    identifiers={tuple(iden) for iden in device["identifiers"]},  # type: ignore[misc]
+                    identifiers={tuple(iden) for iden in device["identifiers"]},
                     id=device["id"],
                     # Introduced in 2021.2
                     orphaned_timestamp=device.get("orphaned_timestamp"),
@@ -786,7 +786,7 @@ def _normalize_connections(connections: set[tuple[str, str]]) -> set[tuple[str, 
 
 
 def _add_device_to_index(
-    devices_index: dict[str, dict[tuple[str, str], str]],
+    devices_index: dict[str, dict[tuple[str, ...], str]],
     device: DeviceEntry | DeletedDeviceEntry,
 ) -> None:
     """Add a device to the index."""
@@ -797,7 +797,7 @@ def _add_device_to_index(
 
 
 def _remove_device_from_index(
-    devices_index: dict[str, dict[tuple[str, str], str]],
+    devices_index: dict[str, dict[tuple[str, ...], str]],
     device: DeviceEntry | DeletedDeviceEntry,
 ) -> None:
     """Remove a device from the index."""


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This reflects current practice, but the intent has been to have them as
2-tuples, and a future change is likely to start enforcing that (again).

Refs https://github.com/home-assistant/core/pull/49670#discussion_r622344872


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #49670
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
