### PR TITLE
Add debug more information when splitting entity ID failed

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -114,7 +114,10 @@ _LOGGER = logging.getLogger(__name__)
 
 def split_entity_id(entity_id: str) -> list[str]:
     """Split a state entity ID into domain and object ID."""
-    return entity_id.split(".", 1)
+    try:
+        return entity_id.split(".", 1)
+    except AttributeError as err:
+        raise HomeAssistantError("Unexpected entity ID format", entity_id) from err
 
 
 VALID_ENTITY_ID = re.compile(r"^(?!.+__)(?!_)[\da-z_]+(?<!_)\.(?!_)[\da-z_]+(?<!_)$")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -52,6 +52,12 @@ def test_split_entity_id():
     assert ha.split_entity_id("domain.object_id") == ["domain", "object_id"]
 
 
+def test_raise_split_invalid_entity_id():
+    """Test split_entity_id."""
+    with pytest.raises(ha.HomeAssistantError, match="Unexpected entity ID format"):
+        assert ha.split_entity_id({"this": "is", "invalid": ["stuff", "homie"]})
+
+
 def test_async_add_hass_job_schedule_callback():
     """Test that we schedule coroutines and add jobs to the job pool."""
     hass = MagicMock()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Small change to a core method, that adds more information as soon as an issue occurs with splitting entity ID's.

Issues from 2 reporters during the beta of 2021.5:

```py
Logger: homeassistant.core
Source: core.py:117
First occurred: 18:07:07 (8 occurrences)
Last logged: 21:22:02

Error in event filter
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/core.py", line 717, in async_fire
    if not event_filter(event):
  File "/usr/src/homeassistant/homeassistant/components/recorder/__init__.py", line 367, in _async_event_filter
    return bool(entity_id is None or self.entity_filter(entity_id))
  File "/usr/src/homeassistant/homeassistant/helpers/entityfilter.py", line 169, in entity_filter_2
    domain = split_entity_id(entity_id)[0]
  File "/usr/src/homeassistant/homeassistant/core.py", line 117, in split_entity_id
    return entity_id.split(".", 1)
AttributeError: 'list' object has no attribute 'split'
```

It would help if we knew the contents that it is trying to split to determine the source of the issue.
This PR adjusts the handling, to raise an HomeAssistant error with the entity_id it actually tries to split.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #49877
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
