### PR TITLE
Ensure zeroconf does not generate config flows when matching attributes are missing

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -340,32 +340,29 @@ async def _async_start_zeroconf_browser(
 
         # Not all homekit types are currently used for discovery
         # so not all service type exist in zeroconf_types
-        for entry in zeroconf_types.get(service_type, []):
-            if len(entry) > 1:
-                if (
-                    uppercase_mac is not None
-                    and "macaddress" in entry
-                    and not fnmatch.fnmatch(uppercase_mac, entry["macaddress"])
+        for matcher in zeroconf_types.get(service_type, []):
+            if len(matcher) > 1:
+                if "macaddress" in matcher and (
+                    uppercase_mac is None
+                    or not fnmatch.fnmatch(uppercase_mac, matcher["macaddress"])
                 ):
                     continue
-                if (
-                    lowercase_name is not None
-                    and "name" in entry
-                    and not fnmatch.fnmatch(lowercase_name, entry["name"])
+                if "name" in matcher and (
+                    lowercase_name is None
+                    or not fnmatch.fnmatch(lowercase_name, matcher["name"])
                 ):
                     continue
-                if (
-                    lowercase_manufacturer is not None
-                    and "manufacturer" in entry
-                    and not fnmatch.fnmatch(
-                        lowercase_manufacturer, entry["manufacturer"]
+                if "manufacturer" in matcher and (
+                    lowercase_manufacturer is None
+                    or not fnmatch.fnmatch(
+                        lowercase_manufacturer, matcher["manufacturer"]
                     )
                 ):
                     continue
 
             hass.add_job(
                 hass.config_entries.flow.async_init(
-                    entry["domain"], context={"source": DOMAIN}, data=info
+                    matcher["domain"], context={"source": DOMAIN}, data=info
                 )  # type: ignore
             )
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If macaddress, name, or manufacturer were missing from the
discovery info, the matcher would accept instead of reject.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
