### PR TITLE
Update LG Netcast to use new backend library

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -258,6 +258,7 @@ homeassistant/components/kulersky/* @emlove
 homeassistant/components/lametric/* @robbiet480
 homeassistant/components/launch_library/* @ludeeus
 homeassistant/components/lcn/* @alengwenus
+homeassistant/components/lg_netcast/* @Drafteed
 homeassistant/components/life360/* @pnbruckner
 homeassistant/components/linux_battery/* @fabaff
 homeassistant/components/litejet/* @joncar

--- a/homeassistant/components/lg_netcast/manifest.json
+++ b/homeassistant/components/lg_netcast/manifest.json
@@ -3,6 +3,6 @@
   "name": "LG Netcast",
   "documentation": "https://www.home-assistant.io/integrations/lg_netcast",
   "requirements": ["pylgnetcast==0.3.3"],
-  "codeowners": [],
+  "codeowners": ["@Drafteed"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/lg_netcast/manifest.json
+++ b/homeassistant/components/lg_netcast/manifest.json
@@ -2,7 +2,7 @@
   "domain": "lg_netcast",
   "name": "LG Netcast",
   "documentation": "https://www.home-assistant.io/integrations/lg_netcast",
-  "requirements": ["pylgnetcast-homeassistant==0.2.0.dev0"],
+  "requirements": ["pylgnetcast==0.3.3"],
   "codeowners": [],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1512,7 +1512,7 @@ pylast==4.2.0
 pylaunches==1.0.0
 
 # homeassistant.components.lg_netcast
-pylgnetcast-homeassistant==0.2.0.dev0
+pylgnetcast==0.3.3
 
 # homeassistant.components.forked_daapd
 pylibrespot-java==0.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR swaps: [wokar/pylgnetcast#0.2.0](https://github.com/wokar/pylgnetcast) to [python-lgnetcast#0.3.3](https://github.com/Drafteed/python-lgnetcast)

PyLgNetcast is currently unmaintained for home-assistant, since the previous maintainer has gone missing from 2016. This commit swaps it out with a new fork and captures important [path](https://github.com/Drafteed/python-lgnetcast/commit/93f4d780ed56b4d11a84e855c15a29f2f83f9545) for correct select non-ascii sources/channels (see #17807).

Based on discussion in home-assistant/core/pull/49563

Change list:
```
* v0.3.3: Serialize and parse XML as UTF-8
* v0.3.1: fixed _get_session_id for hdcp
* v0.3.0: basic support for hdcp protocol of pre 2012 LG TVs
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #17807
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
