### PR TITLE
Remove MQTT cover deprecated options

### DIFF
--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -113,7 +113,7 @@ def validate_options(value):
             f"'{CONF_SET_POSITION_TOPIC}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
         )
 
-    """ if templates are set make sure the topic for the template is also set """
+    # if templates are set make sure the topic for the template is also set
 
     if CONF_VALUE_TEMPLATE in value and CONF_STATE_TOPIC not in value:
         raise vol.Invalid(

--- a/homeassistant/components/mqtt/cover.py
+++ b/homeassistant/components/mqtt/cover.py
@@ -71,7 +71,6 @@ CONF_STATE_OPEN = "state_open"
 CONF_STATE_OPENING = "state_opening"
 CONF_STATE_STOPPED = "state_stopped"
 CONF_TILT_CLOSED_POSITION = "tilt_closed_value"
-CONF_TILT_INVERT_STATE = "tilt_invert_state"
 CONF_TILT_MAX = "tilt_max"
 CONF_TILT_MIN = "tilt_min"
 CONF_TILT_OPEN_POSITION = "tilt_opened_value"
@@ -90,7 +89,6 @@ DEFAULT_POSITION_OPEN = 100
 DEFAULT_RETAIN = False
 DEFAULT_STATE_STOPPED = "stopped"
 DEFAULT_TILT_CLOSED_POSITION = 0
-DEFAULT_TILT_INVERT_STATE = False
 DEFAULT_TILT_MAX = 100
 DEFAULT_TILT_MIN = 0
 DEFAULT_TILT_OPEN_POSITION = 100
@@ -112,25 +110,34 @@ def validate_options(value):
     """
     if CONF_SET_POSITION_TOPIC in value and CONF_GET_POSITION_TOPIC not in value:
         raise vol.Invalid(
-            "'set_position_topic' must be set together with 'position_topic'."
+            f"'{CONF_SET_POSITION_TOPIC}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
         )
 
-    if (
-        CONF_GET_POSITION_TOPIC in value
-        and CONF_STATE_TOPIC not in value
-        and CONF_VALUE_TEMPLATE in value
-    ):
-        _LOGGER.warning(
-            "Using 'value_template' for 'position_topic' is deprecated "
-            "and will be removed from Home Assistant in version 2021.6, "
-            "please replace it with 'position_template'"
+    """ if templates are set make sure the topic for the template is also set """
+
+    if CONF_VALUE_TEMPLATE in value and CONF_STATE_TOPIC not in value:
+        raise vol.Invalid(
+            f"'{CONF_VALUE_TEMPLATE}' must be set together with '{CONF_STATE_TOPIC}'."
         )
 
-    if CONF_TILT_INVERT_STATE in value:
-        _LOGGER.warning(
-            "'tilt_invert_state' is deprecated "
-            "and will be removed from Home Assistant in version 2021.6, "
-            "please invert tilt using 'tilt_min' & 'tilt_max'"
+    if CONF_GET_POSITION_TEMPLATE in value and CONF_GET_POSITION_TOPIC not in value:
+        raise vol.Invalid(
+            f"'{CONF_GET_POSITION_TEMPLATE}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
+        )
+
+    if CONF_SET_POSITION_TEMPLATE in value and CONF_SET_POSITION_TOPIC not in value:
+        raise vol.Invalid(
+            f"'{CONF_SET_POSITION_TEMPLATE}' must be set together with '{CONF_SET_POSITION_TOPIC}'."
+        )
+
+    if CONF_TILT_COMMAND_TEMPLATE in value and CONF_TILT_COMMAND_TOPIC not in value:
+        raise vol.Invalid(
+            f"'{CONF_TILT_COMMAND_TEMPLATE}' must be set together with '{CONF_TILT_COMMAND_TOPIC}'."
+        )
+
+    if CONF_TILT_STATUS_TEMPLATE in value and CONF_TILT_STATUS_TOPIC not in value:
+        raise vol.Invalid(
+            f"'{CONF_TILT_STATUS_TEMPLATE}' must be set together with '{CONF_TILT_STATUS_TOPIC}'."
         )
 
     return value
@@ -164,7 +171,6 @@ PLATFORM_SCHEMA = vol.All(
                 CONF_TILT_CLOSED_POSITION, default=DEFAULT_TILT_CLOSED_POSITION
             ): int,
             vol.Optional(CONF_TILT_COMMAND_TOPIC): mqtt.valid_publish_topic,
-            vol.Optional(CONF_TILT_INVERT_STATE): cv.boolean,
             vol.Optional(CONF_TILT_MAX, default=DEFAULT_TILT_MAX): int,
             vol.Optional(CONF_TILT_MIN, default=DEFAULT_TILT_MIN): int,
             vol.Optional(
@@ -332,12 +338,6 @@ class MqttCover(MqttEntity, CoverEntity):
             payload = msg.payload
 
             template = self._config.get(CONF_GET_POSITION_TEMPLATE)
-
-            # To be removed in 2021.6:
-            # allow using `value_template` as position template if no `state_topic`
-            if template is None and self._config.get(CONF_STATE_TOPIC) is None:
-                template = self._config.get(CONF_VALUE_TEMPLATE)
-
             if template is not None:
                 variables = {
                     "entity_id": self.entity_id,
@@ -665,8 +665,7 @@ class MqttCover(MqttEntity, CoverEntity):
         max_percent = 100
         min_percent = 0
         position_percentage = min(max(position_percentage, min_percent), max_percent)
-        if range_type == TILT_PAYLOAD and self._config.get(CONF_TILT_INVERT_STATE):
-            return 100 - position_percentage
+
         return position_percentage
 
     def find_in_range_from_percent(self, percentage, range_type=TILT_PAYLOAD):
@@ -689,8 +688,6 @@ class MqttCover(MqttEntity, CoverEntity):
         position = round(current_range * (percentage / 100.0))
         position += offset
 
-        if range_type == TILT_PAYLOAD and self._config.get(CONF_TILT_INVERT_STATE):
-            position = max_range - position + offset
         return position
 
     def tilt_payload_received(self, _payload):

--- a/tests/components/mqtt/test_cover.py
+++ b/tests/components/mqtt/test_cover.py
@@ -10,10 +10,22 @@ from homeassistant.components.cover import (
     ATTR_POSITION,
     ATTR_TILT_POSITION,
 )
-from homeassistant.components.mqtt.cover import MqttCover
+from homeassistant.components.mqtt.const import CONF_STATE_TOPIC
+from homeassistant.components.mqtt.cover import (
+    CONF_GET_POSITION_TEMPLATE,
+    CONF_GET_POSITION_TOPIC,
+    CONF_SET_POSITION_TEMPLATE,
+    CONF_SET_POSITION_TOPIC,
+    CONF_TILT_COMMAND_TEMPLATE,
+    CONF_TILT_COMMAND_TOPIC,
+    CONF_TILT_STATUS_TEMPLATE,
+    CONF_TILT_STATUS_TOPIC,
+    MqttCover,
+)
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
+    CONF_VALUE_TEMPLATE,
     SERVICE_CLOSE_COVER,
     SERVICE_CLOSE_COVER_TILT,
     SERVICE_OPEN_COVER,
@@ -336,43 +348,6 @@ async def test_state_via_template_with_json_value(hass, mqtt_mock, caplog):
     assert (
         "Template variable warning: 'dict object' has no attribute 'Var1' when rendering"
     ) in caplog.text
-
-
-async def test_position_via_template(hass, mqtt_mock):
-    """Test the controlling state via topic."""
-    assert await async_setup_component(
-        hass,
-        cover.DOMAIN,
-        {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "position_topic": "get-position-topic",
-                "command_topic": "command-topic",
-                "qos": 0,
-                "value_template": "{{ (value | multiply(0.01)) | int }}",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_UNKNOWN
-
-    async_fire_mqtt_message(hass, "get-position-topic", "10000")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
-
-    async_fire_mqtt_message(hass, "get-position-topic", "5000")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_OPEN
-
-    async_fire_mqtt_message(hass, "get-position-topic", "99")
-
-    state = hass.states.get("cover.test")
-    assert state.state == STATE_CLOSED
 
 
 async def test_position_via_template_and_entity_id(hass, mqtt_mock):
@@ -1899,7 +1874,6 @@ async def test_find_percentage_in_range_defaults(hass, mqtt_mock):
             "tilt_min": 0,
             "tilt_max": 100,
             "tilt_optimistic": False,
-            "tilt_invert_state": False,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -1943,7 +1917,6 @@ async def test_find_percentage_in_range_altered(hass, mqtt_mock):
             "tilt_min": 80,
             "tilt_max": 180,
             "tilt_optimistic": False,
-            "tilt_invert_state": False,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -1984,10 +1957,9 @@ async def test_find_percentage_in_range_defaults_inverted(hass, mqtt_mock):
             "value_template": None,
             "tilt_open_position": 100,
             "tilt_closed_position": 0,
-            "tilt_min": 0,
-            "tilt_max": 100,
+            "tilt_min": 100,
+            "tilt_max": 0,
             "tilt_optimistic": False,
-            "tilt_invert_state": True,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -2028,10 +2000,9 @@ async def test_find_percentage_in_range_altered_inverted(hass, mqtt_mock):
             "value_template": None,
             "tilt_open_position": 180,
             "tilt_closed_position": 80,
-            "tilt_min": 80,
-            "tilt_max": 180,
+            "tilt_min": 180,
+            "tilt_max": 80,
             "tilt_optimistic": False,
-            "tilt_invert_state": True,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -2075,7 +2046,6 @@ async def test_find_in_range_defaults(hass, mqtt_mock):
             "tilt_min": 0,
             "tilt_max": 100,
             "tilt_optimistic": False,
-            "tilt_invert_state": False,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -2119,7 +2089,6 @@ async def test_find_in_range_altered(hass, mqtt_mock):
             "tilt_min": 80,
             "tilt_max": 180,
             "tilt_optimistic": False,
-            "tilt_invert_state": False,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -2160,10 +2129,9 @@ async def test_find_in_range_defaults_inverted(hass, mqtt_mock):
             "value_template": None,
             "tilt_open_position": 100,
             "tilt_closed_position": 0,
-            "tilt_min": 0,
-            "tilt_max": 100,
+            "tilt_min": 100,
+            "tilt_max": 0,
             "tilt_optimistic": False,
-            "tilt_invert_state": True,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -2204,10 +2172,9 @@ async def test_find_in_range_altered_inverted(hass, mqtt_mock):
             "value_template": None,
             "tilt_open_position": 180,
             "tilt_closed_position": 80,
-            "tilt_min": 80,
-            "tilt_max": 180,
+            "tilt_min": 180,
+            "tilt_max": 80,
             "tilt_optimistic": False,
-            "tilt_invert_state": True,
             "set_position_topic": None,
             "set_position_template": None,
             "unique_id": None,
@@ -2428,105 +2395,6 @@ async def test_entity_debug_info_message(hass, mqtt_mock):
     await help_test_entity_debug_info_message(
         hass, mqtt_mock, cover.DOMAIN, DEFAULT_CONFIG
     )
-
-
-async def test_deprecated_value_template_for_position_topic_warning(
-    hass, caplog, mqtt_mock
-):
-    """Test warning when value_template is used for position_topic."""
-    assert await async_setup_component(
-        hass,
-        cover.DOMAIN,
-        {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "position-topic",
-                "value_template": "{{100-62}}",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert (
-        "Using 'value_template' for 'position_topic' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6, "
-        "please replace it with 'position_template'"
-    ) in caplog.text
-
-
-async def test_deprecated_tilt_invert_state_warning(hass, caplog, mqtt_mock):
-    """Test warning when tilt_invert_state is used."""
-    assert await async_setup_component(
-        hass,
-        cover.DOMAIN,
-        {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "tilt_invert_state": True,
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert (
-        "'tilt_invert_state' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6, "
-        "please invert tilt using 'tilt_min' & 'tilt_max'"
-    ) in caplog.text
-
-
-async def test_no_deprecated_tilt_invert_state_warning(hass, caplog, mqtt_mock):
-    """Test warning when tilt_invert_state is used."""
-    assert await async_setup_component(
-        hass,
-        cover.DOMAIN,
-        {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert (
-        "'tilt_invert_state' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6, "
-        "please invert tilt using 'tilt_min' & 'tilt_max'"
-    ) not in caplog.text
-
-
-async def test_no_deprecated_warning_for_position_topic_using_position_template(
-    hass, caplog, mqtt_mock
-):
-    """Test no warning when position_template is used for position_topic."""
-    assert await async_setup_component(
-        hass,
-        cover.DOMAIN,
-        {
-            cover.DOMAIN: {
-                "platform": "mqtt",
-                "name": "test",
-                "command_topic": "command-topic",
-                "set_position_topic": "set-position-topic",
-                "position_topic": "position-topic",
-                "position_template": "{{100-62}}",
-            }
-        },
-    )
-    await hass.async_block_till_done()
-
-    assert (
-        "using 'value_template' for 'position_topic' is deprecated "
-        "and will be removed from Home Assistant in version 2021.6, "
-        "please replace it with 'position_template'"
-    ) not in caplog.text
 
 
 async def test_state_and_position_topics_state_not_set_via_position_topic(
@@ -2969,3 +2837,142 @@ async def test_position_via_position_topic_template_return_invalid_json(
     async_fire_mqtt_message(hass, "get-position-topic", "55")
 
     assert ("Payload '{'position': Undefined}' is not numeric") in caplog.text
+
+
+async def test_set_position_topic_without_get_position_topic_error(
+    hass, caplog, mqtt_mock
+):
+    """Test error when set_position_topic is used without position_topic."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+                "set_position_topic": "set-position-topic",
+                "value_template": "{{100-62}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        f"'{CONF_SET_POSITION_TOPIC}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
+    ) in caplog.text
+
+
+async def test_value_template_without_state_topic_error(hass, caplog, mqtt_mock):
+    """Test error when value_template is used and state_topic is missing."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+                "value_template": "{{100-62}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        f"'{CONF_VALUE_TEMPLATE}' must be set together with '{CONF_STATE_TOPIC}'."
+    ) in caplog.text
+
+
+async def test_position_template_without_position_topic_error(hass, caplog, mqtt_mock):
+    """Test error when position_template is used and position_topic is missing."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+                "position_template": "{{100-52}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        f"'{CONF_GET_POSITION_TEMPLATE}' must be set together with '{CONF_GET_POSITION_TOPIC}'."
+        in caplog.text
+    )
+
+
+async def test_set_position_template_without_set_position_topic(
+    hass, caplog, mqtt_mock
+):
+    """Test error when set_position_template is used and set_position_topic is missing."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+                "set_position_template": "{{100-42}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        f"'{CONF_SET_POSITION_TEMPLATE}' must be set together with '{CONF_SET_POSITION_TOPIC}'."
+        in caplog.text
+    )
+
+
+async def test_tilt_command_template_without_tilt_command_topic(
+    hass, caplog, mqtt_mock
+):
+    """Test error when tilt_command_template is used and tilt_command_topic is missing."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+                "tilt_command_template": "{{100-32}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        f"'{CONF_TILT_COMMAND_TEMPLATE}' must be set together with '{CONF_TILT_COMMAND_TOPIC}'."
+        in caplog.text
+    )
+
+
+async def test_tilt_status_template_without_tilt_status_topic_topic(
+    hass, caplog, mqtt_mock
+):
+    """Test error when tilt_status_template is used and tilt_status_topic is missing."""
+    assert await async_setup_component(
+        hass,
+        cover.DOMAIN,
+        {
+            cover.DOMAIN: {
+                "platform": "mqtt",
+                "name": "test",
+                "command_topic": "command-topic",
+                "tilt_status_template": "{{100-22}}",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert (
+        f"'{CONF_TILT_STATUS_TEMPLATE}' must be set together with '{CONF_TILT_STATUS_TOPIC}'."
+        in caplog.text
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously deprecated features of MQTT cover have been removed:
- Using `value_template` to use for extracting position is no longer allowed an error will be raised if this configuration is used, Instead of using `value_template`, `position_template` should be used.
- `tilt_invert_state` is removed, instead `tilt_min` and `tilt_max` should be used, error will be raised if this is found in configuration.

## Proposed change
#### Remove MQTT cover deprecated options marked to be removed in core 2021.6 by https://github.com/home-assistant/core/pull/46059:
- Using `value_template` to use for extracting position is no longer allowed an error will be raised if this configuration is used, Instead of using `value_template`, `position_template` should be used.
- `tilt_invert_state` is removed, instead `tilt_min` and `tilt_max` should be used, error will be raised if this is found in configuration.

#### Add validation for templates missing the relevant topics:
- Raise error when `value_template` is used and `state_topic` is missing.
- Raise error when `position_template` is used and `position_topic` is missing.
- Raise error when `set_position_template` is used and `set_position_topic` is missing.
- Raise error when `tilt_command_template` is used and `tilt_command_topic` is missing.
- Raise error when `tilt_status_template` is used and `tilt_status_topic` is missing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
