### PR TITLE
2021.5.3

### DIFF
--- a/homeassistant/components/denonavr/manifest.json
+++ b/homeassistant/components/denonavr/manifest.json
@@ -3,7 +3,7 @@
   "name": "Denon AVR Network Receivers",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/denonavr",
-  "requirements": ["denonavr==0.10.7"],
+  "requirements": ["denonavr==0.10.8"],
   "codeowners": ["@scarface-4711", "@starkillerOG"],
   "ssdp": [
     {

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -3,7 +3,7 @@
   "name": "Philips Hue",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/hue",
-  "requirements": ["aiohue==2.3.0"],
+  "requirements": ["aiohue==2.3.1"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -454,7 +454,8 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
 
     async def async_reconnect_player(self) -> None:
         """Set basic information when player is reconnected."""
-        await self.hass.async_add_executor_job(self._reconnect_player)
+        async with self.data.topology_condition:
+            await self.hass.async_add_executor_job(self._reconnect_player)
 
     def _reconnect_player(self) -> None:
         """Set basic information when player is reconnected."""

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -1,7 +1,7 @@
 """Constants used by Home Assistant components."""
 MAJOR_VERSION = 2021
 MINOR_VERSION = 5
-PATCH_VERSION = "2"
+PATCH_VERSION = "3"
 __short_version__ = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__ = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER = (3, 8, 0)

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -193,6 +193,9 @@ async def trace_action(hass, script_run, stop, variables):
 
     try:
         yield trace_element
+    except _StopScript as ex:
+        trace_element.set_error(ex.__cause__ or ex)
+        raise ex
     except Exception as ex:
         trace_element.set_error(ex)
         raise ex

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -182,7 +182,7 @@ aiohomekit==0.2.61
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==2.3.0
+aiohue==2.3.1
 
 # homeassistant.components.imap
 aioimaplib==0.7.15

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -479,7 +479,7 @@ defusedxml==0.6.0
 deluge-client==1.7.1
 
 # homeassistant.components.denonavr
-denonavr==0.10.7
+denonavr==0.10.8
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -119,7 +119,7 @@ aiohomekit==0.2.61
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==2.3.0
+aiohue==2.3.1
 
 # homeassistant.components.apache_kafka
 aiokafka==0.6.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -264,7 +264,7 @@ debugpy==1.2.1
 defusedxml==0.6.0
 
 # homeassistant.components.denonavr
-denonavr==0.10.7
+denonavr==0.10.8
 
 # homeassistant.components.devolo_home_control
 devolo-home-control-api==0.17.3

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -622,7 +622,7 @@ async def test_delay_template_invalid(hass, caplog):
     assert_action_trace(
         {
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
-            "1": [{"error_type": script._StopScript}],
+            "1": [{"error_type": vol.MultipleInvalid}],
         },
         expected_script_execution="aborted",
     )
@@ -683,7 +683,7 @@ async def test_delay_template_complex_invalid(hass, caplog):
     assert_action_trace(
         {
             "0": [{"result": {"event": "test_event", "event_data": {}}}],
-            "1": [{"error_type": script._StopScript}],
+            "1": [{"error_type": vol.MultipleInvalid}],
         },
         expected_script_execution="aborted",
     )
@@ -1138,7 +1138,7 @@ async def test_wait_continue_on_timeout(
     }
     if continue_on_timeout is False:
         expected_trace["0"][0]["result"]["timeout"] = True
-        expected_trace["0"][0]["error_type"] = script._StopScript
+        expected_trace["0"][0]["error_type"] = asyncio.TimeoutError
         expected_script_execution = "aborted"
     else:
         expected_trace["1"] = [


### PR DESCRIPTION
- Handle transport errors when updating media via events ([@bdraco] - [#50480]) ([sonos docs])
- Hotfix for Sonos favorites race condition ([@jjlawren] - [#50495]) ([sonos docs])
- Include _StopScript.__cause__ in trace ([@emontnemery] - [#50441])
- update denonavr version 0.10.8 ([@scarface-4711] - [#50476]) ([denonavr docs])
- Bump aiohue to 2.3.1 ([@balloob] - [#50506]) ([hue docs])

[#50441]: https://github.com/home-assistant/core/pull/50441
[#50476]: https://github.com/home-assistant/core/pull/50476
[#50480]: https://github.com/home-assistant/core/pull/50480
[#50495]: https://github.com/home-assistant/core/pull/50495
[#50506]: https://github.com/home-assistant/core/pull/50506
[@balloob]: https://github.com/balloob
[@bdraco]: https://github.com/bdraco
[@emontnemery]: https://github.com/emontnemery
[@jjlawren]: https://github.com/jjlawren
[@scarface-4711]: https://github.com/scarface-4711
[denonavr docs]: https://www.home-assistant.io/integrations/denonavr/
[hue docs]: https://www.home-assistant.io/integrations/hue/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/