### PR TITLE
Fix zwave_js websocket api KeyError on unloaded entry

### DIFF
--- a/homeassistant/components/websocket_api/const.py
+++ b/homeassistant/components/websocket_api/const.py
@@ -23,6 +23,7 @@ MAX_PENDING_MSG = 2048
 ERR_ID_REUSE = "id_reuse"
 ERR_INVALID_FORMAT = "invalid_format"
 ERR_NOT_FOUND = "not_found"
+ERR_NOT_LOADED = "not_loaded"
 ERR_NOT_SUPPORTED = "not_supported"
 ERR_HOME_ASSISTANT_ERROR = "home_assistant_error"
 ERR_UNKNOWN_COMMAND = "unknown_command"

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -22,6 +22,7 @@ from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.components.websocket_api.const import (
     ERR_NOT_FOUND,
+    ERR_NOT_LOADED,
     ERR_NOT_SUPPORTED,
     ERR_UNKNOWN_ERROR,
 )
@@ -86,7 +87,7 @@ def async_get_entry(orig_func: Callable) -> Callable:
 
         if entry.state != ENTRY_STATE_LOADED:
             connection.send_error(
-                msg[ID], ERR_NOT_FOUND, f"Config entry {entry_id} not loaded"
+                msg[ID], ERR_NOT_LOADED, f"Config entry {entry_id} not loaded"
             )
             return
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -6,7 +6,7 @@ from zwave_js_server.const import LogLevel
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import InvalidNewValue, NotFoundError, SetValueFailed
 
-from homeassistant.components.websocket_api.const import ERR_NOT_FOUND
+from homeassistant.components.websocket_api.const import ERR_NOT_FOUND, ERR_NOT_LOADED
 from homeassistant.components.zwave_js.api import (
     COMMAND_CLASS_ID,
     CONFIG,
@@ -55,7 +55,7 @@ async def test_network_status(hass, integration, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_node_status(hass, integration, multisensor_6, hass_ws_client):
@@ -109,7 +109,7 @@ async def test_node_status(hass, integration, multisensor_6, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_add_node(
@@ -166,7 +166,7 @@ async def test_add_node(
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_client):
@@ -200,7 +200,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
     await ws_client.send_json(
         {ID: 7, TYPE: "zwave_js/stop_exclusion", ENTRY_ID: entry.entry_id}
@@ -208,7 +208,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_remove_node(
@@ -278,7 +278,7 @@ async def test_remove_node(
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_refresh_node_info(
@@ -377,7 +377,7 @@ async def test_refresh_node_info(
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_refresh_node_values(
@@ -505,7 +505,7 @@ async def test_refresh_node_cc_values(
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_set_config_parameter(
@@ -661,7 +661,7 @@ async def test_set_config_parameter(
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_get_config_parameters(hass, integration, multisensor_6, hass_ws_client):
@@ -721,7 +721,7 @@ async def test_get_config_parameters(hass, integration, multisensor_6, hass_ws_c
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_dump_view(integration, hass_client):
@@ -794,7 +794,7 @@ async def test_subscribe_logs(hass, integration, client, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_update_log_config(hass, client, integration, hass_ws_client):
@@ -931,7 +931,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_get_log_config(hass, client, integration, hass_ws_client):
@@ -982,7 +982,7 @@ async def test_get_log_config(hass, client, integration, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_data_collection(hass, client, integration, hass_ws_client):
@@ -1067,7 +1067,7 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
     await ws_client.send_json(
         {
@@ -1080,4 +1080,4 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
     msg = await ws_client.receive_json()
 
     assert not msg["success"]
-    assert msg["error"]["code"] == ERR_NOT_FOUND
+    assert msg["error"]["code"] == ERR_NOT_LOADED

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -968,6 +968,22 @@ async def test_get_log_config(hass, client, integration, hass_ws_client):
     assert log_config["filename"] == "/test.txt"
     assert log_config["force_console"] is False
 
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "zwave_js/get_log_config",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_data_collection(hass, client, integration, hass_ws_client):
     """Test that the data collection WS API commands work."""

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -916,6 +916,23 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
         and "must be provided if logging to file" in msg["error"]["message"]
     )
 
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 7,
+            TYPE: "zwave_js/update_log_config",
+            ENTRY_ID: entry.entry_id,
+            CONFIG: {LEVEL: "Error"},
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_get_log_config(hass, client, integration, hass_ws_client):
     """Test that the get_log_config WS API call works."""

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -626,6 +626,43 @@ async def test_set_config_parameter(
         assert msg["error"]["code"] == "unknown_error"
         assert msg["error"]["message"] == "test"
 
+    # Test getting non-existent node fails
+    await ws_client.send_json(
+        {
+            ID: 5,
+            TYPE: "zwave_js/set_config_parameter",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 9999,
+            PROPERTY: 102,
+            PROPERTY_KEY: 1,
+            VALUE: 1,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 6,
+            TYPE: "zwave_js/set_config_parameter",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 52,
+            PROPERTY: 102,
+            PROPERTY_KEY: 1,
+            VALUE: 1,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_get_config_parameters(hass, integration, multisensor_6, hass_ws_client):
     """Test the get config parameters websocket command."""

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -36,15 +36,6 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
     entry = integration
     ws_client = await hass_ws_client(hass)
 
-    await ws_client.send_json(
-        {ID: 2, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
-    )
-    msg = await ws_client.receive_json()
-    result = msg["result"]
-
-    assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
-    assert result["client"]["server_version"] == "1.0.0"
-
     node = multisensor_6
     await ws_client.send_json(
         {
@@ -109,6 +100,32 @@ async def test_websocket_api(hass, integration, multisensor_6, hass_ws_client):
         }
     )
     msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+
+async def test_network_status(hass, integration, hass_ws_client):
+    """Test the network status websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {ID: 2, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
+    )
+    msg = await ws_client.receive_json()
+    result = msg["result"]
+
+    assert result["client"]["ws_server_url"] == "ws://test:3000/zjs"
+    assert result["client"]["server_version"] == "1.0.0"
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {ID: 3, TYPE: "zwave_js/network_status", ENTRY_ID: entry.entry_id}
+    )
+    msg = await ws_client.receive_json()
+
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -190,6 +190,26 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
     msg = await ws_client.receive_json()
     assert msg["success"]
 
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {ID: 6, TYPE: "zwave_js/stop_inclusion", ENTRY_ID: entry.entry_id}
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    await ws_client.send_json(
+        {ID: 7, TYPE: "zwave_js/stop_exclusion", ENTRY_ID: entry.entry_id}
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_remove_node(
     hass,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -475,6 +475,38 @@ async def test_refresh_node_cc_values(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
+    # Test getting non-existent node fails
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/refresh_node_cc_values",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 9999,
+            COMMAND_CLASS_ID: 112,
+        }
+    )
+    msg = await ws_client.receive_json()
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/refresh_node_cc_values",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 52,
+            COMMAND_CLASS_ID: 112,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_set_config_parameter(
     hass, client, hass_ws_client, multisensor_6, integration

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -784,6 +784,18 @@ async def test_subscribe_logs(hass, integration, client, hass_ws_client):
         "timestamp": "time",
     }
 
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {ID: 2, TYPE: "zwave_js/subscribe_logs", ENTRY_ID: entry.entry_id}
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_update_log_config(hass, client, integration, hass_ws_client):
     """Test that the update_log_config WS API call works and that schema validation works."""

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -268,6 +268,18 @@ async def test_remove_node(
     )
     assert device is None
 
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {ID: 4, TYPE: "zwave_js/remove_node", ENTRY_ID: entry.entry_id}
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_FOUND
+
 
 async def test_refresh_node_info(
     hass, client, integration, hass_ws_client, multisensor_6


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Handle websocket api calls when the config entry is unloaded, eg when the server restarts.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #46439
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
