### PR TITLE
Use mypy-friendly conditional import for zoneinfo

### DIFF
--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 from contextlib import suppress
 import datetime as dt
 import re
+import sys
 from typing import Any
 
-try:
+if sys.version_info[:2] >= (3, 9):
     import zoneinfo
-except ImportError:
+else:
     from backports import zoneinfo
 
 import ciso8601

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 from contextlib import suppress
 import datetime as dt
 import re
-import sys
-from typing import Any, cast
+from typing import Any
+
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo  # type: ignore[no-redef]
 
 import ciso8601
 
 from homeassistant.const import MATCH_ALL
-
-if sys.version_info[:2] >= (3, 9):
-    import zoneinfo  # pylint: disable=import-error
-else:
-    from backports import zoneinfo  # pylint: disable=import-error
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 UTC = dt.timezone.utc
@@ -49,8 +48,7 @@ def get_time_zone(time_zone_str: str) -> dt.tzinfo | None:
     Async friendly.
     """
     try:
-        # Cast can be removed when mypy is switched to Python 3.9.
-        return cast(dt.tzinfo, zoneinfo.ZoneInfo(time_zone_str))
+        return zoneinfo.ZoneInfo(time_zone_str)  # type: ignore[no-any-return]
     except zoneinfo.ZoneInfoNotFoundError:
         return None
 

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -7,14 +7,14 @@ import re
 import sys
 from typing import Any, cast
 
-if sys.version_info[:2] >= (3, 9):
-    import zoneinfo
-else:
-    from backports import zoneinfo
-
 import ciso8601
 
 from homeassistant.const import MATCH_ALL
+
+if sys.version_info[:2] >= (3, 9):
+    import zoneinfo  # pylint: disable=import-error
+else:
+    from backports import zoneinfo  # pylint: disable=import-error
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 UTC = dt.timezone.utc

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import datetime as dt
 import re
 import sys
-from typing import Any
+from typing import Any, cast
 
 if sys.version_info[:2] >= (3, 9):
     import zoneinfo
@@ -49,7 +49,8 @@ def get_time_zone(time_zone_str: str) -> dt.tzinfo | None:
     Async friendly.
     """
     try:
-        return zoneinfo.ZoneInfo(time_zone_str)  # type: ignore
+        # Cast can be removed when mypy is switched to Python 3.9.
+        return cast(dt.tzinfo, zoneinfo.ZoneInfo(time_zone_str))
     except zoneinfo.ZoneInfoNotFoundError:
         return None
 

--- a/homeassistant/util/dt.py
+++ b/homeassistant/util/dt.py
@@ -4,16 +4,17 @@ from __future__ import annotations
 from contextlib import suppress
 import datetime as dt
 import re
-from typing import Any
-
-try:
-    import zoneinfo
-except ImportError:
-    from backports import zoneinfo  # type: ignore[no-redef]
+import sys
+from typing import Any, cast
 
 import ciso8601
 
 from homeassistant.const import MATCH_ALL
+
+if sys.version_info[:2] >= (3, 9):
+    import zoneinfo  # pylint: disable=import-error
+else:
+    from backports import zoneinfo  # pylint: disable=import-error
 
 DATE_STR_FORMAT = "%Y-%m-%d"
 UTC = dt.timezone.utc
@@ -48,7 +49,8 @@ def get_time_zone(time_zone_str: str) -> dt.tzinfo | None:
     Async friendly.
     """
     try:
-        return zoneinfo.ZoneInfo(time_zone_str)  # type: ignore[no-any-return]
+        # Cast can be removed when mypy is switched to Python 3.9.
+        return cast(dt.tzinfo, zoneinfo.ZoneInfo(time_zone_str))
     except zoneinfo.ZoneInfoNotFoundError:
         return None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After https://github.com/home-assistant/core/pull/50387 mypy fails locally for me with:
```
homeassistant/util/dt.py:12: error: Name 'zoneinfo' already defined (possibly by an import)  [no-redef]
```

That's probably because I use Python 3.9 locally. My idea is that CI didn't catch it, because `zoneinfo` is marked as Python 3.9+ and the first import was just ignored. 

I think it's still nice to support Python 3.9 before CI is switched to it.

This is a known issue of mypy and using `sys.version_info` is suggested workaround: https://github.com/python/mypy/issues/1153

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
