### PR TITLE
Improve type annotations for GIOS integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -15,6 +15,7 @@ homeassistant.components.device_automation.*
 homeassistant.components.elgato.*
 homeassistant.components.frontend.*
 homeassistant.components.geo_location.*
+homeassistant.components.gios.*
 homeassistant.components.group.*
 homeassistant.components.history.*
 homeassistant.components.http.*

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any, Dict, cast
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientConnectorError
@@ -77,7 +77,7 @@ class GiosDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         try:
             with timeout(API_TIMEOUT):
-                return cast(dict[str, Any], await self.gios.async_update())
+                return cast(Dict[str, Any], await self.gios.async_update())
         except (
             ApiError,
             NoStationError,

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -27,9 +27,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     station_id = entry.data[CONF_STATION_ID]
     _LOGGER.debug("Using station_id: %s", station_id)
 
+    # We used to use int as config_entry unique_id, convert this to str.
     if isinstance(entry.unique_id, int):  # type: ignore[unreachable]
         hass.config_entries.async_update_entry(entry, unique_id=str(station_id))  # type: ignore[unreachable]
 
+    # We used to use int in device_entry identifiers, convert this to str.
     device_registry = await async_get_registry(hass)
     old_ids = (DOMAIN, station_id)
     device_entry = device_registry.async_get_device({old_ids})

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -12,6 +12,7 @@ from gios import ApiError, Gios, InvalidSensorsData, NoStationError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import async_get_registry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import API_TIMEOUT, CONF_STATION_ID, DOMAIN, SCAN_INTERVAL
@@ -25,6 +26,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up GIOS as config entry."""
     station_id = entry.data[CONF_STATION_ID]
     _LOGGER.debug("Using station_id: %s", station_id)
+
+    if isinstance(entry.unique_id, int):  # type: ignore[unreachable]
+        hass.config_entries.async_update_entry(entry, unique_id=str(station_id))  # type: ignore[unreachable]
+
+    device_registry = await async_get_registry(hass)
+    old_ids = (DOMAIN, station_id)
+    device_entry = device_registry.async_get_device({old_ids})
+    if device_entry and entry.entry_id in device_entry.config_entries:
+        new_ids = (DOMAIN, str(station_id))
+        device_registry.async_update_device(device_entry.id, new_identifiers={new_ids})
 
     websession = async_get_clientsession(hass)
 

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -24,8 +24,8 @@ PLATFORMS = ["air_quality"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up GIOS as config entry."""
-    station_id = entry.data[CONF_STATION_ID]
-    _LOGGER.debug("Using station_id: %s", station_id)
+    station_id: int = entry.data[CONF_STATION_ID]
+    _LOGGER.debug("Using station_id: %d", station_id)
 
     # We used to use int as config_entry unique_id, convert this to str.
     if isinstance(entry.unique_id, int):  # type: ignore[unreachable]
@@ -34,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # We used to use int in device_entry identifiers, convert this to str.
     device_registry = await async_get_registry(hass)
     old_ids = (DOMAIN, station_id)
-    device_entry = device_registry.async_get_device({old_ids})
+    device_entry = device_registry.async_get_device({old_ids})  # type: ignore[arg-type]
     if device_entry and entry.entry_id in device_entry.config_entries:
         new_ids = (DOMAIN, str(station_id))
         device_registry.async_update_device(device_entry.id, new_identifiers={new_ids})

--- a/homeassistant/components/gios/__init__.py
+++ b/homeassistant/components/gios/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientConnectorError
@@ -75,7 +75,7 @@ class GiosDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         try:
             with timeout(API_TIMEOUT):
-                return await self.gios.async_update()
+                return cast(dict[str, Any], await self.gios.async_update())
         except (
             ApiError,
             NoStationError,

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
             old_entity_id, new_unique_id=str(coordinator.gios.station_id)
         )
 
-    async_add_entities([GiosAirQuality(coordinator, name)], False)
+    async_add_entities([GiosAirQuality(coordinator, name)])
 
 
 class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
@@ -71,7 +71,7 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         return self._name
 
     @property
-    def icon(self) -> str | None:
+    def icon(self) -> str:
         """Return the icon."""
         if cast(str, self.air_quality_index) in ICONS_MAP:
             return ICONS_MAP[cast(str, self.air_quality_index)]
@@ -133,7 +133,7 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         }
 
     @property
-    def extra_state_attributes(self) -> dict | None:
+    def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
         # Different measuring stations have different sets of sensors. We don't know
         # what data we will get.
@@ -154,7 +154,4 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
 
 def round_state(state: float | None) -> float | None:
     """Round state."""
-    if isinstance(state, float):
-        return round(state)
-
-    return state
+    return round(state) if state is not None else None

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -1,7 +1,7 @@
 """Support for the GIOS service."""
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Optional, cast
 
 from homeassistant.components.air_quality import AirQualityEntity
 from homeassistant.config_entries import ConfigEntry
@@ -73,14 +73,14 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
     @property
     def icon(self) -> str:
         """Return the icon."""
-        if cast(str, self.air_quality_index) in ICONS_MAP:
-            return ICONS_MAP[cast(str, self.air_quality_index)]
+        if self.air_quality_index is not None and self.air_quality_index in ICONS_MAP:
+            return ICONS_MAP[self.air_quality_index]
         return "mdi:blur"
 
     @property
-    def air_quality_index(self) -> Any:
+    def air_quality_index(self) -> str | None:
         """Return the air quality index."""
-        return self.coordinator.data.get(API_AQI, {}).get("value")
+        return cast(Optional[str], self.coordinator.data.get(API_AQI, {}).get("value"))
 
     @property
     def particulate_matter_2_5(self) -> float | None:

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -1,8 +1,16 @@
 """Support for the GIOS service."""
+from __future__ import annotations
+
 from homeassistant.components.air_quality import AirQualityEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from . import GiosDataUpdateCoordinator
 from .const import (
     API_AQI,
     API_CO,
@@ -23,101 +31,85 @@ from .const import (
 PARALLEL_UPDATES = 1
 
 
-async def async_setup_entry(hass, config_entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Add a GIOS entities from a config_entry."""
-    name = config_entry.data[CONF_NAME]
+    name = entry.data[CONF_NAME]
 
-    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    coordinator = hass.data[DOMAIN][entry.entry_id]
 
     async_add_entities([GiosAirQuality(coordinator, name)], False)
-
-
-def round_state(func):
-    """Round state."""
-
-    def _decorator(self):
-        res = func(self)
-        if isinstance(res, float):
-            return round(res)
-        return res
-
-    return _decorator
 
 
 class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
     """Define an GIOS sensor."""
 
-    def __init__(self, coordinator, name):
+    def __init__(self, coordinator: GiosDataUpdateCoordinator, name: str) -> str:
         """Initialize."""
         super().__init__(coordinator)
         self._name = name
         self._attrs = {}
 
     @property
-    def name(self):
+    def name(self) -> str:
         """Return the name."""
         return self._name
 
     @property
-    def icon(self):
+    def icon(self) -> str | None:
         """Return the icon."""
         if self.air_quality_index in ICONS_MAP:
             return ICONS_MAP[self.air_quality_index]
         return "mdi:blur"
 
     @property
-    def air_quality_index(self):
+    def air_quality_index(self) -> float:
         """Return the air quality index."""
         return self._get_sensor_value(API_AQI)
 
     @property
-    @round_state
-    def particulate_matter_2_5(self):
+    def particulate_matter_2_5(self) -> float:
         """Return the particulate matter 2.5 level."""
-        return self._get_sensor_value(API_PM25)
+        return round_state(self._get_sensor_value(API_PM25))
 
     @property
-    @round_state
-    def particulate_matter_10(self):
+    def particulate_matter_10(self) -> float:
         """Return the particulate matter 10 level."""
-        return self._get_sensor_value(API_PM10)
+        return round_state(self._get_sensor_value(API_PM10))
 
     @property
-    @round_state
-    def ozone(self):
+    def ozone(self) -> float:
         """Return the O3 (ozone) level."""
-        return self._get_sensor_value(API_O3)
+        return round_state(self._get_sensor_value(API_O3))
 
     @property
-    @round_state
-    def carbon_monoxide(self):
+    def carbon_monoxide(self) -> float:
         """Return the CO (carbon monoxide) level."""
-        return self._get_sensor_value(API_CO)
+        return round_state(self._get_sensor_value(API_CO))
 
     @property
-    @round_state
-    def sulphur_dioxide(self):
+    def sulphur_dioxide(self) -> float:
         """Return the SO2 (sulphur dioxide) level."""
-        return self._get_sensor_value(API_SO2)
+        return round_state(self._get_sensor_value(API_SO2))
 
     @property
-    @round_state
-    def nitrogen_dioxide(self):
+    def nitrogen_dioxide(self) -> float:
         """Return the NO2 (nitrogen dioxide) level."""
-        return self._get_sensor_value(API_NO2)
+        return round_state(self._get_sensor_value(API_NO2))
 
     @property
-    def attribution(self):
+    def attribution(self) -> str:
         """Return the attribution."""
         return ATTRIBUTION
 
     @property
-    def unique_id(self):
+    def unique_id(self) -> str:
         """Return a unique_id for this entity."""
         return self.coordinator.gios.station_id
 
     @property
-    def device_info(self):
+    def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return {
             "identifiers": {(DOMAIN, self.coordinator.gios.station_id)},
@@ -127,7 +119,7 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         }
 
     @property
-    def extra_state_attributes(self):
+    def extra_state_attributes(self) -> dict | None:
         """Return the state attributes."""
         # Different measuring stations have different sets of sensors. We don't know
         # what data we will get.
@@ -139,8 +131,16 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         self._attrs[ATTR_STATION] = self.coordinator.gios.station_name
         return self._attrs
 
-    def _get_sensor_value(self, sensor):
+    def _get_sensor_value(self, sensor: str) -> StateType:
         """Return value of specified sensor."""
         if sensor in self.coordinator.data:
             return self.coordinator.data[sensor]["value"]
         return None
+
+
+def round_state(state: float | None) -> float | None:
+    """Round state."""
+    if isinstance(state, float):
+        return round(state)
+
+    return state

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -10,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import async_get_registry
-from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import GiosDataUpdateCoordinator
@@ -73,14 +72,14 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
     @property
     def icon(self) -> str | None:
         """Return the icon."""
-        if self.air_quality_index in ICONS_MAP:
+        if cast(str, self.air_quality_index) in ICONS_MAP:
             return ICONS_MAP[cast(str, self.air_quality_index)]
         return "mdi:blur"
 
     @property
-    def air_quality_index(self) -> float | None:
+    def air_quality_index(self) -> Any:
         """Return the air quality index."""
-        return self._get_sensor_value(API_AQI)
+        return self.coordinator.data.get(API_AQI, {}).get("value")
 
     @property
     def particulate_matter_2_5(self) -> float | None:
@@ -145,10 +144,10 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         self._attrs[ATTR_STATION] = self.coordinator.gios.station_name
         return self._attrs
 
-    def _get_sensor_value(self, sensor: str) -> StateType:
+    def _get_sensor_value(self, sensor: str) -> float | None:
         """Return value of specified sensor."""
         if sensor in self.coordinator.data:
-            return self.coordinator.data[sensor]["value"]
+            return cast(float, self.coordinator.data[sensor]["value"])
         return None
 
 

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -41,6 +41,7 @@ async def async_setup_entry(
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
+    # We used to use int as entity unique_id, convert this to str.
     entity_registry = await async_get_registry(hass)
     old_entity_id = entity_registry.async_get_entity_id(
         "air_quality", DOMAIN, coordinator.gios.station_id

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -78,37 +78,37 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         return "mdi:blur"
 
     @property
-    def air_quality_index(self) -> StateType:
+    def air_quality_index(self) -> float | None:
         """Return the air quality index."""
         return self._get_sensor_value(API_AQI)
 
     @property
-    def particulate_matter_2_5(self) -> StateType:
+    def particulate_matter_2_5(self) -> float | None:
         """Return the particulate matter 2.5 level."""
         return round_state(self._get_sensor_value(API_PM25))
 
     @property
-    def particulate_matter_10(self) -> StateType:
+    def particulate_matter_10(self) -> float | None:
         """Return the particulate matter 10 level."""
         return round_state(self._get_sensor_value(API_PM10))
 
     @property
-    def ozone(self) -> StateType:
+    def ozone(self) -> float | None:
         """Return the O3 (ozone) level."""
         return round_state(self._get_sensor_value(API_O3))
 
     @property
-    def carbon_monoxide(self) -> StateType:
+    def carbon_monoxide(self) -> float | None:
         """Return the CO (carbon monoxide) level."""
         return round_state(self._get_sensor_value(API_CO))
 
     @property
-    def sulphur_dioxide(self) -> StateType:
+    def sulphur_dioxide(self) -> float | None:
         """Return the SO2 (sulphur dioxide) level."""
         return round_state(self._get_sensor_value(API_SO2))
 
     @property
-    def nitrogen_dioxide(self) -> StateType:
+    def nitrogen_dioxide(self) -> float | None:
         """Return the NO2 (nitrogen dioxide) level."""
         return round_state(self._get_sensor_value(API_NO2))
 
@@ -152,7 +152,7 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         return None
 
 
-def round_state(state: StateType) -> StateType:
+def round_state(state: float | None) -> float | None:
     """Round state."""
     if isinstance(state, float):
         return round(state)

--- a/homeassistant/components/gios/air_quality.py
+++ b/homeassistant/components/gios/air_quality.py
@@ -1,12 +1,15 @@
 """Support for the GIOS service."""
 from __future__ import annotations
 
+from typing import Any, cast
+
 from homeassistant.components.air_quality import AirQualityEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_registry import async_get_registry
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -39,17 +42,28 @@ async def async_setup_entry(
 
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
+    entity_registry = await async_get_registry(hass)
+    old_entity_id = entity_registry.async_get_entity_id(
+        "air_quality", DOMAIN, coordinator.gios.station_id
+    )
+    if old_entity_id is not None:
+        entity_registry.async_update_entity(
+            old_entity_id, new_unique_id=str(coordinator.gios.station_id)
+        )
+
     async_add_entities([GiosAirQuality(coordinator, name)], False)
 
 
 class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
     """Define an GIOS sensor."""
 
-    def __init__(self, coordinator: GiosDataUpdateCoordinator, name: str) -> str:
+    coordinator: GiosDataUpdateCoordinator
+
+    def __init__(self, coordinator: GiosDataUpdateCoordinator, name: str) -> None:
         """Initialize."""
         super().__init__(coordinator)
         self._name = name
-        self._attrs = {}
+        self._attrs: dict[str, Any] = {}
 
     @property
     def name(self) -> str:
@@ -60,41 +74,41 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
     def icon(self) -> str | None:
         """Return the icon."""
         if self.air_quality_index in ICONS_MAP:
-            return ICONS_MAP[self.air_quality_index]
+            return ICONS_MAP[cast(str, self.air_quality_index)]
         return "mdi:blur"
 
     @property
-    def air_quality_index(self) -> float:
+    def air_quality_index(self) -> StateType:
         """Return the air quality index."""
         return self._get_sensor_value(API_AQI)
 
     @property
-    def particulate_matter_2_5(self) -> float:
+    def particulate_matter_2_5(self) -> StateType:
         """Return the particulate matter 2.5 level."""
         return round_state(self._get_sensor_value(API_PM25))
 
     @property
-    def particulate_matter_10(self) -> float:
+    def particulate_matter_10(self) -> StateType:
         """Return the particulate matter 10 level."""
         return round_state(self._get_sensor_value(API_PM10))
 
     @property
-    def ozone(self) -> float:
+    def ozone(self) -> StateType:
         """Return the O3 (ozone) level."""
         return round_state(self._get_sensor_value(API_O3))
 
     @property
-    def carbon_monoxide(self) -> float:
+    def carbon_monoxide(self) -> StateType:
         """Return the CO (carbon monoxide) level."""
         return round_state(self._get_sensor_value(API_CO))
 
     @property
-    def sulphur_dioxide(self) -> float:
+    def sulphur_dioxide(self) -> StateType:
         """Return the SO2 (sulphur dioxide) level."""
         return round_state(self._get_sensor_value(API_SO2))
 
     @property
-    def nitrogen_dioxide(self) -> float:
+    def nitrogen_dioxide(self) -> StateType:
         """Return the NO2 (nitrogen dioxide) level."""
         return round_state(self._get_sensor_value(API_NO2))
 
@@ -106,13 +120,13 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique_id for this entity."""
-        return self.coordinator.gios.station_id
+        return str(self.coordinator.gios.station_id)
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device info."""
         return {
-            "identifiers": {(DOMAIN, self.coordinator.gios.station_id)},
+            "identifiers": {(DOMAIN, str(self.coordinator.gios.station_id))},
             "name": DEFAULT_NAME,
             "manufacturer": MANUFACTURER,
             "entry_type": "service",
@@ -138,7 +152,7 @@ class GiosAirQuality(CoordinatorEntity, AirQualityEntity):
         return None
 
 
-def round_state(state: float | None) -> float | None:
+def round_state(state: StateType) -> StateType:
     """Round state."""
     if isinstance(state, float):
         return round(state)

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -11,6 +11,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import API_TIMEOUT, CONF_STATION_ID, DEFAULT_NAME, DOMAIN
@@ -28,14 +29,16 @@ class GiosFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Handle a flow initialized by the user."""
         errors = {}
 
         if user_input is not None:
             try:
                 await self.async_set_unique_id(
-                    user_input[CONF_STATION_ID], raise_on_progress=False
+                    str(user_input[CONF_STATION_ID]), raise_on_progress=False
                 )
                 self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -1,5 +1,8 @@
 """Adds config flow for GIOS."""
+from __future__ import annotations
+
 import asyncio
+from typing import Any
 
 from aiohttp.client_exceptions import ClientConnectorError
 from async_timeout import timeout
@@ -25,7 +28,7 @@ class GiosFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle a flow initialized by the user."""
         errors = {}
 

--- a/homeassistant/components/gios/const.py
+++ b/homeassistant/components/gios/const.py
@@ -1,5 +1,8 @@
 """Constants for GIOS integration."""
+from __future__ import annotations
+
 from datetime import timedelta
+from typing import Final
 
 from homeassistant.components.air_quality import (
     ATTR_CO,
@@ -10,33 +13,33 @@ from homeassistant.components.air_quality import (
     ATTR_SO2,
 )
 
-ATTRIBUTION = "Data provided by GIOŚ"
+ATTRIBUTION: Final = "Data provided by GIOŚ"
 
-ATTR_STATION = "station"
-CONF_STATION_ID = "station_id"
-DEFAULT_NAME = "GIOŚ"
+ATTR_STATION: Final = "station"
+CONF_STATION_ID: Final = "station_id"
+DEFAULT_NAME: Final = "GIOŚ"
 # Term of service GIOŚ allow downloading data no more than twice an hour.
-SCAN_INTERVAL = timedelta(minutes=30)
-DOMAIN = "gios"
-MANUFACTURER = "Główny Inspektorat Ochrony Środowiska"
+SCAN_INTERVAL: Final = timedelta(minutes=30)
+DOMAIN: Final = "gios"
+MANUFACTURER: Final = "Główny Inspektorat Ochrony Środowiska"
 
-API_AQI = "aqi"
-API_CO = "co"
-API_NO2 = "no2"
-API_O3 = "o3"
-API_PM10 = "pm10"
-API_PM25 = "pm2.5"
-API_SO2 = "so2"
+API_AQI: Final = "aqi"
+API_CO: Final = "co"
+API_NO2: Final = "no2"
+API_O3: Final = "o3"
+API_PM10: Final = "pm10"
+API_PM25: Final = "pm2.5"
+API_SO2: Final = "so2"
 
-API_TIMEOUT = 30
+API_TIMEOUT: Final = 30
 
-AQI_GOOD = "dobry"
-AQI_MODERATE = "umiarkowany"
-AQI_POOR = "dostateczny"
-AQI_VERY_GOOD = "bardzo dobry"
-AQI_VERY_POOR = "zły"
+AQI_GOOD: Final = "dobry"
+AQI_MODERATE: Final = "umiarkowany"
+AQI_POOR: Final = "dostateczny"
+AQI_VERY_GOOD: Final = "bardzo dobry"
+AQI_VERY_POOR: Final = "zły"
 
-ICONS_MAP = {
+ICONS_MAP: Final[dict[str, str]] = {
     AQI_VERY_GOOD: "mdi:emoticon-excited",
     AQI_GOOD: "mdi:emoticon-happy",
     AQI_MODERATE: "mdi:emoticon-neutral",
@@ -44,7 +47,7 @@ ICONS_MAP = {
     AQI_VERY_POOR: "mdi:emoticon-dead",
 }
 
-SENSOR_MAP = {
+SENSOR_MAP: Final[dict[str, str]] = {
     API_CO: ATTR_CO,
     API_NO2: ATTR_NO2,
     API_O3: ATTR_OZONE,

--- a/homeassistant/components/gios/system_health.py
+++ b/homeassistant/components/gios/system_health.py
@@ -1,8 +1,12 @@
 """Provide info to system health."""
+from __future__ import annotations
+
+from typing import Any, Final
+
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
 
-API_ENDPOINT = "http://api.gios.gov.pl/"
+API_ENDPOINT: Final = "http://api.gios.gov.pl/"
 
 
 @callback
@@ -13,7 +17,7 @@ def async_register(
     register.async_register_info(system_health_info)
 
 
-async def system_health_info(hass):
+async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get info for the info page."""
     return {
         "can_reach_server": system_health.async_check_can_reach_url(hass, API_ENDPOINT)

--- a/mypy.ini
+++ b/mypy.ini
@@ -761,7 +761,17 @@ ignore_errors = true
 ignore_errors = true
 
 [mypy-homeassistant.components.gios.*]
-ignore_errors = true
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+strict_equality = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_ignores = true
 
 [mypy-homeassistant.components.glances.*]
 ignore_errors = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -176,6 +176,19 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.gios.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+strict_equality = true
+warn_return_any = true
+warn_unreachable = true
+warn_unused_ignores = true
+
 [mypy-homeassistant.components.group.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true
@@ -759,19 +772,6 @@ ignore_errors = true
 
 [mypy-homeassistant.components.geniushub.*]
 ignore_errors = true
-
-[mypy-homeassistant.components.gios.*]
-check_untyped_defs = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-strict_equality = true
-warn_return_any = true
-warn_unreachable = true
-warn_unused_ignores = true
 
 [mypy-homeassistant.components.glances.*]
 ignore_errors = true

--- a/mypy.ini
+++ b/mypy.ini
@@ -184,10 +184,8 @@ disallow_untyped_calls = true
 disallow_untyped_decorators = true
 disallow_untyped_defs = true
 no_implicit_optional = true
-strict_equality = true
 warn_return_any = true
 warn_unreachable = true
-warn_unused_ignores = true
 
 [mypy-homeassistant.components.group.*]
 check_untyped_defs = true

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -73,7 +73,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.fritzbox.*",
     "homeassistant.components.garmin_connect.*",
     "homeassistant.components.geniushub.*",
-    "homeassistant.components.gios.*",
     "homeassistant.components.glances.*",
     "homeassistant.components.gogogate2.*",
     "homeassistant.components.google_assistant.*",

--- a/tests/components/gios/__init__.py
+++ b/tests/components/gios/__init__.py
@@ -17,7 +17,7 @@ async def init_integration(hass, incomplete_data=False) -> MockConfigEntry:
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="Home",
-        unique_id=123,
+        unique_id="123",
         data={"station_id": 123, "name": "Home"},
     )
 

--- a/tests/components/gios/test_air_quality.py
+++ b/tests/components/gios/test_air_quality.py
@@ -13,9 +13,10 @@ from homeassistant.components.air_quality import (
     ATTR_PM_2_5,
     ATTR_PM_10,
     ATTR_SO2,
+    DOMAIN as AIR_QUALITY_DOMAIN,
 )
 from homeassistant.components.gios.air_quality import ATTRIBUTION
-from homeassistant.components.gios.const import AQI_GOOD
+from homeassistant.components.gios.const import AQI_GOOD, DOMAIN
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_ICON,
@@ -122,3 +123,23 @@ async def test_availability(hass):
         assert state
         assert state.state != STATE_UNAVAILABLE
         assert state.state == "4"
+
+
+async def test_migrate_unique_id(hass):
+    """Test migrate unique_id of the air_quality entity."""
+    registry = er.async_get(hass)
+
+    # Pre-create registry entries for disabled by default sensors
+    registry.async_get_or_create(
+        AIR_QUALITY_DOMAIN,
+        DOMAIN,
+        123,
+        suggested_object_id="home",
+        disabled_by=None,
+    )
+
+    await init_integration(hass)
+
+    entry = registry.async_get("air_quality.home")
+    assert entry
+    assert entry.unique_id == "123"

--- a/tests/components/gios/test_air_quality.py
+++ b/tests/components/gios/test_air_quality.py
@@ -55,7 +55,7 @@ async def test_air_quality(hass):
 
     entry = registry.async_get("air_quality.home")
     assert entry
-    assert entry.unique_id == 123
+    assert entry.unique_id == "123"
 
 
 async def test_air_quality_with_incomplete_data(hass):
@@ -83,7 +83,7 @@ async def test_air_quality_with_incomplete_data(hass):
 
     entry = registry.async_get("air_quality.home")
     assert entry
-    assert entry.unique_id == 123
+    assert entry.unique_id == "123"
 
 
 async def test_availability(hass):

--- a/tests/components/gios/test_config_flow.py
+++ b/tests/components/gios/test_config_flow.py
@@ -102,4 +102,4 @@ async def test_create_entry(hass):
         assert result["title"] == CONFIG[CONF_STATION_ID]
         assert result["data"][CONF_STATION_ID] == CONFIG[CONF_STATION_ID]
 
-        assert flow.context["unique_id"] == CONFIG[CONF_STATION_ID]
+        assert flow.context["unique_id"] == "123"

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -1,4 +1,5 @@
 """Test init of GIOS integration."""
+import json
 from unittest.mock import patch
 
 from homeassistant.components.gios.const import DOMAIN
@@ -9,7 +10,9 @@ from homeassistant.config_entries import (
 )
 from homeassistant.const import STATE_UNAVAILABLE
 
-from tests.common import MockConfigEntry
+from . import STATIONS
+
+from tests.common import MockConfigEntry, load_fixture, mock_device_registry
 from tests.components.gios import init_integration
 
 
@@ -53,3 +56,46 @@ async def test_unload_entry(hass):
 
     assert entry.state == ENTRY_STATE_NOT_LOADED
     assert not hass.data.get(DOMAIN)
+
+
+async def test_migrate_device_entry(hass, aioclient_mock):
+    """Test device_info identifiers migration."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Home",
+        unique_id=123,
+        data={
+            "station_id": 123,
+            "name": "Home",
+        },
+    )
+
+    indexes = json.loads(load_fixture("gios/indexes.json"))
+    station = json.loads(load_fixture("gios/station.json"))
+    sensors = json.loads(load_fixture("gios/sensors.json"))
+
+    with patch(
+        "homeassistant.components.gios.Gios._get_stations", return_value=STATIONS
+    ), patch(
+        "homeassistant.components.gios.Gios._get_station",
+        return_value=station,
+    ), patch(
+        "homeassistant.components.gios.Gios._get_all_sensors",
+        return_value=sensors,
+    ), patch(
+        "homeassistant.components.gios.Gios._get_indexes", return_value=indexes
+    ):
+        config_entry.add_to_hass(hass)
+
+        device_reg = mock_device_registry(hass)
+        device_entry = device_reg.async_get_or_create(
+            config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, 123)}
+        )
+
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        migrated_device_entry = device_reg.async_get_or_create(
+            config_entry_id=config_entry.entry_id, identifiers={(DOMAIN, "123")}
+        )
+        assert device_entry.id == migrated_device_entry.id

--- a/tests/components/gios/test_init.py
+++ b/tests/components/gios/test_init.py
@@ -58,8 +58,8 @@ async def test_unload_entry(hass):
     assert not hass.data.get(DOMAIN)
 
 
-async def test_migrate_device_entry(hass, aioclient_mock):
-    """Test device_info identifiers migration."""
+async def test_migrate_device_and_config_entry(hass):
+    """Test device_info identifiers and config entry migration."""
     config_entry = MockConfigEntry(
         domain=DOMAIN,
         title="Home",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR improves type annotations for GIOS integration.
The integration used to use int as `unique_id` in config entry, device entry and entity entry, this PR fixes this.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
