### PR TITLE
Remove no-longer-functioning SimpliSafe websocket support

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -17,13 +17,7 @@ from simplipy.websocket import (
 )
 import voluptuous as vol
 
-from homeassistant.const import (
-    ATTR_CODE,
-    CONF_CODE,
-    CONF_TOKEN,
-    CONF_USERNAME,
-    EVENT_HOMEASSISTANT_STOP,
-)
+from homeassistant.const import ATTR_CODE, CONF_CODE, CONF_TOKEN, CONF_USERNAME
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
@@ -454,17 +448,21 @@ class SimpliSafe:
 
     async def async_init(self):
         """Initialize the data class."""
-        asyncio.create_task(self.websocket.async_connect())
+        # 2021-04-29: Disabling connection to the websocket due to the SimpliSafe cloud
+        # removing it (and not providing a clear alternative).
+        # asyncio.create_task(self.websocket.async_connect())
 
         async def async_websocket_disconnect(_):
             """Define an event handler to disconnect from the websocket."""
             await self.websocket.async_disconnect()
 
-        self._hass.data[DOMAIN][DATA_LISTENER][self.config_entry.entry_id].append(
-            self._hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STOP, async_websocket_disconnect
-            )
-        )
+        # 2021-04-29: Disabling disconnection from the websocket due to the SimpliSafe
+        # cloud removing it (and not providing a clear alternative).
+        # self._hass.data[DOMAIN][DATA_LISTENER][self.config_entry.entry_id].append(
+        #     self._hass.bus.async_listen_once(
+        #         EVENT_HOMEASSISTANT_STOP, async_websocket_disconnect
+        #     )
+        # )
 
         self.systems = await self._api.get_systems()
         for system in self.systems.values():

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -452,9 +452,9 @@ class SimpliSafe:
         # removing it (and not providing a clear alternative).
         # asyncio.create_task(self.websocket.async_connect())
 
-        async def async_websocket_disconnect(_):
-            """Define an event handler to disconnect from the websocket."""
-            await self.websocket.async_disconnect()
+        # async def async_websocket_disconnect(_):
+        #     """Define an event handler to disconnect from the websocket."""
+        #     await self.websocket.async_disconnect()
 
         # 2021-04-29: Disabling disconnection from the websocket due to the SimpliSafe
         # cloud removing it (and not providing a clear alternative).


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The unpublished SimpliSafe cloud API no longer provides a functioning websocket. Therefore, the integration will no longer be able to receive `SIMPLISAFE_EVENT` or `SIMPLISAFE_NOTIFICATION` events, nor will it be possible for stage changes performed outside of Home Assistant (e.g., via the keypad) to be reflected in Home Assistant in near-realtime.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Per https://github.com/home-assistant/core/issues/49513, it appears as though SimpliSafe has shut down the websocket that our integration previously used. This causes an unhandled exception in the current integration that has the side effects listed above. This PR disables the websocket logic – I didn't remove it outright because I'm hopeful I will be able to discover an alternate mechanism and reinstate it at a future date. I'll return to remove everything if I haven't found a solution by 2021.6.0.

I know that we don't normally accept breaking changes once the beta cycle has started, but I recommend we make an exception here; users are pinging me about this constantly, and including it in 2021.5.0 would stem the flow. CC @balloob @frenck @MartinHjelmare 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: https://github.com/home-assistant/core/issues/49513
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17643

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
