### PR TITLE
Fix incorrect attribute checks in Modbus hub

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -237,7 +237,7 @@ class ModbusHub:
             except ModbusException as exception_error:
                 self._log_error(exception_error)
                 result = exception_error
-            if not hasattr(result, "registers"):
+            if not hasattr(result, "bits"):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -251,7 +251,7 @@ class ModbusHub:
                 result = self._client.read_discrete_inputs(address, count, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-            if not hasattr(result, "registers"):
+            if not hasattr(result, "bits"):
                 self._log_error(result)
                 return None
             self._in_error = False
@@ -293,7 +293,7 @@ class ModbusHub:
                 result = self._client.write_coil(address, value, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-            if not hasattr(result, "registers"):
+            if not hasattr(result, "value"):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -307,7 +307,7 @@ class ModbusHub:
                 result = self._client.write_coils(address, values, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-            if not hasattr(result, "registers"):
+            if not hasattr(result, "count"):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -321,7 +321,7 @@ class ModbusHub:
                 result = self._client.write_register(address, value, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-            if not hasattr(result, "registers"):
+            if not hasattr(result, "value"):
                 self._log_error(result)
                 return False
             self._in_error = False
@@ -335,7 +335,7 @@ class ModbusHub:
                 result = self._client.write_registers(address, values, **kwargs)
             except ModbusException as exception_error:
                 result = exception_error
-            if not hasattr(result, "registers"):
+            if not hasattr(result, "count"):
                 self._log_error(result)
                 return False
             self._in_error = False


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It looks like PR #49910 introduced invalid checks. For example, we expected that the response from coil write contains `registers` attribute. I went through all our methods, and replaced wrong expectations with correct ones. My setup works now, and tests still pass.

Further suggestions are welcome.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50010 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
