### PR TITLE
Add zwave_js support for HeatIt Z-TRM2fx

### DIFF
--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -21,6 +21,19 @@ from .discovery_data_template import (
 
 
 @dataclass
+class FirmwareVersionRange:
+    """Firmware version range dictionary."""
+
+    min: str | None = None
+    max: str | None = None
+
+    def __post_init__(self) -> None:
+        """Post dataclass initialization."""
+        if self.min is None and self.max is None:
+            raise ValueError("At least one of min or max must be provided")
+
+
+@dataclass
 class ZwaveDiscoveryInfo:
     """Info discovered from (primary) ZWave Value to create entity."""
 
@@ -65,18 +78,6 @@ class ZWaveValueDiscoverySchema:
     property_key_name: set[str] | None = None
     # [optional] the value's metadata_type must match ANY of these values
     type: set[str] | None = None
-
-
-@dataclass
-class FirmwareVersionRange:
-    """
-    Firmware version range dictionary.
-
-    At least one parameter must be provided.
-    """
-
-    min: str | None = None
-    max: str | None = None
 
 
 @dataclass
@@ -595,10 +596,6 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
             # check firmware_version_range
             if schema.firmware_version_range is not None and (
                 (
-                    schema.firmware_version_range.min is None
-                    and schema.firmware_version_range.max is None
-                )
-                or (
                     schema.firmware_version_range.min is not None
                     and AwesomeVersion(schema.firmware_version_range.min)
                     > AwesomeVersion(value.node.firmware_version)

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from dataclasses import dataclass
+import dataclasses
 from typing import Any
 
 from awesomeversion import AwesomeVersion
@@ -20,20 +20,24 @@ from .discovery_data_template import (
 )
 
 
-@dataclass
-class FirmwareVersionRange:
+class DataclassMustHaveAtLeastOne:
+    """A dataclass that has to have at least one input parameter that is not None."""
+
+    def __post_init__(self) -> None:
+        """Post dataclass initialization."""
+        if all(val is None for val in dataclasses.asdict(self).values()):
+            raise ValueError("At least one input parameter must not be None")
+
+
+@dataclasses.dataclass
+class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
     """Firmware version range dictionary."""
 
     min: str | None = None
     max: str | None = None
 
-    def __post_init__(self) -> None:
-        """Post dataclass initialization."""
-        if self.min is None and self.max is None:
-            raise ValueError("At least one of min or max must be provided")
 
-
-@dataclass
+@dataclasses.dataclass
 class ZwaveDiscoveryInfo:
     """Info discovered from (primary) ZWave Value to create entity."""
 
@@ -55,8 +59,8 @@ class ZwaveDiscoveryInfo:
     additional_value_ids_to_watch: set[str] | None = None
 
 
-@dataclass
-class ZWaveValueDiscoverySchema:
+@dataclasses.dataclass
+class ZWaveValueDiscoverySchema(DataclassMustHaveAtLeastOne):
     """Z-Wave Value discovery schema.
 
     The Z-Wave Value must match these conditions.
@@ -80,7 +84,7 @@ class ZWaveValueDiscoverySchema:
     type: set[str] | None = None
 
 
-@dataclass
+@dataclasses.dataclass
 class ZWaveDiscoverySchema:
     """Z-Wave discovery schema.
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -41,8 +41,8 @@ class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
     def __post_init__(self) -> None:
         """Post dataclass initialization."""
         super().__post_init__()
-        self.min_ver = AwesomeVersion(min)
-        self.max_ver = AwesomeVersion(max)
+        self.min_ver = AwesomeVersion(self.min)
+        self.max_ver = AwesomeVersion(self.max)
 
 
 @dataclasses.dataclass

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -595,6 +595,10 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
             # check firmware_version_range
             if schema.firmware_version_range is not None and (
                 (
+                    schema.firmware_version_range.min is None
+                    and schema.firmware_version_range.max is None
+                )
+                or (
                     schema.firmware_version_range.min is not None
                     and AwesomeVersion(schema.firmware_version_range.min)
                     > AwesomeVersion(value.node.firmware_version)

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-import dataclasses
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from awesomeversion import AwesomeVersion
@@ -25,18 +25,18 @@ class DataclassMustHaveAtLeastOne:
 
     def __post_init__(self) -> None:
         """Post dataclass initialization."""
-        if all(val is None for val in dataclasses.asdict(self).values()):
+        if all(val is None for val in asdict(self).values()):
             raise ValueError("At least one input parameter must not be None")
 
 
-@dataclasses.dataclass
+@dataclass
 class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
     """Firmware version range dictionary."""
 
     min: str | None = None
     max: str | None = None
-    min_ver: AwesomeVersion | None = dataclasses.field(default=None, init=False)
-    max_ver: AwesomeVersion | None = dataclasses.field(default=None, init=False)
+    min_ver: AwesomeVersion | None = field(default=None, init=False)
+    max_ver: AwesomeVersion | None = field(default=None, init=False)
 
     def __post_init__(self) -> None:
         """Post dataclass initialization."""
@@ -47,7 +47,7 @@ class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
             self.max_ver = AwesomeVersion(self.max)
 
 
-@dataclasses.dataclass
+@dataclass
 class ZwaveDiscoveryInfo:
     """Info discovered from (primary) ZWave Value to create entity."""
 
@@ -69,7 +69,7 @@ class ZwaveDiscoveryInfo:
     additional_value_ids_to_watch: set[str] | None = None
 
 
-@dataclasses.dataclass
+@dataclass
 class ZWaveValueDiscoverySchema(DataclassMustHaveAtLeastOne):
     """Z-Wave Value discovery schema.
 
@@ -94,7 +94,7 @@ class ZWaveValueDiscoverySchema(DataclassMustHaveAtLeastOne):
     type: set[str] | None = None
 
 
-@dataclasses.dataclass
+@dataclass
 class ZWaveDiscoverySchema:
     """Z-Wave discovery schema.
 

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -35,14 +35,16 @@ class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
 
     min: str | None = None
     max: str | None = None
-    min_ver: AwesomeVersion = dataclasses.field(init=False)
-    max_ver: AwesomeVersion = dataclasses.field(init=False)
+    min_ver: AwesomeVersion | None = dataclasses.field(default=None, init=False)
+    max_ver: AwesomeVersion | None = dataclasses.field(default=None, init=False)
 
     def __post_init__(self) -> None:
         """Post dataclass initialization."""
         super().__post_init__()
-        self.min_ver = AwesomeVersion(self.min)
-        self.max_ver = AwesomeVersion(self.max)
+        if self.min:
+            self.min_ver = AwesomeVersion(self.min)
+        if self.max:
+            self.max_ver = AwesomeVersion(self.max)
 
 
 @dataclasses.dataclass

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -35,6 +35,14 @@ class FirmwareVersionRange(DataclassMustHaveAtLeastOne):
 
     min: str | None = None
     max: str | None = None
+    min_ver: AwesomeVersion = dataclasses.field(init=False)
+    max_ver: AwesomeVersion = dataclasses.field(init=False)
+
+    def __post_init__(self) -> None:
+        """Post dataclass initialization."""
+        super().__post_init__()
+        self.min_ver = AwesomeVersion(min)
+        self.max_ver = AwesomeVersion(max)
 
 
 @dataclasses.dataclass
@@ -601,12 +609,12 @@ def async_discover_values(node: ZwaveNode) -> Generator[ZwaveDiscoveryInfo, None
             if schema.firmware_version_range is not None and (
                 (
                     schema.firmware_version_range.min is not None
-                    and AwesomeVersion(schema.firmware_version_range.min)
+                    and schema.firmware_version_range.min_ver
                     > AwesomeVersion(value.node.firmware_version)
                 )
                 or (
                     schema.firmware_version_range.max is not None
-                    and AwesomeVersion(schema.firmware_version_range.max)
+                    and schema.firmware_version_range.max_ver
                     < AwesomeVersion(value.node.firmware_version)
                 )
             ):

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -21,7 +21,7 @@ from .discovery_data_template import (
 
 
 class DataclassMustHaveAtLeastOne:
-    """A dataclass that has to have at least one input parameter that is not None."""
+    """A dataclass that must have at least one input parameter that is not None."""
 
     def __post_init__(self) -> None:
         """Post dataclass initialization."""

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -240,6 +240,12 @@ def climate_heatit_z_trm3_state_fixture():
     return json.loads(load_fixture("zwave_js/climate_heatit_z_trm3_state.json"))
 
 
+@pytest.fixture(name="climate_heatit_z_trm2fx_state", scope="session")
+def climate_heatit_z_trm2fx_state_fixture():
+    """Load the climate HEATIT Z-TRM2fx thermostat node state fixture data."""
+    return json.loads(load_fixture("zwave_js/climate_heatit_z_trm2fx_state.json"))
+
+
 @pytest.fixture(name="nortek_thermostat_state", scope="session")
 def nortek_thermostat_state_fixture():
     """Load the nortek thermostat node state fixture data."""
@@ -480,6 +486,14 @@ def climate_eurotronic_spirit_z_fixture(client, climate_eurotronic_spirit_z_stat
 def climate_heatit_z_trm3_fixture(client, climate_heatit_z_trm3_state):
     """Mock a climate radio HEATIT Z-TRM3 node."""
     node = Node(client, copy.deepcopy(climate_heatit_z_trm3_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="climate_heatit_z_trm2fx")
+def climate_heatit_z_trm2fx_fixture(client, climate_heatit_z_trm2fx_state):
+    """Mock a climate radio HEATIT Z-TRM2fx node."""
+    node = Node(client, copy.deepcopy(climate_heatit_z_trm2fx_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -28,6 +28,7 @@ from homeassistant.components.climate.const import (
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_TEMPERATURE,
     SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
     SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
@@ -436,8 +437,10 @@ async def test_setpoint_thermostat(hass, client, climate_danfoss_lc_13, integrat
     client.async_send_command_no_wait.reset_mock()
 
 
-async def test_thermostat_heatit(hass, client, climate_heatit_z_trm3, integration):
-    """Test a thermostat v2 command class entity."""
+async def test_thermostat_heatit_z_trm3(
+    hass, client, climate_heatit_z_trm3, integration
+):
+    """Test a heatit Z-TRM3 entity."""
     node = climate_heatit_z_trm3
     state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
 
@@ -499,6 +502,53 @@ async def test_thermostat_heatit(hass, client, climate_heatit_z_trm3, integratio
     state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
     assert state
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 25.5
+
+
+async def test_thermostat_heatit_z_trm2fx(
+    hass, client, climate_heatit_z_trm2fx, integration
+):
+    """Test a heatit Z-TRM3 entity."""
+    node = climate_heatit_z_trm2fx
+    state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
+
+    assert state
+    assert state.state == HVAC_MODE_HEAT
+    assert state.attributes[ATTR_HVAC_MODES] == [
+        HVAC_MODE_OFF,
+        HVAC_MODE_HEAT,
+        HVAC_MODE_COOL,
+    ]
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 28.8
+    assert state.attributes[ATTR_TEMPERATURE] == 29
+    assert (
+        state.attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+    )
+    assert state.attributes[ATTR_MIN_TEMP] == 7
+    assert state.attributes[ATTR_MAX_TEMP] == 35
+
+    # Try switching to external sensor
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": 24,
+            "args": {
+                "commandClassName": "Configuration",
+                "commandClass": 112,
+                "endpoint": 0,
+                "property": 2,
+                "propertyName": "Sensor mode",
+                "newValue": 4,
+                "prevValue": 2,
+            },
+        },
+    )
+    node.receive_event(event)
+    state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
+    assert state
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 0
 
 
 async def test_thermostat_srt321_hrt4_zw(hass, client, srt321_hrt4_zw, integration):

--- a/tests/components/zwave_js/test_climate.py
+++ b/tests/components/zwave_js/test_climate.py
@@ -507,7 +507,7 @@ async def test_thermostat_heatit_z_trm3(
 async def test_thermostat_heatit_z_trm2fx(
     hass, client, climate_heatit_z_trm2fx, integration
 ):
-    """Test a heatit Z-TRM3 entity."""
+    """Test a heatit Z-TRM2fx entity."""
     node = climate_heatit_z_trm2fx
     state = hass.states.get(CLIMATE_FLOOR_THERMOSTAT_ENTITY)
 

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -1,4 +1,11 @@
 """Test discovery of entities for device-specific schemas for the Z-Wave JS integration."""
+import pytest
+
+from homeassistant.components.zwave_js.discovery import (
+    FirmwareVersionRange,
+    ZWaveDiscoverySchema,
+    ZWaveValueDiscoverySchema,
+)
 
 
 async def test_iblinds_v2(hass, client, iblinds_v2, integration):
@@ -48,3 +55,13 @@ async def test_vision_security_zl7432(
         state = hass.states.get(entity_id)
         assert state
         assert state.attributes["assumed_state"]
+
+
+async def test_firmware_version_range_exception(hass):
+    """Test FirmwareVersionRange exception."""
+    with pytest.raises(ValueError):
+        ZWaveDiscoverySchema(
+            "test",
+            ZWaveValueDiscoverySchema(),
+            firmware_version_range=FirmwareVersionRange(),
+        )

--- a/tests/components/zwave_js/test_discovery.py
+++ b/tests/components/zwave_js/test_discovery.py
@@ -62,6 +62,6 @@ async def test_firmware_version_range_exception(hass):
     with pytest.raises(ValueError):
         ZWaveDiscoverySchema(
             "test",
-            ZWaveValueDiscoverySchema(),
+            ZWaveValueDiscoverySchema(command_class=1),
             firmware_version_range=FirmwareVersionRange(),
         )

--- a/tests/fixtures/zwave_js/climate_heatit_z_trm2fx_state.json
+++ b/tests/fixtures/zwave_js/climate_heatit_z_trm2fx_state.json
@@ -1,0 +1,1444 @@
+{
+	"nodeId": 26,
+	"index": 0,
+	"installerIcon": 4608,
+	"userIcon": 4609,
+	"status": 4,
+	"ready": true,
+	"isListening": true,
+	"isRouting": true,
+	"isSecure": false,
+	"manufacturerId": 411,
+	"productId": 514,
+	"productType": 3,
+	"firmwareVersion": "3.6",
+	"zwavePlusVersion": 1,
+	"deviceConfig": {
+		"filename": "/usr/src/node_modules/@zwave-js/config/config/devices/0x019b/z-trm2fx_3.0.json",
+		"manufacturer": "ThermoFloor",
+		"manufacturerId": 411,
+		"label": "Z-TRM2fx",
+		"description": "Floor thermostat",
+		"devices": [
+			{
+				"productType": 3,
+				"productId": 514
+			}
+		],
+		"firmwareVersion": {
+			"min": "3.0",
+			"max": "255.255"
+		},
+		"paramInformation": {
+			"_map": {}
+		},
+		"compat": {
+			"valueIdRegex": {},
+			"skipConfigurationInfoQuery": true
+		},
+		"isEmbedded": true
+	},
+	"label": "Z-TRM2fx",
+	"neighbors": [6, 7, 8, 11, 12, 13, 14, 15, 16, 17, 19, 20, 24, 25],
+	"endpointCountIsDynamic": false,
+	"endpointsHaveIdenticalCapabilities": false,
+	"individualEndpointCount": 4,
+	"aggregatedEndpointCount": 0,
+	"interviewAttempts": 1,
+	"endpoints": [
+		{
+			"nodeId": 26,
+			"index": 0,
+			"installerIcon": 4608,
+			"userIcon": 4609,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 8,
+					"label": "Thermostat"
+				},
+				"specific": {
+					"key": 6,
+					"label": "General Thermostat V2"
+				},
+				"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+				"mandatoryControlledCCs": []
+			}
+		},
+		{
+			"nodeId": 26,
+			"index": 1,
+			"installerIcon": 4608,
+			"userIcon": 4609,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 8,
+					"label": "Thermostat"
+				},
+				"specific": {
+					"key": 6,
+					"label": "General Thermostat V2"
+				},
+				"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+				"mandatoryControlledCCs": []
+			}
+		},
+		{
+			"nodeId": 26,
+			"index": 2,
+			"installerIcon": 3328,
+			"userIcon": 3329,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 33,
+					"label": "Multilevel Sensor"
+				},
+				"specific": {
+					"key": 1,
+					"label": "Routing Multilevel Sensor"
+				},
+				"mandatorySupportedCCs": [32, 49],
+				"mandatoryControlledCCs": []
+			}
+		},
+		{
+			"nodeId": 26,
+			"index": 3,
+			"installerIcon": 3328,
+			"userIcon": 3329,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 33,
+					"label": "Multilevel Sensor"
+				},
+				"specific": {
+					"key": 1,
+					"label": "Routing Multilevel Sensor"
+				},
+				"mandatorySupportedCCs": [32, 49],
+				"mandatoryControlledCCs": []
+			}
+		},
+		{
+			"nodeId": 26,
+			"index": 4,
+			"installerIcon": 1792,
+			"userIcon": 1793,
+			"deviceClass": {
+				"basic": {
+					"key": 4,
+					"label": "Routing Slave"
+				},
+				"generic": {
+					"key": 16,
+					"label": "Binary Switch"
+				},
+				"specific": {
+					"key": 1,
+					"label": "Binary Power Switch"
+				},
+				"mandatorySupportedCCs": [32, 37, 39],
+				"mandatoryControlledCCs": []
+			}
+		}
+	],
+	"values": [
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 411
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 2,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			},
+			"value": 514
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			},
+			"value": 3
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			},
+			"value": "5.3"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			},
+			"value": ["3.6"]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hardwareVersion",
+			"propertyName": "hardwareVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip hardware version"
+			}
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "sdkVersion",
+			"propertyName": "sdkVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": "6.71.3"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "applicationFrameworkAPIVersion",
+			"propertyName": "applicationFrameworkAPIVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": "3.1.1"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "applicationFrameworkBuildNumber",
+			"propertyName": "applicationFrameworkBuildNumber",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": 52445
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hostInterfaceVersion",
+			"propertyName": "hostInterfaceVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": "unused"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "hostInterfaceBuildNumber",
+			"propertyName": "hostInterfaceBuildNumber",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "zWaveProtocolVersion",
+			"propertyName": "zWaveProtocolVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": "5.3.0"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "zWaveProtocolBuildNumber",
+			"propertyName": "zWaveProtocolBuildNumber",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": 43
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "applicationVersion",
+			"propertyName": "applicationVersion",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": "unused"
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "applicationBuildNumber",
+			"propertyName": "applicationBuildNumber",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 96,
+			"commandClassName": "Multi Channel",
+			"property": "endpointIndizes",
+			"propertyName": "endpointIndizes",
+			"ccVersion": 4,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			},
+			"value": [1, 2, 3, 4]
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 1,
+			"propertyName": "Operation mode",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Operation mode",
+				"default": 0,
+				"min": 0,
+				"max": 11,
+				"states": {
+					"0": "Off. (default)",
+					"1": "Heating mode",
+					"2": "Cooling mode (not implemented)",
+					"11": "Energy saving heating mode"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 2,
+			"propertyName": "Sensor mode",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Sensor mode",
+				"default": 0,
+				"min": 0,
+				"max": 4,
+				"states": {
+					"0": "F-mode, floor sensor mode",
+					"3": "A2-mode, external room sensor mode",
+					"4": "A2F-mode, external sensor with floor limitation"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 3,
+			"propertyName": "Floor sensor type",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Floor sensor type",
+				"default": 0,
+				"min": 0,
+				"max": 5,
+				"states": {
+					"0": "10K-NTC (default)",
+					"1": "12K-NTC",
+					"2": "15K-NTC",
+					"3": "22K-NTC",
+					"4": "33K-NTC",
+					"5": "47K-NTC"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 4,
+			"propertyName": "Temperature control hysteresis (DIFF I)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Temperature control hysteresis (DIFF I)",
+				"default": 5,
+				"min": 3,
+				"max": 30,
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 5
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 5,
+			"propertyName": "Floor minimum temperature limit (FLo)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Floor minimum temperature limit (FLo)",
+				"default": 50,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 50
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 6,
+			"propertyName": "Floor maximum temperature (FHi)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Floor maximum temperature (FHi)",
+				"default": 400,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 400
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 7,
+			"propertyName": "Air (A2) minimum temperature limit (ALo)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Air (A2) minimum temperature limit (ALo)",
+				"default": 50,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 50
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 8,
+			"propertyName": "Air (A2) maximum temperature limit (AHi)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Air (A2) maximum temperature limit (AHi)",
+				"default": 400,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 400
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 9,
+			"propertyName": "Heating mode setpoint (CO)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Heating mode setpoint (CO)",
+				"default": 210,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 290
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 10,
+			"propertyName": "Energy saving mode setpoint (ECO)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Energy saving mode setpoint (ECO)",
+				"default": 180,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 250
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 11,
+			"propertyName": "Cooling setpoint (COOL)",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Cooling setpoint (COOL)",
+				"default": 210,
+				"min": 50,
+				"max": 400,
+				"unit": "oC",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 200
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 12,
+			"propertyName": "Floor sensor calibration",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Floor sensor calibration",
+				"default": 0,
+				"min": -40,
+				"max": 40,
+				"unit": "oC",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 13,
+			"propertyName": "External sensor calibration",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "External sensor calibration",
+				"default": 0,
+				"min": -40,
+				"max": 40,
+				"unit": "oC",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 14,
+			"propertyName": "Temperature display",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Temperature display",
+				"default": 0,
+				"min": 0,
+				"max": 1,
+				"states": {
+					"0": "Display setpoint temperature (default)",
+					"1": "Display measured temperature"
+				},
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": false,
+				"isFromConfig": true
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 15,
+			"propertyName": "Button brightness - dimmed state",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Button brightness - dimmed state",
+				"default": 50,
+				"min": 0,
+				"max": 100,
+				"unit": "%",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 16,
+			"propertyName": "Button brightness - active state",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Button brightness - active state",
+				"default": 100,
+				"min": 0,
+				"max": 100,
+				"unit": "%",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 100
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 17,
+			"propertyName": "Display brightness - dimmed state",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Display brightness - dimmed state",
+				"default": 50,
+				"min": 0,
+				"max": 100,
+				"unit": "%",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 18,
+			"propertyName": "Display brightness - active state",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Display brightness - active state",
+				"default": 100,
+				"min": 0,
+				"max": 100,
+				"unit": "%",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 100
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 19,
+			"propertyName": "Temperature report interval",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Temperature report interval",
+				"default": 60,
+				"min": 0,
+				"max": 32767,
+				"unit": "seconds",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 60
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 20,
+			"propertyName": "Temperature report hysteresis",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Temperature report hysteresis",
+				"default": 10,
+				"min": 1,
+				"max": 100,
+				"unit": "oC",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 10
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 21,
+			"propertyName": "Meter report interval",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Meter report interval",
+				"default": 60,
+				"min": 0,
+				"max": 32767,
+				"unit": "seconds",
+				"valueSize": 2,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 60
+		},
+		{
+			"endpoint": 0,
+			"commandClass": 112,
+			"commandClassName": "Configuration",
+			"property": 22,
+			"propertyName": "Meter report delta value",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Meter report delta value",
+				"default": 10,
+				"min": 0,
+				"max": 127,
+				"unit": "kWh/10",
+				"valueSize": 1,
+				"format": 0,
+				"allowManualEntry": true,
+				"isFromConfig": true
+			},
+			"value": 10
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "manufacturerId",
+			"propertyName": "manufacturerId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Manufacturer ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productType",
+			"propertyName": "productType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product type",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 114,
+			"commandClassName": "Manufacturer Specific",
+			"property": "productId",
+			"propertyName": "productId",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Product ID",
+				"min": 0,
+				"max": 65535
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "mode",
+			"propertyName": "mode",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Thermostat mode",
+				"min": 0,
+				"max": 255,
+				"states": {
+					"0": "Off",
+					"1": "Heat",
+					"2": "Cool",
+					"11": "Energy heat"
+				}
+			},
+			"value": 1
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 64,
+			"commandClassName": "Thermostat Mode",
+			"property": "manufacturerData",
+			"propertyName": "manufacturerData",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": true
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 1,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Heating",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 1
+				},
+				"unit": "\u00b0C"
+			},
+			"value": 29
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 2,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Cooling",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 2
+				},
+				"unit": "\u00b0C"
+			},
+			"value": 20
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 67,
+			"commandClassName": "Thermostat Setpoint",
+			"property": "setpoint",
+			"propertyKey": 11,
+			"propertyName": "setpoint",
+			"propertyKeyName": "Energy Save Heating",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"ccSpecific": {
+					"setpointType": 11
+				},
+				"unit": "\u00b0C"
+			},
+			"value": 25
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "libraryType",
+			"propertyName": "libraryType",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Library type"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "protocolVersion",
+			"propertyName": "protocolVersion",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave protocol version"
+			}
+		},
+		{
+			"endpoint": 1,
+			"commandClass": 134,
+			"commandClassName": "Version",
+			"property": "firmwareVersions",
+			"propertyName": "firmwareVersions",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "any",
+				"readable": true,
+				"writeable": false,
+				"label": "Z-Wave chip firmware versions"
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 2,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 0
+				},
+				"unit": "\u00b0C"
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 3,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value",
+				"min": 0,
+				"max": 99
+			},
+			"value": 0
+		},
+		{
+			"endpoint": 3,
+			"commandClass": 32,
+			"commandClassName": "Basic",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value",
+				"min": 0,
+				"max": 99
+			}
+		},
+		{
+			"endpoint": 3,
+			"commandClass": 49,
+			"commandClassName": "Multilevel Sensor",
+			"property": "Air temperature",
+			"propertyName": "Air temperature",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Air temperature",
+				"ccSpecific": {
+					"sensorType": 1,
+					"scale": 0
+				},
+				"unit": "\u00b0C"
+			},
+			"value": 28.8
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "currentValue",
+			"propertyName": "currentValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": false,
+				"label": "Current value"
+			},
+			"value": false
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 37,
+			"commandClassName": "Binary Switch",
+			"property": "targetValue",
+			"propertyName": "targetValue",
+			"ccVersion": 0,
+			"metadata": {
+				"type": "boolean",
+				"readable": true,
+				"writeable": true,
+				"label": "Target value"
+			}
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "value",
+			"propertyKey": 65537,
+			"propertyName": "value",
+			"propertyKeyName": "Electric_kWh_Consumed",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [kWh]",
+				"ccSpecific": {
+					"meterType": 1,
+					"rateType": 1,
+					"scale": 0
+				},
+				"unit": "kWh"
+			},
+			"value": 795.7
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "value",
+			"propertyKey": 66049,
+			"propertyName": "value",
+			"propertyKeyName": "Electric_W_Consumed",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [W]",
+				"ccSpecific": {
+					"meterType": 1,
+					"rateType": 1,
+					"scale": 2
+				},
+				"unit": "W"
+			},
+			"value": 493.57
+		},
+		{
+			"endpoint": 4,
+			"commandClass": 50,
+			"commandClassName": "Meter",
+			"property": "value",
+			"propertyKey": 66561,
+			"propertyName": "value",
+			"propertyKeyName": "Electric_V_Consumed",
+			"ccVersion": 3,
+			"metadata": {
+				"type": "number",
+				"readable": true,
+				"writeable": false,
+				"label": "Electric Consumed [V]",
+				"ccSpecific": {
+					"meterType": 1,
+					"rateType": 1,
+					"scale": 4
+				},
+				"unit": "V"
+			},
+			"value": 237.1
+		}
+	],
+	"isFrequentListening": false,
+	"maxDataRate": 100000,
+	"supportedDataRates": [40000, 100000],
+	"protocolVersion": 3,
+	"supportsBeaming": true,
+	"supportsSecurity": false,
+	"nodeType": 1,
+	"zwavePlusNodeType": 0,
+	"zwavePlusRoleType": 5,
+	"deviceClass": {
+		"basic": {
+			"key": 4,
+			"label": "Routing Slave"
+		},
+		"generic": {
+			"key": 8,
+			"label": "Thermostat"
+		},
+		"specific": {
+			"key": 6,
+			"label": "General Thermostat V2"
+		},
+		"mandatorySupportedCCs": [32, 114, 64, 67, 134],
+		"mandatoryControlledCCs": []
+	},
+	"commandClasses": [
+		{
+			"id": 114,
+			"name": "Manufacturer Specific",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 64,
+			"name": "Thermostat Mode",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 67,
+			"name": "Thermostat Setpoint",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 134,
+			"name": "Version",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 94,
+			"name": "Z-Wave Plus Info",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 133,
+			"name": "Association",
+			"version": 2,
+			"isSecure": false
+		},
+		{
+			"id": 89,
+			"name": "Association Group Information",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 142,
+			"name": "Multi Channel Association",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 96,
+			"name": "Multi Channel",
+			"version": 4,
+			"isSecure": false
+		},
+		{
+			"id": 90,
+			"name": "Device Reset Locally",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 152,
+			"name": "Security",
+			"version": 1,
+			"isSecure": true
+		},
+		{
+			"id": 108,
+			"name": "Supervision",
+			"version": 1,
+			"isSecure": false
+		},
+		{
+			"id": 112,
+			"name": "Configuration",
+			"version": 3,
+			"isSecure": false
+		},
+		{
+			"id": 122,
+			"name": "Firmware Update Meta Data",
+			"version": 4,
+			"isSecure": false
+		},
+		{
+			"id": 50,
+			"name": "Meter",
+			"version": 3,
+			"isSecure": false
+		}
+	],
+	"interviewStage": "Complete"
+}


### PR DESCRIPTION
## Proposed change
Thanks to the work done in #49804 in terms of figuring out how to handle device specific logic, this change was relatively trivial.

~~Side thought: This device has two different firmware ranges for the same model that have completely different configurations, so I needed something beyond `manufacturer_id`, `product_type`, and `product_id` to discover the right device. Firmware version in its current form as part of the discovery schema is pretty rigid, I don't see it being useful because you would have to explicitly call out every supported firmware version in a range. I think we will need to eventually switch that discovery piece to use firmware version range from the device config. That comes with it's own challenges because we'd need to be able to parse the firmware_version in order to validate it against the range, and I think manufacturers are a bit loose with how they do versioning.~~

~~Anyway, in the interim, I added the device label to the schema because that should be consistent.~~

I added a `firmware_version_range` to the discovery schema to support this device. I left the existing `firmware_version` in place in case it could be of use elsewhere.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45932
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
