### PR TITLE
Fix KNX light unique_id

### DIFF
--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable
 from typing import Any, Callable
 
 from xknx.devices import Light as XknxLight
+from xknx.telegram.address import parse_device_group_address
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -17,12 +18,13 @@ from homeassistant.components.light import (
     SUPPORT_WHITE_VALUE,
     LightEntity,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 import homeassistant.util.color as color_util
 
-from .const import DOMAIN
+from .const import DOMAIN, KNX_ADDRESS
 from .knx_entity import KnxEntity
 from .schema import LightSchema
 
@@ -38,11 +40,87 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up lights for KNX platform."""
+    _async_migrate_unique_id(hass, discovery_info)
     entities = []
     for device in hass.data[DOMAIN].xknx.devices:
         if isinstance(device, XknxLight):
             entities.append(KNXLight(device))
     async_add_entities(entities)
+
+
+@callback
+def _async_migrate_unique_id(
+    hass: HomeAssistant, discovery_info: DiscoveryInfoType | None
+) -> None:
+    """Change unique_ids used in 2021.4 to exchange individual color switch address for brightness address."""
+    entity_registry = er.async_get(hass)
+    if not discovery_info or not discovery_info["platform_config"]:
+        return
+
+    platform_config = discovery_info["platform_config"]
+    for entity_config in platform_config:
+        individual_colors_config = entity_config.get(LightSchema.CONF_INDIVIDUAL_COLORS)
+        if individual_colors_config is None:
+            continue
+        try:
+            ga_red_switch = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][
+                LightSchema.CONF_RED
+            ][KNX_ADDRESS][0]
+            ga_green_switch = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][
+                LightSchema.CONF_GREEN
+            ][KNX_ADDRESS][0]
+            ga_blue_switch = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][
+                LightSchema.CONF_BLUE
+            ][KNX_ADDRESS][0]
+        except KeyError:
+            continue
+        # normalize group address strings
+        ga_red_switch = parse_device_group_address(ga_red_switch)
+        ga_green_switch = parse_device_group_address(ga_green_switch)
+        ga_blue_switch = parse_device_group_address(ga_blue_switch)
+        # white config is optional so it has to be checked for `None` extra
+        white_config = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS].get(
+            LightSchema.CONF_WHITE
+        )
+        white_switch = (
+            white_config.get(KNX_ADDRESS) if white_config is not None else None
+        )
+        ga_white_switch = (
+            parse_device_group_address(white_switch[0])
+            if white_switch is not None
+            else None
+        )
+
+        old_uid = (
+            f"{ga_red_switch}_"
+            f"{ga_green_switch}_"
+            f"{ga_blue_switch}_"
+            f"{ga_white_switch}"
+        )
+        entity_id = entity_registry.async_get_entity_id("light", DOMAIN, old_uid)
+        if entity_id is None:
+            continue
+
+        ga_red_brightness = parse_device_group_address(
+            entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][LightSchema.CONF_RED][
+                LightSchema.CONF_BRIGHTNESS_ADDRESS
+            ][0]
+        )
+        ga_green_brightness = parse_device_group_address(
+            entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][LightSchema.CONF_GREEN][
+                LightSchema.CONF_BRIGHTNESS_ADDRESS
+            ][0]
+        )
+        ga_blue_brightness = parse_device_group_address(
+            entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][LightSchema.CONF_BLUE][
+                LightSchema.CONF_BRIGHTNESS_ADDRESS
+            ][0]
+        )
+
+        new_uid = (
+            f"{ga_red_brightness}_" f"{ga_green_brightness}_" f"{ga_blue_brightness}"
+        )
+        entity_registry.async_update_entity(entity_id, new_unique_id=new_uid)
 
 
 class KNXLight(KnxEntity, LightEntity):
@@ -67,10 +145,9 @@ class KNXLight(KnxEntity, LightEntity):
         if self._device.switch.group_address is not None:
             return f"{self._device.switch.group_address}"
         return (
-            f"{self._device.red.switch.group_address}_"
-            f"{self._device.green.switch.group_address}_"
-            f"{self._device.blue.switch.group_address}_"
-            f"{self._device.white.switch.group_address}"
+            f"{self._device.red.brightness.group_address}_"
+            f"{self._device.green.brightness.group_address}_"
+            f"{self._device.blue.brightness.group_address}"
         )
 
     @property

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -63,15 +63,15 @@ def _async_migrate_unique_id(
         if individual_colors_config is None:
             continue
         try:
-            ga_red_switch = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][
-                LightSchema.CONF_RED
-            ][KNX_ADDRESS][0]
-            ga_green_switch = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][
-                LightSchema.CONF_GREEN
-            ][KNX_ADDRESS][0]
-            ga_blue_switch = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][
-                LightSchema.CONF_BLUE
-            ][KNX_ADDRESS][0]
+            ga_red_switch = individual_colors_config[LightSchema.CONF_RED][KNX_ADDRESS][
+                0
+            ]
+            ga_green_switch = individual_colors_config[LightSchema.CONF_GREEN][
+                KNX_ADDRESS
+            ][0]
+            ga_blue_switch = individual_colors_config[LightSchema.CONF_BLUE][
+                KNX_ADDRESS
+            ][0]
         except KeyError:
             continue
         # normalize group address strings
@@ -79,9 +79,7 @@ def _async_migrate_unique_id(
         ga_green_switch = parse_device_group_address(ga_green_switch)
         ga_blue_switch = parse_device_group_address(ga_blue_switch)
         # white config is optional so it has to be checked for `None` extra
-        white_config = entity_config[LightSchema.CONF_INDIVIDUAL_COLORS].get(
-            LightSchema.CONF_WHITE
-        )
+        white_config = individual_colors_config.get(LightSchema.CONF_WHITE)
         white_switch = (
             white_config.get(KNX_ADDRESS) if white_config is not None else None
         )
@@ -102,24 +100,22 @@ def _async_migrate_unique_id(
             continue
 
         ga_red_brightness = parse_device_group_address(
-            entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][LightSchema.CONF_RED][
+            individual_colors_config[LightSchema.CONF_RED][
                 LightSchema.CONF_BRIGHTNESS_ADDRESS
             ][0]
         )
         ga_green_brightness = parse_device_group_address(
-            entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][LightSchema.CONF_GREEN][
+            individual_colors_config[LightSchema.CONF_GREEN][
                 LightSchema.CONF_BRIGHTNESS_ADDRESS
             ][0]
         )
         ga_blue_brightness = parse_device_group_address(
-            entity_config[LightSchema.CONF_INDIVIDUAL_COLORS][LightSchema.CONF_BLUE][
+            individual_colors_config[LightSchema.CONF_BLUE][
                 LightSchema.CONF_BRIGHTNESS_ADDRESS
             ][0]
         )
 
-        new_uid = (
-            f"{ga_red_brightness}_" f"{ga_green_brightness}_" f"{ga_blue_brightness}"
-        )
+        new_uid = f"{ga_red_brightness}_{ga_green_brightness}_{ga_blue_brightness}"
         entity_registry.async_update_entity(entity_id, new_unique_id=new_uid)
 
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix problems with duplicate unique_ids in the KNX integration (again). 
KNX light individual color configurations allows to set a switch address (`KNX_ADDRESS = "address"`) and brightness address (`CONF_BRIGHTNESS_ADDRESS = "brightness_address"`). Switch should be optional whereas brightness is not (for red, green and blue). See Schema https://github.com/home-assistant/core/blob/1b5596b4c2e11fc88504e9f78b6d9031dd048ee1/homeassistant/components/knx/schema.py#L362-L368

This change migrates the unique_id of lights using individual color configuration from the switch addresses of rgbw to brightness addresses of rgb (white is omited - its presence doesn't matter for unique_id. If r, g and b are set the light is identifiable).

It would be great if it could be included in 2021.5 as then there would only be one month of registry-entries to migrate (unique_id in knx was introduces 2021.4 - cover and climate already have their migration function merged #49677).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #49677 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
