### PR TITLE
Correct Modbus platform cover restore state

### DIFF
--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     STATE_CLOSING,
     STATE_OPEN,
     STATE_OPENING,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
@@ -114,6 +116,8 @@ class ModbusCover(CoverEntity, RestoreEntity):
                 STATE_CLOSING: self._state_closing,
                 STATE_OPENING: self._state_opening,
                 STATE_OPEN: self._state_open,
+                STATE_UNAVAILABLE: None,
+                STATE_UNKNOWN: None,
             }
             self._value = convert[state.state]
 

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -12,6 +12,10 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
+    STATE_CLOSED,
+    STATE_CLOSING,
+    STATE_OPEN,
+    STATE_OPENING,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import async_track_time_interval
@@ -105,7 +109,13 @@ class ModbusCover(CoverEntity, RestoreEntity):
         """Handle entity which will be added."""
         state = await self.async_get_last_state()
         if state:
-            self._value = state.state
+            convert = {
+                STATE_CLOSED: self._state_closed,
+                STATE_CLOSING: self._state_closing,
+                STATE_OPENING: self._state_opening,
+                STATE_OPEN: self._state_open,
+            }
+            self._value = convert[state.state]
 
         async_track_time_interval(self.hass, self.async_update, self._scan_interval)
 

--- a/tests/components/modbus/test_modbus_cover.py
+++ b/tests/components/modbus/test_modbus_cover.py
@@ -1,6 +1,5 @@
 """The tests for the Modbus cover component."""
 import logging
-from unittest import mock
 
 import pytest
 
@@ -29,6 +28,8 @@ from homeassistant.const import (
 from homeassistant.core import State
 
 from .conftest import ReadResult, base_config_test, base_test, prepare_service_update
+
+from tests.common import mock_restore_cache
 
 
 @pytest.mark.parametrize(
@@ -231,18 +232,17 @@ async def test_restore_state_cover(hass, state):
         CONF_STATUS_REGISTER: 1234,
         CONF_STATUS_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
     }
-    with mock.patch(
-        "homeassistant.components.modbus.cover.ModbusCover.async_get_last_state"
-    ) as mock_get_last_state:
-        mock_get_last_state.return_value = State(entity_id, f"{state}")
-
-        await base_config_test(
-            hass,
-            config,
-            cover_name,
-            COVER_DOMAIN,
-            CONF_COVERS,
-            None,
-            method_discovery=True,
-        )
-        assert hass.states.get(entity_id).state == state
+    mock_restore_cache(
+        hass,
+        (State(f"{entity_id}", state),),
+    )
+    await base_config_test(
+        hass,
+        config,
+        cover_name,
+        COVER_DOMAIN,
+        CONF_COVERS,
+        None,
+        method_discovery=True,
+    )
+    assert hass.states.get(entity_id).state == state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
self._value expect values 0-3, but async_get_last_state returns a state.state containing:
STATE_CLOSED, STATE_CLOSING, STATE_OPENING, STATE_OPEN.

This lead to a fault, where cover always showed STATE_OPEN when starting, until the first update().

Added a conversion from STATE_* to 0-3 (or what is configured).

Tests are added to confirm it works.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This PR can go into a patch release, but can easily wait for a normal release.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
