### PR TITLE
Add config flow step user to dsmr

### DIFF
--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -4,16 +4,18 @@ from __future__ import annotations
 import asyncio
 from functools import partial
 import logging
+import os
 from typing import Any
 
 from async_timeout import timeout
 from dsmr_parser import obis_references as obis_ref
 from dsmr_parser.clients.protocol import create_dsmr_reader, create_tcp_dsmr_reader
 import serial
+import serial.tools.list_ports
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import callback
 
 from .const import (
@@ -26,6 +28,8 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+CONF_MANUAL_PATH = "Enter Manually"
 
 
 class DSMRConnection:
@@ -124,6 +128,10 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self):
+        """Initialize flow instance."""
+        self._dsmr_version = None
+
     @staticmethod
     @callback
     def async_get_options_flow(config_entry):
@@ -159,6 +167,138 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="already_configured")
 
         return None
+
+    async def async_step_user(self, user_input=None):
+        """Step when user initializes a integration."""
+        errors = {}
+        if user_input is not None:
+            user_selection = user_input[CONF_TYPE]
+            if user_selection == "Serial":
+                return await self.async_step_setup_serial()
+
+            return await self.async_step_setup_network()
+
+        list_of_types = ["Serial", "Network"]
+
+        schema = vol.Schema({vol.Required(CONF_TYPE): vol.In(list_of_types)})
+        return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    async def async_step_setup_network(self, user_input=None):
+        """Step when setting up network configuration."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                info = await _validate_dsmr_connection(self.hass, user_input)
+
+                data = {**user_input, **info}
+
+                await self.async_set_unique_id(info[CONF_SERIAL_ID])
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(
+                    title=f"{data[CONF_HOST]}:{data[CONF_PORT]}", data=data
+                )
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except CannotCommunicate:
+                errors["base"] = "cannot_communicate"
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_HOST): str,
+                vol.Required(CONF_PORT): int,
+                vol.Required(CONF_DSMR_VERSION): vol.In(["2.2", "4", "5", "5B", "5L"]),
+            }
+        )
+        return self.async_show_form(
+            step_id="setup_network",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_setup_serial(self, user_input=None):
+        """Step when setting up serial configuration."""
+        errors = {}
+
+        if user_input is not None:
+            user_selection = user_input[CONF_PORT]
+            if user_selection == CONF_MANUAL_PATH:
+                self._dsmr_version = user_input[CONF_DSMR_VERSION]
+                return await self.async_step_setup_serial_manual_path()
+
+            dev_path = await self.hass.async_add_executor_job(
+                get_serial_by_id, user_selection
+            )
+
+            data = {CONF_PORT: dev_path}
+
+            try:
+                info = await _validate_dsmr_connection(self.hass, data)
+
+                data = {**data, **info}
+
+                await self.async_set_unique_id(info[CONF_SERIAL_ID])
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(title=dev_path, data=data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except CannotCommunicate:
+                errors["base"] = "cannot_communicate"
+
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        list_of_ports = {}
+        for port in ports:
+            list_of_ports[
+                port.device
+            ] = f"{port}, s/n: {port.serial_number or 'n/a'}" + (
+                f" - {port.manufacturer}" if port.manufacturer else ""
+            )
+        list_of_ports[CONF_MANUAL_PATH] = CONF_MANUAL_PATH
+
+        schema = vol.Schema(
+            {
+                vol.Required(CONF_PORT): vol.In(list_of_ports),
+                vol.Required(CONF_DSMR_VERSION): vol.In(["2.2", "4", "5", "5B", "5L"]),
+            }
+        )
+        return self.async_show_form(
+            step_id="setup_serial",
+            data_schema=schema,
+            errors=errors,
+        )
+
+    async def async_step_setup_serial_manual_path(self, user_input=None):
+        """Select path manually."""
+        errors = {}
+
+        if user_input is not None:
+            try:
+                data = {
+                    CONF_PORT: user_input[CONF_PORT],
+                    CONF_DSMR_VERSION: self._dsmr_version,
+                }
+
+                info = await _validate_dsmr_connection(self.hass, data)
+
+                data = {**data, **info}
+
+                await self.async_set_unique_id(info[CONF_SERIAL_ID])
+                self._abort_if_unique_id_configured()
+
+                return self.async_create_entry(title=data[CONF_PORT], data=data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except CannotCommunicate:
+                errors["base"] = "cannot_communicate"
+
+        schema = vol.Schema({vol.Required(CONF_PORT): str})
+        return self.async_show_form(
+            step_id="setup_serial_manual_path",
+            data_schema=schema,
+            errors=errors,
+        )
 
     async def async_step_import(self, import_config=None):
         """Handle the initial step."""
@@ -214,6 +354,18 @@ class DSMROptionFlowHandler(config_entries.OptionsFlow):
                 }
             ),
         )
+
+
+def get_serial_by_id(dev_path: str) -> str:
+    """Return a /dev/serial/by-id match for given device if available."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return dev_path
+
+    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
+        if os.path.realpath(path) == dev_path:
+            return path
+    return dev_path
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/dsmr/config_flow.py
+++ b/homeassistant/components/dsmr/config_flow.py
@@ -231,7 +231,10 @@ class DSMRFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 get_serial_by_id, user_selection
             )
 
-            data = {CONF_PORT: dev_path}
+            data = {
+                CONF_PORT: dev_path,
+                CONF_DSMR_VERSION: user_input[CONF_DSMR_VERSION],
+            }
 
             try:
                 info = await _validate_dsmr_connection(self.hass, data)

--- a/homeassistant/components/dsmr/manifest.json
+++ b/homeassistant/components/dsmr/manifest.json
@@ -4,6 +4,6 @@
   "documentation": "https://www.home-assistant.io/integrations/dsmr",
   "requirements": ["dsmr_parser==0.29"],
   "codeowners": ["@Robbie1221"],
-  "config_flow": false,
+  "config_flow": true,
   "iot_class": "local_push"
 }

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -344,7 +344,9 @@ class DSMREntity(SensorEntity):
             return self.translate_tariff(value, self._config[CONF_DSMR_VERSION])
 
         with suppress(TypeError):
-            value = round(float(value), self._config[CONF_PRECISION])
+            value = round(
+                float(value), self._config.get(CONF_PRECISION, DEFAULT_PRECISION)
+            )
 
         if value is not None:
             return value

--- a/homeassistant/components/dsmr/strings.json
+++ b/homeassistant/components/dsmr/strings.json
@@ -1,9 +1,43 @@
 {
   "config": {
-    "step": {},
-    "error": {},
+    "step": {
+      "user": {
+        "data": {
+          "type": "Connection type"
+        },
+        "title": "Select connection type"
+      },
+      "setup_network": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "port": "[%key:common::config_flow::data::port%]",
+          "dsmr_version": "Select DSMR version"
+        },
+        "title": "Select connection address"
+      },
+      "setup_serial": {
+        "data": {
+          "port": "Select device",
+          "dsmr_version": "Select DSMR version"
+        },
+        "title": "Device"
+      },
+      "setup_serial_manual_path": {
+        "data": {
+          "port": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Path"
+      }
+    },
+    "error": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "cannot_communicate": "Failed to communicate"
+    },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "cannot_communicate": "Failed to communicate"
     }
   },
   "options": {

--- a/homeassistant/components/dsmr/translations/en.json
+++ b/homeassistant/components/dsmr/translations/en.json
@@ -1,7 +1,43 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "cannot_communicate": "Failed to communicate",
+            "cannot_connect": "Failed to connect"
+        },
+        "error": {
+            "already_configured": "Device is already configured",
+            "cannot_communicate": "Failed to communicate",
+            "cannot_connect": "Failed to connect"
+        },
+        "step": {
+            "setup_network": {
+                "data": {
+                    "dsmr_version": "Select DSMR version",
+                    "host": "Host",
+                    "port": "Port"
+                },
+                "title": "Select connection address"
+            },
+            "setup_serial": {
+                "data": {
+                    "dsmr_version": "Select DSMR version",
+                    "port": "Select device"
+                },
+                "title": "Device"
+            },
+            "setup_serial_manual_path": {
+                "data": {
+                    "port": "USB Device Path"
+                },
+                "title": "Path"
+            },
+            "user": {
+                "data": {
+                    "type": "Connection type"
+                },
+                "title": "Select connection type"
+            }
         }
     },
     "options": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -56,6 +56,7 @@ FLOWS = [
     "dialogflow",
     "directv",
     "doorbird",
+    "dsmr",
     "dunehd",
     "dynalite",
     "eafm",

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -144,6 +144,90 @@ async def test_setup_serial_manual(
     assert result["data"] == {**entry_data, **SERIAL_DATA}
 
 
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+async def test_setup_serial_fail(com_mock, hass, dsmr_connection_send_validate_fixture):
+    """Test failed serial connection."""
+    (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    # override the mock to have it fail the first time and succeed after
+    first_fail_connection_factory = AsyncMock(
+        return_value=(transport, protocol),
+        side_effect=chain([serial.serialutil.SerialException], repeat(DEFAULT)),
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    with patch(
+        "homeassistant.components.dsmr.config_flow.create_dsmr_reader",
+        first_fail_connection_factory,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"port": port.device, "dsmr_version": "2.2"}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+async def test_setup_serial_wrong_telegram(
+    com_mock, hass, dsmr_connection_send_validate_fixture
+):
+    """Test failed telegram data."""
+    (connection_factory, transport, protocol) = dsmr_connection_send_validate_fixture
+
+    await setup.async_setup_component(hass, "persistent_notification", {})
+
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    protocol.telegram = {}
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"port": port.device, "dsmr_version": "2.2"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {"base": "cannot_communicate"}
+
+
 async def test_import_usb(hass, dsmr_connection_send_validate_fixture):
     """Test we can import."""
     await setup.async_setup_component(hass, "persistent_notification", {})

--- a/tests/components/dsmr/test_config_flow.py
+++ b/tests/components/dsmr/test_config_flow.py
@@ -1,16 +1,147 @@
 """Test the DSMR config flow."""
 import asyncio
 from itertools import chain, repeat
-from unittest.mock import DEFAULT, AsyncMock, patch
+import os
+from unittest.mock import DEFAULT, AsyncMock, MagicMock, patch, sentinel
 
 import serial
+import serial.tools.list_ports
 
 from homeassistant import config_entries, data_entry_flow, setup
-from homeassistant.components.dsmr import DOMAIN
+from homeassistant.components.dsmr import DOMAIN, config_flow
 
 from tests.common import MockConfigEntry
 
 SERIAL_DATA = {"serial_id": "12345678", "serial_id_gas": "123456789"}
+
+
+def com_port():
+    """Mock of a serial port."""
+    port = serial.tools.list_ports_common.ListPortInfo("/dev/ttyUSB1234")
+    port.serial_number = "1234"
+    port.manufacturer = "Virtual serial port"
+    port.device = "/dev/ttyUSB1234"
+    port.description = "Some serial port"
+
+    return port
+
+
+async def test_setup_network(hass, dsmr_connection_send_validate_fixture):
+    """Test we can setup network."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Network"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_network"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"host": "10.10.0.1", "port": 1234, "dsmr_version": "2.2"},
+        )
+
+    entry_data = {
+        "host": "10.10.0.1",
+        "port": 1234,
+        "dsmr_version": "2.2",
+    }
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "10.10.0.1:1234"
+    assert result["data"] == {**entry_data, **SERIAL_DATA}
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+async def test_setup_serial(com_mock, hass, dsmr_connection_send_validate_fixture):
+    """Test we can setup serial."""
+    port = com_port()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"port": port.device, "dsmr_version": "2.2"}
+        )
+
+    entry_data = {
+        "port": port.device,
+        "dsmr_version": "2.2",
+    }
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == port.device
+    assert result["data"] == {**entry_data, **SERIAL_DATA}
+
+
+@patch("serial.tools.list_ports.comports", return_value=[com_port()])
+async def test_setup_serial_manual(
+    com_mock, hass, dsmr_connection_send_validate_fixture
+):
+    """Test we can setup serial with manual entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"type": "Serial"},
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"port": "Enter Manually", "dsmr_version": "2.2"}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "setup_serial_manual_path"
+    assert result["errors"] == {}
+
+    with patch("homeassistant.components.dsmr.async_setup_entry", return_value=True):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"port": "/dev/ttyUSB0"}
+        )
+
+    entry_data = {
+        "port": "/dev/ttyUSB0",
+        "dsmr_version": "2.2",
+    }
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == "/dev/ttyUSB0"
+    assert result["data"] == {**entry_data, **SERIAL_DATA}
 
 
 async def test_import_usb(hass, dsmr_connection_send_validate_fixture):
@@ -265,3 +396,50 @@ async def test_import_luxembourg(hass, dsmr_connection_send_validate_fixture):
     assert result["type"] == "create_entry"
     assert result["title"] == "/dev/ttyUSB0"
     assert result["data"] == {**entry_data, **SERIAL_DATA}
+
+
+def test_get_serial_by_id_no_dir():
+    """Test serial by id conversion if there's no /dev/serial/by-id."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=False))
+    p2 = patch("os.scandir")
+    with p1 as is_dir_mock, p2 as scan_mock:
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 0
+
+
+def test_get_serial_by_id():
+    """Test serial by id conversion."""
+    p1 = patch("os.path.isdir", MagicMock(return_value=True))
+    p2 = patch("os.scandir")
+
+    def _realpath(path):
+        if path is sentinel.matched_link:
+            return sentinel.path
+        return sentinel.serial_link_path
+
+    p3 = patch("os.path.realpath", side_effect=_realpath)
+    with p1 as is_dir_mock, p2 as scan_mock, p3:
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.path
+        assert is_dir_mock.call_count == 1
+        assert scan_mock.call_count == 1
+
+        entry1 = MagicMock(spec_set=os.DirEntry)
+        entry1.is_symlink.return_value = True
+        entry1.path = sentinel.some_path
+
+        entry2 = MagicMock(spec_set=os.DirEntry)
+        entry2.is_symlink.return_value = False
+        entry2.path = sentinel.other_path
+
+        entry3 = MagicMock(spec_set=os.DirEntry)
+        entry3.is_symlink.return_value = True
+        entry3.path = sentinel.matched_link
+
+        scan_mock.return_value = [entry1, entry2, entry3]
+        res = config_flow.get_serial_by_id(sentinel.path)
+        assert res is sentinel.matched_link
+        assert is_dir_mock.call_count == 2
+        assert scan_mock.call_count == 2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR will add, aside to the import, the step user to the config flow such that the integration gets a full config flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17757

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
