### PR TITLE
Add unique_id to TotalConnect alarm_control_panel

### DIFF
--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -42,6 +42,7 @@ class TotalConnectAlarm(alarm.AlarmControlPanelEntity):
         """Initialize the TotalConnect status."""
         self._name = name
         self._location_id = location_id
+        self._unique_id = f"{location_id}"
         self._client = client
         self._state = None
         self._extra_state_attributes = {}
@@ -50,6 +51,11 @@ class TotalConnectAlarm(alarm.AlarmControlPanelEntity):
     def name(self):
         """Return the name of the device."""
         return self._name
+
+    @property
+    def unique_id(self):
+        """Return the unique id."""
+        return self._unique_id
 
     @property
     def state(self):

--- a/homeassistant/components/totalconnect/alarm_control_panel.py
+++ b/homeassistant/components/totalconnect/alarm_control_panel.py
@@ -42,7 +42,7 @@ class TotalConnectAlarm(alarm.AlarmControlPanelEntity):
         """Initialize the TotalConnect status."""
         self._name = name
         self._location_id = location_id
-        self._unique_id = f"{location_id}"
+        self._unique_id = str(location_id)
         self._client = client
         self._state = None
         self._extra_state_attributes = {}

--- a/tests/components/totalconnect/common.py
+++ b/tests/components/totalconnect/common.py
@@ -9,8 +9,10 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
+LOCATION_ID = "123456"
+
 LOCATION_INFO_BASIC_NORMAL = {
-    "LocationID": "123456",
+    "LocationID": LOCATION_ID,
     "LocationName": "test",
     "SecurityDeviceID": "987654",
     "PhotoURL": "http://www.example.com/some/path/to/file.jpg",

--- a/tests/components/totalconnect/test_alarm_control_panel.py
+++ b/tests/components/totalconnect/test_alarm_control_panel.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from homeassistant.exceptions import HomeAssistantError
 
 from .common import (
+    LOCATION_ID,
     RESPONSE_ARM_FAILURE,
     RESPONSE_ARM_SUCCESS,
     RESPONSE_ARMED_AWAY,
@@ -44,6 +45,11 @@ async def test_attributes(hass):
         assert state.state == STATE_ALARM_DISARMED
         mock_request.assert_called_once()
         assert state.attributes.get(ATTR_FRIENDLY_NAME) == "test"
+
+        entity_registry = await hass.helpers.entity_registry.async_get_registry()
+        entry = entity_registry.async_get(ENTITY_ID)
+        # TotalConnect alarm device unique_id is the location_id
+        assert entry.unique_id == LOCATION_ID
 
 
 async def test_arm_home_success(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

Adds a unique_id for the alarm_control_panel entity(ies).  Adds a test for it too.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes # n/a
- This PR is related to issue: n/a
- Link to documentation pull request:  n/a

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [n/a] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [n/a] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
