### PR TITLE
Catch non payload modbus messages

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -5,7 +5,6 @@ import threading
 from pymodbus.client.sync import ModbusSerialClient, ModbusTcpClient, ModbusUdpClient
 from pymodbus.constants import Defaults
 from pymodbus.exceptions import ModbusException
-from pymodbus.pdu import ExceptionResponse, IllegalFunctionRequest
 from pymodbus.transaction import ModbusRtuFramer
 
 from homeassistant.const import (
@@ -237,8 +236,9 @@ class ModbusHub:
                 result = self._client.read_coils(address, count, **kwargs)
             except ModbusException as exception_error:
                 self._log_error(exception_error)
-                return None
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -251,9 +251,9 @@ class ModbusHub:
             try:
                 result = self._client.read_discrete_inputs(address, count, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return None
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -266,9 +266,9 @@ class ModbusHub:
             try:
                 result = self._client.read_input_registers(address, count, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return None
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -281,9 +281,9 @@ class ModbusHub:
             try:
                 result = self._client.read_holding_registers(address, count, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return None
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -296,9 +296,9 @@ class ModbusHub:
             try:
                 result = self._client.write_coil(address, value, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return False
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -311,9 +311,9 @@ class ModbusHub:
             try:
                 result = self._client.write_coils(address, values, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return False
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -326,9 +326,9 @@ class ModbusHub:
             try:
                 result = self._client.write_register(address, value, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return False
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -341,9 +341,9 @@ class ModbusHub:
             try:
                 result = self._client.write_registers(address, values, **kwargs)
             except ModbusException as exception_error:
-                self._log_error(exception_error)
-                return False
-            if isinstance(result, (ExceptionResponse, IllegalFunctionRequest)):
+                result = exception_error
+                pass
+            if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
             self._in_error = False

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -237,7 +237,6 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
@@ -252,7 +251,6 @@ class ModbusHub:
                 result = self._client.read_discrete_inputs(address, count, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
@@ -267,7 +265,6 @@ class ModbusHub:
                 result = self._client.read_input_registers(address, count, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
@@ -282,7 +279,6 @@ class ModbusHub:
                 result = self._client.read_holding_registers(address, count, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return None
@@ -297,7 +293,6 @@ class ModbusHub:
                 result = self._client.write_coil(address, value, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
@@ -312,7 +307,6 @@ class ModbusHub:
                 result = self._client.write_coils(address, values, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
@@ -327,7 +321,6 @@ class ModbusHub:
                 result = self._client.write_register(address, value, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False
@@ -342,7 +335,6 @@ class ModbusHub:
                 result = self._client.write_registers(address, values, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-                pass
             if not hasattr(result, "registers"):
                 self._log_error(result)
                 return False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Pymodbus delivers non payload messages from devices,
which can all be seen as errors of some kind, and are therefore
to be handled identical. The non payload messages are real modbus
messages and even though some them have names that reminds
of an exception. Other applications than the modbus integration
uses these messages for different purposes so they cannot be seen
as errors in the general case.

Instead of trying to identify and catch every type, the PR catches
everything that do not have a payload, which are the only thing
we are interested in.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
It would be real nice if this could go into the first possible release/patch release/beta

- This PR fixes or closes issue: fixes #
fixes #49749
fixed #49897
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
