### PR TITLE
Fix KNX climate unque_id

### DIFF
--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -68,7 +68,24 @@ def _async_migrate_unique_id(
         ga_target_temperature_state = parse_device_group_address(
             entity_config[ClimateSchema.CONF_TARGET_TEMPERATURE_STATE_ADDRESS][0]
         )
-        new_uid = f"{ga_temperature_state}_{ga_target_temperature_state}"
+        target_temp = entity_config.get(ClimateSchema.CONF_TARGET_TEMPERATURE_ADDRESS)
+        ga_target_temperature = (
+            parse_device_group_address(target_temp[0])
+            if target_temp is not None
+            else None
+        )
+        setpoint_shift = entity_config.get(ClimateSchema.CONF_SETPOINT_SHIFT_ADDRESS)
+        ga_setpoint_shift = (
+            parse_device_group_address(setpoint_shift[0])
+            if setpoint_shift is not None
+            else None
+        )
+        new_uid = (
+            f"{ga_temperature_state}_"
+            f"{ga_target_temperature_state}_"
+            f"{ga_target_temperature}_"
+            f"{ga_setpoint_shift}"
+        )
         entity_registry.async_update_entity(entity_id, new_unique_id=new_uid)
 
 
@@ -81,7 +98,9 @@ class KNXClimate(KnxEntity, ClimateEntity):
         super().__init__(device)
         self._unique_id = (
             f"{device.temperature.group_address_state}_"
-            f"{device.target_temperature.group_address_state}"
+            f"{device.target_temperature.group_address_state}_"
+            f"{device.target_temperature.group_address}_"
+            f"{device._setpoint_shift.group_address}"  # pylint: disable=protected-access
         )
         self._unit_of_measurement = TEMP_CELSIUS
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds outgoing group address to climate unique_id. This should finally fix all unique_id problems with this platform. 🙏

`target_temperature_address` or `setpoint_shift_address` - one or the other is used for setting new temperatures. Just like for cover (see https://github.com/home-assistant/core/pull/49677#discussion_r622157140 )

It would be great if it could be included in 2021.5 as then there would only be one month of registry-entries to migrate (unique_id in knx was introduces 2021.4).
Note: Merging this would leave orphan entities for beta users (I have not added migration for the unique_id used in current beta until now, only for 2021.4), but I think this is ok for a beta 😬

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49088
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
