### PR TITLE
Handle relation between scan_interval and pymodbus timeout in modbus

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -149,7 +149,7 @@ def control_scan_interval(config: dict) -> dict:
                 minimum_scan_interval = min(scan_interval, minimum_scan_interval)
         if CONF_TIMEOUT in hub and hub[CONF_TIMEOUT] > minimum_scan_interval - 1:
             _LOGGER.warning(
-                "modbus %s timeout(%d) is adjusted(%d) due to scan_interval",
+                "Modbus %s timeout(%d) is adjusted(%d) due to scan_interval",
                 hub.get(CONF_NAME, ""),
                 hub[CONF_TIMEOUT],
                 minimum_scan_interval - 1,

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -145,8 +145,7 @@ def control_scan_interval(config: dict) -> dict:
                         )
                         scan_interval = MINIMUM_SCAN_INTERVAL
                     entry[CONF_SCAN_INTERVAL] = scan_interval
-                    if scan_interval < minimum_scan_interval:
-                        scan_interval = minimum_scan_interval
+                    scan_interval = min(scan_interval, minimum_scan_interval)
         hub[CONF_SECRET_TIMEOUT] = minimum_scan_interval - 1
     return config
 

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -1,5 +1,10 @@
 """Constants used in modbus integration."""
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.climate.const import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     CONF_BINARY_SENSORS,
     CONF_COVERS,
@@ -9,12 +14,9 @@ from homeassistant.const import (
 
 # configuration names
 CONF_BAUDRATE = "baudrate"
-CONF_BINARY_SENSOR = "binary_sensor"
 CONF_BYTESIZE = "bytesize"
-CONF_CLIMATE = "climate"
 CONF_CLIMATES = "climates"
 CONF_COILS = "coils"
-CONF_COVER = "cover"
 CONF_CURRENT_TEMP = "current_temp_register"
 CONF_CURRENT_TEMP_REGISTER_TYPE = "current_temp_register_type"
 CONF_DATA_COUNT = "data_count"
@@ -31,8 +33,6 @@ CONF_REGISTERS = "registers"
 CONF_REVERSE_ORDER = "reverse_order"
 CONF_PRECISION = "precision"
 CONF_SCALE = "scale"
-CONF_SECRET_TIMEOUT = "_secret_pymodbus_timeout"
-CONF_SENSOR = "sensor"
 CONF_STATE_CLOSED = "state_closed"
 CONF_STATE_CLOSING = "state_closing"
 CONF_STATE_OFF = "state_off"
@@ -48,7 +48,6 @@ CONF_SWAP_BYTE = "byte"
 CONF_SWAP_NONE = "none"
 CONF_SWAP_WORD = "word"
 CONF_SWAP_WORD_BYTE = "word_byte"
-CONF_SWITCH = "switch"
 CONF_TARGET_TEMP = "target_temp_register"
 CONF_VERIFY = "verify"
 CONF_VERIFY_REGISTER = "verify_register"
@@ -94,10 +93,10 @@ DEFAULT_STRUCT_FORMAT = {
 DEFAULT_TEMP_UNIT = "C"
 MODBUS_DOMAIN = "modbus"
 
-CONF_PLATFORMS = (
-    (CONF_CLIMATE, CONF_CLIMATES),
-    (CONF_COVER, CONF_COVERS),
-    (CONF_BINARY_SENSOR, CONF_BINARY_SENSORS),
-    (CONF_SENSOR, CONF_SENSORS),
-    (CONF_SWITCH, CONF_SWITCHES),
+PLATFORMS = (
+    (CLIMATE_DOMAIN, CONF_CLIMATES),
+    (COVER_DOMAIN, CONF_COVERS),
+    (BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS),
+    (SENSOR_DOMAIN, CONF_SENSORS),
+    (SWITCH_DOMAIN, CONF_SWITCHES),
 )

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -1,5 +1,12 @@
 """Constants used in modbus integration."""
 
+from homeassistant.const import (
+    CONF_BINARY_SENSORS,
+    CONF_COVERS,
+    CONF_SENSORS,
+    CONF_SWITCHES,
+)
+
 # configuration names
 CONF_BAUDRATE = "baudrate"
 CONF_BINARY_SENSOR = "binary_sensor"
@@ -24,6 +31,7 @@ CONF_REGISTERS = "registers"
 CONF_REVERSE_ORDER = "reverse_order"
 CONF_PRECISION = "precision"
 CONF_SCALE = "scale"
+CONF_SECRET_TIMEOUT = "_secret_pymodbus_timeout"
 CONF_SENSOR = "sensor"
 CONF_STATE_CLOSED = "state_closed"
 CONF_STATE_CLOSING = "state_closing"
@@ -74,6 +82,7 @@ SERVICE_WRITE_REGISTER = "write_register"
 
 # integration names
 DEFAULT_HUB = "modbus_hub"
+MINIMUM_SCAN_INTERVAL = 5  # seconds
 DEFAULT_SCAN_INTERVAL = 15  # seconds
 DEFAULT_SLAVE = 1
 DEFAULT_STRUCTURE_PREFIX = ">f"
@@ -84,3 +93,11 @@ DEFAULT_STRUCT_FORMAT = {
 }
 DEFAULT_TEMP_UNIT = "C"
 MODBUS_DOMAIN = "modbus"
+
+CONF_PLATFORMS = (
+    (CONF_CLIMATE, CONF_CLIMATES),
+    (CONF_COVER, CONF_COVERS),
+    (CONF_BINARY_SENSOR, CONF_BINARY_SENSORS),
+    (CONF_SENSOR, CONF_SENSORS),
+    (CONF_SWITCH, CONF_SWITCHES),
+)

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -8,15 +8,11 @@ from pymodbus.exceptions import ModbusException
 from pymodbus.transaction import ModbusRtuFramer
 
 from homeassistant.const import (
-    CONF_BINARY_SENSORS,
-    CONF_COVERS,
     CONF_DELAY,
     CONF_HOST,
     CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
-    CONF_SENSORS,
-    CONF_SWITCHES,
     CONF_TIMEOUT,
     CONF_TYPE,
     EVENT_HOMEASSISTANT_STOP,
@@ -31,16 +27,13 @@ from .const import (
     ATTR_UNIT,
     ATTR_VALUE,
     CONF_BAUDRATE,
-    CONF_BINARY_SENSOR,
     CONF_BYTESIZE,
-    CONF_CLIMATE,
-    CONF_CLIMATES,
-    CONF_COVER,
     CONF_PARITY,
-    CONF_SENSOR,
+    CONF_PLATFORMS,
+    CONF_SECRET_TIMEOUT,
     CONF_STOPBITS,
-    CONF_SWITCH,
     DEFAULT_HUB,
+    DEFAULT_SCAN_INTERVAL,
     MODBUS_DOMAIN as DOMAIN,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
@@ -63,13 +56,7 @@ def modbus_setup(
         hub_collect[conf_hub[CONF_NAME]].setup(hass)
 
         # load platforms
-        for component, conf_key in (
-            (CONF_CLIMATE, CONF_CLIMATES),
-            (CONF_COVER, CONF_COVERS),
-            (CONF_BINARY_SENSOR, CONF_BINARY_SENSORS),
-            (CONF_SENSOR, CONF_SENSORS),
-            (CONF_SWITCH, CONF_SWITCHES),
-        ):
+        for component, conf_key in CONF_PLATFORMS:
             if conf_key in conf_hub:
                 load_platform(hass, component, DOMAIN, conf_hub, config)
 
@@ -141,7 +128,10 @@ class ModbusHub:
         self._config_timeout = client_config[CONF_TIMEOUT]
         self._config_delay = client_config[CONF_DELAY]
 
-        Defaults.Timeout = 10
+        if CONF_SECRET_TIMEOUT in client_config:
+            Defaults.Timeout = client_config[CONF_SECRET_TIMEOUT]
+        else:
+            Defaults.Timeout = DEFAULT_SCAN_INTERVAL - 1
         if self._config_type == "serial":
             # serial configuration
             self._config_method = client_config[CONF_METHOD]

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -29,12 +29,10 @@ from .const import (
     CONF_BAUDRATE,
     CONF_BYTESIZE,
     CONF_PARITY,
-    CONF_PLATFORMS,
-    CONF_SECRET_TIMEOUT,
     CONF_STOPBITS,
     DEFAULT_HUB,
-    DEFAULT_SCAN_INTERVAL,
     MODBUS_DOMAIN as DOMAIN,
+    PLATFORMS,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
 )
@@ -56,7 +54,7 @@ def modbus_setup(
         hub_collect[conf_hub[CONF_NAME]].setup(hass)
 
         # load platforms
-        for component, conf_key in CONF_PLATFORMS:
+        for component, conf_key in PLATFORMS:
             if conf_key in conf_hub:
                 load_platform(hass, component, DOMAIN, conf_hub, config)
 
@@ -127,11 +125,7 @@ class ModbusHub:
         self._config_port = client_config[CONF_PORT]
         self._config_timeout = client_config[CONF_TIMEOUT]
         self._config_delay = client_config[CONF_DELAY]
-
-        if CONF_SECRET_TIMEOUT in client_config:
-            Defaults.Timeout = client_config[CONF_SECRET_TIMEOUT]
-        else:
-            Defaults.Timeout = DEFAULT_SCAN_INTERVAL - 1
+        Defaults.Timeout = client_config[CONF_TIMEOUT]
         if self._config_type == "serial":
             # serial configuration
             self._config_method = client_config[CONF_METHOD]

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -343,11 +343,14 @@ async def _read_helper(hass, do_group, do_type, do_return, do_exception, mock_py
                 CONF_HOST: "modbusTestHost",
                 CONF_PORT: 5501,
                 CONF_NAME: TEST_MODBUS_NAME,
-                do_group: {
-                    CONF_INPUT_TYPE: do_type,
-                    CONF_NAME: TEST_SENSOR_NAME,
-                    CONF_ADDRESS: 51,
-                },
+                do_group: [
+                    {
+                        CONF_INPUT_TYPE: do_type,
+                        CONF_NAME: TEST_SENSOR_NAME,
+                        CONF_ADDRESS: 51,
+                        CONF_SCAN_INTERVAL: 1,
+                    }
+                ],
             }
         ]
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
scan_interval, if used, in any modbus platform cannot be lower than 5 seconds. Adjustment is done automatically with a warning if needed.

modbus timeout, if used, is automatically adjusted (with a warning) to not be higher than lowest scan interval - 1 second.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If scan_interval+1 is less than timeout, update() and a device is slow or disconnected, update() calls will queue up,
which eventually will exhaust the thread pool.

The individual scan intervals are controlled and adjusted if less than 2 seconds, a warning about stability is given
if the scan_interval is less than the default pymodbus timeout.

This PR calculates the pymodbus (default 10 seconds) timeout based on the individual scan_intervals.

Using this approach should secure that update() do not queue up.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Once reviewed it would be nice if it can be added to 2021.5.2

- This PR fixes or closes issue: fixes #
This is part of  a number of PR that (hopefully) solve the modbus stability problem.

- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
