### PR TITLE
Modify Sun attributes to be datetime objects for easy templating use.

### DIFF
--- a/homeassistant/components/sun/__init__.py
+++ b/homeassistant/components/sun/__init__.py
@@ -129,12 +129,12 @@ class Sun(Entity):
     def extra_state_attributes(self):
         """Return the state attributes of the sun."""
         return {
-            STATE_ATTR_NEXT_DAWN: self.next_dawn.isoformat(),
-            STATE_ATTR_NEXT_DUSK: self.next_dusk.isoformat(),
-            STATE_ATTR_NEXT_MIDNIGHT: self.next_midnight.isoformat(),
-            STATE_ATTR_NEXT_NOON: self.next_noon.isoformat(),
-            STATE_ATTR_NEXT_RISING: self.next_rising.isoformat(),
-            STATE_ATTR_NEXT_SETTING: self.next_setting.isoformat(),
+            STATE_ATTR_NEXT_DAWN: self.next_dawn,
+            STATE_ATTR_NEXT_DUSK: self.next_dusk,
+            STATE_ATTR_NEXT_MIDNIGHT: self.next_midnight,
+            STATE_ATTR_NEXT_NOON: self.next_noon,
+            STATE_ATTR_NEXT_RISING: self.next_rising,
+            STATE_ATTR_NEXT_SETTING: self.next_setting,
             STATE_ATTR_ELEVATION: self.solar_elevation,
             STATE_ATTR_AZIMUTH: self.solar_azimuth,
             STATE_ATTR_RISING: self.rising,

--- a/tests/components/sun/test_init.py
+++ b/tests/components/sun/test_init.py
@@ -85,24 +85,12 @@ async def test_setting_rising(hass, legacy_patchable_time):
             break
         mod += 1
 
-    assert next_dawn == dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_DAWN]
-    )
-    assert next_dusk == dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_DUSK]
-    )
-    assert next_midnight == dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_MIDNIGHT]
-    )
-    assert next_noon == dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_NOON]
-    )
-    assert next_rising == dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_RISING]
-    )
-    assert next_setting == dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_SETTING]
-    )
+    assert next_dawn == state.attributes[sun.STATE_ATTR_NEXT_DAWN]
+    assert next_dusk == state.attributes[sun.STATE_ATTR_NEXT_DUSK]
+    assert next_midnight == state.attributes[sun.STATE_ATTR_NEXT_MIDNIGHT]
+    assert next_noon == state.attributes[sun.STATE_ATTR_NEXT_NOON]
+    assert next_rising == state.attributes[sun.STATE_ATTR_NEXT_RISING]
+    assert next_setting == state.attributes[sun.STATE_ATTR_NEXT_SETTING]
 
 
 async def test_state_change(hass, legacy_patchable_time):
@@ -115,9 +103,7 @@ async def test_state_change(hass, legacy_patchable_time):
 
     await hass.async_block_till_done()
 
-    test_time = dt_util.parse_datetime(
-        hass.states.get(sun.ENTITY_ID).attributes[sun.STATE_ATTR_NEXT_RISING]
-    )
+    test_time = hass.states.get(sun.ENTITY_ID).attributes[sun.STATE_ATTR_NEXT_RISING]
     assert test_time is not None
 
     assert sun.STATE_BELOW_HORIZON == hass.states.get(sun.ENTITY_ID).state
@@ -153,12 +139,12 @@ async def test_norway_in_june(hass):
     state = hass.states.get(sun.ENTITY_ID)
     assert state is not None
 
-    assert dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_RISING]
-    ) == datetime(2016, 7, 24, 22, 59, 45, 689645, tzinfo=dt_util.UTC)
-    assert dt_util.parse_datetime(
-        state.attributes[sun.STATE_ATTR_NEXT_SETTING]
-    ) == datetime(2016, 7, 25, 22, 17, 13, 503932, tzinfo=dt_util.UTC)
+    assert state.attributes[sun.STATE_ATTR_NEXT_RISING] == datetime(
+        2016, 7, 24, 22, 59, 45, 689645, tzinfo=dt_util.UTC
+    )
+    assert state.attributes[sun.STATE_ATTR_NEXT_SETTING] == datetime(
+        2016, 7, 25, 22, 17, 13, 503932, tzinfo=dt_util.UTC
+    )
 
     assert state.state == sun.STATE_ABOVE_HORIZON
 


### PR DESCRIPTION
Sun attributes return a returns a string, this makes doing date operations in templates difficult. 
Conver sun component attributes to provide datetime objects. If isoformat string is still desired then can still be called.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Currently the sun.sun component has the following attributes as string:
```
next_dawn: '2021-05-06T09:34:48.370676+00:00'
next_dusk: '2021-05-06T01:00:37.750493+00:00'
next_midnight: '2021-05-06T05:17:55+00:00'
next_noon: '2021-05-06T17:17:58+00:00'
next_rising: '2021-05-06T10:07:19.684887+00:00'
next_setting: '2021-05-06T00:28:05.161891+00:00'
```

When interacting with sun attributes with templates, switch to understanding these attributes as datetime objects.
Alternatively, adding `.isoformat()` to the template will retain the current functionality.

Example:
`{{states.sun.sun.attributes.next_rising.isoformat()}}`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, doing time operations with sun attributes in templates does not work easily and requires re-parsing the attribute from a string. This prevents basic datetime operations.

Example:
```
{% if states('sun.sun') == 'above_horizon' %}
🌛{% set sec = (states.sun.sun.attributes.next_setting - now()).seconds %}
{% else %}
☀️{% set sec = (states.sun.sun.attributes.next_rising - now()).seconds %}
{% endif %}
{{ sec//3600 }}h{{ sec%3600//60 }}m
```
This results in an error of `TypeError: unsupported operand type(s) for -: 'str' and 'datetime.datetime'` Which would require extra unnecessary calls to `strptime` to be able to do datetime operations.

Currently `{{ states.sun.sun.attributes.next_rising }}` returns a string of `2021-05-06T10:07:19.684887+00:00`

With this change datetime operations in the example above do work.

So the following template:
```
{% if states('sun.sun') == 'above_horizon' %}
🌛{% set sec = (states.sun.sun.attributes.next_setting - now()).seconds %}
{% else %}
☀️{% set sec = (states.sun.sun.attributes.next_rising - now()).seconds %}
{% endif %}
{{ sec//3600 }}h{{ sec%3600//60 }}m

{{states.sun.sun.attributes.next_rising}}
{{states.sun.sun.attributes.next_rising.isoformat()}}
```

Returns a workable and easy to use time operations when working against the sun.
This results in an output of:
```
☀️

9h31m

2021-05-06 10:05:13.809781+00:00
2021-05-06T10:05:13.809781+00:00
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

I've tested this change on my own home assistant instance for about a few weeks now, the UI for the sun component needs no update as the Typescript calls already parse the time as a string, and this has no detrimental effect.

Additionally the developer tools for the sun.sun attributes continue to display the isoformat time as a string:
```
next_dawn: '2021-05-06T09:31:41.757299+00:00'
next_dusk: '2021-05-06T01:05:05.969020+00:00'
next_midnight: '2021-05-06T05:18:36+00:00'
next_noon: '2021-05-06T17:18:39+00:00'
next_rising: '2021-05-06T10:05:13.809781+00:00'
next_setting: '2021-05-07T00:32:42.010663+00:00'
elevation: -1.73
azimuth: 295.09
rising: false
friendly_name: Sun
```

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
