### PR TITLE
Mqtt fan feature for resetting current speed `percentage` or `preset_mode`

### DIFF
--- a/homeassistant/components/mqtt/abbreviations.py
+++ b/homeassistant/components/mqtt/abbreviations.py
@@ -119,6 +119,8 @@ ABBREVIATIONS = {
     "pl_osc_off": "payload_oscillation_off",
     "pl_osc_on": "payload_oscillation_on",
     "pl_paus": "payload_pause",
+    "pl_rst_pct": "payload_reset_percentage",
+    "pl_rst_pr_mode": "payload_reset_preset_mode",
     "pl_stop": "payload_stop",
     "pl_strt": "payload_start",
     "pl_stpa": "payload_start_pause",

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -147,7 +147,6 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_PERCENTAGE_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_PERCENTAGE_STATE_TOPIC): mqtt.valid_subscribe_topic,
             vol.Optional(CONF_PERCENTAGE_VALUE_TEMPLATE): cv.template,
-            vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
             # CONF_PRESET_MODE_COMMAND_TOPIC and CONF_PRESET_MODES_LIST must be used together
             vol.Inclusive(
                 CONF_PRESET_MODE_COMMAND_TOPIC, "preset_modes"

--- a/homeassistant/components/mqtt/fan.py
+++ b/homeassistant/components/mqtt/fan.py
@@ -59,6 +59,7 @@ CONF_PERCENTAGE_STATE_TOPIC = "percentage_state_topic"
 CONF_PERCENTAGE_COMMAND_TOPIC = "percentage_command_topic"
 CONF_PERCENTAGE_VALUE_TEMPLATE = "percentage_value_template"
 CONF_PERCENTAGE_COMMAND_TEMPLATE = "percentage_command_template"
+CONF_PAYLOAD_RESET_PERCENTAGE = "payload_reset_percentage"
 CONF_SPEED_RANGE_MIN = "speed_range_min"
 CONF_SPEED_RANGE_MAX = "speed_range_max"
 CONF_PRESET_MODE_STATE_TOPIC = "preset_mode_state_topic"
@@ -66,6 +67,7 @@ CONF_PRESET_MODE_COMMAND_TOPIC = "preset_mode_command_topic"
 CONF_PRESET_MODE_VALUE_TEMPLATE = "preset_mode_value_template"
 CONF_PRESET_MODE_COMMAND_TEMPLATE = "preset_mode_command_template"
 CONF_PRESET_MODES_LIST = "preset_modes"
+CONF_PAYLOAD_RESET_PRESET_MODE = "payload_reset_preset_mode"
 CONF_SPEED_STATE_TOPIC = "speed_state_topic"
 CONF_SPEED_COMMAND_TOPIC = "speed_command_topic"
 CONF_SPEED_VALUE_TEMPLATE = "speed_value_template"
@@ -84,6 +86,7 @@ CONF_SPEED_LIST = "speeds"
 DEFAULT_NAME = "MQTT Fan"
 DEFAULT_PAYLOAD_ON = "ON"
 DEFAULT_PAYLOAD_OFF = "OFF"
+DEFAULT_PAYLOAD_RESET = "None"
 DEFAULT_OPTIMISTIC = False
 DEFAULT_SPEED_RANGE_MIN = 1
 DEFAULT_SPEED_RANGE_MAX = 100
@@ -113,6 +116,13 @@ def valid_speed_range_configuration(config):
     return config
 
 
+def valid_preset_mode_configuration(config):
+    """Validate that the preset mode reset payload is not one of the preset modes."""
+    if config.get(CONF_PAYLOAD_RESET_PRESET_MODE) in config.get(CONF_PRESET_MODES_LIST):
+        raise ValueError("preset_modes must not contain payload_reset_preset_mode")
+    return config
+
+
 PLATFORM_SCHEMA = vol.All(
     # CONF_SPEED_COMMAND_TOPIC, CONF_SPEED_STATE_TOPIC, CONF_STATE_VALUE_TEMPLATE, CONF_SPEED_LIST and
     # Speeds SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH SPEED_OFF,
@@ -137,6 +147,7 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(CONF_PERCENTAGE_COMMAND_TEMPLATE): cv.template,
             vol.Optional(CONF_PERCENTAGE_STATE_TOPIC): mqtt.valid_subscribe_topic,
             vol.Optional(CONF_PERCENTAGE_VALUE_TEMPLATE): cv.template,
+            vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
             # CONF_PRESET_MODE_COMMAND_TOPIC and CONF_PRESET_MODES_LIST must be used together
             vol.Inclusive(
                 CONF_PRESET_MODE_COMMAND_TOPIC, "preset_modes"
@@ -153,6 +164,12 @@ PLATFORM_SCHEMA = vol.All(
             vol.Optional(
                 CONF_SPEED_RANGE_MAX, default=DEFAULT_SPEED_RANGE_MAX
             ): cv.positive_int,
+            vol.Optional(
+                CONF_PAYLOAD_RESET_PERCENTAGE, default=DEFAULT_PAYLOAD_RESET
+            ): cv.string,
+            vol.Optional(
+                CONF_PAYLOAD_RESET_PRESET_MODE, default=DEFAULT_PAYLOAD_RESET
+            ): cv.string,
             vol.Optional(CONF_PAYLOAD_HIGH_SPEED, default=SPEED_HIGH): cv.string,
             vol.Optional(CONF_PAYLOAD_LOW_SPEED, default=SPEED_LOW): cv.string,
             vol.Optional(CONF_PAYLOAD_MEDIUM_SPEED, default=SPEED_MEDIUM): cv.string,
@@ -177,6 +194,7 @@ PLATFORM_SCHEMA = vol.All(
     ).extend(MQTT_ENTITY_COMMON_SCHEMA.schema),
     valid_fan_speed_configuration,
     valid_speed_range_configuration,
+    valid_preset_mode_configuration,
 )
 
 
@@ -281,6 +299,8 @@ class MqttFan(MqttEntity, FanEntity):
             "SPEED_MEDIUM": config[CONF_PAYLOAD_MEDIUM_SPEED],
             "SPEED_HIGH": config[CONF_PAYLOAD_HIGH_SPEED],
             "SPEED_OFF": config[CONF_PAYLOAD_OFF_SPEED],
+            "PERCENTAGE_RESET": config[CONF_PAYLOAD_RESET_PERCENTAGE],
+            "PRESET_MODE_RESET": config[CONF_PAYLOAD_RESET_PRESET_MODE],
         }
         # The use of legacy speeds is deprecated in the schema, support will be removed after a quarter (2021.7)
         self._feature_legacy_speeds = not self._topic[CONF_SPEED_COMMAND_TOPIC] is None
@@ -364,20 +384,27 @@ class MqttFan(MqttEntity, FanEntity):
         @log_messages(self.hass, self.entity_id)
         def percentage_received(msg):
             """Handle new received MQTT message for the percentage."""
-            numeric_val_str = self._value_templates[ATTR_PERCENTAGE](msg.payload)
-            if not numeric_val_str:
+            rendered_percentage_payload = self._value_templates[ATTR_PERCENTAGE](
+                msg.payload
+            )
+            if not rendered_percentage_payload:
                 _LOGGER.debug("Ignoring empty speed from '%s'", msg.topic)
+                return
+            if rendered_percentage_payload == self._payload["PERCENTAGE_RESET"]:
+                self._percentage = None
+                self._speed = None
+                self.async_write_ha_state()
                 return
             try:
                 percentage = ranged_value_to_percentage(
-                    self._speed_range, int(numeric_val_str)
+                    self._speed_range, int(rendered_percentage_payload)
                 )
             except ValueError:
                 _LOGGER.warning(
                     "'%s' received on topic %s. '%s' is not a valid speed within the speed range",
                     msg.payload,
                     msg.topic,
-                    numeric_val_str,
+                    rendered_percentage_payload,
                 )
                 return
             if percentage < 0 or percentage > 100:
@@ -385,7 +412,7 @@ class MqttFan(MqttEntity, FanEntity):
                     "'%s' received on topic %s. '%s' is not a valid speed within the speed range",
                     msg.payload,
                     msg.topic,
-                    numeric_val_str,
+                    rendered_percentage_payload,
                 )
                 return
             self._percentage = percentage
@@ -404,6 +431,10 @@ class MqttFan(MqttEntity, FanEntity):
         def preset_mode_received(msg):
             """Handle new received MQTT message for preset mode."""
             preset_mode = self._value_templates[ATTR_PRESET_MODE](msg.payload)
+            if preset_mode == self._payload["PRESET_MODE_RESET"]:
+                self._preset_mode = None
+                self.async_write_ha_state()
+                return
             if not preset_mode:
                 _LOGGER.debug("Ignoring empty preset_mode from '%s'", msg.topic)
                 return
@@ -658,7 +689,7 @@ class MqttFan(MqttEntity, FanEntity):
 
         if self._optimistic_preset_mode:
             self._preset_mode = preset_mode
-        self.async_write_ha_state()
+            self.async_write_ha_state()
 
     # async_set_speed is deprecated, support will be removed after a quarter (2021.7)
     async def async_set_speed(self, speed: str) -> None:
@@ -691,7 +722,7 @@ class MqttFan(MqttEntity, FanEntity):
 
             if self._optimistic_speed and speed_payload:
                 self._speed = speed
-            self.async_write_ha_state()
+                self.async_write_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation.

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -100,6 +100,8 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
                 "payload_low_speed": "speed_lOw",
                 "payload_medium_speed": "speed_mEdium",
                 "payload_high_speed": "speed_High",
+                "payload_reset_percentage": "rEset_percentage",
+                "payload_reset_preset_mode": "rEset_preset_mode",
             }
         },
     )
@@ -168,6 +170,10 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
     state = hass.states.get("fan.test")
     assert state.attributes.get("preset_mode") == "silent"
 
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", "rEset_preset_mode")
+    state = hass.states.get("fan.test")
+    assert state.attributes.get("preset_mode") is None
+
     async_fire_mqtt_message(hass, "preset-mode-state-topic", "ModeUnknown")
     assert "not a valid preset mode" in caplog.text
     caplog.clear()
@@ -190,6 +196,11 @@ async def test_controlling_state_via_topic(hass, mqtt_mock, caplog):
     async_fire_mqtt_message(hass, "speed-state-topic", "speed_OfF")
     state = hass.states.get("fan.test")
     assert state.attributes.get("speed") == fan.SPEED_OFF
+
+    async_fire_mqtt_message(hass, "percentage-state-topic", "rEset_percentage")
+    state = hass.states.get("fan.test")
+    assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
+    assert state.attributes.get(fan.ATTR_SPEED) is None
 
     async_fire_mqtt_message(hass, "speed-state-topic", "speed_very_high")
     assert "not a valid speed" in caplog.text
@@ -1895,6 +1906,21 @@ async def test_supported_features(hass, mqtt_mock):
                     "speed_range_min": 0,
                     "speed_range_max": 40,
                 },
+                {
+                    "platform": "mqtt",
+                    "name": "test7reset_payload_in_preset_modes_a",
+                    "command_topic": "command-topic",
+                    "preset_mode_command_topic": "preset-mode-command-topic",
+                    "preset_modes": ["auto", "smart", "normal", "None"],
+                },
+                {
+                    "platform": "mqtt",
+                    "name": "test7reset_payload_in_preset_modes_b",
+                    "command_topic": "command-topic",
+                    "preset_mode_command_topic": "preset-mode-command-topic",
+                    "preset_modes": ["whoosh", "silent", "auto", "None"],
+                    "payload_reset_preset_mode": "normal",
+                },
             ]
         },
     )
@@ -1961,6 +1987,11 @@ async def test_supported_features(hass, mqtt_mock):
     assert state is None
     state = hass.states.get("fan.test6spd_range_c")
     assert state is None
+
+    state = hass.states.get("fan.test7reset_payload_in_preset_modes_a")
+    assert state is None
+    state = hass.states.get("fan.test7reset_payload_in_preset_modes_b")
+    assert state.attributes.get(ATTR_SUPPORTED_FEATURES) == fan.SUPPORT_PRESET_MODE
 
 
 async def test_availability_when_connection_lost(hass, mqtt_mock):

--- a/tests/components/mqtt/test_fan.py
+++ b/tests/components/mqtt/test_fan.py
@@ -419,6 +419,10 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, cap
     state = hass.states.get("fan.test")
     assert state.attributes.get(fan.ATTR_PERCENTAGE) == 100
 
+    async_fire_mqtt_message(hass, "percentage-state-topic", '{"val": "None"}')
+    state = hass.states.get("fan.test")
+    assert state.attributes.get(fan.ATTR_PERCENTAGE) is None
+
     async_fire_mqtt_message(hass, "percentage-state-topic", '{"otherval": 100}')
     assert "Ignoring empty speed from" in caplog.text
     caplog.clear()
@@ -438,6 +442,10 @@ async def test_controlling_state_via_topic_and_json_message(hass, mqtt_mock, cap
     async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "silent"}')
     state = hass.states.get("fan.test")
     assert state.attributes.get("preset_mode") == "silent"
+
+    async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"val": "None"}')
+    state = hass.states.get("fan.test")
+    assert state.attributes.get("preset_mode") is None
 
     async_fire_mqtt_message(hass, "preset-mode-state-topic", '{"otherval": 100}')
     assert "Ignoring empty preset_mode from" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement a feature to allow resetting `preset_mode` or `percentage` to `None` by using a specially defined payload.
Two new attributes are introduced that allow to customize this special reset payload.

- `payload_reset_percentage` (abbreviation `pl_rst_pct`). Defaults to `None`. When this payload is received on the `percentage_state_topic`, the current state or attribute `percentage` (and legacy attribute `speed`, if configured) will be reset to `None`.
- `payload_reset_preset_mode` (abbreviation `pl_rst_pr_mode`). Defaults to `None`. When this special payload is received on `preset_mode_state_topic`, the current state or attribute `preset_mode` will be reset no `None`.

This PR also fixes a new bug found where self.async_write_ha_state() was at async_set_speed() or async_set_preset_mode() called without optimistic mode being enabled.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50435
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/17820
- 
## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
