### PR TITLE
Use header URI in Plex config flow

### DIFF
--- a/tests/components/plex/test_config_flow.py
+++ b/tests/components/plex/test_config_flow.py
@@ -21,7 +21,6 @@ from homeassistant.components.plex.const import (
     PLEX_SERVER_CONFIG,
     SERVERS,
 )
-from homeassistant.config import async_process_ha_core_config
 from homeassistant.config_entries import (
     ENTRY_STATE_LOADED,
     SOURCE_INTEGRATION_DISCOVERY,
@@ -45,13 +44,8 @@ from .mock_classes import MockGDM
 from tests.common import MockConfigEntry
 
 
-async def test_bad_credentials(hass):
+async def test_bad_credentials(hass, current_request_with_host):
     """Test when provided credentials are rejected."""
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -78,13 +72,8 @@ async def test_bad_credentials(hass):
         assert result["errors"][CONF_TOKEN] == "faulty_credentials"
 
 
-async def test_bad_hostname(hass, mock_plex_calls):
+async def test_bad_hostname(hass, mock_plex_calls, current_request_with_host):
     """Test when an invalid address is provided."""
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -112,13 +101,8 @@ async def test_bad_hostname(hass, mock_plex_calls):
         assert result["errors"][CONF_HOST] == "not_found"
 
 
-async def test_unknown_exception(hass):
+async def test_unknown_exception(hass, current_request_with_host):
     """Test when an unknown exception is encountered."""
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -141,14 +125,11 @@ async def test_unknown_exception(hass):
         assert result["reason"] == "unknown"
 
 
-async def test_no_servers_found(hass, mock_plex_calls, requests_mock, empty_payload):
+async def test_no_servers_found(
+    hass, mock_plex_calls, requests_mock, empty_payload, current_request_with_host
+):
     """Test when no servers are on an account."""
     requests_mock.get("https://plex.tv/api/resources", text=empty_payload)
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
@@ -173,14 +154,10 @@ async def test_no_servers_found(hass, mock_plex_calls, requests_mock, empty_payl
         assert result["errors"]["base"] == "no_servers"
 
 
-async def test_single_available_server(hass, mock_plex_calls):
+async def test_single_available_server(
+    hass, mock_plex_calls, current_request_with_host
+):
     """Test creating an entry with one server available."""
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -217,15 +194,13 @@ async def test_single_available_server(hass, mock_plex_calls):
 
 
 async def test_multiple_servers_with_selection(
-    hass, mock_plex_calls, requests_mock, plextv_resources_base
+    hass,
+    mock_plex_calls,
+    requests_mock,
+    plextv_resources_base,
+    current_request_with_host,
 ):
     """Test creating an entry with multiple servers available."""
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -273,15 +248,13 @@ async def test_multiple_servers_with_selection(
 
 
 async def test_adding_last_unconfigured_server(
-    hass, mock_plex_calls, requests_mock, plextv_resources_base
+    hass,
+    mock_plex_calls,
+    requests_mock,
+    plextv_resources_base,
+    current_request_with_host,
 ):
     """Test automatically adding last unconfigured server when multiple servers on account."""
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -331,15 +304,14 @@ async def test_adding_last_unconfigured_server(
 
 
 async def test_all_available_servers_configured(
-    hass, entry, requests_mock, plextv_account, plextv_resources_base
+    hass,
+    entry,
+    requests_mock,
+    plextv_account,
+    plextv_resources_base,
+    current_request_with_host,
 ):
     """Test when all available servers are already configured."""
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     entry.add_to_hass(hass)
 
     MockConfigEntry(
@@ -470,14 +442,8 @@ async def test_option_flow_new_users_available(hass, entry, setup_plex_server):
         assert "[New]" in multiselect_defaults[user]
 
 
-async def test_external_timed_out(hass):
+async def test_external_timed_out(hass, current_request_with_host):
     """Test when external flow times out."""
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -500,14 +466,8 @@ async def test_external_timed_out(hass):
         assert result["reason"] == "token_request_timeout"
 
 
-async def test_callback_view(hass, aiohttp_client):
+async def test_callback_view(hass, aiohttp_client, current_request_with_host):
     """Test callback view."""
-
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
-
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
@@ -529,12 +489,8 @@ async def test_callback_view(hass, aiohttp_client):
         assert resp.status == 200
 
 
-async def test_manual_config(hass, mock_plex_calls):
+async def test_manual_config(hass, mock_plex_calls, current_request_with_host):
     """Test creating via manual configuration."""
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
 
     class WrongCertValidaitionException(requests.exceptions.SSLError):
         """Mock the exception showing an unmatched error."""
@@ -744,13 +700,11 @@ async def test_integration_discovery(hass):
     assert flow["step_id"] == "user"
 
 
-async def test_trigger_reauth(hass, entry, mock_plex_server, mock_websocket):
+async def test_trigger_reauth(
+    hass, entry, mock_plex_server, mock_websocket, current_request_with_host
+):
     """Test setup and reauthorization of a Plex token."""
     await async_setup_component(hass, "persistent_notification", {})
-    await async_process_ha_core_config(
-        hass,
-        {"internal_url": "http://example.local:8123"},
-    )
 
     assert entry.state == ENTRY_STATE_LOADED
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some users still have issues with an unexpected HA redirect URI used in the Plex config flow. This uses a method taken from the [OAuth2 config flow](https://github.com/home-assistant/core/blob/684ea9e49b15651bb49b9f7ffc5758b2cda84bb3/homeassistant/helpers/config_entry_oauth2_flow.py#L129-L142) to grab the base URI from the header sent by the frontend which tends to be more reliable.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
