### PR TITLE
Remove unused py_noaa dependency

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -144,7 +144,6 @@ jobs:
             sed -i "s|# PySwitchbot|PySwitchbot|g" ${requirement_file}
             sed -i "s|# pySwitchmate|pySwitchmate|g" ${requirement_file}
             sed -i "s|# face_recognition|face_recognition|g" ${requirement_file}
-            sed -i "s|# py_noaa|py_noaa|g" ${requirement_file}
             sed -i "s|# bme680|bme680|g" ${requirement_file}
             sed -i "s|# python-gammu|python-gammu|g" ${requirement_file}
           done

--- a/script/gen_requirements_all.py
+++ b/script/gen_requirements_all.py
@@ -27,7 +27,6 @@ COMMENT_REQUIREMENTS = (
     "face_recognition",
     "i2csense",
     "opencv-python-headless",
-    "py_noaa",
     "pybluez",
     "pycups",
     "PySwitchbot",


### PR DESCRIPTION
## Proposed change
The NOAA Tide component https://www.home-assistant.io/integrations/noaa_tides/ changed from py_noaa to noaa-coops dependency in https://github.com/home-assistant/core/commit/762d7357b51c5f3b17524e537e1e731d4a38a5bb#diff-ee8597ecf974f76a8c446500c386d31b8ce457d2477882bf4377fc245105934c. However, the dependency was missed in a few locations and was never completely removed,

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone
