### PR TITLE
Allow additional context to be provided to RequiredParameterMissing

### DIFF
--- a/homeassistant/exceptions.py
+++ b/homeassistant/exceptions.py
@@ -189,13 +189,16 @@ class MaxLengthExceeded(HomeAssistantError):
 class RequiredParameterMissing(HomeAssistantError):
     """Raised when a required parameter is missing from a function call."""
 
-    def __init__(self, parameter_names: list[str]) -> None:
+    def __init__(self, parameter_names: list[str], criteria: str | None = None) -> None:
         """Initialize error."""
+        self.criteria = criteria
+        self.parameter_names = parameter_names
+        if criteria:
+            criteria = f" as a {criteria}"
         super().__init__(
             self,
             (
-                "Call must include at least one of the following parameters: "
-                f"{', '.join(parameter_names)}"
+                "Call must include at least one of the following parameters"
+                f"{criteria}: {', '.join(parameter_names)}"
             ),
         )
-        self.parameter_names = parameter_names

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -261,7 +261,9 @@ class DeviceRegistry:
     ) -> DeviceEntry:
         """Get device. Create if it doesn't exist."""
         if not identifiers and not connections:
-            raise RequiredParameterMissing(["identifiers", "connections"])
+            raise RequiredParameterMissing(
+                ["identifiers", "connections"], "non-empty set"
+            )
 
         if identifiers is None:
             identifiers = set()

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -131,6 +131,7 @@ async def test_requirement_for_identifier_or_connection(registry):
         )
 
     assert exc_info.value.parameter_names == ["identifiers", "connections"]
+    assert exc_info.value.criteria == "non-empty set"
 
 
 async def test_multiple_config_entries(registry):


### PR DESCRIPTION
## Proposed change
See https://github.com/home-assistant/core/pull/49038#issuecomment-834612506 for more details, but the gist of it is that the current place where `RequiredParameterMissing` is used uncovered a potential issue with the `huawei_lte` integration. There were cases where the integration was calling `DeviceRegistry.async_get_or_create` with empty sets for both the `identifiers` and `connections`. This used to work for the integration but now raises an exception, and @scop pointed out that the message returned is not clear that empty sets are not allowed. If we decide to keep this behavior, then this PR adds for optional context to be provided in the message.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/49038
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
