### PR TITLE
Ignore empty output from MQTT fan's value template

### DIFF
--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -344,6 +344,9 @@ class MqttFan(MqttEntity, FanEntity):
         def state_received(msg):
             """Handle new received MQTT message."""
             payload = self._value_templates[CONF_STATE](msg.payload)
+            if not payload:
+                _LOGGER.debug("Ignoring empty state from '%s'", msg.topic)
+                return
             if payload == self._payload["STATE_ON"]:
                 self._state = True
             elif payload == self._payload["STATE_OFF"]:
@@ -470,6 +473,9 @@ class MqttFan(MqttEntity, FanEntity):
         def oscillation_received(msg):
             """Handle new received MQTT message for the oscillation."""
             payload = self._value_templates[ATTR_OSCILLATING](msg.payload)
+            if not payload:
+                _LOGGER.debug("Ignoring empty oscillation from '%s'", msg.topic)
+                return
             if payload == self._payload["OSCILLATE_ON_PAYLOAD"]:
                 self._oscillation = True
             elif payload == self._payload["OSCILLATE_OFF_PAYLOAD"]:

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -362,6 +362,9 @@ class MqttFan(MqttEntity, FanEntity):
         def percentage_received(msg):
             """Handle new received MQTT message for the percentage."""
             numeric_val_str = self._value_templates[ATTR_PERCENTAGE](msg.payload)
+            if not numeric_val_str:
+                _LOGGER.debug("Ignoring empty speed from '%s'", msg.topic)
+                return
             try:
                 percentage = ranged_value_to_percentage(
                     self._speed_range, int(numeric_val_str)
@@ -396,6 +399,9 @@ class MqttFan(MqttEntity, FanEntity):
         def preset_mode_received(msg):
             """Handle new received MQTT message for preset mode."""
             preset_mode = self._value_templates[ATTR_PRESET_MODE](msg.payload)
+            if not preset_mode:
+                _LOGGER.debug("Ignoring empty preset_mode from '%s'", msg.topic)
+                return
             if preset_mode not in self.preset_modes:
                 _LOGGER.warning(
                     "'%s' received on topic %s is not a valid preset mode",

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -374,16 +374,18 @@ class MqttFan(MqttEntity, FanEntity):
                 )
             except ValueError:
                 _LOGGER.warning(
-                    "'%s' received on topic %s is not a valid speed within the speed range",
+                    "'%s' received on topic %s. '%s' is not a valid speed within the speed range",
                     msg.payload,
                     msg.topic,
+                    numeric_val_str,
                 )
                 return
             if percentage < 0 or percentage > 100:
                 _LOGGER.warning(
-                    "'%s' received on topic %s is not a valid speed within the speed range",
+                    "'%s' received on topic %s. '%s' is not a valid speed within the speed range",
                     msg.payload,
                     msg.topic,
+                    numeric_val_str,
                 )
                 return
             self._percentage = percentage
@@ -407,9 +409,10 @@ class MqttFan(MqttEntity, FanEntity):
                 return
             if preset_mode not in self.preset_modes:
                 _LOGGER.warning(
-                    "'%s' received on topic %s is not a valid preset mode",
+                    "'%s' received on topic %s. '%s' is not a valid preset mode",
                     msg.payload,
                     msg.topic,
+                    preset_mode,
                 )
                 return
 
@@ -445,9 +448,10 @@ class MqttFan(MqttEntity, FanEntity):
                 self._speed = speed
             else:
                 _LOGGER.warning(
-                    "'%s' received on topic %s is not a valid speed",
+                    "'%s' received on topic %s. '%s' is not a valid speed",
                     msg.payload,
                     msg.topic,
+                    speed,
                 )
                 return
 

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -408,6 +408,10 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, cap
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 100
 
+    async_fire_mqtt_message(hass, "percentage-state-topic", '{"otherval": 100}')
+    assert "Ignoring empty speed from" in caplog.text
+    caplog.clear()
+
     async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "low"}')
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
@@ -423,6 +427,10 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, cap
     async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "silent"}')
     state = hass.states.get("fan.test")
     assert state.attributes.get("preset_mode") == "silent"
+
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"otherval": 100}')
+    assert "Ignoring empty preset_mode from" in caplog.text
+    caplog.clear()
 
 
 async def test_sending_mqtt_commands_and_optimistic(hass, mqtt_mock, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Ignore empty output from MQTT fan's value template
- Improve logging
- Allow shared state topics

The purpose is to support the case where speed and preset states are sent on the same topic.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50100
- This PR is related to issue: https://github.com/Koenkk/zigbee2mqtt/issues/7318
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
