### PR TITLE
Add support for EDS0066

### DIFF
--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -195,7 +195,19 @@ HOBBYBOARD_EF: dict[str, list[DeviceComponentDescription]] = {
 
 # 7E sensors are special sensors by Embedded Data Systems
 
-EDS_SENSORS: dict[str, list[DeviceComponentDescription]] = {
+EDS_SENSORS = {
+    "EDS0066": [
+        {
+            "path": "EDS0066/temperature",
+            "name": "Temperature",
+            "type": SENSOR_TYPE_TEMPERATURE,
+        },
+        {
+            "path": "EDS0066/pressure",
+            "name": "Pressure",
+            "type": SENSOR_TYPE_PRESSURE,
+        },
+    ],
     "EDS0068": [
         {
             "path": "EDS0068/temperature",

--- a/homeassistant/components/onewire/sensor.py
+++ b/homeassistant/components/onewire/sensor.py
@@ -195,7 +195,7 @@ HOBBYBOARD_EF: dict[str, list[DeviceComponentDescription]] = {
 
 # 7E sensors are special sensors by Embedded Data Systems
 
-EDS_SENSORS = {
+EDS_SENSORS: dict[str, list[DeviceComponentDescription]] = {
     "EDS0066": [
         {
             "path": "EDS0066/temperature",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -796,7 +796,7 @@ MOCK_OWPROXY_DEVICES = {
                 "class": DEVICE_CLASS_TEMPERATURE,
             },
             {
-                "entity_id": "sensor.7e_222222222222_pressure",
+                "entity_id": "sensor.7E_222222222222_pressure",
                 "unique_id": "/7E.222222222222/EDS0066/pressure",
                 "injected_value": b"  1012.21",
                 "result": "1012.2",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -788,7 +788,7 @@ MOCK_OWPROXY_DEVICES = {
         },
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.7E_222222222222_temperature",
+                "entity_id": "sensor.7e_222222222222_temperature",
                 "unique_id": "/7E.222222222222/EDS0066/temperature",
                 "injected_value": b"    13.9375",
                 "result": "13.9",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -788,7 +788,7 @@ MOCK_OWPROXY_DEVICES = {
         },
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.7e_222222222222_temperature",
+                "entity_id": "sensor.7E_222222222222_temperature",
                 "unique_id": "/7E.222222222222/EDS0066/temperature",
                 "injected_value": b"    13.9375",
                 "result": "13.9",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -796,7 +796,7 @@ MOCK_OWPROXY_DEVICES = {
                 "class": DEVICE_CLASS_TEMPERATURE,
             },
             {
-                "entity_id": "sensor.7E_222222222222_pressure",
+                "entity_id": "sensor.7e_222222222222_pressure",
                 "unique_id": "/7E.222222222222/EDS0066/pressure",
                 "injected_value": b"  1012.21",
                 "result": "1012.2",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -788,7 +788,7 @@ MOCK_OWPROXY_DEVICES = {
         },
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.222222222222_temperature",
+                "entity_id": "sensor.7e_222222222222_temperature",
                 "unique_id": "/7E.222222222222/EDS0066/temperature",
                 "injected_value": b"    13.9375",
                 "result": "13.9",

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -775,6 +775,36 @@ MOCK_OWPROXY_DEVICES = {
             },
         ],
     },
+    "7E.222222222222": {
+        "inject_reads": [
+            b"EDS",  # read type
+            b"EDS0066",  # read device_type - note EDS specific
+        ],
+        "device_info": {
+            "identifiers": {(DOMAIN, "7E.222222222222")},
+            "manufacturer": "Maxim Integrated",
+            "model": "EDS",
+            "name": "7E.222222222222",
+        },
+        SENSOR_DOMAIN: [
+            {
+                "entity_id": "sensor.222222222222",
+                "unique_id": "/7E.222222222222/EDS0066/temperature",
+                "injected_value": b"    13.9375",
+                "result": "13.9",
+                "unit": TEMP_CELSIUS,
+                "class": DEVICE_CLASS_TEMPERATURE,
+            },
+            {
+                "entity_id": "sensor.222222222222",
+                "unique_id": "/7E.222222222222/EDS0066/pressure",
+                "injected_value": b"  1012.21",
+                "result": "1012.2",
+                "unit": PRESSURE_MBAR,
+                "class": DEVICE_CLASS_PRESSURE,
+            },
+        ],
+    },
 }
 
 MOCK_SYSBUS_DEVICES = {

--- a/tests/components/onewire/const.py
+++ b/tests/components/onewire/const.py
@@ -788,7 +788,7 @@ MOCK_OWPROXY_DEVICES = {
         },
         SENSOR_DOMAIN: [
             {
-                "entity_id": "sensor.222222222222",
+                "entity_id": "sensor.222222222222_temperature",
                 "unique_id": "/7E.222222222222/EDS0066/temperature",
                 "injected_value": b"    13.9375",
                 "result": "13.9",
@@ -796,7 +796,7 @@ MOCK_OWPROXY_DEVICES = {
                 "class": DEVICE_CLASS_TEMPERATURE,
             },
             {
-                "entity_id": "sensor.222222222222",
+                "entity_id": "sensor.7e_222222222222_pressure",
                 "unique_id": "/7E.222222222222/EDS0066/pressure",
                 "injected_value": b"  1012.21",
                 "result": "1012.2",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change add support for EDS0066 (https://www.embeddeddatasystems.com/OW-ENV-TP--Temperature-Barometric-Pressure-Sensor_p_171.html) a variant of the already supported EDS0068 (https://www.embeddeddatasystems.com/OW-ENV-THPL--Temperature-Humidity-Barometric-Pressure-Light-Sensor_p_175.html). EDS0066 only has temperature and barometric sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17711

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
