### PR TITLE
Add Identify service to Elgato integration

### DIFF
--- a/homeassistant/components/elgato/const.py
+++ b/homeassistant/components/elgato/const.py
@@ -14,3 +14,6 @@ ATTR_ON = "on"
 ATTR_SOFTWARE_VERSION = "sw_version"
 
 CONF_SERIAL_NUMBER = "serial_number"
+
+# Services
+SERVICE_IDENTIFY = "identify"

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -17,7 +17,7 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, Entity
-from homeassistant.helpers.entity_platform import current_platform
+from homeassistant.helpers.entity_platform import async_get_current_platform
 
 from .const import DATA_ELGATO_CLIENT, DOMAIN, SERVICE_IDENTIFY
 
@@ -37,11 +37,8 @@ async def async_setup_entry(
     info = await elgato.info()
     async_add_entities([ElgatoLight(elgato, info)], True)
 
-    platform = current_platform.get()
-    if not platform:
-        return
-
-    platform.async_register_entity_service(  # type: ignore[no-untyped-call]
+    platform = async_get_current_platform()
+    platform.async_register_entity_service(
         SERVICE_IDENTIFY,
         {},
         ElgatoLight.async_identify.__name__,

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -17,8 +17,9 @@ from homeassistant.components.light import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity_platform import current_platform
 
-from .const import DATA_ELGATO_CLIENT, DOMAIN
+from .const import DATA_ELGATO_CLIENT, DOMAIN, SERVICE_IDENTIFY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -35,6 +36,16 @@ async def async_setup_entry(
     elgato: Elgato = hass.data[DOMAIN][entry.entry_id][DATA_ELGATO_CLIENT]
     info = await elgato.info()
     async_add_entities([ElgatoLight(elgato, info)], True)
+
+    platform = current_platform.get()
+    if not platform:
+        return
+
+    platform.async_register_entity_service(  # type: ignore[no-untyped-call]
+        SERVICE_IDENTIFY,
+        {},
+        ElgatoLight.async_identify.__name__,
+    )
 
 
 class ElgatoLight(LightEntity):
@@ -144,3 +155,10 @@ class ElgatoLight(LightEntity):
             "model": self._info.product_name,
             "sw_version": f"{self._info.firmware_version} ({self._info.firmware_build_number})",
         }
+
+    async def async_identify(self) -> None:
+        """Identify the light, will make it blink."""
+        try:
+            await self.elgato.identify()
+        except ElgatoError:
+            _LOGGER.exception("An error occurred while identifying the Elgato Light")

--- a/homeassistant/components/elgato/light.py
+++ b/homeassistant/components/elgato/light.py
@@ -159,3 +159,4 @@ class ElgatoLight(LightEntity):
             await self.elgato.identify()
         except ElgatoError:
             _LOGGER.exception("An error occurred while identifying the Elgato Light")
+            self._state = None

--- a/homeassistant/components/elgato/services.yaml
+++ b/homeassistant/components/elgato/services.yaml
@@ -1,0 +1,9 @@
+identify:
+  name: Identify
+  description: >-
+    Identify an Elgato Light. Blinks the light, which can be useful
+    for, e.g., a visual notification.
+  target:
+    entity:
+      integration: elgato
+      domain: light


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an `identify` service to the Elgato integration. It allows you to identify which light you are talking to, however, it maybe is useful for other things as well (e.g., a visual notification).

```yaml
- service: elgato.identify
  target:
    entity_id: light.key_light
```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
