### PR TITLE
Add support for Elgato Light Strip

### DIFF
--- a/homeassistant/components/elgato/__init__.py
+++ b/homeassistant/components/elgato/__init__.py
@@ -1,4 +1,4 @@
-"""Support for Elgato Key Lights."""
+"""Support for Elgato Lights."""
 import logging
 
 from elgato import Elgato, ElgatoConnectionError
@@ -16,7 +16,7 @@ PLATFORMS = [LIGHT_DOMAIN]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Set up Elgato Key Light from a config entry."""
+    """Set up Elgato Light from a config entry."""
     session = async_get_clientsession(hass)
     elgato = Elgato(
         entry.data[CONF_HOST],
@@ -39,7 +39,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Unload Elgato Key Light config entry."""
+    """Unload Elgato Light config entry."""
     # Unload entities for this entry/device.
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:

--- a/homeassistant/components/elgato/config_flow.py
+++ b/homeassistant/components/elgato/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow to configure the Elgato Key Light integration."""
+"""Config flow to configure the Elgato Light integration."""
 from __future__ import annotations
 
 from typing import Any
@@ -16,7 +16,7 @@ from .const import CONF_SERIAL_NUMBER, DOMAIN
 
 
 class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
-    """Handle a Elgato Key Light config flow."""
+    """Handle a Elgato Light config flow."""
 
     VERSION = 1
 
@@ -91,7 +91,7 @@ class ElgatoFlowHandler(ConfigFlow, domain=DOMAIN):
         )
 
     async def _get_elgato_serial_number(self, raise_on_progress: bool = True) -> None:
-        """Get device information from an Elgato Key Light device."""
+        """Get device information from an Elgato Light device."""
         session = async_get_clientsession(self.hass)
         elgato = Elgato(
             host=self.host,

--- a/homeassistant/components/elgato/const.py
+++ b/homeassistant/components/elgato/const.py
@@ -1,4 +1,4 @@
-"""Constants for the Elgato Key Light integration."""
+"""Constants for the Elgato Light integration."""
 
 # Integration domain
 DOMAIN = "elgato"

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
 
 
 class ElgatoLight(LightEntity):
-    """Defines a Elgato Light."""
+    """Defines an Elgato Light."""
 
     def __init__(self, elgato: Elgato, info: Info, settings: Settings) -> None:
         """Initialize Elgato Light."""

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -60,6 +60,16 @@ class ElgatoLight(LightEntity):
         self._state: State | None = None
         self.elgato = elgato
 
+        self._min_mired = 143
+        self._max_mired = 344
+        self._supported_color_modes = {COLOR_MODE_COLOR_TEMP}
+
+        # Elgato Light supporting color, have a different temperature range
+        if settings.power_on_hue is not None:
+            self._supported_color_modes = {COLOR_MODE_COLOR_TEMP, COLOR_MODE_HS}
+            self._min_mired = 153
+            self._max_mired = 285
+
     @property
     def name(self) -> str:
         """Return the name of the entity."""
@@ -91,29 +101,18 @@ class ElgatoLight(LightEntity):
     @property
     def min_mireds(self) -> int:
         """Return the coldest color_temp that this light supports."""
-        # Elgato lights with color capabilities have a different lowest value
-        if self._settings.power_on_hue is not None:
-            return 153
-        return 143
+        return self._min_mired
 
     @property
     def max_mireds(self) -> int:
         """Return the warmest color_temp that this light supports."""
         # Elgato lights with color capabilities have a different highest value
-        if self._settings.power_on_hue is not None:
-            return 285
-        return 344
+        return self._max_mired
 
     @property
     def supported_color_modes(self) -> set[str]:
         """Flag supported color modes."""
-        modes = [COLOR_MODE_COLOR_TEMP]
-
-        # Check if the light is capable of doing colors
-        if self._settings.power_on_hue is not None:
-            modes += [COLOR_MODE_HS]
-
-        return set(modes)
+        return self._supported_color_modes
 
     @property
     def color_mode(self) -> str | None:

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -145,7 +145,7 @@ class ElgatoLight(LightEntity):
         try:
             await self.elgato.light(on=False)
         except ElgatoError:
-            _LOGGER.exception("An error occurred while updating the Elgato Light")
+            _LOGGER.error("An error occurred while updating the Elgato Light")
             self._state = None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -182,7 +182,7 @@ class ElgatoLight(LightEntity):
                 temperature=temperature,
             )
         except ElgatoError:
-            _LOGGER.exception("An error occurred while updating the Elgato Light")
+            _LOGGER.error("An error occurred while updating the Elgato Light")
             self._state = None
 
     async def async_update(self) -> None:

--- a/homeassistant/components/elgato/manifest.json
+++ b/homeassistant/components/elgato/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "elgato",
-  "name": "Elgato Key Light",
+  "name": "Elgato Light",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/elgato",
   "requirements": ["elgato==2.1.0"],

--- a/homeassistant/components/elgato/strings.json
+++ b/homeassistant/components/elgato/strings.json
@@ -1,17 +1,17 @@
 {
   "config": {
-    "flow_title": "Elgato Key Light: {serial_number}",
+    "flow_title": "Elgato Light: {serial_number}",
     "step": {
       "user": {
-        "description": "Set up your Elgato Key Light to integrate with Home Assistant.",
+        "description": "Set up your Elgato Light to integrate with Home Assistant.",
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
           "port": "[%key:common::config_flow::data::port%]"
         }
       },
       "zeroconf_confirm": {
-        "description": "Do you want to add the Elgato Key Light with serial number `{serial_number}` to Home Assistant?",
-        "title": "Discovered Elgato Key Light device"
+        "description": "Do you want to add the Elgato Light with serial number `{serial_number}` to Home Assistant?",
+        "title": "Discovered Elgato Light device"
       }
     },
     "error": {

--- a/homeassistant/components/elgato/translations/en.json
+++ b/homeassistant/components/elgato/translations/en.json
@@ -7,18 +7,18 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Elgato Key Light: {serial_number}",
+        "flow_title": "Elgato Light: {serial_number}",
         "step": {
             "user": {
                 "data": {
                     "host": "Host",
                     "port": "Port"
                 },
-                "description": "Set up your Elgato Key Light to integrate with Home Assistant."
+                "description": "Set up your Elgato Light to integrate with Home Assistant."
             },
             "zeroconf_confirm": {
-                "description": "Do you want to add the Elgato Key Light with serial number `{serial_number}` to Home Assistant?",
-                "title": "Discovered Elgato Key Light device"
+                "description": "Do you want to add the Elgato Light with serial number `{serial_number}` to Home Assistant?",
+                "title": "Discovered Elgato Light device"
             }
         }
     }

--- a/tests/components/elgato/__init__.py
+++ b/tests/components/elgato/__init__.py
@@ -12,6 +12,8 @@ async def init_integration(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,
     skip_setup: bool = False,
+    color: bool = False,
+    mode_color: bool = False,
 ) -> MockConfigEntry:
     """Set up the Elgato Key Light integration in Home Assistant."""
     aioclient_mock.get(
@@ -20,21 +22,35 @@ async def init_integration(
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 
-    aioclient_mock.put(
-        "http://127.0.0.1:9123/elgato/lights",
-        text=load_fixture("elgato/state.json"),
-        headers={"Content-Type": CONTENT_TYPE_JSON},
-    )
-
-    aioclient_mock.get(
-        "http://127.0.0.1:9123/elgato/lights",
-        text=load_fixture("elgato/state.json"),
-        headers={"Content-Type": CONTENT_TYPE_JSON},
-    )
-
     aioclient_mock.get(
         "http://127.0.0.2:9123/elgato/accessory-info",
         text=load_fixture("elgato/info.json"),
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    settings = "elgato/settings.json"
+    if color:
+        settings = "elgato/settings-color.json"
+
+    aioclient_mock.get(
+        "http://127.0.0.1:9123/elgato/lights/settings",
+        text=load_fixture(settings),
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    state = "elgato/state.json"
+    if mode_color:
+        state = "elgato/state-color.json"
+
+    aioclient_mock.get(
+        "http://127.0.0.1:9123/elgato/lights",
+        text=load_fixture(state),
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    aioclient_mock.put(
+        "http://127.0.0.1:9123/elgato/lights",
+        text=load_fixture("elgato/state.json"),
         headers={"Content-Type": CONTENT_TYPE_JSON},
     )
 

--- a/tests/components/elgato/test_light.py
+++ b/tests/components/elgato/test_light.py
@@ -2,11 +2,19 @@
 from unittest.mock import patch
 
 from elgato import ElgatoError
+import pytest
 
 from homeassistant.components.elgato.const import DOMAIN, SERVICE_IDENTIFY
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
+    ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP,
+    ATTR_HS_COLOR,
+    ATTR_MAX_MIREDS,
+    ATTR_MIN_MIREDS,
+    ATTR_SUPPORTED_COLOR_MODES,
+    COLOR_MODE_COLOR_TEMP,
+    COLOR_MODE_HS,
     DOMAIN as LIGHT_DOMAIN,
 )
 from homeassistant.const import (
@@ -24,10 +32,10 @@ from tests.components.elgato import init_integration
 from tests.test_util.aiohttp import AiohttpClientMocker
 
 
-async def test_light_state(
+async def test_light_state_temperature(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test the creation and values of the Elgato Key Lights."""
+    """Test the creation and values of the Elgato Lights in temperature mode."""
     await init_integration(hass, aioclient_mock)
 
     entity_registry = er.async_get(hass)
@@ -37,6 +45,11 @@ async def test_light_state(
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 54
     assert state.attributes.get(ATTR_COLOR_TEMP) == 297
+    assert state.attributes.get(ATTR_HS_COLOR) is None
+    assert state.attributes.get(ATTR_COLOR_MODE) == COLOR_MODE_COLOR_TEMP
+    assert state.attributes.get(ATTR_MIN_MIREDS) == 143
+    assert state.attributes.get(ATTR_MAX_MIREDS) == 344
+    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [COLOR_MODE_COLOR_TEMP]
     assert state.state == STATE_ON
 
     entry = entity_registry.async_get("light.frenck")
@@ -44,13 +57,42 @@ async def test_light_state(
     assert entry.unique_id == "CN11A1A00001"
 
 
-async def test_light_change_state(
+async def test_light_state_color(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the creation and values of the Elgato Lights in temperature mode."""
+    await init_integration(hass, aioclient_mock, color=True, mode_color=True)
+
+    entity_registry = er.async_get(hass)
+
+    # First segment of the strip
+    state = hass.states.get("light.frenck")
+    assert state
+    assert state.attributes.get(ATTR_BRIGHTNESS) == 128
+    assert state.attributes.get(ATTR_COLOR_TEMP) is None
+    assert state.attributes.get(ATTR_HS_COLOR) == (358.0, 6.0)
+    assert state.attributes.get(ATTR_MIN_MIREDS) == 153
+    assert state.attributes.get(ATTR_MAX_MIREDS) == 285
+    assert state.attributes.get(ATTR_COLOR_MODE) == COLOR_MODE_HS
+    assert state.attributes.get(ATTR_SUPPORTED_COLOR_MODES) == [
+        COLOR_MODE_COLOR_TEMP,
+        COLOR_MODE_HS,
+    ]
+    assert state.state == STATE_ON
+
+    entry = entity_registry.async_get("light.frenck")
+    assert entry
+    assert entry.unique_id == "CN11A1A00001"
+
+
+async def test_light_change_state_temperature(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
     """Test the change of state of a Elgato Key Light device."""
-    await init_integration(hass, aioclient_mock)
+    await init_integration(hass, aioclient_mock, color=True, mode_color=False)
 
     state = hass.states.get("light.frenck")
+    assert state
     assert state.state == STATE_ON
 
     with patch(
@@ -69,12 +111,25 @@ async def test_light_change_state(
         )
         await hass.async_block_till_done()
         assert len(mock_light.mock_calls) == 1
-        mock_light.assert_called_with(on=True, brightness=100, temperature=100)
+        mock_light.assert_called_with(
+            on=True, brightness=100, temperature=100, hue=None, saturation=None
+        )
 
-    with patch(
-        "homeassistant.components.elgato.light.Elgato.light",
-        return_value=mock_coro(),
-    ) as mock_light:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "light.frenck",
+                ATTR_BRIGHTNESS: 255,
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert len(mock_light.mock_calls) == 2
+        mock_light.assert_called_with(
+            on=True, brightness=100, temperature=297, hue=None, saturation=None
+        )
+
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_OFF,
@@ -82,14 +137,46 @@ async def test_light_change_state(
             blocking=True,
         )
         await hass.async_block_till_done()
-        assert len(mock_light.mock_calls) == 1
+        assert len(mock_light.mock_calls) == 3
         mock_light.assert_called_with(on=False)
 
 
-async def test_light_unavailable(
+async def test_light_change_state_color(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
 ) -> None:
-    """Test error/unavailable handling of an Elgato Key Light."""
+    """Test the color state state of a Elgato Light device."""
+    await init_integration(hass, aioclient_mock, color=True)
+
+    state = hass.states.get("light.frenck")
+    assert state
+    assert state.state == STATE_ON
+
+    with patch(
+        "homeassistant.components.elgato.light.Elgato.light",
+        return_value=mock_coro(),
+    ) as mock_light:
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {
+                ATTR_ENTITY_ID: "light.frenck",
+                ATTR_BRIGHTNESS: 255,
+                ATTR_HS_COLOR: (10.1, 20.2),
+            },
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        assert len(mock_light.mock_calls) == 1
+        mock_light.assert_called_with(
+            on=True, brightness=100, temperature=None, hue=10.1, saturation=20.2
+        )
+
+
+@pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
+async def test_light_unavailable(
+    service: str, hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test error/unavailable handling of an Elgato Light."""
     await init_integration(hass, aioclient_mock)
     with patch(
         "homeassistant.components.elgato.light.Elgato.light",
@@ -100,7 +187,7 @@ async def test_light_unavailable(
     ):
         await hass.services.async_call(
             LIGHT_DOMAIN,
-            SERVICE_TURN_OFF,
+            service,
             {ATTR_ENTITY_ID: "light.frenck"},
             blocking=True,
         )

--- a/tests/fixtures/elgato/settings-color.json
+++ b/tests/fixtures/elgato/settings-color.json
@@ -1,0 +1,10 @@
+{
+  "powerOnBehavior": 2,
+  "powerOnHue": 40.0,
+  "powerOnSaturation": 15.0,
+  "powerOnBrightness": 40,
+  "powerOnTemperature": 0,
+  "switchOnDurationMs": 150,
+  "switchOffDurationMs": 400,
+  "colorChangeDurationMs": 150
+}

--- a/tests/fixtures/elgato/settings.json
+++ b/tests/fixtures/elgato/settings.json
@@ -1,0 +1,8 @@
+{
+  "powerOnBehavior": 1,
+  "powerOnBrightness": 20,
+  "powerOnTemperature": 213,
+  "switchOnDurationMs": 100,
+  "switchOffDurationMs": 300,
+  "colorChangeDurationMs": 100
+}

--- a/tests/fixtures/elgato/state-color.json
+++ b/tests/fixtures/elgato/state-color.json
@@ -1,0 +1,11 @@
+{
+  "numberOfLights": 1,
+  "lights": [
+    {
+      "on": 1,
+      "hue": 358.0,
+      "saturation": 6.0,
+      "brightness": 50
+    }
+  ]
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support for the Elgato Light Strips to the Elgato integration.
The Light Strip is color capable and can switch between a temperature or color mode.

Because of this, all occurrences for "Key Light" have been replaced with "Light".
At the time of the creation of this integration, Elgato had only 1 light, now they have multiple (Key Light, Air and Light Strips), which all are supported. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17668

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
