### PR TITLE
Rename Prometheus metrics to conform with naming guidelines

### DIFF
--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -54,12 +54,14 @@ COMPONENT_CONFIG_SCHEMA_ENTRY = vol.Schema(
     {vol.Optional(CONF_OVERRIDE_METRIC): cv.string}
 )
 
+DEFAULT_NAMESPACE = "homeassistant"
+
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
             {
                 vol.Optional(CONF_FILTER, default={}): entityfilter.FILTER_SCHEMA,
-                vol.Optional(CONF_PROM_NAMESPACE): cv.string,
+                vol.Optional(CONF_PROM_NAMESPACE, default=DEFAULT_NAMESPACE): cv.string,
                 vol.Optional(CONF_DEFAULT_METRIC): cv.string,
                 vol.Optional(CONF_OVERRIDE_METRIC): cv.string,
                 vol.Optional(CONF_COMPONENT_CONFIG, default={}): vol.Schema(

--- a/homeassistant/components/prometheus/__init__.py
+++ b/homeassistant/components/prometheus/__init__.py
@@ -291,7 +291,9 @@ class PrometheusMetrics:
 
     def _handle_light(self, state):
         metric = self._metric(
-            "light_state", self.prometheus_cli.Gauge, "Load level of a light (0..1)"
+            "light_brightness_percent",
+            self.prometheus_cli.Gauge,
+            "Light brightness percentage (0..100)",
         )
 
         try:
@@ -317,9 +319,9 @@ class PrometheusMetrics:
             if self._climate_units == TEMP_FAHRENHEIT:
                 temp = fahrenheit_to_celsius(temp)
             metric = self._metric(
-                "temperature_c",
+                "climate_target_temperature_celsius",
                 self.prometheus_cli.Gauge,
-                "Temperature in degrees Celsius",
+                "Target temperature in degrees Celsius",
             )
             metric.labels(**self._labels(state)).set(temp)
 
@@ -328,9 +330,9 @@ class PrometheusMetrics:
             if self._climate_units == TEMP_FAHRENHEIT:
                 current_temp = fahrenheit_to_celsius(current_temp)
             metric = self._metric(
-                "current_temperature_c",
+                "climate_current_temperature_celsius",
                 self.prometheus_cli.Gauge,
-                "Current Temperature in degrees Celsius",
+                "Current temperature in degrees Celsius",
             )
             metric.labels(**self._labels(state)).set(current_temp)
 
@@ -414,7 +416,7 @@ class PrometheusMetrics:
         """Get metric based on device class attribute."""
         metric = state.attributes.get(ATTR_DEVICE_CLASS)
         if metric is not None:
-            return f"{metric}_{unit}"
+            return f"sensor_{metric}_{unit}"
         return None
 
     def _sensor_override_metric(self, state, unit):
@@ -442,8 +444,8 @@ class PrometheusMetrics:
             return
 
         units = {
-            TEMP_CELSIUS: "c",
-            TEMP_FAHRENHEIT: "c",  # F should go into C metric
+            TEMP_CELSIUS: "celsius",
+            TEMP_FAHRENHEIT: "celsius",  # F should go into C metric
             PERCENTAGE: "percent",
         }
         default = unit.replace("/", "_per_")

--- a/tests/components/prometheus/test_init.py
+++ b/tests/components/prometheus/test_init.py
@@ -117,7 +117,7 @@ async def test_view(hass, hass_client):
     )
 
     assert (
-        'temperature_c{domain="sensor",'
+        'sensor_temperature_celsius{domain="sensor",'
         'entity="sensor.outside_temperature",'
         'friendly_name="Outside Temperature"} 15.6' in body
     )
@@ -129,7 +129,7 @@ async def test_view(hass, hass_client):
     )
 
     assert (
-        'current_temperature_c{domain="climate",'
+        'climate_current_temperature_celsius{domain="climate",'
         'entity="climate.heatpump",'
         'friendly_name="HeatPump"} 25.0' in body
     )
@@ -160,7 +160,7 @@ async def test_view(hass, hass_client):
     )
 
     assert (
-        'humidity_percent{domain="sensor",'
+        'sensor_humidity_percent{domain="sensor",'
         'entity="sensor.outside_humidity",'
         'friendly_name="Outside Humidity"} 54.0' in body
     )
@@ -172,7 +172,7 @@ async def test_view(hass, hass_client):
     )
 
     assert (
-        'power_kwh{domain="sensor",'
+        'sensor_power_kwh{domain="sensor",'
         'entity="sensor.radio_energy",'
         'friendly_name="Radio Energy"} 14.0' in body
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This includes a few changes to the names of the exported Prometheus metrics, which now better align with Prometheus [naming guidelines](https://github.com/home-assistant/core/tree/dev/homeassistant/components/prometheus#metric-naming-guidelines):

* Default value for the `namespace` configuration variable is now `homeassistant`, and all metric names now have a default `homeassistant_` prefix.
* Some metrics have been renamed:
    * `light_state` renamed to `light_brightness_percent`
    * `temperature_c` renamed to `climate_target_temperature_celsius`
    * `current_temperature_c` renamed to `climate_current_temperature_celsius`
    * sensor metrics now have a `sensor_` name prefix
    * temperature sensor metrics now have a `_celsius` unit suffix (as opposed to just `_c`)

Note, that users that don't currently explicitly set the `namespace` variable will see names changed for all exported metrics. If keeping existing metric names is important to you, you can adjust your Home Assistant and Prometheus configuration as described below.

To keep metrics exported without the `homeassistant_` prefix, explicitly set an empty namespace in Home Assistant configuration:

```
prometheus:
  namespace: ""
```

To revert the other metric name changes, you can use [metric_relabel_configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs) in your Prometheus configuration file to rename the metrics after scraping. [This set of relabeling rules](https://gist.github.com/knyar/c3a58f8be92a2b7afadba5c16bbfc28f) is a good starting point, but please note that if you set a non-empty `namespace` in Home Assistant you will need to adjust these rules accordingly.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Last year we described the metric naming guidelines (https://github.com/home-assistant/core/pull/37149), but a few older metrics had non-conforming names. This change brings those metrics in alignment with the guidelines.

This follows our discussion in https://github.com/home-assistant/architecture/issues/391 and the [metric naming plan](https://docs.google.com/document/d/1qkKObZXbZPVVVc6E4qHRpD5WNWcN0FrOeZFtL3HD7NE/edit#).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/37149
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
