### PR TITLE
Allow passing options in config flow entry creation

### DIFF
--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -31,7 +31,8 @@ PORT_MSG = {UDP_PORT: "port_987_bind_error", TCP_PORT: "port_997_bind_error"}
 PIN_LENGTH = 8
 
 
-class PlayStation4FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
+@config_entries.HANDLERS.register(DOMAIN)
+class PlayStation4FlowHandler(config_entries.ConfigFlow):
     """Handle a PlayStation 4 config flow."""
 
     VERSION = CONFIG_ENTRY_VERSION

--- a/homeassistant/components/ps4/config_flow.py
+++ b/homeassistant/components/ps4/config_flow.py
@@ -31,8 +31,7 @@ PORT_MSG = {UDP_PORT: "port_987_bind_error", TCP_PORT: "port_997_bind_error"}
 PIN_LENGTH = 8
 
 
-@config_entries.HANDLERS.register(DOMAIN)
-class PlayStation4FlowHandler(config_entries.ConfigFlow):
+class PlayStation4FlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a PlayStation 4 config flow."""
 
     VERSION = CONFIG_ENTRY_VERSION

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -1297,7 +1297,7 @@ class ConfigFlow(data_entry_flow.FlowHandler):
         return await self.async_step_discovery(discovery_info)
 
     @callback
-    def async_create_entry(
+    def async_create_entry(  # pylint: disable=arguments-differ
         self,
         *,
         title: str,

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -150,7 +150,7 @@ class ConfigEntry:
         data: Mapping[str, Any],
         source: str,
         system_options: dict,
-        options: dict | None = None,
+        options: Mapping[str, Any] | None = None,
         unique_id: str | None = None,
         entry_id: str | None = None,
         state: str = ENTRY_STATE_NOT_LOADED,
@@ -628,7 +628,7 @@ class ConfigEntriesFlowManager(data_entry_flow.FlowManager):
             domain=result["handler"],
             title=result["title"],
             data=result["data"],
-            options={},
+            options=result["options"],
             system_options={},
             source=flow.context["source"],
             unique_id=flow.unique_id,
@@ -1295,6 +1295,28 @@ class ConfigFlow(data_entry_flow.FlowHandler):
     ) -> data_entry_flow.FlowResult:
         """Handle a flow initialized by DHCP discovery."""
         return await self.async_step_discovery(discovery_info)
+
+    @callback
+    def async_create_entry(
+        self,
+        *,
+        title: str,
+        data: Mapping[str, Any],
+        description: str | None = None,
+        description_placeholders: dict | None = None,
+        options: Mapping[str, Any] | None = None,
+    ) -> data_entry_flow.FlowResult:
+        """Finish config flow and create a config entry."""
+        result = super().async_create_entry(
+            title=title,
+            data=data,
+            description=description,
+            description_placeholders=description_placeholders,
+        )
+
+        result["options"] = options or {}
+
+        return result
 
 
 class OptionsFlowManager(data_entry_flow.FlowManager):

--- a/homeassistant/data_entry_flow.py
+++ b/homeassistant/data_entry_flow.py
@@ -73,6 +73,7 @@ class FlowResult(TypedDict, total=False):
     context: dict[str, Any]
     result: Any
     last_step: bool | None
+    options: Mapping[str, Any]
 
 
 class FlowManager(abc.ABC):

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -333,6 +333,7 @@ async def test_create_account(hass, client):
         },
         "description": None,
         "description_placeholders": None,
+        "options": {},
     }
 
 
@@ -403,6 +404,7 @@ async def test_two_step_flow(hass, client):
             },
             "description": None,
             "description_placeholders": None,
+            "options": {},
         }
 
 

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -152,6 +152,7 @@ async def test_pairing(hass, mock_tv_pairable, mock_setup_entry):
         "title": "55PUS7181/12 (ABCDEFGHIJKLF)",
         "data": MOCK_CONFIG_PAIRED,
         "version": 1,
+        "options": {},
     }
 
     await hass.async_block_till_done()

--- a/tests/components/ps4/test_init.py
+++ b/tests/components/ps4/test_init.py
@@ -46,6 +46,7 @@ MOCK_FLOW_RESULT = {
     "type": data_entry_flow.RESULT_TYPE_CREATE_ENTRY,
     "title": "test_ps4",
     "data": MOCK_DATA,
+    "options": {},
 }
 
 MOCK_ENTRY_ID = "SomeID"

--- a/tests/components/subaru/test_config_flow.py
+++ b/tests/components/subaru/test_config_flow.py
@@ -115,6 +115,7 @@ async def test_user_form_pin_not_required(hass, user_form):
         "type": "create_entry",
         "version": 1,
         "data": deepcopy(TEST_CONFIG),
+        "options": {},
     }
     expected["data"][CONF_PIN] = None
     result["data"][CONF_DEVICE_ID] = TEST_DEVICE_ID
@@ -176,6 +177,7 @@ async def test_pin_form_success(hass, pin_form):
         "type": "create_entry",
         "version": 1,
         "data": TEST_CONFIG,
+        "options": {},
     }
     result["data"][CONF_DEVICE_ID] = TEST_DEVICE_ID
     assert result == expected

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -941,6 +941,56 @@ async def test_setup_retrying_during_unload_before_started(hass):
     )
 
 
+async def test_create_entry_options(hass):
+    """Test a config entry being created with options."""
+
+    async def mock_async_setup(hass, config):
+        """Mock setup."""
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                "comp",
+                context={"source": config_entries.SOURCE_IMPORT},
+                data={"data": "data", "option": "option"},
+            )
+        )
+        return True
+
+    async_setup_entry = AsyncMock(return_value=True)
+    mock_integration(
+        hass,
+        MockModule(
+            "comp", async_setup=mock_async_setup, async_setup_entry=async_setup_entry
+        ),
+    )
+    mock_entity_platform(hass, "config_flow.comp", None)
+    await async_setup_component(hass, "persistent_notification", {})
+
+    class TestFlow(config_entries.ConfigFlow):
+        """Test flow."""
+
+        VERSION = 1
+
+        async def async_step_import(self, user_input):
+            """Test import step creating entry, with options."""
+            return self.async_create_entry(
+                title="title",
+                data={"example": user_input["data"]},
+                options={"example": user_input["option"]},
+            )
+
+    with patch.dict(config_entries.HANDLERS, {"comp": TestFlow}):
+        assert await async_setup_component(hass, "comp", {})
+
+        await hass.async_block_till_done()
+
+        assert len(async_setup_entry.mock_calls) == 1
+
+        entries = hass.config_entries.async_entries("comp")
+        assert len(entries) == 1
+        assert entries[0].data == {"example": "data"}
+        assert entries[0].options == {"example": "option"}
+
+
 async def test_entry_options(hass, manager):
     """Test that we can set options on an entry."""
     entry = MockConfigEntry(domain="test", data={"first": True}, options=None)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is inspired by #43419 (Config Flow of Wyze, including import).

Currently, we don't have a way to set option in our config flow. While in general, this is not really needed, when importing/migrating existing YAML configuration this becomes needed and problematic.

What happens now (on multiple occasions, not just in the case of Wyze here), is that we send those additional options in config entry data, and migrating them from the config entry data to the config entry options on the first setup.

See: <https://github.com/home-assistant/core/pull/43419/files#diff-93b86b39766f66bae1073f713bef9bcdf699c5d03adafa7924fa975db848c78cR120-R147>

IMHO, that is just:

- Too complicated
- Misuses config entry data
- Adds a lot of code that should not be needed

**This PR allows for passing options at config entry creation from the config flow.**

I know this has been discussed in the past. I vaguely remember something about merging options and data completely, but could not find a reference.

That said, I suggest we at least make it easier to use and migrate until another solution (like the merger of data & options) is implemented. This change should not harm any future implementation and at least makes current implementations less hacky.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
