### PR TITLE
async_track_time_interval wrongly called with None as first parameter in all modbus platforms.

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -94,6 +94,7 @@ async def async_setup_platform(
         sensors.append(
             ModbusBinarySensor(
                 hub,
+                hass,
                 entry[CONF_NAME],
                 entry.get(CONF_SLAVE),
                 entry[CONF_ADDRESS],
@@ -110,10 +111,11 @@ class ModbusBinarySensor(BinarySensorEntity):
     """Modbus binary sensor."""
 
     def __init__(
-        self, hub, name, slave, address, device_class, input_type, scan_interval
+        self, hub, hass, name, slave, address, device_class, input_type, scan_interval
     ):
         """Initialize the Modbus binary sensor."""
         self._hub = hub
+        self._hass = hass
         self._name = name
         self._slave = int(slave) if slave else None
         self._address = int(address)
@@ -126,7 +128,7 @@ class ModbusBinarySensor(BinarySensorEntity):
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         async_track_time_interval(
-            self.hass, lambda arg: self.update(), self._scan_interval
+            self._hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -93,7 +93,7 @@ async def async_setup_platform(
             continue
 
         entity[CONF_STRUCTURE] = structure
-        entities.append(ModbusThermostat(hub, entity))
+        entities.append(ModbusThermostat(hub, hass, entity))
 
     async_add_entities(entities)
 
@@ -104,10 +104,12 @@ class ModbusThermostat(ClimateEntity):
     def __init__(
         self,
         hub: ModbusHub,
+        hass: HomeAssistant,
         config: dict[str, Any],
     ):
         """Initialize the modbus thermostat."""
         self._hub: ModbusHub = hub
+        self._hass: HomeAssistant = hass
         self._name = config[CONF_NAME]
         self._slave = config.get(CONF_SLAVE)
         self._target_temperature_register = config[CONF_TARGET_TEMP]
@@ -133,7 +135,7 @@ class ModbusThermostat(ClimateEntity):
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         async_track_time_interval(
-            self.hass, lambda arg: self.update(), self._scan_interval
+            self._hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -54,7 +54,7 @@ async def async_setup_platform(
     covers = []
     for cover in discovery_info[CONF_COVERS]:
         hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
-        covers.append(ModbusCover(hub, cover))
+        covers.append(ModbusCover(hub, hass, cover))
 
     async_add_entities(covers)
 
@@ -65,10 +65,12 @@ class ModbusCover(CoverEntity, RestoreEntity):
     def __init__(
         self,
         hub: ModbusHub,
+        hass: HomeAssistant,
         config: dict[str, Any],
     ):
         """Initialize the modbus cover."""
         self._hub: ModbusHub = hub
+        self._hass: HomeAssistant = hass
         self._coil = config.get(CALL_TYPE_COIL)
         self._device_class = config.get(CONF_DEVICE_CLASS)
         self._name = config[CONF_NAME]
@@ -107,7 +109,7 @@ class ModbusCover(CoverEntity, RestoreEntity):
             self._value = state.state
 
         async_track_time_interval(
-            self.hass, lambda arg: self.update(), self._scan_interval
+            self._hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -181,6 +181,7 @@ async def async_setup_platform(
         sensors.append(
             ModbusRegisterSensor(
                 hub,
+                hass,
                 entry,
                 structure,
             )
@@ -197,11 +198,13 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
     def __init__(
         self,
         hub,
+        hass,
         entry,
         structure,
     ):
         """Initialize the modbus register sensor."""
         self._hub = hub
+        self._hass = hass
         self._name = entry[CONF_NAME]
         slave = entry.get(CONF_SLAVE)
         self._slave = int(slave) if slave else None
@@ -227,7 +230,7 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
             self._value = state.state
 
         async_track_time_interval(
-            self.hass, lambda arg: self.update(), self._scan_interval
+            self._hass, lambda arg: self.update(), self._scan_interval
         )
 
     @property


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
the call async_track_time_interval(self.hass, ....) result in async_track_time_interval was called with None, because self.hass was never declared. Strangely enough the code works and the timed function gets called.

The consequences are unknown, but can be a reason why the modbus integration have been unstable since
approximately when the async_track_time_interval was introduced.

Solved by adding hass as a parameter to the __init__ function and storing it in the class.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
It would be nice if a person who knows helpers/event.py would comment on the possible consequence of calling with None in the first parameter, thanks in advance.

async_track_time_interval() starts function:
def update()
which contain synchronous calls to pymodbus, that I suspect can hang for a while if there are modbus
connection problems.

If confirmed it can be a problem, please add this PR to the first patch possible.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
