### PR TITLE
Prevent parallel reload of automations

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -1,7 +1,6 @@
 """Allow to set up simple automation rules via the config file."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from typing import Any, Awaitable, Callable, Dict, cast
 
@@ -55,7 +54,10 @@ from homeassistant.helpers.script import (
     Script,
 )
 from homeassistant.helpers.script_variables import ScriptVariables
-from homeassistant.helpers.service import async_register_admin_service
+from homeassistant.helpers.service import (
+    ReloadServiceHelper,
+    async_register_admin_service,
+)
 from homeassistant.helpers.trace import (
     TraceElement,
     script_execution_set,
@@ -245,20 +247,23 @@ async def async_setup(hass, config):
         "async_turn_off",
     )
 
-    reload_lock = asyncio.Lock()
-
     async def reload_service_handler(service_call):
         """Remove all automations and load new ones from config."""
-        async with reload_lock:
-            conf = await component.async_prepare_reload()
-            if conf is None:
-                return
-            async_get_blueprints(hass).async_reset_cache()
-            await _async_process_config(hass, conf, component)
-            hass.bus.async_fire(EVENT_AUTOMATION_RELOADED, context=service_call.context)
+        conf = await component.async_prepare_reload()
+        if conf is None:
+            return
+        async_get_blueprints(hass).async_reset_cache()
+        await _async_process_config(hass, conf, component)
+        hass.bus.async_fire(EVENT_AUTOMATION_RELOADED, context=service_call.context)
+
+    reload_helper = ReloadServiceHelper(reload_service_handler)
 
     async_register_admin_service(
-        hass, DOMAIN, SERVICE_RELOAD, reload_service_handler, schema=vol.Schema({})
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        reload_helper.execute_service,
+        schema=vol.Schema({}),
     )
 
     return True

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -783,3 +783,43 @@ def verify_domain_control(
         return check_permissions
 
     return decorator
+
+
+class ReloadServiceHelper:
+    """Helper for reload services to minimize unnecessary reloads."""
+
+    def __init__(self, service_func: Callable[[ServiceCall], Awaitable]):
+        """Initialize ReloadServiceHelper."""
+        self._service_func = service_func
+        self._service_running = False
+        self._service_condition = asyncio.Condition()
+
+    async def execute_service(self, service_call: ServiceCall) -> None:
+        """Execute the service.
+
+        If a previous reload if currently in progress, wait for it to finish first.
+        Once the previous reload is finished, one of the waiting tasks will be assigned to
+        execute the reload, the others will wait for the reload to finish.
+        """
+
+        do_reload = False
+        async with self._service_condition:
+            if self._service_running:
+                # A previous reload task is already in progress, wait for it to finish
+                await self._service_condition.wait()
+
+        async with self._service_condition:
+            if not self._service_running:
+                # This task will do the reload
+                self._service_running = True
+                do_reload = True
+            else:
+                # Another task will perform the reload, wait for it to finish
+                await self._service_condition.wait()
+
+        if do_reload:
+            # Reload, then notify other tasks
+            await self._service_func(service_call)
+            async with self._service_condition:
+                self._service_running = False
+                self._service_condition.notify_all()

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -797,9 +797,9 @@ class ReloadServiceHelper:
     async def execute_service(self, service_call: ServiceCall) -> None:
         """Execute the service.
 
-        If a previous reload if currently in progress, wait for it to finish first.
-        Once the previous reload is finished, one of the waiting tasks will be assigned to
-        execute the reload, the others will wait for the reload to finish.
+        If a previous reload task if currently in progress, wait for it to finish first.
+        Once the previous reload task has finished, one of the waiting tasks will be
+        assigned to execute the reload, the others will wait for the reload to finish.
         """
 
         do_reload = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent parallel reload of automations where multiple reload service calls are racing against each other.

This adds a new helper `ReloadServiceHelper` with the following behavior:
- If a previous reload task if currently in progress, wait for it to finish first.
- Once the previous reload is finished, one of the waiting tasks will be assigned to execute the reload, the others will wait for the reload to finish before returning.

~~An alternative solution was in #50009~~


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
