### PR TITLE
Allign error handling for restart for hassio with core

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -477,11 +477,12 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:  # noqa: C90
             and await recorder.async_migration_in_progress(hass)
         ):
             _LOGGER.error(
-                "The system cannot %s while a database upgrade in progress",
+                "The system cannot %s while a database upgrade is in progress",
                 call.service,
             )
             raise HomeAssistantError(
-                f"The system cannot {call.service} while a database upgrade in progress."
+                f"The system cannot {call.service} "
+                "while a database upgrade is in progress."
             )
 
         if call.service == SERVICE_HOMEASSISTANT_STOP:
@@ -502,7 +503,8 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:  # noqa: C90
                 f"{HASS_DOMAIN}.check_config",
             )
             raise HomeAssistantError(
-                f"The system cannot {call.service} because the configuration is not valid: {errors}"
+                f"The system cannot {call.service} "
+                f"because the configuration is not valid: {errors}"
             )
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components.homeassistant import (
-    DOMAIN as HA_DOMAIN,
     SERVICE_CHECK_CONFIG,
     SHUTDOWN_SERVICES,
 )
@@ -500,7 +499,7 @@ async def async_setup(hass: HomeAssistant, config: Config) -> bool:  # noqa: C90
             hass.components.persistent_notification.async_create(
                 "Config error. See [the logs](/config/logs) for details.",
                 "Config validating",
-                f"{HA_DOMAIN}.check_config",
+                f"{HASS_DOMAIN}.check_config",
             )
             raise HomeAssistantError(
                 f"The system cannot {call.service} because the configuration is not valid: {errors}"

--- a/homeassistant/components/homeassistant/__init__.py
+++ b/homeassistant/components/homeassistant/__init__.py
@@ -133,11 +133,12 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:  # noqa: C9
             and await recorder.async_migration_in_progress(hass)
         ):
             _LOGGER.error(
-                "The system cannot %s while a database upgrade in progress",
+                "The system cannot %s while a database upgrade is in progress",
                 call.service,
             )
             raise HomeAssistantError(
-                f"The system cannot {call.service} while a database upgrade in progress."
+                f"The system cannot {call.service} "
+                "while a database upgrade is in progress."
             )
 
         if call.service == SERVICE_HOMEASSISTANT_STOP:
@@ -158,7 +159,8 @@ async def async_setup(hass: ha.HomeAssistant, config: dict) -> bool:  # noqa: C9
                 f"{ha.DOMAIN}.check_config",
             )
             raise HomeAssistantError(
-                f"The system cannot {call.service} because the configuration is not valid: {errors}"
+                f"The system cannot {call.service} "
+                f"because the configuration is not valid: {errors}"
             )
 
         if call.service == SERVICE_HOMEASSISTANT_RESTART:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Implement the same level of feedback when using restart/stop services for installations with a supervisor.

![image](https://user-images.githubusercontent.com/15093472/117145370-5f9fee00-adb3-11eb-8828-f0c68b8cd184.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
