### PR TITLE
Update xknx to version 0.18.2

### DIFF
--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -251,7 +251,7 @@ def _create_climate(knx_module: XKNX, config: ConfigType) -> XknxClimate:
         group_address_setpoint_shift_state=config.get(
             ClimateSchema.CONF_SETPOINT_SHIFT_STATE_ADDRESS
         ),
-        setpoint_shift_mode=config[ClimateSchema.CONF_SETPOINT_SHIFT_MODE],
+        setpoint_shift_mode=config.get(ClimateSchema.CONF_SETPOINT_SHIFT_MODE),
         setpoint_shift_max=config[ClimateSchema.CONF_SETPOINT_SHIFT_MAX],
         setpoint_shift_min=config[ClimateSchema.CONF_SETPOINT_SHIFT_MIN],
         temperature_step=config[ClimateSchema.CONF_TEMPERATURE_STEP],

--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "knx",
   "name": "KNX",
   "documentation": "https://www.home-assistant.io/integrations/knx",
-  "requirements": ["xknx==0.18.1"],
+  "requirements": ["xknx==0.18.2"],
   "codeowners": ["@Julius2342", "@farmio", "@marvin-w"],
   "quality_scale": "silver",
   "iot_class": "local_push"

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -175,9 +175,6 @@ class ClimateSchema:
             {
                 vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
                 vol.Optional(
-                    CONF_SETPOINT_SHIFT_MODE, default=DEFAULT_SETPOINT_SHIFT_MODE
-                ): vol.All(vol.Upper, cv.enum(SetpointShiftMode)),
-                vol.Optional(
                     CONF_SETPOINT_SHIFT_MAX, default=DEFAULT_SETPOINT_SHIFT_MAX
                 ): vol.All(int, vol.Range(min=0, max=32)),
                 vol.Optional(
@@ -189,8 +186,21 @@ class ClimateSchema:
                 vol.Required(CONF_TEMPERATURE_ADDRESS): ga_list_validator,
                 vol.Required(CONF_TARGET_TEMPERATURE_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_TARGET_TEMPERATURE_ADDRESS): ga_list_validator,
-                vol.Optional(CONF_SETPOINT_SHIFT_ADDRESS): ga_list_validator,
-                vol.Optional(CONF_SETPOINT_SHIFT_STATE_ADDRESS): ga_list_validator,
+                vol.Inclusive(
+                    CONF_SETPOINT_SHIFT_ADDRESS,
+                    "setpoint_shift",
+                    msg="'setpoint_shift_address' and 'setpoint_shift_state_address' "
+                    "are required for setpoint_shift configuration",
+                ): ga_list_validator,
+                vol.Inclusive(
+                    CONF_SETPOINT_SHIFT_STATE_ADDRESS,
+                    "setpoint_shift",
+                    msg="'setpoint_shift_address' and 'setpoint_shift_state_address' "
+                    "are required for setpoint_shift configuration",
+                ): ga_list_validator,
+                vol.Optional(CONF_SETPOINT_SHIFT_MODE): vol.Maybe(
+                    vol.All(vol.Upper, cv.enum(SetpointShiftMode))
+                ),
                 vol.Optional(CONF_OPERATION_MODE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_OPERATION_MODE_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_CONTROLLER_STATUS_ADDRESS): ga_list_validator,

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -377,9 +377,21 @@ class LightSchema:
                 vol.Optional(CONF_BRIGHTNESS_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_BRIGHTNESS_STATE_ADDRESS): ga_list_validator,
                 vol.Exclusive(CONF_INDIVIDUAL_COLORS, "color"): {
-                    vol.Inclusive(CONF_RED, "colors"): COLOR_SCHEMA,
-                    vol.Inclusive(CONF_GREEN, "colors"): COLOR_SCHEMA,
-                    vol.Inclusive(CONF_BLUE, "colors"): COLOR_SCHEMA,
+                    vol.Inclusive(
+                        CONF_RED,
+                        "individual_colors",
+                        msg="'red', 'green' and 'blue' are required for individual colors configuration",
+                    ): COLOR_SCHEMA,
+                    vol.Inclusive(
+                        CONF_GREEN,
+                        "individual_colors",
+                        msg="'red', 'green' and 'blue' are required for individual colors configuration",
+                    ): COLOR_SCHEMA,
+                    vol.Inclusive(
+                        CONF_BLUE,
+                        "individual_colors",
+                        msg="'red', 'green' and 'blue' are required for individual colors configuration",
+                    ): COLOR_SCHEMA,
                     vol.Optional(CONF_WHITE): COLOR_SCHEMA,
                 },
                 vol.Exclusive(CONF_COLOR_ADDRESS, "color"): ga_list_validator,
@@ -400,14 +412,11 @@ class LightSchema:
             }
         ),
         vol.Any(
-            # either global "address" or all addresses for individual colors are required
+            # either global "address" "individual_colors" is required
             vol.Schema(
                 {
-                    vol.Required(CONF_INDIVIDUAL_COLORS): {
-                        vol.Required(CONF_RED): {vol.Required(KNX_ADDRESS): object},
-                        vol.Required(CONF_GREEN): {vol.Required(KNX_ADDRESS): object},
-                        vol.Required(CONF_BLUE): {vol.Required(KNX_ADDRESS): object},
-                    },
+                    # brightness addresses are required in COLOR_SCHEMA
+                    vol.Required(CONF_INDIVIDUAL_COLORS): object,
                 },
                 extra=vol.ALLOW_EXTRA,
             ),

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -422,7 +422,7 @@ class LightSchema:
             }
         ),
         vol.Any(
-            # either global "address" "individual_colors" is required
+            # either global "address" or "individual_colors" is required
             vol.Schema(
                 {
                     # brightness addresses are required in COLOR_SCHEMA

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2356,7 +2356,7 @@ xbox-webapi==2.0.11
 xboxapi==2.0.1
 
 # homeassistant.components.knx
-xknx==0.18.1
+xknx==0.18.2
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1259,7 +1259,7 @@ wolf_smartset==0.1.8
 xbox-webapi==2.0.11
 
 # homeassistant.components.knx
-xknx==0.18.1
+xknx==0.18.2
 
 # homeassistant.components.bluesound
 # homeassistant.components.fritz


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update xknx from version 0.18.1 to version 0.18.2

Release notes: [xknx 0.18.2 release notes](https://github.com/XKNX/xknx/releases/tag/0.18.2)

Changes:
- Climate: make `setpoint_shift_mode` configuration optional. When None auto-assign its DPT from the first incoming payload.
- Light: Support individual color lights without switch object, only brightness group address.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17798

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
