### PR TITLE
Add color modes to KNX light

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -84,11 +84,16 @@ class KNXLight(KnxEntity, LightEntity):
         """Return the brightness of this light between 0..255."""
         if self._device.supports_brightness:
             return self._device.current_brightness
+        if (rgb := self.rgb_color) is not None:
+            return max(rgb)
         return None
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the rgb color value [int, int, int]."""
+        if (rgbw := self.rgbw_color) is not None:
+            # used in brightness calculation when no address is given
+            return color_util.color_rgbw_to_rgb(*rgbw)
         if self._device.supports_color:
             rgb, _ = self._device.current_color
             return rgb

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -27,10 +27,6 @@ from .const import DOMAIN
 from .knx_entity import KnxEntity
 from .schema import LightSchema
 
-DEFAULT_COLOR = (0.0, 0.0)
-DEFAULT_BRIGHTNESS = 255
-DEFAULT_WHITE_VALUE = 255
-
 
 async def async_setup_platform(
     hass: HomeAssistant,
@@ -187,7 +183,6 @@ class KNXLight(KnxEntity, LightEntity):
             await self._device.set_on()
             return
 
-        # return after RGB(W) color has changed as it implicitly sets the brightness
         async def set_color(
             rgb: tuple[int, int, int], white: int | None, brightness: int | None
         ) -> None:
@@ -204,6 +199,7 @@ class KNXLight(KnxEntity, LightEntity):
                 white = white * brightness // 255 if white is not None else None
             await self._device.set_color(rgb, white)
 
+        # return after RGB(W) color has changed as it implicitly sets the brightness
         if rgbw is not None:
             await set_color(rgbw[:3], rgbw[3], brightness)
             return


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color modes support to KNX light, according to: #47720

I have no colored lights, so I could not test this on a real installation with rgb and rgbw. Maybe someone can give it a try and report if everything works as before.

The questions from #49112 still stand: Is a light supporting  `COLOR_MODE_ONOFF` supposed to turn on when `brightness` is in `kwargs`? Currently this case is not handled and left to the integration to decide. 
I think this should be handled in `homeassistant.components.light.LightEntity`, what do you think @emontnemery 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49110
- This PR is related to issue: #49112 (related)
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
