### PR TITLE
Move attribute imports to use core constants (A-B)

### DIFF
--- a/homeassistant/components/abode/__init__.py
+++ b/homeassistant/components/abode/__init__.py
@@ -14,6 +14,9 @@ from homeassistant.const import (
     ATTR_DATE,
     ATTR_DEVICE_ID,
     ATTR_ENTITY_ID,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_NAME,
     ATTR_TIME,
     CONF_PASSWORD,
     CONF_USERNAME,
@@ -370,9 +373,9 @@ class AbodeDevice(AbodeEntity):
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            "identifiers": {(DOMAIN, self._device.device_id)},
-            "manufacturer": "Abode",
-            "name": self._device.name,
+            ATTR_IDENTIFIERS: {(DOMAIN, self._device.device_id)},
+            ATTR_MANUFACTURER: "Abode",
+            ATTR_NAME: self._device.name,
             "device_type": self._device.type,
         }
 

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -9,6 +9,9 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_NAME,
     CONF_NAME,
     DEVICE_CLASS_TEMPERATURE,
 )
@@ -109,9 +112,9 @@ class AccuWeatherSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.location_key)},
-            "name": NAME,
-            "manufacturer": MANUFACTURER,
+            ATTR_IDENTIFIERS: {(DOMAIN, self.coordinator.location_key)},
+            ATTR_NAME: NAME,
+            ATTR_MANUFACTURER: MANUFACTURER,
             "entry_type": "service",
         }
 

--- a/homeassistant/components/accuweather/weather.py
+++ b/homeassistant/components/accuweather/weather.py
@@ -17,7 +17,14 @@ from homeassistant.components.weather import (
     WeatherEntity,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_NAME, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_NAME,
+    CONF_NAME,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -82,9 +89,9 @@ class AccuWeatherEntity(CoordinatorEntity, WeatherEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.location_key)},
-            "name": NAME,
-            "manufacturer": MANUFACTURER,
+            ATTR_IDENTIFIERS: {(DOMAIN, self.coordinator.location_key)},
+            ATTR_NAME: NAME,
+            ATTR_MANUFACTURER: MANUFACTURER,
             "entry_type": "service",
         }
 

--- a/homeassistant/components/acmeda/base.py
+++ b/homeassistant/components/acmeda/base.py
@@ -1,6 +1,7 @@
 """Base class for Acmeda Roller Blinds."""
 import aiopulse
 
+from homeassistant.const import ATTR_IDENTIFIERS, ATTR_MANUFACTURER, ATTR_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import entity
 from homeassistant.helpers.device_registry import async_get_registry as get_dev_reg
@@ -80,8 +81,8 @@ class AcmedaBase(entity.Entity):
     def device_info(self):
         """Return the device info."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.roller.name,
-            "manufacturer": "Rollease Acmeda",
+            ATTR_IDENTIFIERS: {(DOMAIN, self.unique_id)},
+            ATTR_NAME: self.roller.name,
+            ATTR_MANUFACTURER: "Rollease Acmeda",
             "via_device": (DOMAIN, self.roller.hub.id),
         }

--- a/homeassistant/components/adguard/__init__.py
+++ b/homeassistant/components/adguard/__init__.py
@@ -8,6 +8,10 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
     CONF_HOST,
     CONF_NAME,
     CONF_PASSWORD,
@@ -197,12 +201,12 @@ class AdGuardHomeDeviceEntity(AdGuardHomeEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information about this AdGuard Home instance."""
         return {
-            "identifiers": {
+            ATTR_IDENTIFIERS: {
                 (DOMAIN, self.adguard.host, self.adguard.port, self.adguard.base_path)
             },
-            "name": "AdGuard Home",
-            "manufacturer": "AdGuard Team",
-            "sw_version": self.hass.data[DOMAIN][self._entry.entry_id].get(
+            ATTR_NAME: "AdGuard Home",
+            ATTR_MANUFACTURER: "AdGuard Team",
+            ATTR_SW_VERSION: self.hass.data[DOMAIN][self._entry.entry_id].get(
                 DATA_ADGUARD_VERSION
             ),
             "entry_type": "service",

--- a/homeassistant/components/advantage_air/entity.py
+++ b/homeassistant/components/advantage_air/entity.py
@@ -1,5 +1,12 @@
 """Advantage Air parent entity class."""
 
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
@@ -27,9 +34,9 @@ class AdvantageAirEntity(CoordinatorEntity):
     def device_info(self):
         """Return parent device information."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.data["system"]["rid"])},
-            "name": self.coordinator.data["system"]["name"],
-            "manufacturer": "Advantage Air",
-            "model": self.coordinator.data["system"]["sysType"],
-            "sw_version": self.coordinator.data["system"]["myAppRev"],
+            ATTR_IDENTIFIERS: {(DOMAIN, self.coordinator.data["system"]["rid"])},
+            ATTR_NAME: self.coordinator.data["system"]["name"],
+            ATTR_MANUFACTURER: "Advantage Air",
+            ATTR_MODEL: self.coordinator.data["system"]["sysType"],
+            ATTR_SW_VERSION: self.coordinator.data["system"]["myAppRev"],
         }

--- a/homeassistant/components/aftership/sensor.py
+++ b/homeassistant/components/aftership/sensor.py
@@ -11,7 +11,13 @@ from homeassistant.components.sensor import (
     PLATFORM_SCHEMA as BASE_PLATFORM_SCHEMA,
     SensorEntity,
 )
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_API_KEY, CONF_NAME, HTTP_OK
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_NAME,
+    CONF_API_KEY,
+    CONF_NAME,
+    HTTP_OK,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -186,7 +192,7 @@ class AfterShipSensor(SensorEntity):
             status_counts[status] = status_counts.get(status, 0) + 1
             trackings.append(
                 {
-                    "name": name,
+                    ATTR_NAME: name,
                     "tracking_number": track["tracking_number"],
                     "slug": track["slug"],
                     "link": f"{BASE}{track['slug']}/{track['tracking_number']}",

--- a/homeassistant/components/agent_dvr/alarm_control_panel.py
+++ b/homeassistant/components/agent_dvr/alarm_control_panel.py
@@ -6,6 +6,10 @@ from homeassistant.components.alarm_control_panel.const import (
     SUPPORT_ALARM_ARM_NIGHT,
 )
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_SW_VERSION,
     STATE_ALARM_ARMED_AWAY,
     STATE_ALARM_ARMED_HOME,
     STATE_ALARM_ARMED_NIGHT,
@@ -62,10 +66,10 @@ class AgentBaseStation(AlarmControlPanelEntity):
     def device_info(self):
         """Return the device info for adding the entity to the agent object."""
         return {
-            "identifiers": {(AGENT_DOMAIN, self._client.unique)},
-            "manufacturer": "Agent",
-            "model": CONST_ALARM_CONTROL_PANEL_NAME,
-            "sw_version": self._client.version,
+            ATTR_IDENTIFIERS: {(AGENT_DOMAIN, self._client.unique)},
+            ATTR_MANUFACTURER: "Agent",
+            ATTR_MODEL: CONST_ALARM_CONTROL_PANEL_NAME,
+            ATTR_SW_VERSION: self._client.version,
         }
 
     async def async_update(self):

--- a/homeassistant/components/agent_dvr/camera.py
+++ b/homeassistant/components/agent_dvr/camera.py
@@ -11,7 +11,15 @@ from homeassistant.components.mjpeg.camera import (
     MjpegCamera,
     filter_urllib3_logging,
 )
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+    CONF_NAME,
+)
 from homeassistant.helpers import entity_platform
 
 from .const import (
@@ -87,11 +95,11 @@ class AgentCamera(MjpegCamera):
     def device_info(self):
         """Return the device info for adding the entity to the agent object."""
         return {
-            "identifiers": {(AGENT_DOMAIN, self._unique_id)},
-            "name": self._name,
-            "manufacturer": "Agent",
-            "model": "Camera",
-            "sw_version": self.device.client.version,
+            ATTR_IDENTIFIERS: {(AGENT_DOMAIN, self._unique_id)},
+            ATTR_NAME: self._name,
+            ATTR_MANUFACTURER: "Agent",
+            ATTR_MODEL: "Camera",
+            ATTR_SW_VERSION: self.device.client.version,
         }
 
     async def async_update(self):

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -9,6 +9,9 @@ from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_NAME,
     CONF_NAME,
 )
 from homeassistant.core import HomeAssistant
@@ -119,13 +122,13 @@ class AirlySensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return {
-            "identifiers": {
+            ATTR_IDENTIFIERS: {
                 (
                     DOMAIN,
                     f"{self.coordinator.latitude}-{self.coordinator.longitude}",
                 )
             },
-            "name": DEFAULT_NAME,
-            "manufacturer": MANUFACTURER,
+            ATTR_NAME: DEFAULT_NAME,
+            ATTR_MANUFACTURER: MANUFACTURER,
             "entry_type": "service",
         }

--- a/homeassistant/components/airvisual/air_quality.py
+++ b/homeassistant/components/airvisual/air_quality.py
@@ -1,5 +1,12 @@
 """Support for AirVisual Node/Pro units."""
 from homeassistant.components.air_quality import AirQualityEntity
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
 from homeassistant.core import callback
 
 from . import AirVisualEntity
@@ -56,11 +63,11 @@ class AirVisualNodeProSensor(AirVisualEntity, AirQualityEntity):
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.data["serial_number"])},
-            "name": self.coordinator.data["settings"]["node_name"],
-            "manufacturer": "AirVisual",
-            "model": f'{self.coordinator.data["status"]["model"]}',
-            "sw_version": (
+            ATTR_IDENTIFIERS: {(DOMAIN, self.coordinator.data["serial_number"])},
+            ATTR_NAME: self.coordinator.data["settings"]["node_name"],
+            ATTR_MANUFACTURER: "AirVisual",
+            ATTR_MODEL: f'{self.coordinator.data["status"]["model"]}',
+            ATTR_SW_VERSION: (
                 f'Version {self.coordinator.data["status"]["system_version"]}'
                 f'{self.coordinator.data["status"]["app_version"]}'
             ),

--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -1,9 +1,14 @@
 """Support for AirVisual air quality sensors."""
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
     ATTR_LATITUDE,
     ATTR_LONGITUDE,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
     ATTR_STATE,
+    ATTR_SW_VERSION,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_BILLION,
     CONCENTRATION_PARTS_PER_MILLION,
@@ -256,11 +261,11 @@ class AirVisualNodeProSensor(AirVisualEntity, SensorEntity):
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.data["serial_number"])},
-            "name": self.coordinator.data["settings"]["node_name"],
-            "manufacturer": "AirVisual",
-            "model": f'{self.coordinator.data["status"]["model"]}',
-            "sw_version": (
+            ATTR_IDENTIFIERS: {(DOMAIN, self.coordinator.data["serial_number"])},
+            ATTR_NAME: self.coordinator.data["settings"]["node_name"],
+            ATTR_MANUFACTURER: "AirVisual",
+            ATTR_MODEL: f'{self.coordinator.data["status"]["model"]}',
+            ATTR_SW_VERSION: (
                 f'Version {self.coordinator.data["status"]["system_version"]}'
                 f'{self.coordinator.data["status"]["app_version"]}'
             ),

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -21,6 +21,7 @@ from homeassistant.components.alarm_control_panel.const import (
 import homeassistant.components.climate.const as climate
 import homeassistant.components.media_player.const as media_player
 from homeassistant.const import (
+    ATTR_NAME,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
@@ -256,7 +257,7 @@ class AlexaCapability:
                 continue
 
             result = {
-                "name": prop_name,
+                ATTR_NAME: prop_name,
                 "namespace": self.name(),
                 "value": prop_value,
                 "timeOfSample": dt_util.utcnow().strftime(DATE_FORMAT),
@@ -328,7 +329,7 @@ class AlexaEndpointHealth(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "connectivity"}]
+        return [{ATTR_NAME: "connectivity"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -373,7 +374,7 @@ class AlexaPowerController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "powerState"}]
+        return [{ATTR_NAME: "powerState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -431,7 +432,7 @@ class AlexaLockController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "lockState"}]
+        return [{ATTR_NAME: "lockState"}]
 
     def properties_retrievable(self):
         """Return True if properties can be retrieved."""
@@ -509,7 +510,7 @@ class AlexaBrightnessController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "brightness"}]
+        return [{ATTR_NAME: "brightness"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -555,7 +556,7 @@ class AlexaColorController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "color"}]
+        return [{ATTR_NAME: "color"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -606,7 +607,7 @@ class AlexaColorTemperatureController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "colorTemperatureInKelvin"}]
+        return [{ATTR_NAME: "colorTemperatureInKelvin"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -652,7 +653,7 @@ class AlexaPercentageController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "percentage"}]
+        return [{ATTR_NAME: "percentage"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -701,11 +702,11 @@ class AlexaSpeaker(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        properties = [{"name": "volume"}]
+        properties = [{ATTR_NAME: "volume"}]
 
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & media_player.SUPPORT_VOLUME_MUTE:
-            properties.append({"name": "muted"})
+            properties.append({ATTR_NAME: "muted"})
 
         return properties
 
@@ -819,7 +820,7 @@ class AlexaInputController(AlexaCapability):
             )
             if formatted_source in Inputs.VALID_SOURCE_NAME_MAP:
                 input_list.append(
-                    {"name": Inputs.VALID_SOURCE_NAME_MAP[formatted_source]}
+                    {ATTR_NAME: Inputs.VALID_SOURCE_NAME_MAP[formatted_source]}
                 )
 
         return input_list
@@ -855,7 +856,7 @@ class AlexaTemperatureSensor(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "temperature"}]
+        return [{ATTR_NAME: "temperature"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -921,7 +922,7 @@ class AlexaContactSensor(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "detectionState"}]
+        return [{ATTR_NAME: "detectionState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -970,7 +971,7 @@ class AlexaMotionSensor(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "detectionState"}]
+        return [{ATTR_NAME: "detectionState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1021,13 +1022,13 @@ class AlexaThermostatController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        properties = [{"name": "thermostatMode"}]
+        properties = [{ATTR_NAME: "thermostatMode"}]
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & climate.SUPPORT_TARGET_TEMPERATURE:
-            properties.append({"name": "targetSetpoint"})
+            properties.append({ATTR_NAME: "targetSetpoint"})
         if supported & climate.SUPPORT_TARGET_TEMPERATURE_RANGE:
-            properties.append({"name": "lowerSetpoint"})
-            properties.append({"name": "upperSetpoint"})
+            properties.append({ATTR_NAME: "lowerSetpoint"})
+            properties.append({ATTR_NAME: "upperSetpoint"})
         return properties
 
     def properties_proactively_reported(self):
@@ -1137,7 +1138,7 @@ class AlexaPowerLevelController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "powerLevel"}]
+        return [{ATTR_NAME: "powerLevel"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1190,7 +1191,7 @@ class AlexaSecurityPanelController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "armState"}]
+        return [{ATTR_NAME: "armState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1281,7 +1282,7 @@ class AlexaModeController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "mode"}]
+        return [{ATTR_NAME: "mode"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1460,7 +1461,7 @@ class AlexaRangeController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "rangeValue"}]
+        return [{ATTR_NAME: "rangeValue"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1705,7 +1706,7 @@ class AlexaToggleController(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "toggleState"}]
+        return [{ATTR_NAME: "toggleState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1813,7 +1814,7 @@ class AlexaPlaybackStateReporter(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "playbackState"}]
+        return [{ATTR_NAME: "playbackState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1869,7 +1870,7 @@ class AlexaEventDetectionSensor(AlexaCapability):
 
     def properties_supported(self):
         """Return what properties this entity supports."""
-        return [{"name": "humanPresenceDetectionState"}]
+        return [{ATTR_NAME: "humanPresenceDetectionState"}]
 
     def properties_proactively_reported(self):
         """Return True if properties asynchronously reported."""
@@ -1933,7 +1934,7 @@ class AlexaEqualizerController(AlexaCapability):
 
         Either bands, mode or both can be specified. Only mode is supported at this time.
         """
-        return [{"name": "mode"}]
+        return [{ATTR_NAME: "mode"}]
 
     def properties_retrievable(self):
         """Return True if properties can be retrieved."""
@@ -1969,7 +1970,7 @@ class AlexaEqualizerController(AlexaCapability):
             sound_mode = sound_mode.upper()
 
             if sound_mode in cls.VALID_SOUND_MODES:
-                input_list.append({"name": sound_mode})
+                input_list.append({ATTR_NAME: sound_mode})
 
         return input_list
 

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -29,6 +29,8 @@ from homeassistant.components import (
 from homeassistant.components.climate import const as climate
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
     ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT,
     CLOUD_NEVER_EXPOSED_ENTITIES,
@@ -332,8 +334,8 @@ class AlexaEntity:
             "description": self.description(),
             "manufacturerName": "Home Assistant",
             "additionalAttributes": {
-                "manufacturer": "Home Assistant",
-                "model": self.entity.domain,
+                ATTR_MANUFACTURER: "Home Assistant",
+                ATTR_MODEL: self.entity.domain,
                 "softwareVersion": __version__,
                 "customIdentifier": f"{self.config.user_identifier()}-{self.entity_id}",
             },

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -18,6 +18,7 @@ from homeassistant.components.climate import const as climate
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_ENTITY_PICTURE,
+    ATTR_NAME,
     ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     SERVICE_ALARM_ARM_AWAY,
@@ -406,7 +407,7 @@ async def async_api_lock(hass, config, directive, context):
 
     response = directive.response()
     response.add_context_property(
-        {"name": "lockState", "namespace": "Alexa.LockController", "value": "LOCKED"}
+        {ATTR_NAME: "lockState", "namespace": "Alexa.LockController", "value": "LOCKED"}
     )
     return response
 
@@ -429,7 +430,11 @@ async def async_api_unlock(hass, config, directive, context):
 
     response = directive.response()
     response.add_context_property(
-        {"namespace": "Alexa.LockController", "name": "lockState", "value": "UNLOCKED"}
+        {
+            "namespace": "Alexa.LockController",
+            ATTR_NAME: "lockState",
+            "value": "UNLOCKED",
+        }
     )
 
     return response
@@ -678,7 +683,7 @@ async def async_api_set_target_temp(hass, config, directive, context):
         data[ATTR_TEMPERATURE] = temp
         response.add_context_property(
             {
-                "name": "targetSetpoint",
+                ATTR_NAME: "targetSetpoint",
                 "namespace": "Alexa.ThermostatController",
                 "value": {"value": temp, "scale": API_TEMP_UNITS[unit]},
             }
@@ -690,7 +695,7 @@ async def async_api_set_target_temp(hass, config, directive, context):
         data[climate.ATTR_TARGET_TEMP_LOW] = temp_low
         response.add_context_property(
             {
-                "name": "lowerSetpoint",
+                ATTR_NAME: "lowerSetpoint",
                 "namespace": "Alexa.ThermostatController",
                 "value": {"value": temp_low, "scale": API_TEMP_UNITS[unit]},
             }
@@ -702,7 +707,7 @@ async def async_api_set_target_temp(hass, config, directive, context):
         data[climate.ATTR_TARGET_TEMP_HIGH] = temp_high
         response.add_context_property(
             {
-                "name": "upperSetpoint",
+                ATTR_NAME: "upperSetpoint",
                 "namespace": "Alexa.ThermostatController",
                 "value": {"value": temp_high, "scale": API_TEMP_UNITS[unit]},
             }
@@ -747,7 +752,7 @@ async def async_api_adjust_target_temp(hass, config, directive, context):
     )
     response.add_context_property(
         {
-            "name": "targetSetpoint",
+            ATTR_NAME: "targetSetpoint",
             "namespace": "Alexa.ThermostatController",
             "value": {"value": target_temp, "scale": API_TEMP_UNITS[unit]},
         }
@@ -810,7 +815,7 @@ async def async_api_set_thermostat_mode(hass, config, directive, context):
     )
     response.add_context_property(
         {
-            "name": "thermostatMode",
+            ATTR_NAME: "thermostatMode",
             "namespace": "Alexa.ThermostatController",
             "value": mode,
         }
@@ -899,7 +904,7 @@ async def async_api_arm(hass, config, directive, context):
 
     response.add_context_property(
         {
-            "name": "armState",
+            ATTR_NAME: "armState",
             "namespace": "Alexa.SecurityPanelController",
             "value": arm_state,
         }
@@ -932,7 +937,7 @@ async def async_api_disarm(hass, config, directive, context):
 
     response.add_context_property(
         {
-            "name": "armState",
+            ATTR_NAME: "armState",
             "namespace": "Alexa.SecurityPanelController",
             "value": "DISARMED",
         }
@@ -992,7 +997,7 @@ async def async_api_set_mode(hass, config, directive, context):
         {
             "namespace": "Alexa.ModeController",
             "instance": instance,
-            "name": "mode",
+            ATTR_NAME: "mode",
             "value": mode,
         }
     )
@@ -1039,7 +1044,7 @@ async def async_api_toggle_on(hass, config, directive, context):
         {
             "namespace": "Alexa.ToggleController",
             "instance": instance,
-            "name": "toggleState",
+            ATTR_NAME: "toggleState",
             "value": "ON",
         }
     )
@@ -1073,7 +1078,7 @@ async def async_api_toggle_off(hass, config, directive, context):
         {
             "namespace": "Alexa.ToggleController",
             "instance": instance,
-            "name": "toggleState",
+            ATTR_NAME: "toggleState",
             "value": "OFF",
         }
     )
@@ -1164,7 +1169,7 @@ async def async_api_set_range(hass, config, directive, context):
         {
             "namespace": "Alexa.RangeController",
             "instance": instance,
-            "name": "rangeValue",
+            ATTR_NAME: "rangeValue",
             "value": range_value,
         }
     )
@@ -1279,7 +1284,7 @@ async def async_api_adjust_range(hass, config, directive, context):
         {
             "namespace": "Alexa.RangeController",
             "instance": instance,
-            "name": "rangeValue",
+            ATTR_NAME: "rangeValue",
             "value": response_value,
         }
     )
@@ -1331,7 +1336,7 @@ async def async_api_changechannel(hass, config, directive, context):
     response.add_context_property(
         {
             "namespace": "Alexa.ChannelController",
-            "name": "channel",
+            ATTR_NAME: "channel",
             "value": {payload_name: channel},
         }
     )
@@ -1362,7 +1367,7 @@ async def async_api_skipchannel(hass, config, directive, context):
     response.add_context_property(
         {
             "namespace": "Alexa.ChannelController",
-            "name": "channel",
+            ATTR_NAME: "channel",
             "value": {"number": ""},
         }
     )
@@ -1403,7 +1408,9 @@ async def async_api_seek(hass, config, directive, context):
     # convert seconds to milliseconds for StateReport.
     seek_position = int(seek_position * 1000)
 
-    payload = {"properties": [{"name": "positionMilliseconds", "value": seek_position}]}
+    payload = {
+        "properties": [{ATTR_NAME: "positionMilliseconds", "value": seek_position}]
+    }
     return directive.response(
         name="StateReport", namespace="Alexa.SeekController", payload=payload
     )

--- a/homeassistant/components/alexa/logbook.py
+++ b/homeassistant/components/alexa/logbook.py
@@ -1,4 +1,5 @@
 """Describe logbook events."""
+from homeassistant.const import ATTR_NAME
 from homeassistant.core import callback
 
 from .const import DOMAIN, EVENT_ALEXA_SMART_HOME
@@ -23,6 +24,6 @@ def async_describe_events(hass, async_describe_event):
                 f"sent command {data['request']['namespace']}/{data['request']['name']}"
             )
 
-        return {"name": "Amazon Alexa", "message": message, "entity_id": entity_id}
+        return {ATTR_NAME: "Amazon Alexa", "message": message, "entity_id": entity_id}
 
     async_describe_event(DOMAIN, EVENT_ALEXA_SMART_HOME, async_describe_logbook_event)

--- a/homeassistant/components/alexa/resources.py
+++ b/homeassistant/components/alexa/resources.py
@@ -1,5 +1,7 @@
 """Alexa Resources and Assets."""
 
+from homeassistant.const import ATTR_NAME
+
 
 class AlexaGlobalCatalog:
     """The Global Alexa catalog.
@@ -384,7 +386,7 @@ class AlexaSemantics:
             {
                 "@type": self.ACTIONS_TO_DIRECTIVE,
                 "actions": actions,
-                "directive": {"name": directive, "payload": payload},
+                "directive": {ATTR_NAME: directive, "payload": payload},
             }
         )
 

--- a/homeassistant/components/alexa/smart_home.py
+++ b/homeassistant/components/alexa/smart_home.py
@@ -1,6 +1,7 @@
 """Support for alexa Smart Home Skill API."""
 import logging
 
+from homeassistant.const import ATTR_NAME
 import homeassistant.core as ha
 
 from .const import API_DIRECTIVE, API_HEADER, EVENT_ALEXA_SMART_HOME
@@ -49,7 +50,7 @@ async def async_handle_message(hass, config, request, context=None, enabled=True
             error_type=err.error_type, error_message=err.error_message
         )
 
-    request_info = {"namespace": directive.namespace, "name": directive.name}
+    request_info = {"namespace": directive.namespace, ATTR_NAME: directive.name}
 
     if directive.has_endpoint:
         request_info["entity_id"] = directive.entity_id
@@ -58,7 +59,7 @@ async def async_handle_message(hass, config, request, context=None, enabled=True
         EVENT_ALEXA_SMART_HOME,
         {
             "request": request_info,
-            "response": {"namespace": response.namespace, "name": response.name},
+            "response": {"namespace": response.namespace, ATTR_NAME: response.name},
         },
         context=context,
     )

--- a/homeassistant/components/almond/__init__.py
+++ b/homeassistant/components/almond/__init__.py
@@ -15,6 +15,7 @@ from homeassistant.auth.const import GROUP_ID_ADMIN
 from homeassistant.components import conversation
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
+    ATTR_NAME,
     CONF_CLIENT_ID,
     CONF_CLIENT_SECRET,
     CONF_HOST,
@@ -258,7 +259,7 @@ class AlmondAgent(conversation.AbstractConversationAgent):
     @property
     def attribution(self):
         """Return the attribution."""
-        return {"name": "Powered by Almond", "url": "https://almond.stanford.edu/"}
+        return {ATTR_NAME: "Powered by Almond", "url": "https://almond.stanford.edu/"}
 
     async def async_get_onboarding(self):
         """Get onboard url if not onboarded."""

--- a/homeassistant/components/ambiclimate/climate.py
+++ b/homeassistant/components/ambiclimate/climate.py
@@ -12,6 +12,8 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
     ATTR_NAME,
     ATTR_TEMPERATURE,
     CONF_CLIENT_ID,
@@ -157,9 +159,9 @@ class AmbiclimateEntity(ClimateEntity):
     def device_info(self):
         """Return the device info."""
         return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
-            "manufacturer": "Ambiclimate",
+            ATTR_IDENTIFIERS: {(DOMAIN, self.unique_id)},
+            ATTR_NAME: self.name,
+            ATTR_MANUFACTURER: "Ambiclimate",
         }
 
     @property

--- a/homeassistant/components/ambient_station/__init__.py
+++ b/homeassistant/components/ambient_station/__init__.py
@@ -11,7 +11,9 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
     ATTR_LOCATION,
+    ATTR_MANUFACTURER,
     ATTR_NAME,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     CONCENTRATION_PARTS_PER_MILLION,
@@ -530,9 +532,9 @@ class AmbientWeatherEntity(Entity):
     def device_info(self):
         """Return device registry information for this entity."""
         return {
-            "identifiers": {(DOMAIN, self._mac_address)},
-            "name": self._station_name,
-            "manufacturer": "Ambient Weather",
+            ATTR_IDENTIFIERS: {(DOMAIN, self._mac_address)},
+            ATTR_NAME: self._station_name,
+            ATTR_MANUFACTURER: "Ambient Weather",
         }
 
     @property

--- a/homeassistant/components/apcupsd/sensor.py
+++ b/homeassistant/components/apcupsd/sensor.py
@@ -6,6 +6,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.const import (
+    ATTR_MODEL,
     CONF_RESOURCES,
     ELECTRICAL_CURRENT_AMPERE,
     ELECTRICAL_VOLT_AMPERE,
@@ -63,7 +64,7 @@ SENSOR_TYPES = {
     "mbattchg": ["Battery Shutdown", PERCENTAGE, "mdi:battery-alert"],
     "minlinev": ["Input Voltage Low", VOLT, "mdi:flash"],
     "mintimel": ["Shutdown Time", "", "mdi:timer-outline"],
-    "model": ["Model", "", "mdi:information-outline"],
+    ATTR_MODEL: ["Model", "", "mdi:information-outline"],
     "nombattv": ["Battery Nominal Voltage", VOLT, "mdi:flash"],
     "nominv": ["Nominal Input Voltage", VOLT, "mdi:flash"],
     "nomoutv": ["Nominal Output Voltage", VOLT, "mdi:flash"],

--- a/homeassistant/components/apple_tv/__init__.py
+++ b/homeassistant/components/apple_tv/__init__.py
@@ -10,6 +10,9 @@ from homeassistant.components.media_player import DOMAIN as MP_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_NAME,
     CONF_ADDRESS,
     CONF_NAME,
     CONF_PROTOCOL,
@@ -145,7 +148,7 @@ class AppleTVEntity(Entity):
     def device_info(self):
         """Return the device info."""
         return {
-            "identifiers": {(DOMAIN, self._identifier)},
+            ATTR_IDENTIFIERS: {(DOMAIN, self._identifier)},
         }
 
 
@@ -341,9 +344,9 @@ class AppleTVManager:
 
     async def _async_setup_device_registry(self):
         attrs = {
-            "identifiers": {(DOMAIN, self.config_entry.unique_id)},
-            "manufacturer": "Apple",
-            "name": self.config_entry.data[CONF_NAME],
+            ATTR_IDENTIFIERS: {(DOMAIN, self.config_entry.unique_id)},
+            ATTR_MANUFACTURER: "Apple",
+            ATTR_NAME: self.config_entry.data[CONF_NAME],
         }
 
         area = attrs["name"]

--- a/homeassistant/components/apple_tv/config_flow.py
+++ b/homeassistant/components/apple_tv/config_flow.py
@@ -10,6 +10,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import (
+    ATTR_NAME,
     CONF_ADDRESS,
     CONF_NAME,
     CONF_PIN,
@@ -99,7 +100,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(info[CONF_IDENTIFIER])
         self.target_device = info[CONF_IDENTIFIER]
 
-        self.context["title_placeholders"] = {"name": info[CONF_NAME]}
+        self.context["title_placeholders"] = {ATTR_NAME: info[CONF_NAME]}
         self.context["identifier"] = self.unique_id
         return await self.async_step_reconfigure()
 
@@ -166,7 +167,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
 
         self.context["identifier"] = self.unique_id
-        self.context["title_placeholders"] = {"name": name}
+        self.context["title_placeholders"] = {ATTR_NAME: name}
         self.target_device = identifier
         return await self.async_find_device_wrapper(self.async_step_confirm)
 
@@ -213,7 +214,7 @@ class AppleTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             return await self.async_begin_pairing()
         return self.async_show_form(
-            step_id="confirm", description_placeholders={"name": self.atv.name}
+            step_id="confirm", description_placeholders={ATTR_NAME: self.atv.name}
         )
 
     async def async_begin_pairing(self):

--- a/homeassistant/components/arcam_fmj/media_player.py
+++ b/homeassistant/components/arcam_fmj/media_player.py
@@ -21,7 +21,15 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_STEP,
 )
 from homeassistant.components.media_player.errors import BrowseError
-from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    STATE_OFF,
+    STATE_ON,
+)
 from homeassistant.core import HomeAssistant, callback
 
 from .config_flow import get_entry_client
@@ -114,13 +122,13 @@ class ArcamFmj(MediaPlayerEntity):
     def device_info(self):
         """Return a device description for device registry."""
         return {
-            "name": self._device_name,
-            "identifiers": {
+            ATTR_NAME: self._device_name,
+            ATTR_IDENTIFIERS: {
                 (DOMAIN, self._uuid),
                 (DOMAIN, self._state.client.host, self._state.client.port),
             },
-            "model": "Arcam FMJ AVR",
-            "manufacturer": "Arcam",
+            ATTR_MODEL: "Arcam FMJ AVR",
+            ATTR_MANUFACTURER: "Arcam",
         }
 
     @property

--- a/homeassistant/components/aruba/device_tracker.py
+++ b/homeassistant/components/aruba/device_tracker.py
@@ -10,7 +10,7 @@ from homeassistant.components.device_tracker import (
     PLATFORM_SCHEMA as PARENT_PLATFORM_SCHEMA,
     DeviceScanner,
 )
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import ATTR_NAME, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 import homeassistant.helpers.config_validation as cv
 
 _LOGGER = logging.getLogger(__name__)
@@ -130,6 +130,6 @@ class ArubaDeviceScanner(DeviceScanner):
                 devices[match.group("ip")] = {
                     "ip": match.group("ip"),
                     "mac": match.group("mac").upper(),
-                    "name": match.group("name"),
+                    ATTR_NAME: match.group("name"),
                 }
         return devices

--- a/homeassistant/components/arwn/sensor.py
+++ b/homeassistant/components/arwn/sensor.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.components import mqtt
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.const import DEGREE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import ATTR_NAME, DEGREE, TEMP_CELSIUS, TEMP_FAHRENHEIT
 from homeassistant.core import callback
 from homeassistant.util import slugify
 
@@ -100,13 +100,13 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
                 store[sensor.name] = sensor
                 _LOGGER.debug(
                     "Registering sensor %(name)s => %(event)s",
-                    {"name": sensor.name, "event": event},
+                    {ATTR_NAME: sensor.name, "event": event},
                 )
                 async_add_entities((sensor,), True)
             else:
                 _LOGGER.debug(
                     "Recording sensor %(name)s => %(event)s",
-                    {"name": sensor.name, "event": event},
+                    {ATTR_NAME: sensor.name, "event": event},
                 )
                 store[sensor.name].set_event(event)
 

--- a/homeassistant/components/asuswrt/router.py
+++ b/homeassistant/components/asuswrt/router.py
@@ -14,6 +14,10 @@ from homeassistant.components.device_tracker.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
     CONF_HOST,
     CONF_MODE,
     CONF_PASSWORD,
@@ -372,10 +376,10 @@ class AsusWrtRouter:
     def device_info(self) -> DeviceInfo:
         """Return the device information."""
         return {
-            "identifiers": {(DOMAIN, "AsusWRT")},
-            "name": self._host,
-            "model": self._model,
-            "manufacturer": "Asus",
+            ATTR_IDENTIFIERS: {(DOMAIN, "AsusWRT")},
+            ATTR_NAME: self._host,
+            ATTR_MODEL: self._model,
+            ATTR_MANUFACTURER: "Asus",
             "sw_version": self._sw_v,
         }
 

--- a/homeassistant/components/atag/__init__.py
+++ b/homeassistant/components/atag/__init__.py
@@ -9,6 +9,13 @@ from homeassistant.components.climate import DOMAIN as CLIMATE
 from homeassistant.components.sensor import DOMAIN as SENSOR
 from homeassistant.components.water_heater import DOMAIN as WATER_HEATER
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
@@ -83,11 +90,11 @@ class AtagEntity(CoordinatorEntity):
         device = self.coordinator.data.id
         version = self.coordinator.data.apiversion
         return {
-            "identifiers": {(DOMAIN, device)},
-            "name": "Atag Thermostat",
-            "model": "Atag One",
-            "sw_version": version,
-            "manufacturer": "Atag",
+            ATTR_IDENTIFIERS: {(DOMAIN, device)},
+            ATTR_NAME: "Atag Thermostat",
+            ATTR_MODEL: "Atag One",
+            ATTR_SW_VERSION: version,
+            ATTR_MANUFACTURER: "Atag",
         }
 
     @property

--- a/homeassistant/components/august/entity.py
+++ b/homeassistant/components/august/entity.py
@@ -1,4 +1,11 @@
 """Base class for August entity."""
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
 from homeassistant.core import callback
 from homeassistant.helpers.entity import Entity
 
@@ -35,11 +42,11 @@ class AugustEntityMixin(Entity):
         """Return the device_info of the device."""
         name = self._device.device_name
         return {
-            "identifiers": {(DOMAIN, self._device_id)},
-            "name": name,
-            "manufacturer": MANUFACTURER,
-            "sw_version": self._detail.firmware_version,
-            "model": self._detail.model,
+            ATTR_IDENTIFIERS: {(DOMAIN, self._device_id)},
+            ATTR_NAME: name,
+            ATTR_MANUFACTURER: MANUFACTURER,
+            ATTR_SW_VERSION: self._detail.firmware_version,
+            ATTR_MODEL: self._detail.model,
             "suggested_area": _remove_device_types(name, DEVICE_TYPES),
         }
 

--- a/homeassistant/components/aurora/__init__.py
+++ b/homeassistant/components/aurora/__init__.py
@@ -7,7 +7,15 @@ from aiohttp import ClientError
 from auroranoaa import AuroraForecast
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_NAME, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    CONF_LATITUDE,
+    CONF_LONGITUDE,
+    CONF_NAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import (
@@ -18,9 +26,6 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     ATTR_ENTRY_TYPE,
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
     ATTRIBUTION,
     AURORA_API,
     CONF_THRESHOLD,

--- a/homeassistant/components/aurora/const.py
+++ b/homeassistant/components/aurora/const.py
@@ -3,9 +3,6 @@
 DOMAIN = "aurora"
 COORDINATOR = "coordinator"
 AURORA_API = "aurora_api"
-ATTR_IDENTIFIERS = "identifiers"
-ATTR_MANUFACTURER = "manufacturer"
-ATTR_MODEL = "model"
 ATTR_ENTRY_TYPE = "entry_type"
 DEFAULT_POLLING_INTERVAL = 5
 CONF_THRESHOLD = "forecast_threshold"

--- a/homeassistant/components/auth/__init__.py
+++ b/homeassistant/components/auth/__init__.py
@@ -77,7 +77,7 @@ The result payload likes
     "success": true,
     "result": {
         "id": "USER_ID",
-        "name": "John Doe",
+        ATTR_NAME: "John Doe",
         "is_owner": true,
         "credentials": [{
             "auth_provider_type": "homeassistant",
@@ -85,7 +85,7 @@ The result payload likes
         }],
         "mfa_modules": [{
             "id": "totp",
-            "name": "TOTP",
+            ATTR_NAME: "TOTP",
             "enabled": true
         }]
     }
@@ -133,7 +133,7 @@ from homeassistant.components.http.auth import async_sign_path
 from homeassistant.components.http.ban import log_invalid_auth
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
-from homeassistant.const import HTTP_BAD_REQUEST, HTTP_FORBIDDEN, HTTP_OK
+from homeassistant.const import ATTR_NAME, HTTP_BAD_REQUEST, HTTP_FORBIDDEN, HTTP_OK
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.loader import bind_hass
 from homeassistant.util import dt as dt_util
@@ -467,7 +467,7 @@ async def websocket_current_user(
             msg["id"],
             {
                 "id": user.id,
-                "name": user.name,
+                ATTR_NAME: user.name,
                 "is_owner": user.is_owner,
                 "is_admin": user.is_admin,
                 "credentials": [
@@ -480,7 +480,7 @@ async def websocket_current_user(
                 "mfa_modules": [
                     {
                         "id": module.id,
-                        "name": module.name,
+                        ATTR_NAME: module.name,
                         "enabled": module.id in enabled_modules,
                     }
                     for module in hass.auth.auth_mfa_modules

--- a/homeassistant/components/auth/login_flow.py
+++ b/homeassistant/components/auth/login_flow.py
@@ -6,7 +6,7 @@ Return a list of auth providers. Example:
 
 [
     {
-        "name": "Local",
+        ATTR_NAME: "Local",
         "id": null,
         "type": "local_provider",
     }
@@ -37,8 +37,8 @@ flow for details.
 
 {
     "data_schema": [
-        {"name": "username", "type": "string"},
-        {"name": "password", "type": "string"}
+        {ATTR_NAME: "username", "type": "string"},
+        {ATTR_NAME: "password", "type": "string"}
     ],
     "errors": {},
     "flow_id": "8f7e42faab604bcab7ac43c44ca34d58",
@@ -81,6 +81,7 @@ from homeassistant.components.http.ban import (
 from homeassistant.components.http.data_validator import RequestDataValidator
 from homeassistant.components.http.view import HomeAssistantView
 from homeassistant.const import (
+    ATTR_NAME,
     HTTP_BAD_REQUEST,
     HTTP_METHOD_NOT_ALLOWED,
     HTTP_NOT_FOUND,
@@ -115,7 +116,7 @@ class AuthProvidersView(HomeAssistantView):
 
         return self.json(
             [
-                {"name": provider.name, "id": provider.id, "type": provider.type}
+                {ATTR_NAME: provider.name, "id": provider.id, "type": provider.type}
                 for provider in hass.auth.auth_providers
             ]
         )

--- a/homeassistant/components/automation/logbook.py
+++ b/homeassistant/components/automation/logbook.py
@@ -19,7 +19,7 @@ def async_describe_events(hass: HomeAssistant, async_describe_event):  # type: i
             message = f"{message} by {data[ATTR_SOURCE]}"
 
         return {
-            "name": data.get(ATTR_NAME),
+            ATTR_NAME: data.get(ATTR_NAME),
             "message": message,
             "source": data.get(ATTR_SOURCE),
             "entity_id": data.get(ATTR_ENTITY_ID),

--- a/homeassistant/components/awair/sensor.py
+++ b/homeassistant/components/awair/sensor.py
@@ -7,7 +7,14 @@ import voluptuous as vol
 from homeassistant.components.awair import AwairDataUpdateCoordinator, AwairResult
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import ATTR_ATTRIBUTION, ATTR_DEVICE_CLASS, CONF_ACCESS_TOKEN
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_DEVICE_CLASS,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    CONF_ACCESS_TOKEN,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 import homeassistant.helpers.config_validation as cv
@@ -213,9 +220,9 @@ class AwairSensor(CoordinatorEntity, SensorEntity):
     def device_info(self) -> DeviceInfo:
         """Device information."""
         info = {
-            "identifiers": {(DOMAIN, self._device.uuid)},
-            "manufacturer": "Awair",
-            "model": self._device.model,
+            ATTR_IDENTIFIERS: {(DOMAIN, self._device.uuid)},
+            ATTR_MANUFACTURER: "Awair",
+            ATTR_MODEL: self._device.model,
         }
 
         if self._device.name:

--- a/homeassistant/components/azure_devops/__init__.py
+++ b/homeassistant/components/azure_devops/__init__.py
@@ -7,6 +7,7 @@ from aioazuredevops.client import DevOpsClient
 import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_IDENTIFIERS, ATTR_MANUFACTURER, ATTR_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers.entity import DeviceInfo, Entity
@@ -100,14 +101,14 @@ class AzureDevOpsDeviceEntity(AzureDevOpsEntity):
     def device_info(self) -> DeviceInfo:
         """Return device information about this Azure DevOps instance."""
         return {
-            "identifiers": {
+            ATTR_IDENTIFIERS: {
                 (
                     DOMAIN,
                     self.organization,
                     self.project,
                 )
             },
-            "manufacturer": self.organization,
-            "name": self.project,
+            ATTR_MANUFACTURER: self.organization,
+            ATTR_NAME: self.project,
             "entry_type": "service",
         }

--- a/homeassistant/components/blebox/__init__.py
+++ b/homeassistant/components/blebox/__init__.py
@@ -6,7 +6,15 @@ from blebox_uniapi.products import Products
 from blebox_uniapi.session import ApiHost
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+    CONF_HOST,
+    CONF_PORT,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -102,9 +110,9 @@ class BleBoxEntity(Entity):
         """Return device information for this entity."""
         product = self._feature.product
         return {
-            "identifiers": {(DOMAIN, product.unique_id)},
-            "name": product.name,
-            "manufacturer": product.brand,
-            "model": product.model,
-            "sw_version": product.firmware_version,
+            ATTR_IDENTIFIERS: {(DOMAIN, product.unique_id)},
+            ATTR_NAME: product.name,
+            ATTR_MANUFACTURER: product.brand,
+            ATTR_MODEL: product.model,
+            ATTR_SW_VERSION: product.firmware_version,
         }

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -32,6 +32,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_NAME,
     CONF_HOST,
     CONF_HOSTS,
     CONF_NAME,
@@ -468,7 +469,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             self._capture_items.append(
                 {
                     "title": item.get("@text", ""),
-                    "name": item.get("@text", ""),
+                    ATTR_NAME: item.get("@text", ""),
                     "type": item.get("@serviceType", "Capture"),
                     "image": item.get("@image", ""),
                     "url": item.get("@URL", ""),
@@ -496,7 +497,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             self._preset_items.append(
                 {
                     "title": item.get("@name", ""),
-                    "name": item.get("@name", ""),
+                    ATTR_NAME: item.get("@name", ""),
                     "type": "preset",
                     "image": item.get("@image", ""),
                     "is_raw_url": True,
@@ -526,7 +527,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             self._services_items.append(
                 {
                     "title": item.get("@displayname", ""),
-                    "name": item.get("@name", ""),
+                    ATTR_NAME: item.get("@name", ""),
                     "type": item.get("@type", ""),
                     "image": item.get("@icon", ""),
                     "url": item.get("@name", ""),

--- a/homeassistant/components/bluetooth_le_tracker/device_tracker.py
+++ b/homeassistant/components/bluetooth_le_tracker/device_tracker.py
@@ -20,7 +20,7 @@ from homeassistant.components.device_tracker.legacy import (
     YAML_DEVICES,
     async_load_config,
 )
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.const import ATTR_NAME, EVENT_HOMEASSISTANT_STOP
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.event import track_point_in_utc_time
 import homeassistant.util.dt as dt_util
@@ -92,7 +92,7 @@ def setup_scanner(hass, config, see, discovery_info=None):  # noqa: C901
                     )
             else:
                 _LOGGER.debug("Seen %s for the first time", address)
-                new_devices[address] = {"seen": 1, "name": name}
+                new_devices[address] = {"seen": 1, ATTR_NAME: name}
                 return
 
         see(

--- a/homeassistant/components/bmw_connected_drive/__init__.py
+++ b/homeassistant/components/bmw_connected_drive/__init__.py
@@ -11,6 +11,10 @@ from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
     CONF_DEVICE_ID,
     CONF_NAME,
     CONF_PASSWORD,
@@ -331,10 +335,10 @@ class BMWConnectedDriveBaseEntity(Entity):
     def device_info(self) -> DeviceInfo:
         """Return info for device registry."""
         return {
-            "identifiers": {(DOMAIN, self._vehicle.vin)},
-            "name": f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
-            "model": self._vehicle.name,
-            "manufacturer": self._vehicle.attributes.get("brand"),
+            ATTR_IDENTIFIERS: {(DOMAIN, self._vehicle.vin)},
+            ATTR_NAME: f'{self._vehicle.attributes.get("brand")} {self._vehicle.name}',
+            ATTR_MODEL: self._vehicle.name,
+            ATTR_MANUFACTURER: self._vehicle.attributes.get("brand"),
         }
 
     @property

--- a/homeassistant/components/bond/entity.py
+++ b/homeassistant/components/bond/entity.py
@@ -10,6 +10,7 @@ from typing import Any
 from aiohttp import ClientError
 from bond_api import BPUPSubscriptions
 
+from homeassistant.const import ATTR_IDENTIFIERS, ATTR_MANUFACTURER
 from homeassistant.core import callback
 from homeassistant.helpers.entity import DeviceInfo, Entity
 from homeassistant.helpers.event import async_track_time_interval
@@ -67,9 +68,9 @@ class BondEntity(Entity):
     def device_info(self) -> DeviceInfo:
         """Get a an HA device representing this Bond controlled device."""
         device_info: DeviceInfo = {
-            "manufacturer": self._hub.make,
+            ATTR_MANUFACTURER: self._hub.make,
             # type ignore: tuple items should not be Optional
-            "identifiers": {(DOMAIN, self._hub.bond_id, self._device.device_id)},  # type: ignore[arg-type]
+            ATTR_IDENTIFIERS: {(DOMAIN, self._hub.bond_id, self._device.device_id)},  # type: ignore[arg-type]
         }
         if self.name is not None:
             device_info["name"] = self.name

--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -7,14 +7,13 @@ from bravia_tv.braviarc import NoIPControl
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
+from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_MAC, CONF_PIN
 from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
     ATTR_CID,
     ATTR_MAC,
-    ATTR_MODEL,
     CLIENTID_PREFIX,
     CONF_IGNORED_SOURCES,
     DOMAIN,

--- a/homeassistant/components/braviatv/const.py
+++ b/homeassistant/components/braviatv/const.py
@@ -1,13 +1,12 @@
 """Constants for Bravia TV integration."""
 ATTR_CID = "cid"
 ATTR_MAC = "macAddr"
-ATTR_MANUFACTURER = "Sony"
-ATTR_MODEL = "model"
+MANUFACTURER = "Sony"
 
 CONF_IGNORED_SOURCES = "ignored_sources"
 
 BRAVIA_CONFIG_FILE = "bravia.conf"
 CLIENTID_PREFIX = "HomeAssistant"
-DEFAULT_NAME = f"{ATTR_MANUFACTURER} Bravia TV"
+DEFAULT_NAME = f"{MANUFACTURER} Bravia TV"
 DOMAIN = "braviatv"
 NICKNAME = "Home Assistant"

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -13,10 +13,18 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    STATE_OFF,
+    STATE_PAUSED,
+    STATE_PLAYING,
+)
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_MANUFACTURER, DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN, MANUFACTURER
 
 SUPPORT_BRAVIA = (
     SUPPORT_PAUSE
@@ -39,10 +47,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
     unique_id = config_entry.unique_id
     device_info = {
-        "identifiers": {(DOMAIN, unique_id)},
-        "name": DEFAULT_NAME,
-        "manufacturer": ATTR_MANUFACTURER,
-        "model": config_entry.title,
+        ATTR_IDENTIFIERS: {(DOMAIN, unique_id)},
+        ATTR_NAME: DEFAULT_NAME,
+        ATTR_MANUFACTURER: MANUFACTURER,
+        ATTR_MODEL: config_entry.title,
     }
 
     async_add_entities(

--- a/homeassistant/components/braviatv/remote.py
+++ b/homeassistant/components/braviatv/remote.py
@@ -3,7 +3,7 @@
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTR_MANUFACTURER, DEFAULT_NAME, DOMAIN
+from .const import DEFAULT_NAME, DOMAIN, MANUFACTURER
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -14,7 +14,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     device_info = {
         "identifiers": {(DOMAIN, unique_id)},
         "name": DEFAULT_NAME,
-        "manufacturer": ATTR_MANUFACTURER,
+        "manufacturer": MANUFACTURER,
         "model": config_entry.title,
     }
 

--- a/homeassistant/components/broadlink/config_flow.py
+++ b/homeassistant/components/broadlink/config_flow.py
@@ -15,7 +15,15 @@ import voluptuous as vol
 from homeassistant import config_entries, data_entry_flow
 from homeassistant.components.dhcp import IP_ADDRESS, MAC_ADDRESS
 from homeassistant.config_entries import SOURCE_REAUTH
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME, CONF_TIMEOUT, CONF_TYPE
+from homeassistant.const import (
+    ATTR_MODEL,
+    ATTR_NAME,
+    CONF_HOST,
+    CONF_MAC,
+    CONF_NAME,
+    CONF_TIMEOUT,
+    CONF_TYPE,
+)
 from homeassistant.helpers import config_validation as cv
 
 from .const import DEFAULT_PORT, DEFAULT_TIMEOUT, DOMAIN, DOMAINS_AND_TYPES
@@ -50,8 +58,8 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         self.device = device
 
         self.context["title_placeholders"] = {
-            "name": device.name,
-            "model": device.model,
+            ATTR_NAME: device.name,
+            ATTR_MODEL: device.model,
             "host": device.host[0],
         }
 
@@ -206,8 +214,8 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="reset",
                 errors=errors,
                 description_placeholders={
-                    "name": device.name,
-                    "model": device.model,
+                    ATTR_NAME: device.name,
+                    ATTR_MODEL: device.model,
                     "host": device.host[0],
                 },
             )
@@ -264,8 +272,8 @@ class BroadlinkFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             errors=errors,
             data_schema=vol.Schema(data_schema),
             description_placeholders={
-                "name": device.name,
-                "model": device.model,
+                ATTR_NAME: device.name,
+                ATTR_MODEL: device.model,
                 "host": device.host[0],
             },
         )

--- a/homeassistant/components/brother/config_flow.py
+++ b/homeassistant/components/brother/config_flow.py
@@ -9,7 +9,7 @@ from brother import Brother, SnmpError, UnsupportedModel
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
-from homeassistant.const import CONF_HOST, CONF_TYPE
+from homeassistant.const import ATTR_MODEL, CONF_HOST, CONF_TYPE
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.typing import DiscoveryInfoType
 
@@ -102,7 +102,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             {
                 "title_placeholders": {
                     "serial_number": self.brother.serial,
-                    "model": self.brother.model,
+                    ATTR_MODEL: self.brother.model,
                 }
             }
         )
@@ -125,7 +125,7 @@ class BrotherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             description_placeholders={
                 "serial_number": self.brother.serial,
-                "model": self.brother.model,
+                ATTR_MODEL: self.brother.model,
             },
         )
 

--- a/homeassistant/components/brother/const.py
+++ b/homeassistant/components/brother/const.py
@@ -40,7 +40,6 @@ ATTR_MAGENTA_DRUM_REMAINING_LIFE: Final = "magenta_drum_remaining_life"
 ATTR_MAGENTA_DRUM_REMAINING_PAGES: Final = "magenta_drum_remaining_pages"
 ATTR_MAGENTA_INK_REMAINING: Final = "magenta_ink_remaining"
 ATTR_MAGENTA_TONER_REMAINING: Final = "magenta_toner_remaining"
-ATTR_MANUFACTURER: Final = "Brother"
 ATTR_PAGE_COUNTER: Final = "page_counter"
 ATTR_PF_KIT_1_REMAINING_LIFE: Final = "pf_kit_1_remaining_life"
 ATTR_PF_KIT_MP_REMAINING_LIFE: Final = "pf_kit_mp_remaining_life"
@@ -57,6 +56,8 @@ ATTR_YELLOW_TONER_REMAINING: Final = "yellow_toner_remaining"
 DATA_CONFIG_ENTRY: Final = "config_entry"
 
 DOMAIN: Final = "brother"
+
+MANUFACTURER: Final = "Brother"
 
 UNIT_PAGES: Final = "p"
 

--- a/homeassistant/components/brother/sensor.py
+++ b/homeassistant/components/brother/sensor.py
@@ -5,7 +5,15 @@ from typing import Any
 
 from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ICON
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -16,13 +24,13 @@ from .const import (
     ATTR_COUNTER,
     ATTR_ENABLED,
     ATTR_LABEL,
-    ATTR_MANUFACTURER,
     ATTR_REMAINING_PAGES,
     ATTR_UNIT,
     ATTR_UPTIME,
     ATTRS_MAP,
     DATA_CONFIG_ENTRY,
     DOMAIN,
+    MANUFACTURER,
     SENSOR_TYPES,
 )
 
@@ -36,11 +44,11 @@ async def async_setup_entry(
     sensors = []
 
     device_info: DeviceInfo = {
-        "identifiers": {(DOMAIN, coordinator.data.serial)},
-        "name": coordinator.data.model,
-        "manufacturer": ATTR_MANUFACTURER,
-        "model": coordinator.data.model,
-        "sw_version": getattr(coordinator.data, "firmware", None),
+        ATTR_IDENTIFIERS: {(DOMAIN, coordinator.data.serial)},
+        ATTR_NAME: coordinator.data.model,
+        ATTR_MANUFACTURER: MANUFACTURER,
+        ATTR_MODEL: coordinator.data.model,
+        ATTR_SW_VERSION: getattr(coordinator.data, "firmware", None),
     }
 
     for sensor in SENSOR_TYPES:

--- a/homeassistant/components/bsblan/climate.py
+++ b/homeassistant/components/bsblan/climate.py
@@ -21,6 +21,9 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
     ATTR_NAME,
     ATTR_TEMPERATURE,
     TEMP_CELSIUS,
@@ -30,14 +33,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import (
-    ATTR_IDENTIFIERS,
-    ATTR_MANUFACTURER,
-    ATTR_MODEL,
-    ATTR_TARGET_TEMPERATURE,
-    DATA_BSBLAN_CLIENT,
-    DOMAIN,
-)
+from .const import ATTR_TARGET_TEMPERATURE, DATA_BSBLAN_CLIENT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bsblan/const.py
+++ b/homeassistant/components/bsblan/const.py
@@ -6,10 +6,6 @@ DATA_BSBLAN_CLIENT = "bsblan_client"
 DATA_BSBLAN_TIMER = "bsblan_timer"
 DATA_BSBLAN_UPDATED = "bsblan_updated"
 
-ATTR_IDENTIFIERS = "identifiers"
-ATTR_MODEL = "model"
-ATTR_MANUFACTURER = "manufacturer"
-
 ATTR_TARGET_TEMPERATURE = "target_temperature"
 ATTR_INSIDE_TEMPERATURE = "inside_temperature"
 ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Import `ATTR_IDENTIFIERS`, `ATTR_MANUFACTURER`, `ATTR_MODEL`, `ATTR_NAME`, `ATTR_SW_VERSION` from `homeassistant.const` for applicable components instead of using component constants. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
