### PR TITLE
Add support for tracking entity attributes in ESPHome

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -164,6 +164,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         async def send_home_assistant_state_event(event: Event) -> None:
             """Forward Home Assistant states updates to ESPHome."""
+
+            # Only communicate changes to the state or attribute tracked
+            if (
+                "old_state" in event.data
+                and "new_state" in event.data
+                and (
+                    (
+                        not attribute
+                        and event.data["old_state"].state
+                        == event.data["new_state"].state
+                    )
+                    or (
+                        attribute
+                        and attribute in event.data["old_state"].attributes
+                        and attribute in event.data["new_state"].attributes
+                        and event.data["old_state"].attributes[attribute]
+                        == event.data["new_state"].attributes[attribute]
+                    )
+                )
+            ):
+                return
+
             await _send_home_assistant_state(
                 event.data["entity_id"], attribute, event.data.get("new_state")
             )

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -140,34 +140,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
             )
 
-    async def send_home_assistant_state_event(event: Event) -> None:
-        """Forward Home Assistant states updates to ESPHome."""
-        new_state = event.data.get("new_state")
-        if new_state is None:
-            return
-        entity_id = event.data.get("entity_id")
-        await cli.send_home_assistant_state(entity_id, None, new_state.state)
-
     async def _send_home_assistant_state(
-        entity_id: str, new_state: State | None
+        entity_id: str, attribute: str | None, state: State | None
     ) -> None:
         """Forward Home Assistant states to ESPHome."""
-        await cli.send_home_assistant_state(entity_id, None, new_state.state)
+        if state is None or (attribute and attribute not in state.attributes):
+            return
+
+        send_state = state.state
+        if attribute:
+            send_state = state.attributes[attribute]
+            # ESPHome only handles "on"/"off" for boolean values
+            if isinstance(send_state, bool):
+                send_state = "on" if send_state else "off"
+
+        await cli.send_home_assistant_state(entity_id, attribute, str(send_state))
 
     @callback
     def async_on_state_subscription(
         entity_id: str, attribute: str | None = None
     ) -> None:
         """Subscribe and forward states for requested entities."""
+
+        async def send_home_assistant_state_event(event: Event) -> None:
+            """Forward Home Assistant states updates to ESPHome."""
+            await _send_home_assistant_state(
+                event.data["entity_id"], attribute, event.data.get("new_state")
+            )
+
         unsub = async_track_state_change_event(
             hass, [entity_id], send_home_assistant_state_event
         )
         entry_data.disconnect_callbacks.append(unsub)
-        new_state = hass.states.get(entity_id)
-        if new_state is None:
-            return
+
         # Send initial state
-        hass.async_create_task(_send_home_assistant_state(entity_id, new_state))
+        hass.async_create_task(
+            _send_home_assistant_state(entity_id, attribute, hass.states.get(entity_id))
+        )
 
     async def on_login() -> None:
         """Subscribe to states and list entities on successful API login."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The PR implements support for tracking state changes of entity state attributes.

Tested against existing ESPHome devices to ensure backward compatibility. Additionally tested against the newly implemented branch @ ESPHome:

```yaml
---
esphome:
  name: esphome-dev
  comment: Board used for ESPHome development
  platform: ESP32
  board: lolin32

sensor:
  - platform: homeassistant
    id: current_brightness
    entity_id: light.ceiling_lights
    attribute: brightness

binary_sensor:
  - platform: homeassistant
    id: is_muted
    entity_id: media_player.kitchen
    attribute: is_volume_muted

text_sensor:
  - platform: homeassistant
    id: effect
    entity_id: light.esp02
    attribute: effect
```

Results:
```
[16:27:14][I][app:105]: ESPHome version 1.19.0-dev compiled on May 12 2021, 16:26:03
...
[16:27:14][C][homeassistant.binary_sensor:037]: Homeassistant Binary Sensor 'is_muted'
[16:27:14][C][homeassistant.binary_sensor:038]:   Entity ID: 'media_player.kitchen'
[16:27:14][C][homeassistant.binary_sensor:040]:   Attribute: 'is_volume_muted'
[16:27:14][C][homeassistant.sensor:029]: Homeassistant Sensor 'current_brightness'
[16:27:14][C][homeassistant.sensor:029]:   Unit of Measurement: ''
[16:27:14][C][homeassistant.sensor:029]:   Accuracy Decimals: 1
[16:27:14][C][homeassistant.sensor:030]:   Entity ID: 'light.ceiling_lights'
[16:27:14][C][homeassistant.sensor:032]:   Attribute: 'brightness'
[16:27:14][C][homeassistant.text_sensor:022]: Homeassistant Text Sensor 'effect'
[16:27:14][C][homeassistant.text_sensor:023]:   Entity ID: 'light.esp02'
[16:27:14][C][homeassistant.text_sensor:025]:   Attribute: 'effect'
[16:27:33][D][homeassistant.sensor:021]: 'light.ceiling_lights::brightness': Got attribute state 125.00
[16:27:33][D][sensor:099]: 'current_brightness': Sending state 125.00000  with 1 decimals of accuracy
[16:27:34][D][homeassistant.sensor:021]: 'light.ceiling_lights::brightness': Got attribute state 191.00
[16:27:34][D][sensor:099]: 'current_brightness': Sending state 191.00000  with 1 decimals of accuracy
[16:27:46][D][homeassistant.binary_sensor:023]: 'media_player.kitchen::is_volume_muted': Got attribute state ON
[16:27:46][D][binary_sensor:036]: 'is_muted': Sending state ON
[16:27:48][D][homeassistant.binary_sensor:023]: 'media_player.kitchen::is_volume_muted': Got attribute state OFF
[16:27:48][D][binary_sensor:036]: 'is_muted': Sending state OFF
[16:28:00][D][homeassistant.text_sensor:014]: 'light.esp02::effect': Got attribute state 'Sparkle'
[16:28:00][D][text_sensor:015]: 'effect': Sending state 'Sparkle'
[16:28:04][D][homeassistant.text_sensor:014]: 'light.esp02::effect': Got attribute state 'Spots'
[16:28:04][D][text_sensor:015]: 'effect': Sending state 'Spots'
[16:28:09][D][homeassistant.text_sensor:014]: 'light.esp02::effect': Got attribute state 'Solid Pattern'
[16:28:09][D][text_sensor:015]: 'effect': Sending state 'Solid Pattern'
```

Upstream links:
- Feature request: <https://github.com/esphome/feature-requests/issues/1112>
- aioesphomeapi change: <https://github.com/esphome/aioesphomeapi/pull/30>
- ESPHome implementation: <https://github.com/esphome/esphome/pull/1770>
- ESPHome documentation: <https://github.com/esphome/esphome-docs/pull/1159>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
