### PR TITLE
Add typing to async_register_entity_service

### DIFF
--- a/homeassistant/components/zwave_js/lock.py
+++ b/homeassistant/components/zwave_js/lock.py
@@ -71,7 +71,7 @@ async def async_setup_entry(
     platform = entity_platform.current_platform.get()
     assert platform
 
-    platform.async_register_entity_service(  # type: ignore
+    platform.async_register_entity_service(
         SERVICE_SET_LOCK_USERCODE,
         {
             vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),
@@ -80,7 +80,7 @@ async def async_setup_entry(
         "async_set_lock_usercode",
     )
 
-    platform.async_register_entity_service(  # type: ignore
+    platform.async_register_entity_service(
         SERVICE_CLEAR_LOCK_USERCODE,
         {
             vol.Required(ATTR_CODE_SLOT): vol.Coerce(int),

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -862,17 +862,19 @@ ENTITY_SERVICE_FIELDS = {
 
 def make_entity_service_schema(
     schema: dict, *, extra: int = vol.PREVENT_EXTRA
-) -> vol.All:
+) -> vol.Schema:
     """Create an entity service schema."""
-    return vol.All(
-        vol.Schema(
-            {
-                **schema,
-                **ENTITY_SERVICE_FIELDS,
-            },
-            extra=extra,
-        ),
-        has_at_least_one_key(*ENTITY_SERVICE_FIELDS),
+    return vol.Schema(
+        vol.All(
+            vol.Schema(
+                {
+                    **schema,
+                    **ENTITY_SERVICE_FIELDS,
+                },
+                extra=extra,
+            ),
+            has_at_least_one_key(*ENTITY_SERVICE_FIELDS),
+        )
     )
 
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta
 import logging
 from logging import Logger
 from types import ModuleType
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from typing_extensions import Protocol
 
@@ -625,7 +625,13 @@ class EntityPlatform:
         )
 
     @callback
-    def async_register_entity_service(self, name, schema, func, required_features=None):  # type: ignore[no-untyped-def]
+    def async_register_entity_service(
+        self,
+        name: str,
+        schema: dict,
+        func: str | Callable[..., Any],
+        required_features: Iterable[int] | None = None,
+    ) -> None:
         """Register an entity service.
 
         Services will automatically be shared by all platforms of the same domain.
@@ -634,7 +640,7 @@ class EntityPlatform:
             return
 
         if isinstance(schema, dict):
-            schema = cv.make_entity_service_schema(schema)
+            service_schema = cv.make_entity_service_schema(schema)
 
         async def handle_service(call: ServiceCall) -> None:
             """Handle the service."""
@@ -651,7 +657,7 @@ class EntityPlatform:
             )
 
         self.hass.services.async_register(
-            self.platform_name, name, handle_service, schema
+            self.platform_name, name, handle_service, service_schema
         )
 
     async def _update_entity_states(self, now: datetime) -> None:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -11,6 +11,7 @@ from types import ModuleType
 from typing import TYPE_CHECKING, Any, Callable
 
 from typing_extensions import Protocol
+import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import (
@@ -628,7 +629,7 @@ class EntityPlatform:
     def async_register_entity_service(
         self,
         name: str,
-        schema: dict,
+        schema: dict | vol.Schema,
         func: str | Callable[..., Any],
         required_features: Iterable[int] | None = None,
     ) -> None:
@@ -640,7 +641,7 @@ class EntityPlatform:
             return
 
         if isinstance(schema, dict):
-            service_schema = cv.make_entity_service_schema(schema)
+            schema = cv.make_entity_service_schema(schema)
 
         async def handle_service(call: ServiceCall) -> None:
             """Handle the service."""
@@ -657,7 +658,7 @@ class EntityPlatform:
             )
 
         self.hass.services.async_register(
-            self.platform_name, name, handle_service, service_schema
+            self.platform_name, name, handle_service, schema
         )
 
     async def _update_entity_states(self, now: datetime) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds typing to `entity_platform.async_register_entity_service`, to make it possible for integrations using those to enable strict typing without having to ignore this call.

Adjusted zwavejs, which already had an ignored occurrence.

Inspired by: <https://github.com/home-assistant/core/pull/49990#pullrequestreview-650115470>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
