### PR TITLE
Abstract Rituals API data processing to PyPI

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import ACCOUNT_HASH, COORDINATORS, DEVICES, DOMAIN, HUB, HUBLOT
+from .const import ACCOUNT_HASH, COORDINATORS, DEVICES, DOMAIN, HUBLOT
 
 PLATFORMS = ["binary_sensor", "sensor", "switch"]
 
@@ -70,7 +70,7 @@ class RitualsPerufmeGenieDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN}-{device.data[HUB][HUBLOT]}",
+            name=f"{DOMAIN}-{device.hub_data[HUBLOT]}",
             update_interval=UPDATE_INTERVAL,
         )
 

--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     }
 
     for device in account_devices:
-        hublot = device.data[HUB][HUBLOT]
+        hublot = device.hub_data[HUBLOT]
 
         coordinator = RitualsPerufmeGenieDataUpdateCoordinator(hass, device)
         await coordinator.async_refresh()
@@ -74,7 +74,6 @@ class RitualsPerufmeGenieDataUpdateCoordinator(DataUpdateCoordinator):
             update_interval=UPDATE_INTERVAL,
         )
 
-    async def _async_update_data(self) -> dict:
+    async def _async_update_data(self) -> None:
         """Fetch data from Rituals."""
         await self._device.update_data()
-        return self._device.data

--- a/homeassistant/components/rituals_perfume_genie/binary_sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/binary_sensor.py
@@ -1,4 +1,6 @@
 """Support for Rituals Perfume Genie binary sensors."""
+from __future__ import annotations
+
 from typing import Callable
 
 from pyrituals import Diffuser
@@ -11,8 +13,8 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BATTERY, COORDINATORS, DEVICES, DOMAIN, HUB, ID
-from .entity import SENSORS, DiffuserEntity
+from .const import COORDINATORS, DEVICES, DOMAIN
+from .entity import DiffuserEntity
 
 CHARGING_SUFFIX = " Battery Charging"
 BATTERY_CHARGING_ID = 21
@@ -26,7 +28,7 @@ async def async_setup_entry(
     coordinators = hass.data[DOMAIN][config_entry.entry_id][COORDINATORS]
     entities = []
     for hublot, diffuser in diffusers.items():
-        if BATTERY in diffuser.data[HUB][SENSORS]:
+        if diffuser.has_battery:
             coordinator = coordinators[hublot]
             entities.append(DiffuserBatteryChargingBinarySensor(diffuser, coordinator))
 
@@ -43,7 +45,7 @@ class DiffuserBatteryChargingBinarySensor(DiffuserEntity, BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return the state of the battery charging binary sensor."""
-        return self.coordinator.data[HUB][SENSORS][BATTERY][ID] == BATTERY_CHARGING_ID
+        return self._diffuser.charging
 
     @property
     def device_class(self) -> str:

--- a/homeassistant/components/rituals_perfume_genie/const.py
+++ b/homeassistant/components/rituals_perfume_genie/const.py
@@ -6,8 +6,6 @@ DEVICES = "devices"
 
 ACCOUNT_HASH = "account_hash"
 ATTRIBUTES = "attributes"
-BATTERY = "battc"
-HUB = "hub"
 HUBLOT = "hublot"
 ID = "id"
 SENSORS = "sensors"

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -7,7 +7,7 @@ from pyrituals import Diffuser
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTES, BATTERY, DOMAIN, HUB, HUBLOT, SENSORS
+from .const import ATTRIBUTES, DOMAIN, HUBLOT, SENSORS
 
 MANUFACTURER = "Rituals Cosmetics"
 MODEL = "The Perfume Genie"
@@ -30,8 +30,8 @@ class DiffuserEntity(CoordinatorEntity):
         super().__init__(coordinator)
         self._diffuser = diffuser
         self._entity_suffix = entity_suffix
-        self._hublot = self.coordinator.data[HUB][HUBLOT]
-        self._hubname = self.coordinator.data[HUB][ATTRIBUTES][ROOMNAME]
+        self._hublot = self._diffuser.hub_data[HUBLOT]
+        self._hubname = self._diffuser.hub_data[ATTRIBUTES][ROOMNAME]
 
     @property
     def unique_id(self) -> str:
@@ -46,9 +46,7 @@ class DiffuserEntity(CoordinatorEntity):
     @property
     def available(self) -> bool:
         """Return if the entity is available."""
-        return (
-            super().available and self.coordinator.data[HUB][STATUS] == AVAILABLE_STATE
-        )
+        return super().available and self._diffuser.hub_data[STATUS] == AVAILABLE_STATE
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -57,6 +55,6 @@ class DiffuserEntity(CoordinatorEntity):
             "name": self._hubname,
             "identifiers": {(DOMAIN, self._hublot)},
             "manufacturer": MANUFACTURER,
-            "model": MODEL if BATTERY in self._diffuser.data[HUB][SENSORS] else MODEL2,
-            "sw_version": self.coordinator.data[HUB][SENSORS][VERSION],
+            "model": MODEL if self._diffuser.has_battery else MODEL2,
+            "sw_version": self._diffuser.hub_data[SENSORS][VERSION],
         }

--- a/homeassistant/components/rituals_perfume_genie/manifest.json
+++ b/homeassistant/components/rituals_perfume_genie/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rituals Perfume Genie",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rituals_perfume_genie",
-  "requirements": ["pyrituals==0.0.2"],
+  "requirements": ["pyrituals==0.0.3"],
   "codeowners": ["@milanmeu"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import BATTERY, COORDINATORS, DEVICES, DOMAIN, HUB, ID, SENSORS
+from .const import COORDINATORS, DEVICES, DOMAIN, ID, SENSORS
 from .entity import DiffuserEntity
 
 TITLE = "title"
@@ -44,7 +44,7 @@ async def async_setup_entry(
         entities.append(DiffuserPerfumeSensor(diffuser, coordinator))
         entities.append(DiffuserFillSensor(diffuser, coordinator))
         entities.append(DiffuserWifiSensor(diffuser, coordinator))
-        if BATTERY in diffuser.data[HUB][SENSORS]:
+        if diffuser.has_battery:
             entities.append(DiffuserBatterySensor(diffuser, coordinator))
 
     async_add_entities(entities)
@@ -60,14 +60,14 @@ class DiffuserPerfumeSensor(DiffuserEntity):
     @property
     def icon(self) -> str:
         """Return the perfume sensor icon."""
-        if self.coordinator.data[HUB][SENSORS][PERFUME][ID] == PERFUME_NO_CARTRIDGE_ID:
+        if self._diffuser.hub_data[SENSORS][PERFUME][ID] == PERFUME_NO_CARTRIDGE_ID:
             return "mdi:tag-remove"
         return "mdi:tag-text"
 
     @property
     def state(self) -> str:
         """Return the state of the perfume sensor."""
-        return self.coordinator.data[HUB][SENSORS][PERFUME][TITLE]
+        return self._diffuser.hub_data[SENSORS][PERFUME][TITLE]
 
 
 class DiffuserFillSensor(DiffuserEntity):
@@ -80,14 +80,14 @@ class DiffuserFillSensor(DiffuserEntity):
     @property
     def icon(self) -> str:
         """Return the fill sensor icon."""
-        if self.coordinator.data[HUB][SENSORS][FILL][ID] == FILL_NO_CARTRIDGE_ID:
+        if self._diffuser.hub_data[SENSORS][FILL][ID] == FILL_NO_CARTRIDGE_ID:
             return "mdi:beaker-question"
         return "mdi:beaker"
 
     @property
     def state(self) -> str:
         """Return the state of the fill sensor."""
-        return self.coordinator.data[HUB][SENSORS][FILL][TITLE]
+        return self._diffuser.hub_data[SENSORS][FILL][TITLE]
 
 
 class DiffuserBatterySensor(DiffuserEntity):
@@ -100,15 +100,7 @@ class DiffuserBatterySensor(DiffuserEntity):
     @property
     def state(self) -> int:
         """Return the state of the battery sensor."""
-        # Use ICON because TITLE may change in the future.
-        # ICON filename does not match the image.
-        return {
-            "battery-charge.png": 100,
-            "battery-full.png": 100,
-            "Battery-75.png": 50,
-            "battery-50.png": 25,
-            "battery-low.png": 10,
-        }[self.coordinator.data[HUB][SENSORS][BATTERY][ICON]]
+        return self._diffuser.battery_percentage
 
     @property
     def device_class(self) -> str:
@@ -131,13 +123,7 @@ class DiffuserWifiSensor(DiffuserEntity):
     @property
     def state(self) -> int:
         """Return the state of the wifi sensor."""
-        # Use ICON because TITLE may change in the future.
-        return {
-            "icon-signal.png": 100,
-            "icon-signal-75.png": 70,
-            "icon-signal-low.png": 25,
-            "icon-signal-0.png": 0,
-        }[self.coordinator.data[HUB][SENSORS][WIFI][ICON]]
+        return self._diffuser.wifi_percentage
 
     @property
     def device_class(self) -> str:

--- a/homeassistant/components/rituals_perfume_genie/switch.py
+++ b/homeassistant/components/rituals_perfume_genie/switch.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTES, COORDINATORS, DEVICES, DOMAIN, HUB
+from .const import ATTRIBUTES, COORDINATORS, DEVICES, DOMAIN
 from .entity import DiffuserEntity
 
 FAN = "fanc"
@@ -40,7 +40,7 @@ class DiffuserSwitch(SwitchEntity, DiffuserEntity):
     def __init__(self, diffuser: Diffuser, coordinator: CoordinatorEntity) -> None:
         """Initialize the diffuser switch."""
         super().__init__(diffuser, coordinator, "")
-        self._is_on = self.coordinator.data[HUB][ATTRIBUTES][FAN] == ON_STATE
+        self._is_on = self._diffuser.is_on
 
     @property
     def icon(self) -> str:
@@ -51,8 +51,8 @@ class DiffuserSwitch(SwitchEntity, DiffuserEntity):
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
         attributes = {
-            "fan_speed": self.coordinator.data[HUB][ATTRIBUTES][SPEED],
-            "room_size": self.coordinator.data[HUB][ATTRIBUTES][ROOM],
+            "fan_speed": self._diffuser.hub_data[ATTRIBUTES][SPEED],
+            "room_size": self._diffuser.hub_data[ATTRIBUTES][ROOM],
         }
         return attributes
 
@@ -76,5 +76,5 @@ class DiffuserSwitch(SwitchEntity, DiffuserEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self._is_on = self.coordinator.data[HUB][ATTRIBUTES][FAN] == ON_STATE
+        self._is_on = self._diffuser.is_on
         self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1676,7 +1676,7 @@ pyrepetier==3.0.5
 pyrisco==0.3.1
 
 # homeassistant.components.rituals_perfume_genie
-pyrituals==0.0.2
+pyrituals==0.0.3
 
 # homeassistant.components.zeroconf
 pyroute2==0.5.18

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -924,7 +924,7 @@ pyqwikswitch==0.93
 pyrisco==0.3.1
 
 # homeassistant.components.rituals_perfume_genie
-pyrituals==0.0.2
+pyrituals==0.0.3
 
 # homeassistant.components.zeroconf
 pyroute2==0.5.18


### PR DESCRIPTION
## Proposed change

- Abstract Rituals API data processing to PyPI
- Use Diffuser data instead of DataUpdateCoordinator data
- Dependency upgrade as this is required to use the new properties

As requested by @bdraco in https://github.com/home-assistant/core/pull/49661#discussion_r619881278. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
