### PR TITLE
Add Etekcity VeSync light bulbs to Homeassistant

### DIFF
--- a/homeassistant/components/vesync/common.py
+++ b/homeassistant/components/vesync/common.py
@@ -21,6 +21,10 @@ async def async_process_devices(hass, manager):
         devices[VS_FANS].extend(manager.fans)
         _LOGGER.info("%d VeSync fans found", len(manager.fans))
 
+    if manager.bulbs:
+        devices[VS_LIGHTS].extend(manager.bulbs)
+        _LOGGER.info("%d VeSync lights found", len(manager.bulbs))
+
     if manager.outlets:
         devices[VS_SWITCHES].extend(manager.outlets)
         _LOGGER.info("%d VeSync outlets found", len(manager.outlets))

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -35,6 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DOMAIN][VS_DISPATCHERS].append(disp)
 
     _async_setup_entities(hass.data[DOMAIN][VS_LIGHTS], async_add_entities)
+    return True
 
 
 @callback
@@ -47,7 +48,7 @@ def _async_setup_entities(devices, async_add_entities):
         elif DEV_TYPE_TO_HA.get(dev.device_type) == "bulb":
             entities.append(VeSyncBulbHA(dev))
         else:
-            _LOGGER.debug(
+            _LOGGER.warning(
                 "%s - Unknown device type - %s", dev.device_name, dev.device_type
             )
             continue

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -35,7 +35,6 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DOMAIN][VS_DISPATCHERS].append(disp)
 
     _async_setup_entities(hass.data[DOMAIN][VS_LIGHTS], async_add_entities)
-    return True
 
 
 @callback
@@ -48,7 +47,7 @@ def _async_setup_entities(devices, async_add_entities):
         elif DEV_TYPE_TO_HA.get(dev.device_type) == "bulb":
             entities.append(VeSyncBulbHA(dev))
         else:
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "%s - Unknown device type - %s", dev.device_name, dev.device_type
             )
             continue

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -104,7 +104,7 @@ class VeSyncDimmableLightHA(VeSyncBaseLight, LightEntity):
         return [COLOR_MODE_BRIGHTNESS]
 
 
-class VeSyncTunableWhiteLightHA(VeSyncDevice, LightEntity):
+class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
     """Representation of a VeSync Tunable White Light device."""
 
     def __init__(self, device):
@@ -121,9 +121,9 @@ class VeSyncTunableWhiteLightHA(VeSyncDevice, LightEntity):
             brightness = round((brightness / 255) * 100)
             # clamp to 1-100
             brightness = max(1, min(brightness, 100))
+            # pass value to pyvesync library api
             self.device.set_brightness(brightness)
-        # Avoid turning device back on if this is just a brightness adjustment
-        elif ATTR_COLOR_TEMP in kwargs:
+        if ATTR_COLOR_TEMP in kwargs:
             # get brightness from HA data
             color_temp = int(kwargs[ATTR_COLOR_TEMP])
             # flip cold/warm to what pyvesync api expects

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -60,11 +60,6 @@ def _async_setup_entities(devices, async_add_entities):
 class VeSyncBaseLight(VeSyncDevice, LightEntity):
     """Base class for VeSync Light Devices Representations."""
 
-    def __init__(self, device):
-        """Initialize the VeSync LightDevice."""
-        super().__init__(device)
-        self.device = device
-
     @property
     def brightness(self):
         """Get light brightness."""
@@ -132,11 +127,6 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
 class VeSyncDimmableLightHA(VeSyncBaseLight, LightEntity):
     """Representation of a VeSync dimmable light device."""
 
-    def __init__(self, device):
-        """Initialize the VeSync dimmable light device."""
-        super().__init__(device)
-        self.device = device
-
     @property
     def color_mode(self):
         """Set color mode for this entity."""
@@ -150,11 +140,6 @@ class VeSyncDimmableLightHA(VeSyncBaseLight, LightEntity):
 
 class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
     """Representation of a VeSync Tunable White Light device."""
-
-    def __init__(self, device):
-        """Initialize the VeSync Tunable White Light device."""
-        super().__init__(device)
-        self.device = device
 
     @property
     def color_temp(self):
@@ -181,8 +166,7 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
             + ((self.max_mireds - self.min_mireds) / 100 * color_temp_value)
         )
         # ensure value between minimum and maximum Mireds
-        color_temp_value = max(self.min_mireds, min(color_temp_value, self.max_mireds))
-        return color_temp_value
+        return max(self.min_mireds, min(color_temp_value, self.max_mireds))
 
     @property
     def min_mireds(self):

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -81,8 +81,7 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
             )
             return 0
         # convert percent brightness to ha expected range
-        brightness_value = round((max(1, brightness_value) / 100) * 255)
-        return brightness_value
+        return round((max(1, brightness_value) / 100) * 255)
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -62,6 +62,7 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
 
     def __init__(self, device):
         """Initialize the VeSync LightDevice."""
+        super().__init__(device)
         self.device = device
 
     @property

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -15,8 +15,10 @@ from .const import DOMAIN, VS_DISCOVERY, VS_DISPATCHERS, VS_LIGHTS
 _LOGGER = logging.getLogger(__name__)
 
 DEV_TYPE_TO_HA = {
-    "ESD16": "light",
-    "ESWD16": "light",
+    "ESD16": "dimmerswitch",
+    "ESWD16": "dimmerswitch",
+    "ESL100": "bulb",
+    "ESL100CW": "bulb",
 }
 
 
@@ -33,6 +35,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     hass.data[DOMAIN][VS_DISPATCHERS].append(disp)
 
     _async_setup_entities(hass.data[DOMAIN][VS_LIGHTS], async_add_entities)
+    return True
 
 
 @callback
@@ -40,10 +43,12 @@ def _async_setup_entities(devices, async_add_entities):
     """Check if device is online and add entity."""
     entities = []
     for dev in devices:
-        if DEV_TYPE_TO_HA.get(dev.device_type) == "light":
+        if DEV_TYPE_TO_HA.get(dev.device_type) == "dimmerswitch":
             entities.append(VeSyncDimmerHA(dev))
+        elif DEV_TYPE_TO_HA.get(dev.device_type) == "bulb":
+            entities.append(VeSyncBulbHA(dev))
         else:
-            _LOGGER.debug(
+            _LOGGER.warning(
                 "%s - Unknown device type - %s", dev.device_name, dev.device_type
             )
             continue
@@ -82,3 +87,36 @@ class VeSyncDimmerHA(VeSyncDevice, LightEntity):
     def brightness(self):
         """Get dimmer brightness."""
         return round((int(self.dimmer.brightness) / 100) * 255)
+
+
+class VeSyncBulbHA(VeSyncDevice, LightEntity):
+    """Representation of a VeSync bulb."""
+
+    def __init__(self, bulb):
+        """Initialize the VeSync bulb device."""
+        super().__init__(bulb)
+        self.bulb = bulb
+
+    def turn_on(self, **kwargs):
+        """Turn the device on."""
+        if ATTR_BRIGHTNESS in kwargs:
+            # get brightness from HA data
+            brightness = int(kwargs[ATTR_BRIGHTNESS])
+            # convert to percent that vesync api expects
+            brightness = round((brightness / 255) * 100)
+            # clamp to 1-100
+            brightness = max(1, min(brightness, 100))
+            self.bulb.set_brightness(brightness)
+        # Avoid turning device back on if this is just a brightness adjustment
+        if not self.is_on:
+            self.device.turn_on()
+
+    @property
+    def supported_features(self):
+        """Get supported features for this entity."""
+        return SUPPORT_BRIGHTNESS
+
+    @property
+    def brightness(self):
+        """Get bulb brightness."""
+        return round((int(self.bulb.brightness) / 100) * 255)

--- a/homeassistant/components/vesync/light.py
+++ b/homeassistant/components/vesync/light.py
@@ -73,16 +73,16 @@ class VeSyncBaseLight(VeSyncDevice, LightEntity):
         try:
             # check for validity of brightness value received
             brightness_value = int(result)
-            # convert percent brightness to ha expected range
-            brightness_value = round((max(1, brightness_value) / 100) * 255)
-            return brightness_value
         except ValueError:
-            # deal if any unexpected value
+            # deal if any unexpected/non numeric value
             _LOGGER.debug(
-                "VeSync - received brightness level from pyvesync api out of range: %d",
+                "VeSync - received unexpected 'brightness' value from pyvesync api: %s",
                 result,
             )
             return 0
+        # convert percent brightness to ha expected range
+        brightness_value = round((max(1, brightness_value) / 100) * 255)
+        return brightness_value
 
     def turn_on(self, **kwargs):
         """Turn the device on."""
@@ -165,27 +165,25 @@ class VeSyncTunableWhiteLightHA(VeSyncBaseLight, LightEntity):
         try:
             # check for validity of brightness value received
             color_temp_value = int(result)
-            # flip cold/warm
-            color_temp_value = 100 - color_temp_value
-            # ensure value between 0-100
-            color_temp_value = max(0, min(color_temp_value, 100))
-            # convert percent value to Mireds
-            color_temp_value = round(
-                self.min_mireds
-                + ((self.max_mireds - self.min_mireds) / 100 * color_temp_value)
-            )
-            # ensure value between minimum and maximum Mireds
-            color_temp_value = max(
-                self.min_mireds, min(color_temp_value, self.max_mireds)
-            )
-            return color_temp_value
         except ValueError:
-            # deal if any unexpected value
+            # deal if any unexpected/non numeric value
             _LOGGER.debug(
-                "VeSync - received color_temp_pct level from pyvesync api out of range: %d",
+                "VeSync - received unexpected 'color_temp_pct' value from pyvesync api: %s",
                 result,
             )
             return 0
+        # flip cold/warm
+        color_temp_value = 100 - color_temp_value
+        # ensure value between 0-100
+        color_temp_value = max(0, min(color_temp_value, 100))
+        # convert percent value to Mireds
+        color_temp_value = round(
+            self.min_mireds
+            + ((self.max_mireds - self.min_mireds) / 100 * color_temp_value)
+        )
+        # ensure value between minimum and maximum Mireds
+        color_temp_value = max(self.min_mireds, min(color_temp_value, self.max_mireds))
+        return color_temp_value
 
     @property
     def min_mireds(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add etekcity vesync smart bulbs to Home Assistant.

This pull request adds the light bulbs platform to the vesync integration.
The bulbs can be switched, and brightness and white temperature can be adjusted.
For the attributes adjustments, this pull request uses the new **color_modes** structure in lieu of the deprecated ones.

I'm really new to homeassistant core code structure, and git. and I'm not a programmer, so please help me through the git merging process


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/17745

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
