### PR TITLE
Fix options flow bugs in Google/Waze Time Travel

### DIFF
--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -63,7 +63,7 @@ class GoogleOptionsFlow(config_entries.OptionsFlow):
             default_time = self.config_entry.options[CONF_ARRIVAL_TIME]
         else:
             default_time_type = DEPARTURE_TIME
-            default_time = self.config_entry.options.get(CONF_ARRIVAL_TIME)
+            default_time = self.config_entry.options.get(CONF_ARRIVAL_TIME, "")
 
         return self.async_show_form(
             step_id="init",
@@ -75,10 +75,10 @@ class GoogleOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_LANGUAGE,
                         default=self.config_entry.options.get(CONF_LANGUAGE),
-                    ): vol.In(ALL_LANGUAGES),
+                    ): vol.In([None, *ALL_LANGUAGES]),
                     vol.Optional(
                         CONF_AVOID, default=self.config_entry.options.get(CONF_AVOID)
-                    ): vol.In(AVOID),
+                    ): vol.In([None, *AVOID]),
                     vol.Optional(
                         CONF_UNITS, default=self.config_entry.options[CONF_UNITS]
                     ): vol.In(UNITS),
@@ -89,17 +89,17 @@ class GoogleOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_TRAFFIC_MODEL,
                         default=self.config_entry.options.get(CONF_TRAFFIC_MODEL),
-                    ): vol.In(TRAVEL_MODEL),
+                    ): vol.In([None, *TRAVEL_MODEL]),
                     vol.Optional(
                         CONF_TRANSIT_MODE,
                         default=self.config_entry.options.get(CONF_TRANSIT_MODE),
-                    ): vol.In(TRANSPORT_TYPE),
+                    ): vol.In([None, *TRANSPORT_TYPE]),
                     vol.Optional(
                         CONF_TRANSIT_ROUTING_PREFERENCE,
                         default=self.config_entry.options.get(
                             CONF_TRANSIT_ROUTING_PREFERENCE
                         ),
-                    ): vol.In(TRANSIT_PREFS),
+                    ): vol.In([None, *TRANSIT_PREFS]),
                 }
             ),
         )

--- a/homeassistant/components/google_travel_time/config_flow.py
+++ b/homeassistant/components/google_travel_time/config_flow.py
@@ -56,7 +56,10 @@ class GoogleOptionsFlow(config_entries.OptionsFlow):
                     user_input[CONF_ARRIVAL_TIME] = time
                 else:
                     user_input[CONF_DEPARTURE_TIME] = time
-            return self.async_create_entry(title="", data=user_input)
+            return self.async_create_entry(
+                title="",
+                data={k: v for k, v in user_input.items() if v not in (None, "")},
+            )
 
         if CONF_ARRIVAL_TIME in self.config_entry.options:
             default_time_type = ARRIVAL_TIME

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -41,10 +41,6 @@ class WazeOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Handle the initial step."""
         if user_input is not None:
-            for key in user_input:
-                if user_input[key] in (None, ""):
-                    user_input.pop(key)
-
             return self.async_create_entry(
                 title="",
                 data={k: v for k, v in user_input.items() if v not in (None, "")},

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -41,7 +41,14 @@ class WazeOptionsFlow(config_entries.OptionsFlow):
     async def async_step_init(self, user_input=None):
         """Handle the initial step."""
         if user_input is not None:
-            return self.async_create_entry(title="", data=user_input)
+            for key in user_input:
+                if user_input[key] in (None, ""):
+                    user_input.pop(key)
+
+            return self.async_create_entry(
+                title="",
+                data={k: v for k, v in user_input.items() if v not in (None, "")},
+            )
 
         return self.async_show_form(
             step_id="init",

--- a/homeassistant/components/waze_travel_time/config_flow.py
+++ b/homeassistant/components/waze_travel_time/config_flow.py
@@ -49,11 +49,11 @@ class WazeOptionsFlow(config_entries.OptionsFlow):
                 {
                     vol.Optional(
                         CONF_INCL_FILTER,
-                        default=self.config_entry.options.get(CONF_INCL_FILTER),
+                        default=self.config_entry.options.get(CONF_INCL_FILTER, ""),
                     ): cv.string,
                     vol.Optional(
                         CONF_EXCL_FILTER,
-                        default=self.config_entry.options.get(CONF_EXCL_FILTER),
+                        default=self.config_entry.options.get(CONF_EXCL_FILTER, ""),
                     ): cv.string,
                     vol.Optional(
                         CONF_REALTIME,

--- a/homeassistant/components/waze_travel_time/sensor.py
+++ b/homeassistant/components/waze_travel_time/sensor.py
@@ -331,7 +331,11 @@ class WazeTravelTimeData:
                         if excl_filter.lower() not in k.lower()
                     }
 
-                route = list(routes)[0]
+                if len(routes) > 0:
+                    route = list(routes)[0]
+                else:
+                    _LOGGER.warning("No routes found")
+                    return
 
                 self.duration, distance = routes[route]
 


### PR DESCRIPTION
## Proposed change
In config flows, `vol.Optional` seems to have no effect in the sense that it will still treat no value as an input and validate it. Thus, we need to handle cases where the user does not actually fill something in, as they should be able to do. Because this is specific to how the frontend handles validation, I don't know if a test would provide value here.

I also ran into an uncaught exception with the Waze sensor while testing so I have resolved that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
