### PR TITLE
Remove redundant names from config flow titles

### DIFF
--- a/homeassistant/components/apple_tv/strings.json
+++ b/homeassistant/components/apple_tv/strings.json
@@ -1,7 +1,7 @@
 {
   "title": "Apple TV",
   "config": {
-    "flow_title": "Apple TV: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Setup a new Apple TV",

--- a/homeassistant/components/apple_tv/translations/en.json
+++ b/homeassistant/components/apple_tv/translations/en.json
@@ -16,7 +16,7 @@
             "no_usable_service": "A device was found but could not identify any way to establish a connection to it. If you keep seeing this message, try specifying its IP address or restarting your Apple TV.",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Apple TV: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "description": "You are about to add the Apple TV named `{name}` to Home Assistant.\n\n**To complete the process, you may have to enter multiple PIN codes.**\n\nPlease note that you will *not* be able to power off your Apple TV with this integration. Only the media player in Home Assistant will turn off!",

--- a/homeassistant/components/arcam_fmj/strings.json
+++ b/homeassistant/components/arcam_fmj/strings.json
@@ -6,7 +6,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },
     "error": {},
-    "flow_title": "Arcam FMJ on {host}",
+    "flow_title": "{host}",
     "step": {
       "confirm": {
         "description": "Do you want to add Arcam FMJ on `{host}` to Home Assistant?"

--- a/homeassistant/components/arcam_fmj/translations/en.json
+++ b/homeassistant/components/arcam_fmj/translations/en.json
@@ -5,7 +5,8 @@
             "already_in_progress": "Configuration flow is already in progress",
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Arcam FMJ on {host}",
+        "error": {},
+        "flow_title": "{host}",
         "step": {
             "confirm": {
                 "description": "Do you want to add Arcam FMJ on `{host}` to Home Assistant?"

--- a/homeassistant/components/azure_devops/strings.json
+++ b/homeassistant/components/azure_devops/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Azure DevOps: {project_url}",
+    "flow_title": "{project_url}",
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",

--- a/homeassistant/components/azure_devops/translations/en.json
+++ b/homeassistant/components/azure_devops/translations/en.json
@@ -9,7 +9,7 @@
             "invalid_auth": "Invalid authentication",
             "project_error": "Could not get project info."
         },
-        "flow_title": "Azure DevOps: {project_url}",
+        "flow_title": "{project_url}",
         "step": {
             "reauth": {
                 "data": {

--- a/homeassistant/components/blebox/strings.json
+++ b/homeassistant/components/blebox/strings.json
@@ -9,7 +9,7 @@
       "unsupported_version": "BleBox device has outdated firmware. Please upgrade it first.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "flow_title": "BleBox device: {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "description": "Set up your BleBox to integrate with Home Assistant.",

--- a/homeassistant/components/blebox/translations/en.json
+++ b/homeassistant/components/blebox/translations/en.json
@@ -9,7 +9,7 @@
             "unknown": "Unexpected error",
             "unsupported_version": "BleBox device has outdated firmware. Please upgrade it first."
         },
-        "flow_title": "BleBox device: {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/bond/strings.json
+++ b/homeassistant/components/bond/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Bond: {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "confirm": {
         "description": "Do you want to set up {name}?",

--- a/homeassistant/components/bond/translations/en.json
+++ b/homeassistant/components/bond/translations/en.json
@@ -9,7 +9,7 @@
             "old_firmware": "Unsupported old firmware on the Bond device - please upgrade before continuing",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Bond: {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "confirm": {
                 "data": {

--- a/homeassistant/components/brother/strings.json
+++ b/homeassistant/components/brother/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Brother Printer: {model} {serial_number}",
+    "flow_title": "{model} {serial_number}",
     "step": {
       "user": {
         "description": "Set up Brother printer integration. If you have problems with configuration go to: https://www.home-assistant.io/integrations/brother",

--- a/homeassistant/components/brother/translations/en.json
+++ b/homeassistant/components/brother/translations/en.json
@@ -9,7 +9,7 @@
             "snmp_error": "SNMP server turned off or printer not supported.",
             "wrong_host": "Invalid hostname or IP address."
         },
-        "flow_title": "Brother Printer: {model} {serial_number}",
+        "flow_title": "{model} {serial_number}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "BSB-Lan: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Connect to the BSB-Lan device",

--- a/homeassistant/components/bsblan/translations/en.json
+++ b/homeassistant/components/bsblan/translations/en.json
@@ -6,7 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "BSB-Lan: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/canary/strings.json
+++ b/homeassistant/components/canary/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Canary: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Connect to Canary",

--- a/homeassistant/components/canary/translations/en.json
+++ b/homeassistant/components/canary/translations/en.json
@@ -7,7 +7,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Canary: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/cloudflare/strings.json
+++ b/homeassistant/components/cloudflare/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Cloudflare: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Connect to Cloudflare",

--- a/homeassistant/components/cloudflare/translations/en.json
+++ b/homeassistant/components/cloudflare/translations/en.json
@@ -9,7 +9,7 @@
             "invalid_auth": "Invalid authentication",
             "invalid_zone": "Invalid zone"
         },
-        "flow_title": "Cloudflare: {name}",
+        "flow_title": "{name}",
         "step": {
             "records": {
                 "data": {

--- a/homeassistant/components/deconz/strings.json
+++ b/homeassistant/components/deconz/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "deCONZ Zigbee gateway ({host})",
+    "flow_title": "{host}",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/deconz/translations/en.json
+++ b/homeassistant/components/deconz/translations/en.json
@@ -11,7 +11,7 @@
         "error": {
             "no_key": "Couldn't get an API key"
         },
-        "flow_title": "deCONZ Zigbee gateway ({host})",
+        "flow_title": "{host}",
         "step": {
             "hassio_confirm": {
                 "description": "Do you want to configure Home Assistant to connect to the deCONZ gateway provided by the add-on {addon}?",

--- a/homeassistant/components/denonavr/strings.json
+++ b/homeassistant/components/denonavr/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Denon AVR Network Receiver: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Denon AVR Network Receivers",

--- a/homeassistant/components/denonavr/translations/en.json
+++ b/homeassistant/components/denonavr/translations/en.json
@@ -10,7 +10,7 @@
         "error": {
             "discovery_error": "Failed to discover a Denon AVR Network Receiver"
         },
-        "flow_title": "Denon AVR Network Receiver: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "description": "Please confirm adding the receiver",

--- a/homeassistant/components/directv/strings.json
+++ b/homeassistant/components/directv/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "DirecTV: {name}",
+    "flow_title": "{name}",
     "step": {
       "ssdp_confirm": {
         "data": {},

--- a/homeassistant/components/directv/translations/en.json
+++ b/homeassistant/components/directv/translations/en.json
@@ -7,9 +7,10 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "DirecTV: {name}",
+        "flow_title": "{name}",
         "step": {
             "ssdp_confirm": {
+                "data": {},
                 "description": "Do you want to set up {name}?"
             },
             "user": {

--- a/homeassistant/components/doorbird/strings.json
+++ b/homeassistant/components/doorbird/strings.json
@@ -26,7 +26,7 @@
       "link_local_address": "Link local addresses are not supported",
       "not_doorbird_device": "This device is not a DoorBird"
     },
-    "flow_title": "DoorBird {name} ({host})",
+    "flow_title": "{name} ({host})",
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",

--- a/homeassistant/components/doorbird/translations/en.json
+++ b/homeassistant/components/doorbird/translations/en.json
@@ -10,7 +10,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "DoorBird {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/elgato/strings.json
+++ b/homeassistant/components/elgato/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Elgato Light: {serial_number}",
+    "flow_title": "{serial_number}",
     "step": {
       "user": {
         "description": "Set up your Elgato Light to integrate with Home Assistant.",

--- a/homeassistant/components/elgato/translations/en.json
+++ b/homeassistant/components/elgato/translations/en.json
@@ -7,7 +7,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Elgato Light: {serial_number}",
+        "flow_title": "{serial_number}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/emonitor/strings.json
+++ b/homeassistant/components/emonitor/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "SiteSage {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/emonitor/translations/en.json
+++ b/homeassistant/components/emonitor/translations/en.json
@@ -7,7 +7,7 @@
             "cannot_connect": "Failed to connect",
             "unknown": "Unexpected error"
         },
-        "flow_title": "SiteSage {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "description": "Do you want to setup {name} ({host})?",

--- a/homeassistant/components/enphase_envoy/strings.json
+++ b/homeassistant/components/enphase_envoy/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Envoy {serial} ({host})",
+    "flow_title": "{serial} ({host})",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/enphase_envoy/translations/en.json
+++ b/homeassistant/components/enphase_envoy/translations/en.json
@@ -9,7 +9,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Envoy {serial} ({host})",
+        "flow_title": "{serial} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/esphome/strings.json
+++ b/homeassistant/components/esphome/strings.json
@@ -28,6 +28,6 @@
         "title": "Discovered ESPHome node"
       }
     },
-    "flow_title": "ESPHome: {name}"
+    "flow_title": "{name}"
   }
 }

--- a/homeassistant/components/esphome/translations/en.json
+++ b/homeassistant/components/esphome/translations/en.json
@@ -9,7 +9,7 @@
             "invalid_auth": "Invalid authentication",
             "resolve_error": "Can't resolve address of the ESP. If this error persists, please set a static IP address: https://esphomelib.com/esphomeyaml/components/wifi.html#manual-ips"
         },
-        "flow_title": "ESPHome: {name}",
+        "flow_title": "{name}",
         "step": {
             "authenticate": {
                 "data": {

--- a/homeassistant/components/forked_daapd/strings.json
+++ b/homeassistant/components/forked_daapd/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "forked-daapd server: {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "title": "Set up forked-daapd device",

--- a/homeassistant/components/forked_daapd/translations/en.json
+++ b/homeassistant/components/forked_daapd/translations/en.json
@@ -12,7 +12,7 @@
             "wrong_password": "Incorrect password.",
             "wrong_server_type": "The forked-daapd integration requires a forked-daapd server with version >= 27.0."
         },
-        "flow_title": "forked-daapd server: {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/fritz/strings.json
+++ b/homeassistant/components/fritz/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "FRITZ!Box Tools: {name}",
+    "flow_title": "{name}",
     "step": {
       "confirm": {
         "title": "Setup FRITZ!Box Tools",

--- a/homeassistant/components/fritz/translations/en.json
+++ b/homeassistant/components/fritz/translations/en.json
@@ -11,7 +11,7 @@
             "connection_error": "Failed to connect",
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "FRITZ!Box Tools: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "data": {

--- a/homeassistant/components/fritzbox/strings.json
+++ b/homeassistant/components/fritzbox/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "AVM FRITZ!SmartHome: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "description": "Enter your AVM FRITZ!Box information.",

--- a/homeassistant/components/fritzbox/translations/en.json
+++ b/homeassistant/components/fritzbox/translations/en.json
@@ -10,7 +10,7 @@
         "error": {
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "AVM FRITZ!SmartHome: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "data": {

--- a/homeassistant/components/fritzbox_callmonitor/strings.json
+++ b/homeassistant/components/fritzbox_callmonitor/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "AVM FRITZ!Box call monitor: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/fritzbox_callmonitor/translations/en.json
+++ b/homeassistant/components/fritzbox_callmonitor/translations/en.json
@@ -8,7 +8,7 @@
         "error": {
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "AVM FRITZ!Box call monitor: {name}",
+        "flow_title": "{name}",
         "step": {
             "phonebook": {
                 "data": {

--- a/homeassistant/components/harmony/strings.json
+++ b/homeassistant/components/harmony/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Logitech Harmony Hub {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Setup Logitech Harmony Hub",

--- a/homeassistant/components/harmony/translations/en.json
+++ b/homeassistant/components/harmony/translations/en.json
@@ -7,7 +7,7 @@
             "cannot_connect": "Failed to connect",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Logitech Harmony Hub {name}",
+        "flow_title": "{name}",
         "step": {
             "link": {
                 "description": "Do you want to setup {name} ({host})?",

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -1,7 +1,7 @@
 {
   "title": "HomeKit Controller",
   "config": {
-    "flow_title": "{name} via HomeKit Accessory Protocol",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Device selection",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -17,7 +17,7 @@
             "unable_to_pair": "Unable to pair, please try again.",
             "unknown_error": "Device reported an unknown error. Pairing failed."
         },
-        "flow_title": "{name} via HomeKit Accessory Protocol",
+        "flow_title": "{name}",
         "step": {
             "busy_error": {
                 "description": "Abort pairing on all controllers, or try restarting the device, then continue to resume pairing.",

--- a/homeassistant/components/huawei_lte/strings.json
+++ b/homeassistant/components/huawei_lte/strings.json
@@ -15,7 +15,7 @@
       "response_error": "Unknown error from device",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "flow_title": "Huawei LTE: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/huawei_lte/translations/en.json
+++ b/homeassistant/components/huawei_lte/translations/en.json
@@ -15,7 +15,7 @@
             "response_error": "Unknown error from device",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Huawei LTE: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {
@@ -34,7 +34,6 @@
                 "data": {
                     "name": "Notification service name (change requires restart)",
                     "recipient": "SMS notification recipients",
-                    "track_new_devices": "Track new devices",
                     "track_wired_clients": "Track wired network clients"
                 }
             }

--- a/homeassistant/components/ipp/strings.json
+++ b/homeassistant/components/ipp/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Printer: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Link your printer",

--- a/homeassistant/components/ipp/translations/en.json
+++ b/homeassistant/components/ipp/translations/en.json
@@ -13,7 +13,7 @@
             "cannot_connect": "Failed to connect",
             "connection_upgrade": "Failed to connect to printer. Please try again with SSL/TLS option checked."
         },
-        "flow_title": "Printer: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/isy994/strings.json
+++ b/homeassistant/components/isy994/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Universal Devices ISY994 {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/isy994/translations/en.json
+++ b/homeassistant/components/isy994/translations/en.json
@@ -9,7 +9,7 @@
             "invalid_host": "The host entry was not in full URL format, e.g., http://192.168.10.100:80",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Universal Devices ISY994 {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/kodi/strings.json
+++ b/homeassistant/components/kodi/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Kodi: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "description": "Kodi connection information. Please make sure to enable \"Allow control of Kodi via HTTP\" in System/Settings/Network/Services.",

--- a/homeassistant/components/kodi/translations/en.json
+++ b/homeassistant/components/kodi/translations/en.json
@@ -12,7 +12,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Kodi: {name}",
+        "flow_title": "{name}",
         "step": {
             "credentials": {
                 "data": {

--- a/homeassistant/components/lutron_caseta/strings.json
+++ b/homeassistant/components/lutron_caseta/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Lutron Caséta {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "import_failed": {
         "title": "Failed to import Caséta bridge configuration.",

--- a/homeassistant/components/lutron_caseta/translations/en.json
+++ b/homeassistant/components/lutron_caseta/translations/en.json
@@ -8,7 +8,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Lutron Cas\u00e9ta {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "import_failed": {
                 "description": "Couldn\u2019t setup bridge (host: {host}) imported from configuration.yaml.",

--- a/homeassistant/components/motion_blinds/strings.json
+++ b/homeassistant/components/motion_blinds/strings.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "flow_title": "Motion Blinds",
     "step": {
       "user": {
         "title": "Motion Blinds",

--- a/homeassistant/components/motion_blinds/translations/en.json
+++ b/homeassistant/components/motion_blinds/translations/en.json
@@ -8,7 +8,6 @@
         "error": {
             "discovery_error": "Failed to discover a Motion Gateway"
         },
-        "flow_title": "Motion Blinds",
         "step": {
             "connect": {
                 "data": {
@@ -26,7 +25,6 @@
             },
             "user": {
                 "data": {
-                    "api_key": "API Key",
                     "host": "IP Address"
                 },
                 "description": "Connect to your Motion Gateway, if the IP address is not set, auto-discovery is used",

--- a/homeassistant/components/nightscout/strings.json
+++ b/homeassistant/components/nightscout/strings.json
@@ -1,6 +1,5 @@
 {
     "config": {
-        "flow_title": "Nightscout",
         "step": {
             "user": {
                 "title": "Enter your Nightscout server information.",

--- a/homeassistant/components/nightscout/translations/en.json
+++ b/homeassistant/components/nightscout/translations/en.json
@@ -8,7 +8,6 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Nightscout",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/nzbget/strings.json
+++ b/homeassistant/components/nzbget/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "NZBGet: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Connect to NZBGet",

--- a/homeassistant/components/nzbget/translations/en.json
+++ b/homeassistant/components/nzbget/translations/en.json
@@ -7,7 +7,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "NZBGet: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/ovo_energy/strings.json
+++ b/homeassistant/components/ovo_energy/strings.json
@@ -1,6 +1,6 @@
 {
     "config": {
-        "flow_title": "OVO Energy: {username}",
+        "flow_title": "{username}",
         "error": {
             "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
             "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",

--- a/homeassistant/components/ovo_energy/translations/en.json
+++ b/homeassistant/components/ovo_energy/translations/en.json
@@ -5,7 +5,7 @@
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "OVO Energy: {username}",
+        "flow_title": "{username}",
         "step": {
             "reauth": {
                 "data": {

--- a/homeassistant/components/plugwise/strings.json
+++ b/homeassistant/components/plugwise/strings.json
@@ -37,6 +37,6 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_service%]"
     },
-    "flow_title": "Smile: {name}"
+    "flow_title": "{name}"
   }
 }

--- a/homeassistant/components/plugwise/translations/en.json
+++ b/homeassistant/components/plugwise/translations/en.json
@@ -8,7 +8,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Smile: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/powerwall/strings.json
+++ b/homeassistant/components/powerwall/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Tesla Powerwall ({ip_address})",
+    "flow_title": "{ip_address}",
     "step": {
       "user": {
         "title": "Connect to the powerwall",

--- a/homeassistant/components/powerwall/translations/en.json
+++ b/homeassistant/components/powerwall/translations/en.json
@@ -10,7 +10,7 @@
             "unknown": "Unexpected error",
             "wrong_version": "Your powerwall uses a software version that is not supported. Please consider upgrading or reporting this issue so it can be resolved."
         },
-        "flow_title": "Tesla Powerwall ({ip_address})",
+        "flow_title": "{ip_address}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/rainmachine/strings.json
+++ b/homeassistant/components/rainmachine/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "RainMachine {ip}",
+    "flow_title": "{ip}",
     "step": {
       "user": {
         "title": "Fill in your information",

--- a/homeassistant/components/rainmachine/translations/en.json
+++ b/homeassistant/components/rainmachine/translations/en.json
@@ -6,7 +6,7 @@
         "error": {
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "RainMachine {ip}",
+        "flow_title": "{ip}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/roku/strings.json
+++ b/homeassistant/components/roku/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Roku: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "description": "Enter your Roku information.",

--- a/homeassistant/components/roku/translations/en.json
+++ b/homeassistant/components/roku/translations/en.json
@@ -8,13 +8,10 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Roku: {name}",
+        "flow_title": "{name}",
         "step": {
             "discovery_confirm": {
-                "description": "Do you want to set up {name}?",
-                "title": "Roku"
-            },
-            "ssdp_confirm": {
+                "data": {},
                 "description": "Do you want to set up {name}?",
                 "title": "Roku"
             },

--- a/homeassistant/components/roomba/strings.json
+++ b/homeassistant/components/roomba/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "iRobot {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "init": {
         "title": "Automatically connect to the device",

--- a/homeassistant/components/roomba/translations/en.json
+++ b/homeassistant/components/roomba/translations/en.json
@@ -9,7 +9,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "iRobot {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "init": {
                 "data": {
@@ -36,17 +36,6 @@
                 },
                 "description": "No Roomba or Braava have been discovered on your network. The BLID is the portion of the device hostname after `iRobot-` or `Roomba-`. Please follow the steps outlined in the documentation at: {auth_help_url}",
                 "title": "Manually connect to the device"
-            },
-            "user": {
-                "data": {
-                    "blid": "BLID",
-                    "continuous": "Continuous",
-                    "delay": "Delay",
-                    "host": "Host",
-                    "password": "Password"
-                },
-                "description": "Currently retrieving the BLID and password is a manual process. Please follow the steps outlined in the documentation at: https://www.home-assistant.io/integrations/roomba/#retrieving-your-credentials",
-                "title": "Connect to the device"
             }
         }
     },

--- a/homeassistant/components/samsungtv/strings.json
+++ b/homeassistant/components/samsungtv/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Samsung TV: {model}",
+    "flow_title": "{model}",
     "step": {
       "user": {
         "description": "Enter your Samsung TV information. If you never connected Home Assistant before you should see a popup on your TV asking for authorization.",

--- a/homeassistant/components/samsungtv/translations/en.json
+++ b/homeassistant/components/samsungtv/translations/en.json
@@ -7,7 +7,7 @@
             "cannot_connect": "Failed to connect",
             "not_supported": "This Samsung TV device is currently not supported."
         },
-        "flow_title": "Samsung TV: {model}",
+        "flow_title": "{model}",
         "step": {
             "confirm": {
                 "description": "Do you want to set up Samsung TV {model}? If you never connected Home Assistant before you should see a popup on your TV asking for authorization. Manual configurations for this TV will be overwritten.",

--- a/homeassistant/components/screenlogic/strings.json
+++ b/homeassistant/components/screenlogic/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "ScreenLogic {name}",
+    "flow_title": "{name}",
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     },

--- a/homeassistant/components/screenlogic/translations/en.json
+++ b/homeassistant/components/screenlogic/translations/en.json
@@ -6,7 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "ScreenLogic {name}",
+        "flow_title": "{name}",
         "step": {
             "gateway_entry": {
                 "data": {

--- a/homeassistant/components/smappee/strings.json
+++ b/homeassistant/components/smappee/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Smappee: {name}",
+    "flow_title": "{name}",
     "step": {
       "environment": {
         "description": "Set up your Smappee to integrate with Home Assistant.",

--- a/homeassistant/components/smappee/translations/en.json
+++ b/homeassistant/components/smappee/translations/en.json
@@ -9,7 +9,7 @@
             "missing_configuration": "The component is not configured. Please follow the documentation.",
             "no_url_available": "No URL available. For information about this error, [check the help section]({docs_url})"
         },
-        "flow_title": "Smappee: {name}",
+        "flow_title": "{name}",
         "step": {
             "environment": {
                 "data": {

--- a/homeassistant/components/somfy_mylink/strings.json
+++ b/homeassistant/components/somfy_mylink/strings.json
@@ -1,7 +1,6 @@
 {
-  "title": "Somfy MyLink",
   "config": {
-    "flow_title": "Somfy MyLink {mac} ({ip})",
+    "flow_title": "{mac} ({ip})",
     "step": {
       "user": {
         "description": "The System ID can be obtained in the MyLink app under Integration by selecting any non-Cloud service.",

--- a/homeassistant/components/somfy_mylink/translations/en.json
+++ b/homeassistant/components/somfy_mylink/translations/en.json
@@ -8,7 +8,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Somfy MyLink {mac} ({ip})",
+        "flow_title": "{mac} ({ip})",
         "step": {
             "user": {
                 "data": {
@@ -25,17 +25,8 @@
             "cannot_connect": "Failed to connect"
         },
         "step": {
-            "entity_config": {
-                "data": {
-                    "reverse": "Cover is reversed"
-                },
-                "description": "Configure options for `{entity_id}`",
-                "title": "Configure Entity"
-            },
             "init": {
                 "data": {
-                    "default_reverse": "Default reversal status for unconfigured covers",
-                    "entity_id": "Configure a specific entity.",
                     "target_id": "Configure options for a cover."
                 },
                 "title": "Configure MyLink Options"
@@ -48,6 +39,5 @@
                 "title": "Configure MyLink Cover"
             }
         }
-    },
-    "title": "Somfy MyLink"
+    }
 }

--- a/homeassistant/components/sonarr/strings.json
+++ b/homeassistant/components/sonarr/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Sonarr: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/sonarr/translations/en.json
+++ b/homeassistant/components/sonarr/translations/en.json
@@ -9,7 +9,7 @@
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "Sonarr: {name}",
+        "flow_title": "{name}",
         "step": {
             "reauth_confirm": {
                 "description": "The Sonarr integration needs to be manually re-authenticated with the Sonarr API hosted at: {host}",

--- a/homeassistant/components/songpal/strings.json
+++ b/homeassistant/components/songpal/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Sony Songpal {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/songpal/translations/en.json
+++ b/homeassistant/components/songpal/translations/en.json
@@ -7,7 +7,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "Sony Songpal {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "init": {
                 "description": "Do you want to set up {name} ({host})?"

--- a/homeassistant/components/squeezebox/strings.json
+++ b/homeassistant/components/squeezebox/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Logitech Squeezebox: {host}",
+    "flow_title": "{host}",
     "step": {
       "user": {
         "data": {

--- a/homeassistant/components/squeezebox/translations/en.json
+++ b/homeassistant/components/squeezebox/translations/en.json
@@ -10,7 +10,7 @@
             "no_server_found": "Could not automatically discover server.",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Logitech Squeezebox: {host}",
+        "flow_title": "{host}",
         "step": {
             "edit": {
                 "data": {

--- a/homeassistant/components/syncthru/strings.json
+++ b/homeassistant/components/syncthru/strings.json
@@ -8,7 +8,7 @@
       "syncthru_not_supported": "Device does not support SyncThru",
       "unknown_state": "Printer state unknown, verify URL and network connectivity"
     },
-    "flow_title": "Samsung SyncThru Printer: {name}",
+    "flow_title": "{name}",
     "step": {
       "confirm": {
         "data": {

--- a/homeassistant/components/syncthru/translations/en.json
+++ b/homeassistant/components/syncthru/translations/en.json
@@ -8,7 +8,7 @@
             "syncthru_not_supported": "Device does not support SyncThru",
             "unknown_state": "Printer state unknown, verify URL and network connectivity"
         },
-        "flow_title": "Samsung SyncThru Printer: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "data": {

--- a/homeassistant/components/synology_dsm/strings.json
+++ b/homeassistant/components/synology_dsm/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Synology DSM {name} ({host})",
+    "flow_title": "{name} ({host})",
     "step": {
       "user": {
         "title": "Synology DSM",

--- a/homeassistant/components/synology_dsm/translations/en.json
+++ b/homeassistant/components/synology_dsm/translations/en.json
@@ -10,7 +10,7 @@
             "otp_failed": "Two-step authentication failed, retry with a new pass code",
             "unknown": "Unexpected error"
         },
-        "flow_title": "Synology DSM {name} ({host})",
+        "flow_title": "{name} ({host})",
         "step": {
             "2sa": {
                 "data": {

--- a/homeassistant/components/system_bridge/strings.json
+++ b/homeassistant/components/system_bridge/strings.json
@@ -1,12 +1,11 @@
 {
-  "title": "System Bridge",
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
-    "flow_title": "System Bridge: {name}",
+    "flow_title": "{name}",
     "step": {
       "authenticate": {
         "data": {

--- a/homeassistant/components/system_bridge/translations/en.json
+++ b/homeassistant/components/system_bridge/translations/en.json
@@ -10,7 +10,7 @@
             "invalid_auth": "Invalid authentication",
             "unknown": "Unexpected error"
         },
-        "flow_title": "System Bridge: {name}",
+        "flow_title": "{name}",
         "step": {
             "authenticate": {
                 "data": {
@@ -27,6 +27,5 @@
                 "description": "Please enter your connection details."
             }
         }
-    },
-    "title": "System Bridge"
+    }
 }

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -1,6 +1,5 @@
 {
   "config": {
-    "flow_title": "Tuya configuration",
     "step": {
       "user": {
         "title": "Tuya",

--- a/homeassistant/components/tuya/translations/en.json
+++ b/homeassistant/components/tuya/translations/en.json
@@ -8,7 +8,6 @@
         "error": {
             "invalid_auth": "Invalid authentication"
         },
-        "flow_title": "Tuya configuration",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/unifi/strings.json
+++ b/homeassistant/components/unifi/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "UniFi Network {site} ({host})",
+    "flow_title": "{site} ({host})",
     "step": {
       "user": {
         "title": "Set up UniFi Controller",

--- a/homeassistant/components/unifi/translations/en.json
+++ b/homeassistant/components/unifi/translations/en.json
@@ -10,7 +10,7 @@
             "service_unavailable": "Failed to connect",
             "unknown_client_mac": "No client available on that MAC address"
         },
-        "flow_title": "UniFi Network {site} ({host})",
+        "flow_title": "{site} ({host})",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "upnp",
-  "name": "UPnP",
+  "name": "UPnP/IGD",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
   "requirements": ["async-upnp-client==0.17.0"],

--- a/homeassistant/components/upnp/strings.json
+++ b/homeassistant/components/upnp/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "UPnP/IGD: {name}",
+    "flow_title": "{name}",
     "step": {
       "init": {
       },

--- a/homeassistant/components/upnp/translations/en.json
+++ b/homeassistant/components/upnp/translations/en.json
@@ -5,8 +5,9 @@
             "incomplete_discovery": "Incomplete discovery",
             "no_devices_found": "No devices found on the network"
         },
-        "flow_title": "UPnP/IGD: {name}",
+        "flow_title": "{name}",
         "step": {
+            "init": {},
             "ssdp_confirm": {
                 "description": "Do you want to set up this UPnP/IGD device?"
             },

--- a/homeassistant/components/wilight/strings.json
+++ b/homeassistant/components/wilight/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "WiLight: {name}",
+    "flow_title": "{name}",
     "step": {
       "confirm": {
         "title": "WiLight",

--- a/homeassistant/components/wilight/translations/en.json
+++ b/homeassistant/components/wilight/translations/en.json
@@ -5,7 +5,7 @@
             "not_supported_device": "This WiLight is currently not supported",
             "not_wilight_device": "This Device is not WiLight"
         },
-        "flow_title": "WiLight: {name}",
+        "flow_title": "{name}",
         "step": {
             "confirm": {
                 "description": "Do you want to set up WiLight {name}?\n\n It supports: {components}",

--- a/homeassistant/components/withings/strings.json
+++ b/homeassistant/components/withings/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Withings: {profile}",
+    "flow_title": "{profile}",
     "step": {
       "profile": {
         "title": "User Profile.",

--- a/homeassistant/components/withings/translations/en.json
+++ b/homeassistant/components/withings/translations/en.json
@@ -12,7 +12,7 @@
         "error": {
             "already_configured": "Account is already configured"
         },
-        "flow_title": "Withings: {profile}",
+        "flow_title": "{profile}",
         "step": {
             "pick_implementation": {
                 "title": "Pick Authentication Method"

--- a/homeassistant/components/wled/strings.json
+++ b/homeassistant/components/wled/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "WLED: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "description": "Set up your WLED to integrate with Home Assistant.",

--- a/homeassistant/components/wled/translations/en.json
+++ b/homeassistant/components/wled/translations/en.json
@@ -7,7 +7,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "WLED: {name}",
+        "flow_title": "{name}",
         "step": {
             "user": {
                 "data": {

--- a/homeassistant/components/xiaomi_aqara/strings.json
+++ b/homeassistant/components/xiaomi_aqara/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "Xiaomi Aqara Gateway: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "Xiaomi Aqara Gateway",

--- a/homeassistant/components/xiaomi_aqara/translations/en.json
+++ b/homeassistant/components/xiaomi_aqara/translations/en.json
@@ -12,7 +12,7 @@
             "invalid_key": "Invalid gateway key",
             "invalid_mac": "Invalid Mac Address"
         },
-        "flow_title": "Xiaomi Aqara Gateway: {name}",
+        "flow_title": "{name}",
         "step": {
             "select": {
                 "data": {

--- a/homeassistant/components/xiaomi_miio/strings.json
+++ b/homeassistant/components/xiaomi_miio/strings.json
@@ -8,7 +8,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown_device": "The device model is not known, not able to setup the device using config flow."
     },
-    "flow_title": "Xiaomi Miio: {name}",
+    "flow_title": "{name}",
     "step": {
       "device": {
         "data": {

--- a/homeassistant/components/xiaomi_miio/translations/en.json
+++ b/homeassistant/components/xiaomi_miio/translations/en.json
@@ -6,36 +6,18 @@
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "no_device_selected": "No device selected, please select one device.",
             "unknown_device": "The device model is not known, not able to setup the device using config flow."
         },
-        "flow_title": "Xiaomi Miio: {name}",
+        "flow_title": "{name}",
         "step": {
             "device": {
                 "data": {
                     "host": "IP Address",
                     "model": "Device model (Optional)",
-                    "name": "Name of the device",
                     "token": "API Token"
                 },
                 "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/xiaomi_miio#retrieving-the-access-token for instructions. Please note, that this API Token is different from the key used by the Xiaomi Aqara integration.",
                 "title": "Connect to a Xiaomi Miio Device or Xiaomi Gateway"
-            },
-            "gateway": {
-                "data": {
-                    "host": "IP Address",
-                    "name": "Name of the Gateway",
-                    "token": "API Token"
-                },
-                "description": "You will need the 32 character API Token, see https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/#retrieving-the-access-token for instructions. Please note, that this API Token is different from the key used by the Xiaomi Aqara integration.",
-                "title": "Connect to a Xiaomi Gateway"
-            },
-            "user": {
-                "data": {
-                    "gateway": "Connect to a Xiaomi Gateway"
-                },
-                "description": "Select to which device you want to connect.",
-                "title": "Xiaomi Miio"
             }
         }
     }

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "flow_title": "ZHA: {name}",
+    "flow_title": "{name}",
     "step": {
       "user": {
         "title": "ZHA",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -6,7 +6,7 @@
         "error": {
             "cannot_connect": "Failed to connect"
         },
-        "flow_title": "ZHA: {name}",
+        "flow_title": "{name}",
         "step": {
             "pick_radio": {
                 "data": {


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove redundant names from config flow titles.  The names were showing up twice with the new, and the description of the device was frequently cut off.  The UI already lists the integration name below the title.

Before:
<img width="293" alt="Screen Shot 2021-05-09 at 6 20 56 PM" src="https://user-images.githubusercontent.com/663432/117590377-d2330580-b0f4-11eb-84df-911971ef68f2.png">
<img width="302" alt="Screen Shot 2021-05-09 at 6 18 09 PM" src="https://user-images.githubusercontent.com/663432/117590378-d2cb9c00-b0f4-11eb-9743-30957aa0dcd2.png">
<img width="293" alt="Screen Shot 2021-05-09 at 6 18 05 PM" src="https://user-images.githubusercontent.com/663432/117590379-d2cb9c00-b0f4-11eb-8216-638582ac376d.png">
<img width="294" alt="Screen Shot 2021-05-09 at 6 18 03 PM" src="https://user-images.githubusercontent.com/663432/117590380-d2cb9c00-b0f4-11eb-888d-e5354b520569.png">
<img width="287" alt="Screen Shot 2021-05-09 at 6 17 59 PM" src="https://user-images.githubusercontent.com/663432/117590381-d2cb9c00-b0f4-11eb-937f-553f9120affa.png">
<img width="291" alt="Screen Shot 2021-05-09 at 6 17 56 PM" src="https://user-images.githubusercontent.com/663432/117590382-d3643280-b0f4-11eb-880a-bb0e91ecddf0.png">
<img width="289" alt="Screen Shot 2021-05-09 at 6 17 51 PM" src="https://user-images.githubusercontent.com/663432/117590383-d3643280-b0f4-11eb-8464-9f383414390a.png">

After:
<img width="303" alt="Screen Shot 2021-05-09 at 6 33 49 PM" src="https://user-images.githubusercontent.com/663432/117590451-20e09f80-b0f5-11eb-84a5-43ba7d1a72ae.png">
<img width="308" alt="Screen Shot 2021-05-09 at 6 33 41 PM" src="https://user-images.githubusercontent.com/663432/117590452-21793600-b0f5-11eb-9b3a-11ced633924e.png">
<img width="295" alt="Screen Shot 2021-05-09 at 6 33 28 PM" src="https://user-images.githubusercontent.com/663432/117590454-2211cc80-b0f5-11eb-801d-76ee04252c79.png">
<img width="299" alt="Screen Shot 2021-05-09 at 6 33 20 PM" src="https://user-images.githubusercontent.com/663432/117590455-2211cc80-b0f5-11eb-8e6c-be4cdece511f.png">
<img width="293" alt="Screen Shot 2021-05-09 at 6 33 13 PM" src="https://user-images.githubusercontent.com/663432/117590456-2211cc80-b0f5-11eb-8b70-f87524913767.png">
<img width="285" alt="Screen Shot 2021-05-09 at 6 33 04 PM" src="https://user-images.githubusercontent.com/663432/117590457-2211cc80-b0f5-11eb-9a64-76827e6caa51.png">
<img width="300" alt="Screen Shot 2021-05-09 at 6 32 48 PM" src="https://user-images.githubusercontent.com/663432/117590458-22aa6300-b0f5-11eb-97d2-8eda83d6c4c0.png">


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
