### PR TITLE
Rename _update() to update() for modbus platforms.

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -129,7 +129,7 @@ class ModbusBinarySensor(BinarySensorEntity):
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         async_track_time_interval(
-            self.hass, lambda arg: self._update(), self._scan_interval
+            self.hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property
@@ -162,7 +162,7 @@ class ModbusBinarySensor(BinarySensorEntity):
         """Return True if entity is available."""
         return self._available
 
-    def _update(self):
+    def update(self):
         """Update the state of the sensor."""
         if self._input_type == CALL_TYPE_COIL:
             result = self._hub.read_coils(self._slave, self._address, 1)

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -133,7 +133,7 @@ class ModbusThermostat(ClimateEntity):
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         async_track_time_interval(
-            self.hass, lambda arg: self._update(), self._scan_interval
+            self.hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property
@@ -214,14 +214,14 @@ class ModbusThermostat(ClimateEntity):
             self._target_temperature_register,
             register_value,
         )
-        self._update()
+        self.update()
 
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
         return self._available
 
-    def _update(self):
+    def update(self):
         """Update Target & Current Temperature."""
         self._target_temperature = self._read_register(
             CALL_TYPE_REGISTER_HOLDING, self._target_temperature_register

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -108,7 +108,7 @@ class ModbusCover(CoverEntity, RestoreEntity):
         self._value = state.state
 
         async_track_time_interval(
-            self.hass, lambda arg: self._update(), self._scan_interval
+            self.hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property
@@ -162,7 +162,7 @@ class ModbusCover(CoverEntity, RestoreEntity):
         else:
             self._write_register(self._state_open)
 
-        self._update()
+        self.update()
 
     def close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
@@ -171,9 +171,9 @@ class ModbusCover(CoverEntity, RestoreEntity):
         else:
             self._write_register(self._state_closed)
 
-        self._update()
+        self.update()
 
-    def _update(self):
+    def update(self):
         """Update the state of the cover."""
         if self._coil is not None and self._status_register is None:
             self._value = self._read_coil()

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -229,7 +229,7 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
             self._value = state.state
 
         async_track_time_interval(
-            self.hass, lambda arg: self._update(), self._scan_interval
+            self.hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property
@@ -282,7 +282,7 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
             registers.reverse()
         return registers
 
-    def _update(self):
+    def update(self):
         """Update the state of the sensor."""
         if self._register_type == CALL_TYPE_REGISTER_INPUT:
             result = self._hub.read_input_registers(

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -99,7 +99,7 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
 
         if self._verify_active:
             async_track_time_interval(
-                self.hass, lambda arg: self._update(), self._scan_interval
+                self.hass, lambda arg: self.update(), self._scan_interval
             )
 
     @property
@@ -132,7 +132,7 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
         else:
             self._available = True
             if self._verify_active:
-                self._update()
+                self.update()
             else:
                 self._is_on = True
                 self.schedule_update_ha_state()
@@ -146,12 +146,12 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
         else:
             self._available = True
             if self._verify_active:
-                self._update()
+                self.update()
             else:
                 self._is_on = False
                 self.schedule_update_ha_state()
 
-    def _update(self):
+    def update(self):
         """Update the entity state."""
         if not self._verify_active:
             return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A review comment quite a while ago asked to rename update() to _update(), which made sense,
because _update() was called internally from a timer and not from the HA polling, so with the
rename confusion was avoided.

However due to the script "homeassistant.update_entity" update() needs to be present, even
though we are not using polling.

Instead of letting update() call _update(), _update() is renamed to update().

Tests are added to show that the scripting now works, however they are submitted in a seperate
PR, because they needed an update to the common test harness.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This fix should not be released until 2021.6, because it uses #49386 (already merged), which
will not be released until 2021.6

- This PR fixes or closes issue: fixes #
fixes #49831 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
