### PR TITLE
Correct humidifier detection in Venstar component and add tests

### DIFF
--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -124,7 +124,7 @@ class VenstarThermostat(ClimateEntity):
         if self._client.mode == self._client.MODE_AUTO:
             features |= SUPPORT_TARGET_TEMPERATURE_RANGE
 
-        if self._humidifier and hasattr(self._client, "hum_active"):
+        if self._humidifier and self._client.hum_setpoint is not None:
             features |= SUPPORT_TARGET_HUMIDITY
 
         return features

--- a/homeassistant/components/venstar/manifest.json
+++ b/homeassistant/components/venstar/manifest.json
@@ -2,7 +2,7 @@
   "domain": "venstar",
   "name": "Venstar",
   "documentation": "https://www.home-assistant.io/integrations/venstar",
-  "requirements": ["venstarcolortouch==0.13"],
+  "requirements": ["venstarcolortouch==0.14"],
   "codeowners": [],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2293,7 +2293,7 @@ uvcclient==0.11.0
 vallox-websocket-api==2.4.0
 
 # homeassistant.components.venstar
-venstarcolortouch==0.13
+venstarcolortouch==0.14
 
 # homeassistant.components.vilfo
 vilfo-api-client==0.3.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1228,6 +1228,9 @@ url-normalize==1.4.1
 # homeassistant.components.uvc
 uvcclient==0.11.0
 
+# homeassistant.components.venstar
+venstarcolortouch==0.14
+
 # homeassistant.components.vilfo
 vilfo-api-client==0.3.2
 

--- a/tests/components/venstar/__init__.py
+++ b/tests/components/venstar/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the venstar integration."""

--- a/tests/components/venstar/test_climate.py
+++ b/tests/components/venstar/test_climate.py
@@ -1,0 +1,79 @@
+"""The climate tests for the venstar integration."""
+
+from homeassistant.components.climate.const import (
+    SUPPORT_FAN_MODE,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_HUMIDITY,
+    SUPPORT_TARGET_TEMPERATURE,
+)
+
+from .util import async_init_integration, mock_venstar_devices
+
+EXPECTED_BASE_SUPPORTED_FEATURES = (
+    SUPPORT_TARGET_TEMPERATURE | SUPPORT_FAN_MODE | SUPPORT_PRESET_MODE
+)
+
+
+@mock_venstar_devices
+async def test_colortouch(hass):
+    """Test interfacing with a venstar colortouch with attached humidifier."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("climate.colortouch")
+    assert state.state == "heat"
+
+    expected_attributes = {
+        "hvac_modes": ["heat", "cool", "off", "auto"],
+        "min_temp": 7,
+        "max_temp": 35,
+        "min_humidity": 0,
+        "max_humidity": 60,
+        "fan_modes": ["on", "auto"],
+        "preset_modes": ["none", "away", "temperature"],
+        "current_temperature": 21.0,
+        "temperature": 20.5,
+        "current_humidity": 41,
+        "humidity": 30,
+        "fan_mode": "auto",
+        "hvac_action": "idle",
+        "preset_mode": "temperature",
+        "fan_state": 0,
+        "hvac_mode": 0,
+        "friendly_name": "COLORTOUCH",
+        "supported_features": EXPECTED_BASE_SUPPORTED_FEATURES
+        | SUPPORT_TARGET_HUMIDITY,
+    }
+    # Only test for a subset of attributes in case
+    # HA changes the implementation and a new one appears
+    assert all(item in state.attributes.items() for item in expected_attributes.items())
+
+
+@mock_venstar_devices
+async def test_t2000(hass):
+    """Test interfacing with a venstar T2000 presently turned off."""
+
+    await async_init_integration(hass)
+
+    state = hass.states.get("climate.t2000")
+    assert state.state == "off"
+
+    expected_attributes = {
+        "hvac_modes": ["heat", "cool", "off", "auto"],
+        "min_temp": 7,
+        "max_temp": 35,
+        "fan_modes": ["on", "auto"],
+        "preset_modes": ["none", "away", "temperature"],
+        "current_temperature": 14.0,
+        "temperature": None,
+        "fan_mode": "auto",
+        "hvac_action": "idle",
+        "preset_mode": "temperature",
+        "fan_state": 0,
+        "hvac_mode": 0,
+        "friendly_name": "T2000",
+        "supported_features": EXPECTED_BASE_SUPPORTED_FEATURES,
+    }
+    # Only test for a subset of attributes in case
+    # HA changes the implementation and a new one appears
+    assert all(item in state.attributes.items() for item in expected_attributes.items())

--- a/tests/components/venstar/util.py
+++ b/tests/components/venstar/util.py
@@ -1,0 +1,57 @@
+"""Tests for the venstar integration."""
+
+import requests_mock
+
+from homeassistant.components.climate.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PLATFORM
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+from tests.common import load_fixture
+
+TEST_MODELS = ["t2k", "colortouch"]
+
+
+def mock_venstar_devices(f):
+    """Decorate function to mock a Venstar Colortouch and T2000 thermostat API."""
+
+    async def wrapper(hass):
+        # Mock thermostats are:
+        # Venstar T2000, FW 4.38
+        # Venstar "colortouch" T7850, FW 5.1
+        with requests_mock.mock() as m:
+            for model in TEST_MODELS:
+                m.get(
+                    f"http://venstar-{model}.localdomain/",
+                    text=load_fixture(f"venstar/{model}_root.json"),
+                )
+                m.get(
+                    f"http://venstar-{model}.localdomain/query/info",
+                    text=load_fixture(f"venstar/{model}_info.json"),
+                )
+                m.get(
+                    f"http://venstar-{model}.localdomain/query/sensors",
+                    text=load_fixture(f"venstar/{model}_sensors.json"),
+                )
+            return await f(hass)
+
+    return wrapper
+
+
+async def async_init_integration(
+    hass: HomeAssistant,
+    skip_setup: bool = False,
+):
+    """Set up the venstar integration in Home Assistant."""
+    platform_config = []
+    for model in TEST_MODELS:
+        platform_config.append(
+            {
+                CONF_PLATFORM: "venstar",
+                CONF_HOST: f"venstar-{model}.localdomain",
+            }
+        )
+    config = {DOMAIN: platform_config}
+
+    await async_setup_component(hass, DOMAIN, config)
+    await hass.async_block_till_done()

--- a/tests/fixtures/venstar/colortouch_info.json
+++ b/tests/fixtures/venstar/colortouch_info.json
@@ -1,0 +1,1 @@
+{"name":"COLORTOUCH","mode":1,"state":0,"fan":0,"fanstate":0,"tempunits":0,"schedule":0,"schedulepart":255,"away":0,"spacetemp":71.0,"heattemp":69.0,"cooltemp":74.0,"cooltempmin":35.0,"cooltempmax":99.0,"heattempmin":35.00,"heattempmax":99.0,"activestage":0,"hum_active":0,"hum":41,"hum_setpoint":30,"dehum_setpoint":99,"setpointdelta":2.0,"availablemodes":0}

--- a/tests/fixtures/venstar/colortouch_root.json
+++ b/tests/fixtures/venstar/colortouch_root.json
@@ -1,0 +1,1 @@
+{"api_ver":7,"type":"residential","model":"COLORTOUCH","firmware":"5.1"}

--- a/tests/fixtures/venstar/colortouch_sensors.json
+++ b/tests/fixtures/venstar/colortouch_sensors.json
@@ -1,0 +1,1 @@
+{"sensors":[{"name":"Thermostat","temp":70.0,"hum":41},{"name":"Space Temp","temp":70.0}]}

--- a/tests/fixtures/venstar/t2k_info.json
+++ b/tests/fixtures/venstar/t2k_info.json
@@ -1,0 +1,1 @@
+{"name":"T2000","mode":0,"state":0,"activestage":0,"fan":0,"fanstate":0,"tempunits":0,"schedule":0,"schedulepart":1,"away":0,"spacetemp":14.5,"heattemp":10.0,"cooltemp":29.5,"cooltempmin":2.0,"cooltempmax":37.0,"heattempmin":2.0,"heattempmax":37.0,"setpointdelta":2,"availablemodes":2}

--- a/tests/fixtures/venstar/t2k_root.json
+++ b/tests/fixtures/venstar/t2k_root.json
@@ -1,0 +1,1 @@
+{"api_ver": 7, "type": "residential", "model": "T2000", "firmware": "4.38"}

--- a/tests/fixtures/venstar/t2k_sensors.json
+++ b/tests/fixtures/venstar/t2k_sensors.json
@@ -1,0 +1,1 @@
+{"sensors": [{"name":"Thermostat","temp":14},{"name":"Space Temp","temp":14}]}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
As of version 0.12 onwards, the venstar_colortouch lib always initializes hum_setpoint to None. When a thermostat actually reports a humidifier state, this value is replaced with the integer value of the setpoint. 

This changeset updates venstarcolortouch to 0.14 and corrects the humidifier detection, as well as adds basic test cases for the Venstar platform.

Diff: https://github.com/hpeyerl/venstar_colortouch/compare/175042b091b814c8e118780c032f1e9ebbc2426c...9e63eb4878a9b25139985ca2007366b20b72d623

Note: I have opted to keep the bugfix and addition of tests as one PR as these tests will fail (by design) if the humidifier detection does not work correctly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- No changes to user visible functionality

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io