### PR TITLE
Add smhi wind gust speed and thunder probability

### DIFF
--- a/homeassistant/components/smhi/const.py
+++ b/homeassistant/components/smhi/const.py
@@ -2,6 +2,8 @@
 from homeassistant.components.weather import DOMAIN as WEATHER_DOMAIN
 
 ATTR_SMHI_CLOUDINESS = "cloudiness"
+ATTR_SMHI_WIND_GUST_SPEED = "wind_gust_speed"
+ATTR_SMHI_THUNDER_PROBABILITY = "thunder_probability"
 
 DOMAIN = "smhi"
 

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -38,7 +38,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.util import Throttle, slugify
 
-from .const import ATTR_SMHI_CLOUDINESS, ENTITY_ID_SENSOR_FORMAT
+from .const import ATTR_SMHI_CLOUDINESS, ATTR_SMHI_WIND_GUST_SPEED, ATTR_SMHI_THUNDER_PROBABILITY, ENTITY_ID_SENSOR_FORMAT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -166,6 +166,14 @@ class SmhiWeather(WeatherEntity):
             # Convert from m/s to km/h
             return round(self._forecasts[0].wind_speed * 18 / 5)
         return None
+        
+    @property
+    def wind_gust_speed(self) -> float:
+        """Return the wind gust speed."""
+        if self._forecasts is not None:
+            # Convert from m/s to km/h
+            return round(self._forecasts[0].wind_gust * 18 / 5)
+        return None
 
     @property
     def wind_bearing(self) -> int:
@@ -193,6 +201,13 @@ class SmhiWeather(WeatherEntity):
         """Return the cloudiness."""
         if self._forecasts is not None:
             return self._forecasts[0].cloudiness
+        return None
+        
+    @property
+    def thunder(self) -> int:
+        """Return the chance of thunder (Percent)."""
+        if self._forecasts is not None:
+            return self._forecasts[0].thunder
         return None
 
     @property
@@ -238,5 +253,11 @@ class SmhiWeather(WeatherEntity):
     @property
     def extra_state_attributes(self) -> dict:
         """Return SMHI specific attributes."""
-        if self.cloudiness:
-            return {ATTR_SMHI_CLOUDINESS: self.cloudiness}
+        extra_attributes = {}
+        if self.cloudiness is not None:
+            extra_attributes.update( {ATTR_SMHI_CLOUDINESS: self.cloudiness} )
+        if self.wind_gust_speed is not None:
+            extra_attributes.update( {ATTR_SMHI_WIND_GUST_SPEED: self.wind_gust_speed} )
+        if self.thunder is not None:
+            extra_attributes.update( {ATTR_SMHI_THUNDER_PROBABILITY: self.thunder} )
+        return extra_attributes

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -38,7 +38,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.util import Throttle, slugify
 
-from .const import ATTR_SMHI_CLOUDINESS, ATTR_SMHI_THUNDER_PROBABILITY, ATTR_SMHI_WIND_GUST_SPEED, ENTITY_ID_SENSOR_FORMAT
+from .const import (
+    ATTR_SMHI_CLOUDINESS,
+    ATTR_SMHI_THUNDER_PROBABILITY,
+    ATTR_SMHI_WIND_GUST_SPEED,
+    ENTITY_ID_SENSOR_FORMAT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -166,7 +171,7 @@ class SmhiWeather(WeatherEntity):
             # Convert from m/s to km/h
             return round(self._forecasts[0].wind_speed * 18 / 5)
         return None
-    
+
     @property
     def wind_gust_speed(self) -> float:
         """Return the wind gust speed."""
@@ -202,7 +207,7 @@ class SmhiWeather(WeatherEntity):
         if self._forecasts is not None:
             return self._forecasts[0].cloudiness
         return None
-    
+
     @property
     def thunder(self) -> int:
         """Return the chance of thunder, unit Percent."""

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -38,7 +38,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.util import Throttle, slugify
 
-from .const import ATTR_SMHI_CLOUDINESS, ATTR_SMHI_WIND_GUST_SPEED, ATTR_SMHI_THUNDER_PROBABILITY, ENTITY_ID_SENSOR_FORMAT
+from .const import ATTR_SMHI_CLOUDINESS, ATTR_SMHI_THUNDER_PROBABILITY, ATTR_SMHI_WIND_GUST_SPEED, ENTITY_ID_SENSOR_FORMAT
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -166,7 +166,7 @@ class SmhiWeather(WeatherEntity):
             # Convert from m/s to km/h
             return round(self._forecasts[0].wind_speed * 18 / 5)
         return None
-        
+    
     @property
     def wind_gust_speed(self) -> float:
         """Return the wind gust speed."""
@@ -202,10 +202,10 @@ class SmhiWeather(WeatherEntity):
         if self._forecasts is not None:
             return self._forecasts[0].cloudiness
         return None
-        
+    
     @property
     def thunder(self) -> int:
-        """Return the chance of thunder (Percent)."""
+        """Return the chance of thunder, unit Percent."""
         if self._forecasts is not None:
             return self._forecasts[0].thunder
         return None
@@ -255,9 +255,9 @@ class SmhiWeather(WeatherEntity):
         """Return SMHI specific attributes."""
         extra_attributes = {}
         if self.cloudiness is not None:
-            extra_attributes.update( {ATTR_SMHI_CLOUDINESS: self.cloudiness} )
+            extra_attributes.update({ATTR_SMHI_CLOUDINESS: self.cloudiness})
         if self.wind_gust_speed is not None:
-            extra_attributes.update( {ATTR_SMHI_WIND_GUST_SPEED: self.wind_gust_speed} )
+            extra_attributes.update({ATTR_SMHI_WIND_GUST_SPEED: self.wind_gust_speed})
         if self.thunder is not None:
-            extra_attributes.update( {ATTR_SMHI_THUNDER_PROBABILITY: self.thunder} )
+            extra_attributes.update({ATTR_SMHI_THUNDER_PROBABILITY: self.thunder})
         return extra_attributes

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -260,9 +260,9 @@ class SmhiWeather(WeatherEntity):
         """Return SMHI specific attributes."""
         extra_attributes = {}
         if self.cloudiness is not None:
-            extra_attributes.update({ATTR_SMHI_CLOUDINESS: self.cloudiness})
+            extra_attributes[ATTR_SMHI_CLOUDINESS] = self.cloudiness
         if self.wind_gust_speed is not None:
-            extra_attributes.update({ATTR_SMHI_WIND_GUST_SPEED: self.wind_gust_speed})
+            extra_attributes[ATTR_SMHI_WIND_GUST_SPEED] = self.wind_gust_speed
         if self.thunder is not None:
-            extra_attributes.update({ATTR_SMHI_THUNDER_PROBABILITY: self.thunder})
+            extra_attributes[ATTR_SMHI_THUNDER_PROBABILITY] = self.thunder
         return extra_attributes

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -263,6 +263,6 @@ class SmhiWeather(WeatherEntity):
             extra_attributes[ATTR_SMHI_CLOUDINESS] = self.cloudiness
         if self.wind_gust_speed is not None:
             extra_attributes[ATTR_SMHI_WIND_GUST_SPEED] = self.wind_gust_speed
-        if self.thunder is not None:
+        if self.thunder_probability is not None:
             extra_attributes[ATTR_SMHI_THUNDER_PROBABILITY] = self.thunder_probability
         return extra_attributes

--- a/homeassistant/components/smhi/weather.py
+++ b/homeassistant/components/smhi/weather.py
@@ -209,7 +209,7 @@ class SmhiWeather(WeatherEntity):
         return None
 
     @property
-    def thunder(self) -> int:
+    def thunder_probability(self) -> int:
         """Return the chance of thunder, unit Percent."""
         if self._forecasts is not None:
             return self._forecasts[0].thunder
@@ -264,5 +264,5 @@ class SmhiWeather(WeatherEntity):
         if self.wind_gust_speed is not None:
             extra_attributes[ATTR_SMHI_WIND_GUST_SPEED] = self.wind_gust_speed
         if self.thunder is not None:
-            extra_attributes[ATTR_SMHI_THUNDER_PROBABILITY] = self.thunder
+            extra_attributes[ATTR_SMHI_THUNDER_PROBABILITY] = self.thunder_probability
         return extra_attributes

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -61,8 +61,8 @@ async def test_setup_hass(hass: HomeAssistant, aioclient_mock) -> None:
 
     assert state.state == "sunny"
     assert state.attributes[ATTR_SMHI_CLOUDINESS] == 50
-    assert state.attributes[ATTR_SMHI_THUNDER_PROBABILITY] == 29
-    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 11
+    assert state.attributes[ATTR_SMHI_THUNDER_PROBABILITY] == 33
+    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 17
     assert state.attributes[ATTR_WEATHER_ATTRIBUTION].find("SMHI") >= 0
     assert state.attributes[ATTR_WEATHER_HUMIDITY] == 55
     assert state.attributes[ATTR_WEATHER_PRESSURE] == 1024
@@ -91,12 +91,12 @@ def test_properties_no_data(hass: HomeAssistant) -> None:
     assert weather.temperature is None
     assert weather.humidity is None
     assert weather.wind_speed is None
-    assert weather.wind_gust is None
+    assert weather.wind_gust_speed is None
     assert weather.wind_bearing is None
     assert weather.visibility is None
     assert weather.pressure is None
     assert weather.cloudiness is None
-    assert weather.thunder is None
+    assert weather.thunder_probability is None
     assert weather.condition is None
     assert weather.forecast is None
     assert weather.temperature_unit == TEMP_CELSIUS
@@ -112,12 +112,12 @@ def test_properties_unknown_symbol() -> None:
     data.total_precipitation = 1
     data.humidity = 5
     data.wind_speed = 10
-    data.wind_gust = 17
+    data.wind_gust_speed = 17
     data.wind_direction = 180
     data.horizontal_visibility = 6
     data.pressure = 1008
     data.cloudiness = 52
-    data.thunder = 41
+    data.thunder_probability = 41
     data.symbol = 100  # Faulty symbol
     data.valid_time = datetime(2018, 1, 1, 0, 1, 2)
 
@@ -127,12 +127,12 @@ def test_properties_unknown_symbol() -> None:
     data2.total_precipitation = 1
     data2.humidity = 5
     data2.wind_speed = 10
-    data2.wind_gust = 17
+    data2.wind_gust_speed = 17
     data2.wind_direction = 180
     data2.horizontal_visibility = 6
     data2.pressure = 1008
     data2.cloudiness = 52
-    data2.thunder = 41
+    data2.thunder_probability = 41
     data2.symbol = 100  # Faulty symbol
     data2.valid_time = datetime(2018, 1, 1, 12, 1, 2)
 
@@ -142,12 +142,12 @@ def test_properties_unknown_symbol() -> None:
     data3.total_precipitation = 1
     data3.humidity = 5
     data3.wind_speed = 10
-    data3.wind_gust = 17
+    data3.wind_gust_speed = 17
     data3.wind_direction = 180
     data3.horizontal_visibility = 6
     data3.pressure = 1008
     data3.cloudiness = 52
-    data3.thunder = 41
+    data3.thunder_probability = 41
     data3.symbol = 100  # Faulty symbol
     data3.valid_time = datetime(2018, 1, 2, 12, 1, 2)
 

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock, Mock, patch
 from smhi.smhi_lib import APIURL_TEMPLATE, SmhiForecastException
 
 from homeassistant.components.smhi import weather as weather_smhi
-from homeassistant.components.smhi.const import ATTR_SMHI_CLOUDINESS
+from homeassistant.components.smhi.const import (
+    ATTR_SMHI_CLOUDINESS,
+    ATTR_SMHI_THUNDER_PROBABILITY,
+    ATTR_SMHI_WIND_GUST_SPEED,
+)
 from homeassistant.components.weather import (
     ATTR_FORECAST_CONDITION,
     ATTR_FORECAST_PRECIPITATION,

--- a/tests/components/smhi/test_weather.py
+++ b/tests/components/smhi/test_weather.py
@@ -57,6 +57,8 @@ async def test_setup_hass(hass: HomeAssistant, aioclient_mock) -> None:
 
     assert state.state == "sunny"
     assert state.attributes[ATTR_SMHI_CLOUDINESS] == 50
+    assert state.attributes[ATTR_SMHI_THUNDER_PROBABILITY] == 29
+    assert state.attributes[ATTR_SMHI_WIND_GUST_SPEED] == 11
     assert state.attributes[ATTR_WEATHER_ATTRIBUTION].find("SMHI") >= 0
     assert state.attributes[ATTR_WEATHER_HUMIDITY] == 55
     assert state.attributes[ATTR_WEATHER_PRESSURE] == 1024
@@ -85,10 +87,12 @@ def test_properties_no_data(hass: HomeAssistant) -> None:
     assert weather.temperature is None
     assert weather.humidity is None
     assert weather.wind_speed is None
+    assert weather.wind_gust is None
     assert weather.wind_bearing is None
     assert weather.visibility is None
     assert weather.pressure is None
     assert weather.cloudiness is None
+    assert weather.thunder is None
     assert weather.condition is None
     assert weather.forecast is None
     assert weather.temperature_unit == TEMP_CELSIUS
@@ -104,10 +108,12 @@ def test_properties_unknown_symbol() -> None:
     data.total_precipitation = 1
     data.humidity = 5
     data.wind_speed = 10
+    data.wind_gust = 17
     data.wind_direction = 180
     data.horizontal_visibility = 6
     data.pressure = 1008
     data.cloudiness = 52
+    data.thunder = 41
     data.symbol = 100  # Faulty symbol
     data.valid_time = datetime(2018, 1, 1, 0, 1, 2)
 
@@ -117,10 +123,12 @@ def test_properties_unknown_symbol() -> None:
     data2.total_precipitation = 1
     data2.humidity = 5
     data2.wind_speed = 10
+    data2.wind_gust = 17
     data2.wind_direction = 180
     data2.horizontal_visibility = 6
     data2.pressure = 1008
     data2.cloudiness = 52
+    data2.thunder = 41
     data2.symbol = 100  # Faulty symbol
     data2.valid_time = datetime(2018, 1, 1, 12, 1, 2)
 
@@ -130,10 +138,12 @@ def test_properties_unknown_symbol() -> None:
     data3.total_precipitation = 1
     data3.humidity = 5
     data3.wind_speed = 10
+    data3.wind_gust = 17
     data3.wind_direction = 180
     data3.horizontal_visibility = 6
     data3.pressure = 1008
     data3.cloudiness = 52
+    data3.thunder = 41
     data3.symbol = 100  # Faulty symbol
     data3.valid_time = datetime(2018, 1, 2, 12, 1, 2)
 


### PR DESCRIPTION
Added the extra attributes:
wind_gust_speed and
thunder_probability
that were already implemented in the underlaying library (joysoftware/pypi_smhi).

Also for the existing extra attribute "cloudiness", it is now added if "is not None" instead of just "if self.cloudiness" which would make it False (and therefore not available) if cloudiness = 0, which I think was a bug. Therefore i don't consider it to be a breaking change?
I found this because thunder probability is often 0... and I first wrote the attribute code exactly as the old one.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds wind gust speed and thunder probability as extra attributes. These were already implemented in the underlaying library.

I am sorry, but I am not sure how to run the required tests according to the lists below.
I just made the changes in notepad++, uploaded to custom_components folder and it seems to work without any error logs.

Variables/attributes are added, but as I think they are self explaining, and the existing ones are not documented either, I have not proposed any changes to home-assistant.io.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
