### PR TITLE
Handle Timeout exceptions in system_health

### DIFF
--- a/homeassistant/components/system_health/__init__.py
+++ b/homeassistant/components/system_health/__init__.py
@@ -216,6 +216,8 @@ async def async_check_can_reach_url(
         return "ok"
     except aiohttp.ClientError:
         data = {"type": "failed", "error": "unreachable"}
-        if more_info is not None:
-            data["more_info"] = more_info
-        return data
+    except asyncio.TimeoutError:
+        data = {"type": "failed", "error": "timeout"}
+    if more_info is not None:
+        data["more_info"] = more_info
+    return data

--- a/tests/components/system_health/test_init.py
+++ b/tests/components/system_health/test_init.py
@@ -113,6 +113,7 @@ async def test_platform_loading(hass, hass_ws_client, aioclient_mock):
     """Test registering via platform."""
     aioclient_mock.get("http://example.com/status", text="")
     aioclient_mock.get("http://example.com/status_fail", exc=ClientError)
+    aioclient_mock.get("http://example.com/timeout", exc=asyncio.TimeoutError)
     hass.config.components.add("fake_integration")
     mock_platform(
         hass,
@@ -128,6 +129,11 @@ async def test_platform_loading(hass, hass_ws_client, aioclient_mock):
                         "server_fail_reachable": system_health.async_check_can_reach_url(
                             hass,
                             "http://example.com/status_fail",
+                            more_info="http://more-info-url.com",
+                        ),
+                        "server_timeout": system_health.async_check_can_reach_url(
+                            hass,
+                            "http://example.com/timeout",
                             more_info="http://more-info-url.com",
                         ),
                         "async_crash": AsyncMock(side_effect=ValueError)(),
@@ -148,6 +154,11 @@ async def test_platform_loading(hass, hass_ws_client, aioclient_mock):
             "server_fail_reachable": {
                 "type": "failed",
                 "error": "unreachable",
+                "more_info": "http://more-info-url.com",
+            },
+            "server_timeout": {
+                "type": "failed",
+                "error": "timeout",
                 "more_info": "http://more-info-url.com",
             },
             "async_crash": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Handle `asyncio.TimeoutError` exceptions in `async_check_can_reach_url`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://discord.com/channels/330944238910963714/427516175237382144/838736156068806656 fixes #48986
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
