### PR TITLE
Fix RM pro temperature sensor

### DIFF
--- a/homeassistant/components/broadlink/sensor.py
+++ b/homeassistant/components/broadlink/sensor.py
@@ -51,7 +51,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     sensors = [
         BroadlinkSensor(device, monitored_condition)
         for monitored_condition in sensor_data
-        if sensor_data[monitored_condition] or device.api.type == "A1"
+        if sensor_data[monitored_condition] != 0 or device.api.type == "A1"
     ]
     async_add_entities(sensors)
 

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -60,7 +60,7 @@ class BroadlinkUpdateManager(ABC):
         try:
             data = await self.async_fetch_data()
 
-        except (BroadlinkException, ValueError, OSError) as err:
+        except (BroadlinkException, OSError) as err:
             if self.available and (
                 dt.utcnow() - self.last_update > self.SCAN_INTERVAL * 3
                 or isinstance(err, (AuthorizationError, OSError))

--- a/homeassistant/components/broadlink/updater.py
+++ b/homeassistant/components/broadlink/updater.py
@@ -132,7 +132,7 @@ class BroadlinkRMUpdateManager(BroadlinkUpdateManager):
         if data["temperature"] == -7:
             if previous_data is None or previous_data["temperature"] is None:
                 data["temperature"] = None
-            elif previous_data["temperature"] - data["temperature"] > 3:
+            elif abs(previous_data["temperature"] - data["temperature"]) > 3:
                 data["temperature"] = previous_data["temperature"]
         return data
 

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -144,7 +144,10 @@ async def test_device_setup_update_authorization_error(hass):
     """Test we handle an authorization error in the update step."""
     device = get_device("Office")
     mock_api = device.get_mock_api()
-    mock_api.check_sensors.side_effect = (blke.AuthorizationError(), None)
+    mock_api.check_sensors.side_effect = (
+        blke.AuthorizationError(),
+        {"temperature": 30},
+    )
 
     with patch.object(
         hass.config_entries, "async_forward_entry_setup"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## The problem

RM pro has a firmware issue that causes it to return -7 ºC when we call check_sensors() around 22.9 and 23 ºC.

If we ignore the issue, we return unreliable data. If we add a conditional and raise an exception, we raise false positives (-7 ºC may be a valid temperature), and it would also flood the logs, this behavior is consistent.

The right place to fix this is the firmware, but we don't have access to it.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a conditional to the update manager and replace -7 with the previous temperature when the variation is bigger than 3 °C.

If we get -7 °C at startup, we return None, so the temperature will be unknown until we get a different value, from which it will be possible to determine whether the next -7 is valid or not.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/42100
- This PR is related to issue: https://github.com/frankjoke/ioBroker.broadlink2/issues/32 https://github.com/lprhodes/homebridge-broadlink-rm/issues/319 https://github.com/home-assistant/core/issues/543
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
