### PR TITLE
Use 'current_summ_delivered' attrib for ZHA Smart energy channel

### DIFF
--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -7,6 +7,7 @@ import zigpy.zcl.clusters.smartenergy as smartenergy
 
 from homeassistant.const import (
     ENERGY_KILO_WATT_HOUR,
+    POWER_WATT,
     TIME_HOURS,
     TIME_SECONDS,
     VOLUME_FLOW_RATE_CUBIC_FEET_PER_MINUTE,

--- a/homeassistant/components/zha/core/channels/smartenergy.py
+++ b/homeassistant/components/zha/core/channels/smartenergy.py
@@ -63,7 +63,9 @@ class Messaging(ZigbeeChannel):
 class Metering(ZigbeeChannel):
     """Metering channel."""
 
-    REPORT_CONFIG = [{"attr": "current_summ_delivered", "config": REPORT_CONFIG_DEFAULT}]
+    REPORT_CONFIG = [
+        {"attr": "current_summ_delivered", "config": REPORT_CONFIG_DEFAULT}
+    ]
 
     unit_of_measure_map = {
         0x00: ENERGY_KILO_WATT_HOUR,

--- a/homeassistant/components/zha/sensor.py
+++ b/homeassistant/components/zha/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_ILLUMINANCE,
     DEVICE_CLASS_POWER,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_TEMPERATURE,
     DOMAIN,
@@ -255,8 +256,8 @@ class Illuminance(Sensor):
 class SmartEnergyMetering(Sensor):
     """Metering sensor."""
 
-    SENSOR_ATTR = "instantaneous_demand"
-    _device_class = DEVICE_CLASS_POWER
+    SENSOR_ATTR = "current_summ_delivered"
+    _device_class = DEVICE_CLASS_ENERGY
 
     def formatter(self, value: int) -> int | float:
         """Pass through channel formatter."""


### PR DESCRIPTION
Use the 'current_summ_delivered' attrib (id: 0x0000) on the 'smartenergy_metering' cluster (id: 0x0702); don't use the 'instantaneous_demand' attr (id: 0x0400).

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
  ZHA Smart energy channel no longer reports attribute 'instantaneous_demand', but
  attribute 'current_summ_delivered'. 


## Proposed change
  As reported in issue #44539 "ZHA plugs - smartenergy_metering > wrong cluster"
  many (most?) energy metering capable devices support reporting energy 
  consumption with attribute 'current_summ_delivered'; not with attribute
  'instantaneous_demand'.

  Furthermore, Page 215/16 of the zigbee smart energy profile says that cluster
  0x702 attribute 0x0 is "CurrentSummationDelivered represents the most recent
  summed value of Energy, Gas, or Water delivered and consumed in the premises.
  CurrentSummationDelivered is mandatory and must be provided as part of the
  minimum data set to be provided by the metering device"


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #44539 
- This PR is related to issue: #44539 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
