### PR TITLE
Add support for fan speed percentage and preset modes to google_assistant integration

### DIFF
--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -118,6 +118,7 @@ COMMAND_THERMOSTAT_TEMPERATURE_SET_RANGE = (
 COMMAND_THERMOSTAT_SET_MODE = f"{PREFIX_COMMANDS}ThermostatSetMode"
 COMMAND_LOCKUNLOCK = f"{PREFIX_COMMANDS}LockUnlock"
 COMMAND_FANSPEED = f"{PREFIX_COMMANDS}SetFanSpeed"
+COMMAND_FANSPEEDRELATIVE = f"{PREFIX_COMMANDS}SetFanSpeedRelative"
 COMMAND_MODES = f"{PREFIX_COMMANDS}SetModes"
 COMMAND_INPUT = f"{PREFIX_COMMANDS}SetInput"
 COMMAND_NEXT_INPUT = f"{PREFIX_COMMANDS}NextInput"
@@ -1273,6 +1274,7 @@ class FanSpeedTrait(_Trait):
         reversible = False
 
         if domain == fan.DOMAIN:
+            # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
             modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
             for mode in modes:
                 if mode not in self.speed_synonyms:
@@ -1301,6 +1303,7 @@ class FanSpeedTrait(_Trait):
             "availableFanSpeeds": {"speeds": speeds, "ordered": True},
             "reversible": reversible,
             "supportsFanSpeedPercent": True,
+            "commandOnlyFanSpeed": True,
         }
 
     def query_attributes(self):
@@ -1339,7 +1342,19 @@ class FanSpeedTrait(_Trait):
             service_params = {
                 ATTR_ENTITY_ID: self.state.entity_id,
             }
-            if "fanSpeedPercent" in params:
+            if command == COMMAND_FANSPEEDRELATIVE:
+                if "fanSpeedRelativePercent" in params:
+                    relative_percentage = params["fanSpeedRelativePercent"]
+                else:
+                    relative_percentage = params[
+                        "fanSpeedRelativeWeight"
+                    ] * self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP)
+                if relative_percentage > 0:
+                    service = fan.SERVICE_INCREASE_SPEED
+                else:
+                    service = fan.SERVICE_DECREASE_SPEED
+                service_params[fan.ATTR_PERCENTAGE_STEP] = abs(relative_percentage)
+            elif "fanSpeedPercent" in params:
                 service = fan.SERVICE_SET_PERCENTAGE
                 service_params[fan.ATTR_PERCENTAGE] = params["fanSpeedPercent"]
             else:
@@ -1373,6 +1388,9 @@ class ModesTrait(_Trait):
     @staticmethod
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
+        if domain == fan.DOMAIN and features & fan.SUPPORT_PRESET_MODE:
+            return True
+
         if domain == input_select.DOMAIN:
             return True
 
@@ -1416,6 +1434,7 @@ class ModesTrait(_Trait):
         modes = []
 
         for domain, attr, name in (
+            (fan.DOMAIN, fan.ATTR_PRESET_MODES, "preset mode"),
             (media_player.DOMAIN, media_player.ATTR_SOUND_MODE_LIST, "sound mode"),
             (input_select.DOMAIN, input_select.ATTR_OPTIONS, "option"),
             (humidifier.DOMAIN, humidifier.ATTR_AVAILABLE_MODES, "mode"),
@@ -1442,7 +1461,10 @@ class ModesTrait(_Trait):
         response = {}
         mode_settings = {}
 
-        if self.state.domain == media_player.DOMAIN:
+        if self.state.domain == fan.DOMAIN:
+            if fan.ATTR_PRESET_MODES in attrs:
+                mode_settings["preset mode"] = attrs.get(fan.ATTR_PRESET_MODE)
+        elif self.state.domain == media_player.DOMAIN:
             if media_player.ATTR_SOUND_MODE_LIST in attrs:
                 mode_settings["sound mode"] = attrs.get(media_player.ATTR_SOUND_MODE)
         elif self.state.domain == input_select.DOMAIN:
@@ -1463,8 +1485,19 @@ class ModesTrait(_Trait):
         """Execute a SetModes command."""
         settings = params.get("updateModeSettings")
 
+        if self.state.domain == fan.DOMAIN:
+            preset_mode = settings["preset mode"]
+            await self.hass.services.async_call(
+                fan.DOMAIN,
+                fan.SERVICE_SET_PRESET_MODE,
+                {
+                    ATTR_ENTITY_ID: self.state.entity_id,
+                    fan.ATTR_PRESET_MODE: preset_mode,
+                },
+            )
+
         if self.state.domain == input_select.DOMAIN:
-            option = params["updateModeSettings"]["option"]
+            option = settings["option"]
             await self.hass.services.async_call(
                 input_select.DOMAIN,
                 input_select.SERVICE_SELECT_OPTION,

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1277,8 +1277,6 @@ class FanSpeedTrait(_Trait):
             # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
             modes = self.state.attributes.get(fan.ATTR_SPEED_LIST, [])
             for mode in modes:
-                if mode not in self.speed_synonyms:
-                    continue
                 speed = {
                     "speed_name": mode,
                     "speed_values": [
@@ -1542,26 +1540,25 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain != media_player.DOMAIN:
-            _LOGGER.info(
-                "Received an Options command for unrecognised domain %s",
-                self.state.domain,
-            )
-            return
+        if self.state.domain == media_player.DOMAIN:
+            sound_mode = settings.get("sound mode")
+            if sound_mode:
+                await self.hass.services.async_call(
+                    media_player.DOMAIN,
+                    media_player.SERVICE_SELECT_SOUND_MODE,
+                    {
+                        ATTR_ENTITY_ID: self.state.entity_id,
+                        media_player.ATTR_SOUND_MODE: sound_mode,
+                    },
+                    blocking=True,
+                    context=data.context,
+                )
 
-        sound_mode = settings.get("sound mode")
-
-        if sound_mode:
-            await self.hass.services.async_call(
-                media_player.DOMAIN,
-                media_player.SERVICE_SELECT_SOUND_MODE,
-                {
-                    ATTR_ENTITY_ID: self.state.entity_id,
-                    media_player.ATTR_SOUND_MODE: sound_mode,
-                },
-                blocking=True,
-                context=data.context,
-            )
+        _LOGGER.info(
+            "Received an Options command for unrecognised domain %s",
+            self.state.domain,
+        )
+        return
 
 
 @register_trait

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1303,7 +1303,6 @@ class FanSpeedTrait(_Trait):
             "availableFanSpeeds": {"speeds": speeds, "ordered": True},
             "reversible": reversible,
             "supportsFanSpeedPercent": True,
-            "commandOnlyFanSpeed": True,
         }
 
     def query_attributes(self):
@@ -1321,6 +1320,7 @@ class FanSpeedTrait(_Trait):
             if speed is not None:
                 response["on"] = speed != fan.SPEED_OFF
                 response["currentFanSpeedSetting"] = speed
+            if percent:
                 response["currentFanSpeedPercent"] = percent
         return response
 
@@ -1381,6 +1381,7 @@ class ModesTrait(_Trait):
     commands = [COMMAND_MODES]
 
     SYNONYMS = {
+        "preset mode": ["preset mode", "preset"],
         "sound mode": ["sound mode", "effects"],
         "option": ["option", "setting", "mode", "value"],
     }
@@ -1494,7 +1495,10 @@ class ModesTrait(_Trait):
                     ATTR_ENTITY_ID: self.state.entity_id,
                     fan.ATTR_PRESET_MODE: preset_mode,
                 },
+                blocking=True,
+                context=data.context,
             )
+            return
 
         if self.state.domain == input_select.DOMAIN:
             option = settings["option"]

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -1318,7 +1318,7 @@ class FanSpeedTrait(_Trait):
             if speed is not None:
                 response["on"] = speed != fan.SPEED_OFF
                 response["currentFanSpeedSetting"] = speed
-            if percent:
+            if percent is not None:
                 response["currentFanSpeedPercent"] = percent
         return response
 
@@ -1340,19 +1340,7 @@ class FanSpeedTrait(_Trait):
             service_params = {
                 ATTR_ENTITY_ID: self.state.entity_id,
             }
-            if command == COMMAND_FANSPEEDRELATIVE:
-                if "fanSpeedRelativePercent" in params:
-                    relative_percentage = params["fanSpeedRelativePercent"]
-                else:
-                    relative_percentage = params[
-                        "fanSpeedRelativeWeight"
-                    ] * self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP)
-                if relative_percentage > 0:
-                    service = fan.SERVICE_INCREASE_SPEED
-                else:
-                    service = fan.SERVICE_DECREASE_SPEED
-                service_params[fan.ATTR_PERCENTAGE_STEP] = abs(relative_percentage)
-            elif "fanSpeedPercent" in params:
+            if "fanSpeedPercent" in params:
                 service = fan.SERVICE_SET_PERCENTAGE
                 service_params[fan.ATTR_PERCENTAGE] = params["fanSpeedPercent"]
             else:
@@ -1379,7 +1367,7 @@ class ModesTrait(_Trait):
     commands = [COMMAND_MODES]
 
     SYNONYMS = {
-        "preset mode": ["preset mode", "preset"],
+        "preset mode": ["preset mode", "mode", "preset"],
         "sound mode": ["sound mode", "effects"],
         "option": ["option", "setting", "mode", "value"],
     }

--- a/tests/components/google_assistant/__init__.py
+++ b/tests/components/google_assistant/__init__.py
@@ -247,14 +247,20 @@ DEMO_DEVICES = [
     {
         "id": "fan.living_room_fan",
         "name": {"name": "Living Room Fan"},
-        "traits": ["action.devices.traits.FanSpeed", "action.devices.traits.OnOff"],
+        "traits": [
+            "action.devices.traits.FanSpeed",
+            "action.devices.traits.OnOff",
+        ],
         "type": "action.devices.types.FAN",
         "willReportState": False,
     },
     {
         "id": "fan.ceiling_fan",
         "name": {"name": "Ceiling Fan"},
-        "traits": ["action.devices.traits.FanSpeed", "action.devices.traits.OnOff"],
+        "traits": [
+            "action.devices.traits.FanSpeed",
+            "action.devices.traits.OnOff",
+        ],
         "type": "action.devices.types.FAN",
         "willReportState": False,
     },
@@ -275,7 +281,10 @@ DEMO_DEVICES = [
     {
         "id": "fan.preset_only_limited_fan",
         "name": {"name": "Preset Only Limited Fan"},
-        "traits": ["action.devices.traits.OnOff"],
+        "traits": [
+            "action.devices.traits.OnOff",
+            "action.devices.traits.Modes",
+        ],
         "type": "action.devices.types.FAN",
         "willReportState": False,
     },

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1474,7 +1474,6 @@ async def test_fan_speed(hass):
         },
         "reversible": False,
         "supportsFanSpeedPercent": True,
-        "commandOnlyFanSpeed": True,
     }
 
     assert trt.query_attributes() == {
@@ -1589,7 +1588,6 @@ async def test_climate_fan_speed(hass):
         },
         "reversible": False,
         "supportsFanSpeedPercent": True,
-        "commandOnlyFanSpeed": True,
     }
 
     assert trt.query_attributes() == {
@@ -1992,6 +1990,77 @@ async def test_sound_modes(hass):
     assert calls[0].data == {
         "entity_id": "media_player.living_room",
         "sound_mode": "stereo",
+    }
+
+
+async def test_preset_modes(hass):
+    """Test Mode trait for fan preset modes."""
+    assert helpers.get_google_type(media_player.DOMAIN, None) is not None
+    assert trait.ModesTrait.supported(
+        media_player.DOMAIN, media_player.SUPPORT_SELECT_SOUND_MODE, None, None
+    )
+
+    trt = trait.ModesTrait(
+        hass,
+        State(
+            "fan.living_room",
+            STATE_ON,
+            attributes={
+                fan.ATTR_PRESET_MODES: ["auto", "whoosh"],
+                fan.ATTR_PRESET_MODE: "auto",
+                ATTR_SUPPORTED_FEATURES: fan.SUPPORT_PRESET_MODE,
+            },
+        ),
+        BASIC_CONFIG,
+    )
+
+    attribs = trt.sync_attributes()
+    assert attribs == {
+        "availableModes": [
+            {
+                "name": "preset mode",
+                "name_values": [
+                    {"name_synonym": ["preset mode", "preset"], "lang": "en"}
+                ],
+                "settings": [
+                    {
+                        "setting_name": "auto",
+                        "setting_values": [{"setting_synonym": ["auto"], "lang": "en"}],
+                    },
+                    {
+                        "setting_name": "whoosh",
+                        "setting_values": [
+                            {"setting_synonym": ["whoosh"], "lang": "en"}
+                        ],
+                    },
+                ],
+                "ordered": False,
+            }
+        ]
+    }
+
+    assert trt.query_attributes() == {
+        "currentModeSettings": {"preset mode": "auto"},
+        "on": True,
+    }
+
+    assert trt.can_execute(
+        trait.COMMAND_MODES,
+        params={"updateModeSettings": {"preset mode": "auto"}},
+    )
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_SET_PRESET_MODE)
+    await trt.execute(
+        trait.COMMAND_MODES,
+        BASIC_DATA,
+        {"updateModeSettings": {"preset mode": "auto"}},
+        {},
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {
+        "entity_id": "fan.living_room",
+        "preset_mode": "auto",
     }
 
 

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1995,10 +1995,8 @@ async def test_sound_modes(hass):
 
 async def test_preset_modes(hass):
     """Test Mode trait for fan preset modes."""
-    assert helpers.get_google_type(media_player.DOMAIN, None) is not None
-    assert trait.ModesTrait.supported(
-        media_player.DOMAIN, media_player.SUPPORT_SELECT_SOUND_MODE, None, None
-    )
+    assert helpers.get_google_type(fan.DOMAIN, None) is not None
+    assert trait.ModesTrait.supported(fan.DOMAIN, fan.SUPPORT_PRESET_MODE, None, None)
 
     trt = trait.ModesTrait(
         hass,
@@ -2062,6 +2060,28 @@ async def test_preset_modes(hass):
         "entity_id": "fan.living_room",
         "preset_mode": "auto",
     }
+
+
+async def test_traits_unknown_domains(hass, caplog):
+    """Test Mode trait for unsupported domain."""
+    trt = trait.ModesTrait(
+        hass,
+        State(
+            "switch.living_room",
+            STATE_ON,
+        ),
+        BASIC_CONFIG,
+    )
+
+    assert trt.supported("not_supported_domain", False, None, None) is False
+    await trt.execute(
+        trait.COMMAND_MODES,
+        BASIC_DATA,
+        {"updateModeSettings": {}},
+        {},
+    )
+    assert "Received an Options command for unrecognised domain" in caplog.text
+    caplog.clear()
 
 
 async def test_openclose_cover(hass):

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1425,6 +1425,7 @@ async def test_fan_speed(hass):
                 ],
                 "speed": "low",
                 "percentage": 33,
+                "percentage_step": 1.0,
             },
         ),
         BASIC_CONFIG,
@@ -1473,6 +1474,7 @@ async def test_fan_speed(hass):
         },
         "reversible": False,
         "supportsFanSpeedPercent": True,
+        "commandOnlyFanSpeed": True,
     }
 
     assert trt.query_attributes() == {
@@ -1496,6 +1498,51 @@ async def test_fan_speed(hass):
 
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage": 10}
+
+    assert trt.can_execute(
+        trait.COMMAND_FANSPEED, params={"fanSpeedRelativePercent": 10}
+    )
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_INCREASE_SPEED)
+    await trt.execute(
+        trait.COMMAND_FANSPEEDRELATIVE, BASIC_DATA, {"fanSpeedRelativePercent": 10}, {}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 10}
+
+    assert trt.can_execute(
+        trait.COMMAND_FANSPEED, params={"fanSpeedRelativePercent": -10.0}
+    )
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_DECREASE_SPEED)
+    await trt.execute(
+        trait.COMMAND_FANSPEEDRELATIVE,
+        BASIC_DATA,
+        {"fanSpeedRelativePercent": -10.0},
+        {},
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 10}
+
+    assert trt.can_execute(trait.COMMAND_FANSPEED, params={"fanSpeedRelativeWeight": 2})
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_INCREASE_SPEED)
+    await trt.execute(
+        trait.COMMAND_FANSPEEDRELATIVE, BASIC_DATA, {"fanSpeedRelativeWeight": 2}, {}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 2}
+
+    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_DECREASE_SPEED)
+    await trt.execute(
+        trait.COMMAND_FANSPEEDRELATIVE, BASIC_DATA, {"fanSpeedRelativeWeight": -2}, {}
+    )
+
+    assert len(calls) == 1
+    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 2}
 
 
 async def test_climate_fan_speed(hass):
@@ -1542,6 +1589,7 @@ async def test_climate_fan_speed(hass):
         },
         "reversible": False,
         "supportsFanSpeedPercent": True,
+        "commandOnlyFanSpeed": True,
     }
 
     assert trt.query_attributes() == {

--- a/tests/components/google_assistant/test_trait.py
+++ b/tests/components/google_assistant/test_trait.py
@@ -1498,51 +1498,6 @@ async def test_fan_speed(hass):
     assert len(calls) == 1
     assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage": 10}
 
-    assert trt.can_execute(
-        trait.COMMAND_FANSPEED, params={"fanSpeedRelativePercent": 10}
-    )
-
-    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_INCREASE_SPEED)
-    await trt.execute(
-        trait.COMMAND_FANSPEEDRELATIVE, BASIC_DATA, {"fanSpeedRelativePercent": 10}, {}
-    )
-
-    assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 10}
-
-    assert trt.can_execute(
-        trait.COMMAND_FANSPEED, params={"fanSpeedRelativePercent": -10.0}
-    )
-
-    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_DECREASE_SPEED)
-    await trt.execute(
-        trait.COMMAND_FANSPEEDRELATIVE,
-        BASIC_DATA,
-        {"fanSpeedRelativePercent": -10.0},
-        {},
-    )
-
-    assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 10}
-
-    assert trt.can_execute(trait.COMMAND_FANSPEED, params={"fanSpeedRelativeWeight": 2})
-
-    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_INCREASE_SPEED)
-    await trt.execute(
-        trait.COMMAND_FANSPEEDRELATIVE, BASIC_DATA, {"fanSpeedRelativeWeight": 2}, {}
-    )
-
-    assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 2}
-
-    calls = async_mock_service(hass, fan.DOMAIN, fan.SERVICE_DECREASE_SPEED)
-    await trt.execute(
-        trait.COMMAND_FANSPEEDRELATIVE, BASIC_DATA, {"fanSpeedRelativeWeight": -2}, {}
-    )
-
-    assert len(calls) == 1
-    assert calls[0].data == {"entity_id": "fan.living_room_fan", "percentage_step": 2}
-
 
 async def test_climate_fan_speed(hass):
     """Test FanSpeed trait speed control support for climate domain."""
@@ -2018,7 +1973,7 @@ async def test_preset_modes(hass):
             {
                 "name": "preset mode",
                 "name_values": [
-                    {"name_synonym": ["preset mode", "preset"], "lang": "en"}
+                    {"name_synonym": ["preset mode", "mode", "preset"], "lang": "en"}
                 ],
                 "settings": [
                     {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Support for relative fan speeds and preset_modes in google_assistant integration

Google Assistant now supports:
- Fan preset modes
- Percentage based fan speeds
- Legacy low/medium/high speed

Note: The support for legacy low/medium/high speed attribute will be removed in a future release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #47728
- This PR is related to issue: #47267
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
