### PR TITLE
Improve type annotations in Brother integration

### DIFF
--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -1,9 +1,9 @@
 """Constants for Brother integration."""
 from __future__ import annotations
 
-from typing import TypedDict
-
 from homeassistant.const import PERCENTAGE
+
+from .model import SensorDescription
 
 ATTR_BELT_UNIT_REMAINING_LIFE = "belt_unit_remaining_life"
 ATTR_BLACK_DRUM_COUNTER = "black_drum_counter"
@@ -217,12 +217,3 @@ SENSOR_TYPES: dict[str, SensorDescription] = {
         "enabled": False,
     },
 }
-
-
-class SensorDescription(TypedDict):
-    """Sensor description class."""
-
-    icon: str | None
-    label: str
-    unit: str | None
-    enabled: bool

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -1,57 +1,61 @@
 """Constants for Brother integration."""
 from __future__ import annotations
 
+from typing import Final
+
 from homeassistant.const import PERCENTAGE
 
 from .model import SensorDescription
 
-ATTR_BELT_UNIT_REMAINING_LIFE = "belt_unit_remaining_life"
-ATTR_BLACK_DRUM_COUNTER = "black_drum_counter"
-ATTR_BLACK_DRUM_REMAINING_LIFE = "black_drum_remaining_life"
-ATTR_BLACK_DRUM_REMAINING_PAGES = "black_drum_remaining_pages"
-ATTR_BLACK_INK_REMAINING = "black_ink_remaining"
-ATTR_BLACK_TONER_REMAINING = "black_toner_remaining"
-ATTR_BW_COUNTER = "b/w_counter"
-ATTR_COLOR_COUNTER = "color_counter"
-ATTR_CYAN_DRUM_COUNTER = "cyan_drum_counter"
-ATTR_CYAN_DRUM_REMAINING_LIFE = "cyan_drum_remaining_life"
-ATTR_CYAN_DRUM_REMAINING_PAGES = "cyan_drum_remaining_pages"
-ATTR_CYAN_INK_REMAINING = "cyan_ink_remaining"
-ATTR_CYAN_TONER_REMAINING = "cyan_toner_remaining"
-ATTR_DRUM_COUNTER = "drum_counter"
-ATTR_DRUM_REMAINING_LIFE = "drum_remaining_life"
-ATTR_DRUM_REMAINING_PAGES = "drum_remaining_pages"
-ATTR_DUPLEX_COUNTER = "duplex_unit_pages_counter"
-ATTR_FUSER_REMAINING_LIFE = "fuser_remaining_life"
-ATTR_LASER_REMAINING_LIFE = "laser_remaining_life"
-ATTR_MAGENTA_DRUM_COUNTER = "magenta_drum_counter"
-ATTR_MAGENTA_DRUM_REMAINING_LIFE = "magenta_drum_remaining_life"
-ATTR_MAGENTA_DRUM_REMAINING_PAGES = "magenta_drum_remaining_pages"
-ATTR_MAGENTA_INK_REMAINING = "magenta_ink_remaining"
-ATTR_MAGENTA_TONER_REMAINING = "magenta_toner_remaining"
-ATTR_MANUFACTURER = "Brother"
-ATTR_PAGE_COUNTER = "page_counter"
-ATTR_PF_KIT_1_REMAINING_LIFE = "pf_kit_1_remaining_life"
-ATTR_PF_KIT_MP_REMAINING_LIFE = "pf_kit_mp_remaining_life"
-ATTR_STATUS = "status"
-ATTR_UPTIME = "uptime"
-ATTR_YELLOW_DRUM_COUNTER = "yellow_drum_counter"
-ATTR_YELLOW_DRUM_REMAINING_LIFE = "yellow_drum_remaining_life"
-ATTR_YELLOW_DRUM_REMAINING_PAGES = "yellow_drum_remaining_pages"
-ATTR_YELLOW_INK_REMAINING = "yellow_ink_remaining"
-ATTR_YELLOW_TONER_REMAINING = "yellow_toner_remaining"
+ATTR_BELT_UNIT_REMAINING_LIFE: Final = "belt_unit_remaining_life"
+ATTR_BLACK_DRUM_COUNTER: Final = "black_drum_counter"
+ATTR_BLACK_DRUM_REMAINING_LIFE: Final = "black_drum_remaining_life"
+ATTR_BLACK_DRUM_REMAINING_PAGES: Final = "black_drum_remaining_pages"
+ATTR_BLACK_INK_REMAINING: Final = "black_ink_remaining"
+ATTR_BLACK_TONER_REMAINING: Final = "black_toner_remaining"
+ATTR_BW_COUNTER: Final = "b/w_counter"
+ATTR_COLOR_COUNTER: Final = "color_counter"
+ATTR_COUNTER: Final = "counter"
+ATTR_CYAN_DRUM_COUNTER: Final = "cyan_drum_counter"
+ATTR_CYAN_DRUM_REMAINING_LIFE: Final = "cyan_drum_remaining_life"
+ATTR_CYAN_DRUM_REMAINING_PAGES: Final = "cyan_drum_remaining_pages"
+ATTR_CYAN_INK_REMAINING: Final = "cyan_ink_remaining"
+ATTR_CYAN_TONER_REMAINING: Final = "cyan_toner_remaining"
+ATTR_DRUM_COUNTER: Final = "drum_counter"
+ATTR_DRUM_REMAINING_LIFE: Final = "drum_remaining_life"
+ATTR_DRUM_REMAINING_PAGES: Final = "drum_remaining_pages"
+ATTR_DUPLEX_COUNTER: Final = "duplex_unit_pages_counter"
+ATTR_FUSER_REMAINING_LIFE: Final = "fuser_remaining_life"
+ATTR_LASER_REMAINING_LIFE: Final = "laser_remaining_life"
+ATTR_MAGENTA_DRUM_COUNTER: Final = "magenta_drum_counter"
+ATTR_MAGENTA_DRUM_REMAINING_LIFE: Final = "magenta_drum_remaining_life"
+ATTR_MAGENTA_DRUM_REMAINING_PAGES: Final = "magenta_drum_remaining_pages"
+ATTR_MAGENTA_INK_REMAINING: Final = "magenta_ink_remaining"
+ATTR_MAGENTA_TONER_REMAINING: Final = "magenta_toner_remaining"
+ATTR_MANUFACTURER: Final = "Brother"
+ATTR_PAGE_COUNTER: Final = "page_counter"
+ATTR_PF_KIT_1_REMAINING_LIFE: Final = "pf_kit_1_remaining_life"
+ATTR_PF_KIT_MP_REMAINING_LIFE: Final = "pf_kit_mp_remaining_life"
+ATTR_REMAINING_PAGES: Final = "remaining_pages"
+ATTR_STATUS: Final = "status"
+ATTR_UPTIME: Final = "uptime"
+ATTR_YELLOW_DRUM_COUNTER: Final = "yellow_drum_counter"
+ATTR_YELLOW_DRUM_REMAINING_LIFE: Final = "yellow_drum_remaining_life"
+ATTR_YELLOW_DRUM_REMAINING_PAGES: Final = "yellow_drum_remaining_pages"
+ATTR_YELLOW_INK_REMAINING: Final = "yellow_ink_remaining"
+ATTR_YELLOW_TONER_REMAINING: Final = "yellow_toner_remaining"
 
-DATA_CONFIG_ENTRY = "config_entry"
+DATA_CONFIG_ENTRY: Final = "config_entry"
 
-DOMAIN = "brother"
+DOMAIN: Final = "brother"
 
-UNIT_PAGES = "p"
+UNIT_PAGES: Final = "p"
 
-PRINTER_TYPES = ["laser", "ink"]
+PRINTER_TYPES: Final = ["laser", "ink"]
 
-SNMP = "snmp"
+SNMP: Final = "snmp"
 
-ATTRS_MAP: dict[str, tuple[str, str]] = {
+ATTRS_MAP: Final[dict[str, tuple[str, str]]] = {
     ATTR_DRUM_REMAINING_LIFE: (ATTR_DRUM_REMAINING_PAGES, ATTR_DRUM_COUNTER),
     ATTR_BLACK_DRUM_REMAINING_LIFE: (
         ATTR_BLACK_DRUM_REMAINING_PAGES,
@@ -71,7 +75,7 @@ ATTRS_MAP: dict[str, tuple[str, str]] = {
     ),
 }
 
-SENSOR_TYPES: dict[str, SensorDescription] = {
+SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
     ATTR_STATUS: {
         "icon": "mdi:printer",
         "label": ATTR_STATUS.title(),

--- a/homeassistant/components/brother/model.py
+++ b/homeassistant/components/brother/model.py
@@ -1,0 +1,13 @@
+"""Type definitions for Brother integration."""
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class SensorDescription(TypedDict):
+    """Sensor description class."""
+
+    icon: str | None
+    label: str
+    unit: str | None
+    enabled: bool

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -13,16 +13,15 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import BrotherDataUpdateCoordinator
 from .const import (
+    ATTR_COUNTER,
     ATTR_MANUFACTURER,
+    ATTR_REMAINING_PAGES,
     ATTR_UPTIME,
     ATTRS_MAP,
     DATA_CONFIG_ENTRY,
     DOMAIN,
     SENSOR_TYPES,
 )
-
-ATTR_COUNTER = "counter"
-ATTR_REMAINING_PAGES = "remaining_pages"
 
 
 async def async_setup_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- moves `SensorDescription` type definition to `model.py` file
- uses `Final` type for constans

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
