### PR TITLE
Use zoneinfo instead of dateutil

### DIFF
--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -8,6 +8,7 @@ async-upnp-client==0.17.0
 async_timeout==3.0.1
 attrs==21.2.0
 awesomeversion==21.2.3
+backports.zoneinfo;python_version<"3.9"
 bcrypt==3.1.7
 certifi>=2020.12.5
 ciso8601==2.1.3
@@ -24,7 +25,6 @@ paho-mqtt==1.5.1
 pillow==8.1.2
 pip>=8.0.3,<20.3
 pyroute2==0.5.18
-python-dateutil==2.8.1
 python-slugify==4.0.1
 pyyaml==5.4.1
 requests==2.25.1

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -357,11 +357,11 @@ def find_next_time_expression_time(
 def datetime_exists(dattim: dt.datetime) -> bool:
     """Check if a datetime exists."""
     assert dattim.tzinfo is not None
-    tz = dattim.tzinfo
+    original_tzinfo = dattim.tzinfo
     # Check if we can round trip to UTC
-    return dattim.replace(tzinfo=None) == dattim.astimezone(UTC).astimezone(tz).replace(
-        tzinfo=None
-    )
+    return dattim.replace(tzinfo=None) == dattim.astimezone(UTC).astimezone(
+        original_tzinfo
+    ).replace(tzinfo=None)
 
 
 def datetime_ambiguous(dattim: dt.datetime) -> bool:

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -359,9 +359,7 @@ def _datetime_exists(dattim: dt.datetime) -> bool:
     assert dattim.tzinfo is not None
     original_tzinfo = dattim.tzinfo
     # Check if we can round trip to UTC
-    return dattim.replace(tzinfo=None) == dattim.astimezone(UTC).astimezone(
-        original_tzinfo
-    ).replace(tzinfo=None)
+    return dattim == dattim.astimezone(UTC).astimezone(original_tzinfo)
 
 
 def _datetime_ambiguous(dattim: dt.datetime) -> bool:

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -367,7 +367,4 @@ def _datetime_ambiguous(dattim: dt.datetime) -> bool:
     assert dattim.tzinfo is not None
     non_folded = dattim.replace(fold=0)
     folded = dattim.replace(fold=1)
-    return not (
-        non_folded.utcoffset() == folded.utcoffset()
-        and non_folded.dst() == folded.dst()
-    )
+    return non_folded.utcoffset() != folded.utcoffset()

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -365,6 +365,5 @@ def _datetime_exists(dattim: dt.datetime) -> bool:
 def _datetime_ambiguous(dattim: dt.datetime) -> bool:
     """Check whether a datetime is ambiguous."""
     assert dattim.tzinfo is not None
-    non_folded = dattim.replace(fold=0)
-    folded = dattim.replace(fold=1)
-    return non_folded.utcoffset() != folded.utcoffset()
+    opposite_fold = dattim.replace(fold=not dattim.fold)
+    return _datetime_exists(dattim) and dattim.utcoffset() != opposite_fold.utcoffset()

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -318,7 +318,7 @@ def find_next_time_expression_time(
     if result.tzinfo in (None, UTC):
         return result
 
-    if datetime_ambiguous(result):
+    if _datetime_ambiguous(result):
         # This happens when we're leaving daylight saving time and local
         # clocks are rolled back. In this case, we want to trigger
         # on both the DST and non-DST time. So when "now" is in the DST
@@ -327,7 +327,7 @@ def find_next_time_expression_time(
         if result.fold != fold:
             result = result.replace(fold=fold)
 
-    if not datetime_exists(result):
+    if not _datetime_exists(result):
         # This happens when we're entering daylight saving time and local
         # clocks are rolled forward, thus there are local times that do
         # not exist. In this case, we want to trigger on the next time
@@ -344,17 +344,17 @@ def find_next_time_expression_time(
     # For example: if triggering on 2:30 and now is 28.10.2018 2:30 (in DST)
     # we should trigger next on 28.10.2018 2:30 (out of DST), but our
     # algorithm above would produce 29.10.2018 2:30 (out of DST)
-    if datetime_ambiguous(now):
+    if _datetime_ambiguous(now):
         check_result = find_next_time_expression_time(
             now + _dst_offset_diff(now), seconds, minutes, hours
         )
-        if datetime_ambiguous(check_result):
+        if _datetime_ambiguous(check_result):
             return check_result
 
     return result
 
 
-def datetime_exists(dattim: dt.datetime) -> bool:
+def _datetime_exists(dattim: dt.datetime) -> bool:
     """Check if a datetime exists."""
     assert dattim.tzinfo is not None
     original_tzinfo = dattim.tzinfo
@@ -364,7 +364,7 @@ def datetime_exists(dattim: dt.datetime) -> bool:
     ).replace(tzinfo=None)
 
 
-def datetime_ambiguous(dattim: dt.datetime) -> bool:
+def _datetime_ambiguous(dattim: dt.datetime) -> bool:
     """Check whether a datetime is ambiguous."""
     assert dattim.tzinfo is not None
     non_folded = dattim.replace(fold=0)

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -6,8 +6,12 @@ import datetime as dt
 import re
 from typing import Any
 
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
 import ciso8601
-from dateutil import tz
 
 from homeassistant.const import MATCH_ALL
 
@@ -43,7 +47,10 @@ def get_time_zone(time_zone_str: str) -> dt.tzinfo | None:
 
     Async friendly.
     """
-    return tz.gettz(time_zone_str)
+    try:
+        return zoneinfo.ZoneInfo(time_zone_str)  # type: ignore
+    except zoneinfo.ZoneInfoNotFoundError:
+        return None
 
 
 def utcnow() -> dt.datetime:
@@ -311,7 +318,7 @@ def find_next_time_expression_time(
     if result.tzinfo in (None, UTC):
         return result
 
-    if tz.datetime_ambiguous(result):
+    if datetime_ambiguous(result):
         # This happens when we're leaving daylight saving time and local
         # clocks are rolled back. In this case, we want to trigger
         # on both the DST and non-DST time. So when "now" is in the DST
@@ -320,7 +327,7 @@ def find_next_time_expression_time(
         if result.fold != fold:
             result = result.replace(fold=fold)
 
-    if not tz.datetime_exists(result):
+    if not datetime_exists(result):
         # This happens when we're entering daylight saving time and local
         # clocks are rolled forward, thus there are local times that do
         # not exist. In this case, we want to trigger on the next time
@@ -337,11 +344,34 @@ def find_next_time_expression_time(
     # For example: if triggering on 2:30 and now is 28.10.2018 2:30 (in DST)
     # we should trigger next on 28.10.2018 2:30 (out of DST), but our
     # algorithm above would produce 29.10.2018 2:30 (out of DST)
-    if tz.datetime_ambiguous(now):
+    if datetime_ambiguous(now):
         check_result = find_next_time_expression_time(
             now + _dst_offset_diff(now), seconds, minutes, hours
         )
-        if tz.datetime_ambiguous(check_result):
+        if datetime_ambiguous(check_result):
             return check_result
 
     return result
+
+
+def datetime_exists(dattim: dt.datetime) -> bool:
+    """Check if a datetime exists.
+
+    From https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html#detecting-ambiguous-and-imaginary-times
+    """
+    # There are no non-existent times in UTC, and comparisons between
+    # aware time zones always compare absolute times; if a datetime is
+    # not equal to the same datetime represented in UTC, it is imaginary.
+    return dattim.astimezone(dt.timezone.utc) == dattim
+
+
+def datetime_ambiguous(dattim: dt.datetime) -> bool:
+    """Check whether a datetime is ambiguous.
+
+    From https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html#detecting-ambiguous-and-imaginary-times
+    """
+    # If a datetime exists and its UTC offset changes in response to
+    # changing `fold`, it is ambiguous in the zone specified.
+    return datetime_exists(dattim) and (
+        dattim.replace(fold=not dattim.fold).utcoffset() != dattim.utcoffset()
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,10 +15,10 @@ PyJWT==1.7.1
 cryptography==3.3.2
 pip>=8.0.3,<20.3
 python-slugify==4.0.1
-python-dateutil==2.8.1
 pyyaml==5.4.1
 requests==2.25.1
 ruamel.yaml==0.15.100
 voluptuous==0.12.1
 voluptuous-serialize==2.4.0
 yarl==1.6.3
+backports.zoneinfo;python_version<"3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ astral==2.2
 async_timeout==3.0.1
 attrs==21.2.0
 awesomeversion==21.2.3
+backports.zoneinfo;python_version<"3.9"
 bcrypt==3.1.7
 certifi>=2020.12.5
 ciso8601==2.1.3
@@ -21,4 +22,3 @@ ruamel.yaml==0.15.100
 voluptuous==0.12.1
 voluptuous-serialize==2.4.0
 yarl==1.6.3
-backports.zoneinfo;python_version<"3.9"

--- a/setup.py
+++ b/setup.py
@@ -47,13 +47,13 @@ REQUIRES = [
     "cryptography==3.3.2",
     "pip>=8.0.3,<20.3",
     "python-slugify==4.0.1",
-    "python-dateutil==2.8.1",
     "pyyaml==5.4.1",
     "requests==2.25.1",
     "ruamel.yaml==0.15.100",
     "voluptuous==0.12.1",
     "voluptuous-serialize==2.4.0",
     "yarl==1.6.3",
+    'backports.zoneinfo;python_version<"3.9"',
 ]
 
 MIN_PY_VERSION = ".".join(map(str, hass_const.REQUIRED_PYTHON_VER))

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ REQUIRES = [
     "async_timeout==3.0.1",
     "attrs==21.2.0",
     "awesomeversion==21.2.3",
+    'backports.zoneinfo;python_version<"3.9"',
     "bcrypt==3.1.7",
     "certifi>=2020.12.5",
     "ciso8601==2.1.3",
@@ -53,7 +54,6 @@ REQUIRES = [
     "voluptuous==0.12.1",
     "voluptuous-serialize==2.4.0",
     "yarl==1.6.3",
-    'backports.zoneinfo;python_version<"3.9"',
 ]
 
 MIN_PY_VERSION = ".".join(map(str, hass_const.REQUIRED_PYTHON_VER))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

First pass to use `zoneinfo` instead of `python-dateutil` for timezone info as per @pganssle https://twitter.com/pganssle/status/1390977390680190980

Open question:

Should we include `tzdata` or should we rely on the system having this installed? In the past we had issues with Alpine accidentally stripping their TZ data, but that's been fixed and so all-but-core installation don't need this. I would vote against adding it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
