### PR TITLE
Fix vizio integration

### DIFF
--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -117,7 +117,7 @@ class VizioAppsDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     (
                         "Unable to retrieve the apps list from the external server "
-                        "for %s days straight. Please open a GH issue so the codeowner"
+                        "for %s days straight. Please open an issue so the codeowner"
                         "can investigate."
                     ),
                     self.fail_threshold,

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -126,7 +126,7 @@ class VizioAppsDataUpdateCoordinator(DataUpdateCoordinator):
                 self.fail_threshold += 10
             else:
                 self.fail_count += 1
-            return APPS
+            return self.data
         self.fail_count = 0
         self.fail_threshold = 10
         return sorted(data, key=lambda app: app["name"])

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_APPS, CONF_DEVICE_CLASS, DOMAIN, VIZIO_SCHEMA
 
@@ -111,5 +111,5 @@ class VizioAppsDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         data = await gen_apps_list_from_url(session=async_get_clientsession(self.hass))
         if not data:
-            raise UpdateFailed
+            return APPS
         return sorted(data, key=lambda app: app["name"])

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -117,8 +117,7 @@ class VizioAppsDataUpdateCoordinator(DataUpdateCoordinator):
                 _LOGGER.warning(
                     (
                         "Unable to retrieve the apps list from the external server "
-                        "for %s days straight. Please open an issue so the codeowner"
-                        "can investigate."
+                        "for the last %s days"
                     ),
                     self.fail_threshold,
                 )

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -68,6 +68,16 @@ def vizio_data_coordinator_update_fixture():
         yield
 
 
+@pytest.fixture(name="vizio_data_coordinator_update_failure")
+def vizio_data_coordinator_update_failure_fixture():
+    """Mock get data coordinator update failure."""
+    with patch(
+        "homeassistant.components.vizio.gen_apps_list_from_url",
+        return_value=None,
+    ):
+        yield
+
+
 @pytest.fixture(name="vizio_no_unique_id")
 def vizio_no_unique_id_fixture():
     """Mock no vizio unique ID returrned."""

--- a/tests/components/vizio/test_init.py
+++ b/tests/components/vizio/test_init.py
@@ -1,4 +1,6 @@
 """Tests for Vizio init."""
+from datetime import timedelta
+
 import pytest
 
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
@@ -6,10 +8,11 @@ from homeassistant.components.vizio.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+import homeassistant.util.dt as dt_util
 
 from .const import MOCK_SPEAKER_CONFIG, MOCK_USER_VALID_TV_CONFIG, UNIQUE_ID
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_setup_component(
@@ -71,3 +74,34 @@ async def test_speaker_load_and_unload(
     for entity in entities:
         assert hass.states.get(entity).state == STATE_UNAVAILABLE
     assert DOMAIN not in hass.data
+
+
+async def test_coordinator_update_failure(
+    hass: HomeAssistant,
+    vizio_connect: pytest.fixture,
+    vizio_bypass_update: pytest.fixture,
+    vizio_data_coordinator_update_failure: pytest.fixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test coordinator update failure after 10 days."""
+    now = dt_util.now()
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data=MOCK_USER_VALID_TV_CONFIG, unique_id=UNIQUE_ID
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert len(hass.states.async_entity_ids(MP_DOMAIN)) == 1
+    assert DOMAIN in hass.data
+
+    for days in range(1, 10):
+        async_fire_time_changed(hass, now + timedelta(days=days))
+        await hass.async_block_till_done()
+        assert (
+            "Unable to retrieve the apps list from the external server"
+            not in caplog.text
+        )
+
+    async_fire_time_changed(hass, now + timedelta(days=10))
+    await hass.async_block_till_done()
+    assert "Unable to retrieve the apps list from the external server" in caplog.text


### PR DESCRIPTION
## Proposed change
In order to be able to display the apps that a vizio TV supports, the integration needs an apps list. This used to be a statically defined list in the lib, but people were constantly asking for additional app support. At some point, I found an external resource that we could query on a daily basis to get the latest apps list without having to update the library, so we switched to that. ~~Unfortunately, it looks like the location of the resource changed. I previously found the location by decompiling the SmartCast Android app but I am currently unable to do that. In the meantime, the data coordinator is constantly spamming user logs with failures.~~ It looks like the external resource was unavailable for a period of time. It recovered on its own, but in the meantime users were getting spammed with failures.

This change falls back to the statically defined app list when the external resource can't be reached~~, which is currently never. I am hoping I will be able to find the new external location so I can update the code and have things work as before, but in the interim this will make the device functional and will stop the logs from getting spammed.~~ so that the integration remains functional. I also have introduced a log that will let the user know to alert me in case this is a persistent problem


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/50140
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
