### PR TITLE
Alexa fan preset_mode support

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1155,8 +1155,6 @@ class AlexaPowerLevelController(AlexaCapability):
         if self.entity.domain == fan.DOMAIN:
             return self.entity.attributes.get(fan.ATTR_PERCENTAGE) or 0
 
-        return None
-
 
 class AlexaSecurityPanelController(AlexaCapability):
     """Implements Alexa.SecurityPanelController.

--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -1304,6 +1304,12 @@ class AlexaModeController(AlexaCapability):
             if mode in (fan.DIRECTION_FORWARD, fan.DIRECTION_REVERSE, STATE_UNKNOWN):
                 return f"{fan.ATTR_DIRECTION}.{mode}"
 
+        # Fan preset_mode
+        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
+            mode = self.entity.attributes.get(fan.ATTR_PRESET_MODE, None)
+            if mode in self.entity.attributes.get(fan.ATTR_PRESET_MODES, None):
+                return f"{fan.ATTR_PRESET_MODE}.{mode}"
+
         # Cover Position
         if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
             # Return state instead of position when using ModeController.
@@ -1340,6 +1346,17 @@ class AlexaModeController(AlexaCapability):
             self._resource.add_mode(
                 f"{fan.ATTR_DIRECTION}.{fan.DIRECTION_REVERSE}", [fan.DIRECTION_REVERSE]
             )
+            return self._resource.serialize_capability_resources()
+
+        # Fan preset_mode
+        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
+            self._resource = AlexaModeResource(
+                [AlexaGlobalCatalog.SETTING_PRESET], False
+            )
+            for preset_mode in self.entity.attributes.get(fan.ATTR_PRESET_MODES, []):
+                self._resource.add_mode(
+                    f"{fan.ATTR_PRESET_MODE}.{preset_mode}", [preset_mode]
+                )
             return self._resource.serialize_capability_resources()
 
         # Cover Position Resources

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -532,12 +532,17 @@ class FanCapabilities(AlexaEntity):
         if supported & fan.SUPPORT_SET_SPEED:
             yield AlexaPercentageController(self.entity)
             yield AlexaPowerLevelController(self.entity)
+            # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
             yield AlexaRangeController(
                 self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_SPEED}"
             )
         if supported & fan.SUPPORT_OSCILLATE:
             yield AlexaToggleController(
                 self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}"
+            )
+        if supported & fan.SUPPORT_PRESET_MODE:
+            yield AlexaModeController(
+                self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}"
             )
         if supported & fan.SUPPORT_DIRECTION:
             yield AlexaModeController(

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -961,6 +961,16 @@ async def async_api_set_mode(hass, config, directive, context):
             service = fan.SERVICE_SET_DIRECTION
             data[fan.ATTR_DIRECTION] = direction
 
+    # Fan preset_mode
+    elif instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
+        preset_mode = mode.split(".")[1]
+        if preset_mode in entity.attributes.get(fan.ATTR_PRESET_MODES):
+            service = fan.SERVICE_SET_PRESET_MODE
+            data[fan.ATTR_PRESET_MODE] = preset_mode
+        else:
+            msg = f"Entity '{entity.entity_id}' does not support Preset '{preset_mode}'"
+            raise AlexaInvalidValueError(msg)
+
     # Cover Position
     elif instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
         position = mode.split(".")[1]

--- a/tests/components/alexa/test_capabilities.py
+++ b/tests/components/alexa/test_capabilities.py
@@ -400,6 +400,48 @@ async def test_report_fan_speed_state(hass):
     properties.assert_equal("Alexa.RangeController", "rangeValue", 3)
 
 
+async def test_report_fan_preset_mode(hass):
+    """Test ModeController reports fan preset_mode correctly."""
+    hass.states.async_set(
+        "fan.preset_mode",
+        "eco",
+        {
+            "friendly_name": "eco enabled fan",
+            "supported_features": 8,
+            "preset_mode": "eco",
+            "preset_modes": ["eco", "smart", "whoosh"],
+        },
+    )
+    properties = await reported_properties(hass, "fan.preset_mode")
+    properties.assert_equal("Alexa.ModeController", "mode", "preset_mode.eco")
+
+    hass.states.async_set(
+        "fan.preset_mode",
+        "smart",
+        {
+            "friendly_name": "smart enabled fan",
+            "supported_features": 8,
+            "preset_mode": "smart",
+            "preset_modes": ["eco", "smart", "whoosh"],
+        },
+    )
+    properties = await reported_properties(hass, "fan.preset_mode")
+    properties.assert_equal("Alexa.ModeController", "mode", "preset_mode.smart")
+
+    hass.states.async_set(
+        "fan.preset_mode",
+        "whoosh",
+        {
+            "friendly_name": "whoosh enabled fan",
+            "supported_features": 8,
+            "preset_mode": "whoosh",
+            "preset_modes": ["eco", "smart", "whoosh"],
+        },
+    )
+    properties = await reported_properties(hass, "fan.preset_mode")
+    properties.assert_equal("Alexa.ModeController", "mode", "preset_mode.whoosh")
+
+
 async def test_report_fan_oscillating(hass):
     """Test ToggleController reports fan oscillating correctly."""
     hass.states.async_set(

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -2484,7 +2484,7 @@ async def test_alarm_control_panel_disarmed(hass):
     properties = ReportedProperties(msg["context"]["properties"])
     properties.assert_equal("Alexa.SecurityPanelController", "armState", "ARMED_AWAY")
 
-    call, msg = await assert_request_calls_service(
+    _, msg = await assert_request_calls_service(
         "Alexa.SecurityPanelController",
         "Arm",
         "alarm_control_panel#test_1",

--- a/tests/components/alexa/test_smart_home.py
+++ b/tests/components/alexa/test_smart_home.py
@@ -846,6 +846,89 @@ async def test_fan_range_off(hass):
     )
 
 
+async def test_preset_mode_fan(hass, caplog):
+    """Test fan discovery.
+
+    This one has preset modes.
+    """
+    device = (
+        "fan.test_7",
+        "off",
+        {
+            "friendly_name": "Test fan 7",
+            "supported_features": 8,
+            "preset_modes": ["auto", "eco", "smart", "whoosh"],
+            "preset_mode": "auto",
+        },
+    )
+    appliance = await discovery_test(device, hass)
+
+    assert appliance["endpointId"] == "fan#test_7"
+    assert appliance["displayCategories"][0] == "FAN"
+    assert appliance["friendlyName"] == "Test fan 7"
+
+    capabilities = assert_endpoint_capabilities(
+        appliance,
+        "Alexa.EndpointHealth",
+        "Alexa.ModeController",
+        "Alexa.PowerController",
+        "Alexa",
+    )
+
+    range_capability = get_capability(capabilities, "Alexa.ModeController")
+    assert range_capability is not None
+    assert range_capability["instance"] == "fan.preset_mode"
+
+    properties = range_capability["properties"]
+    assert properties["nonControllable"] is False
+    assert {"name": "mode"} in properties["supported"]
+
+    capability_resources = range_capability["capabilityResources"]
+    assert capability_resources is not None
+    assert {
+        "@type": "asset",
+        "value": {"assetId": "Alexa.Setting.Preset"},
+    } in capability_resources["friendlyNames"]
+
+    configuration = range_capability["configuration"]
+    assert configuration is not None
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "fan#test_7",
+        "fan.set_preset_mode",
+        hass,
+        payload={"mode": "preset_mode.eco"},
+        instance="fan.preset_mode",
+    )
+    assert call.data["preset_mode"] == "eco"
+
+    call, _ = await assert_request_calls_service(
+        "Alexa.ModeController",
+        "SetMode",
+        "fan#test_7",
+        "fan.set_preset_mode",
+        hass,
+        payload={"mode": "preset_mode.whoosh"},
+        instance="fan.preset_mode",
+    )
+    assert call.data["preset_mode"] == "whoosh"
+
+    with pytest.raises(AssertionError):
+        await assert_request_calls_service(
+            "Alexa.ModeController",
+            "SetMode",
+            "fan#test_7",
+            "fan.set_preset_mode",
+            hass,
+            payload={"mode": "preset_mode.invalid"},
+            instance="fan.preset_mode",
+        )
+    assert "Entity 'fan.test_7' does not support Preset 'invalid'" in caplog.text
+    caplog.clear()
+
+
 async def test_lock(hass):
     """Test lock discovery."""
     device = ("lock.test", "off", {"friendly_name": "Test lock"})

--- a/tests/components/alexa/test_state_report.py
+++ b/tests/components/alexa/test_state_report.py
@@ -50,10 +50,13 @@ async def test_report_state_instance(hass, aioclient_mock):
         "off",
         {
             "friendly_name": "Test fan",
-            "supported_features": 3,
-            "speed": "off",
+            "supported_features": 15,
+            "speed": None,
             "speed_list": ["off", "low", "high"],
             "oscillating": False,
+            "preset_mode": None,
+            "preset_modes": ["auto", "smart"],
+            "percentage": None,
         },
     )
 
@@ -64,10 +67,13 @@ async def test_report_state_instance(hass, aioclient_mock):
         "on",
         {
             "friendly_name": "Test fan",
-            "supported_features": 3,
+            "supported_features": 15,
             "speed": "high",
             "speed_list": ["off", "low", "high"],
             "oscillating": True,
+            "preset_mode": "smart",
+            "preset_modes": ["auto", "smart"],
+            "percentage": 90,
         },
     )
 
@@ -82,11 +88,33 @@ async def test_report_state_instance(hass, aioclient_mock):
     assert call_json["event"]["header"]["name"] == "ChangeReport"
 
     change_reports = call_json["event"]["payload"]["change"]["properties"]
+
+    checks = 0
     for report in change_reports:
         if report["name"] == "toggleState":
             assert report["value"] == "ON"
             assert report["instance"] == "fan.oscillating"
             assert report["namespace"] == "Alexa.ToggleController"
+            checks += 1
+        if report["name"] == "mode":
+            assert report["value"] == "preset_mode.smart"
+            assert report["instance"] == "fan.preset_mode"
+            assert report["namespace"] == "Alexa.ModeController"
+            checks += 1
+        if report["name"] == "percentage":
+            assert report["value"] == 90
+            assert report["namespace"] == "Alexa.PercentageController"
+            checks += 1
+        if report["name"] == "powerLevel":
+            assert report["value"] == 90
+            assert report["namespace"] == "Alexa.PowerLevelController"
+            checks += 1
+        if report["name"] == "rangeValue":
+            assert report["value"] == 2
+            assert report["instance"] == "fan.speed"
+            assert report["namespace"] == "Alexa.RangeController"
+            checks += 1
+    assert checks == 5
 
     assert call_json["event"]["endpoint"]["endpointId"] == "fan#test_fan"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for fan `preset_modes` feature to Alexa Smart Home.
Alexa now supports:
- Fan preset modes
- Percentage based fan speeds
- Legacy low/medium/high `speed`

Note: The support for legacy low/medium/high `speed` attribute will be removed in a future release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50198
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/17800

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
