### PR TITLE
Centralize storage and updating of Sonos favorites

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import OrderedDict
 import datetime
 import logging
 import socket
@@ -66,7 +67,7 @@ class SonosData:
 
     def __init__(self) -> None:
         """Initialize the data."""
-        self.discovered: dict[str, SonosSpeaker] = {}
+        self.discovered: OrderedDict[str, SonosSpeaker] = OrderedDict()
         self.favorites: dict[str, SonosFavorites] = {}
         self.topology_condition = asyncio.Condition()
         self.discovery_thread = None
@@ -129,7 +130,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     speaker = SonosSpeaker(hass, soco, speaker_info)
                     data.discovered[soco.uid] = speaker
                     if soco.household_id not in data.favorites:
-                        data.favorites[soco.household_id] = SonosFavorites(hass, soco)
+                        data.favorites[soco.household_id] = SonosFavorites(
+                            hass, soco.household_id
+                        )
                         data.favorites[soco.household_id].update()
                     speaker.setup()
                 else:

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -67,6 +67,7 @@ class SonosData:
 
     def __init__(self) -> None:
         """Initialize the data."""
+        # OrderedDict behavior used by SonosFavorites
         self.discovered: OrderedDict[str, SonosSpeaker] = OrderedDict()
         self.favorites: dict[str, SonosFavorites] = {}
         self.topology_condition = asyncio.Condition()

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -128,8 +128,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     _LOGGER.debug("Adding new speaker: %s", speaker_info)
                     speaker = SonosSpeaker(hass, soco, speaker_info)
                     data.discovered[soco.uid] = speaker
-                    data.favorites.setdefault(soco.household_id, SonosFavorites(soco))
-                    data.favorites[soco.household_id].update()
+                    if soco.household_id not in data.favorites:
+                        data.favorites[soco.household_id] = SonosFavorites(hass, soco)
+                        data.favorites[soco.household_id].update()
                     speaker.setup()
                 else:
                     dispatcher_send(hass, f"{SONOS_SEEN}-{soco.uid}", soco)

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -136,6 +136,7 @@ SONOS_CREATE_MEDIA_PLAYER = "sonos_create_media_player"
 SONOS_ENTITY_CREATED = "sonos_entity_created"
 SONOS_ENTITY_UPDATE = "sonos_entity_update"
 SONOS_GROUP_UPDATE = "sonos_group_update"
+SONOS_HOUSEHOLD_UPDATED = "sonos_household_updated"
 SONOS_STATE_UPDATED = "sonos_state_updated"
 SONOS_SEEN = "sonos_seen"
 

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -16,6 +16,7 @@ from .const import (
     DOMAIN,
     SONOS_ENTITY_CREATED,
     SONOS_ENTITY_UPDATE,
+    SONOS_HOUSEHOLD_UPDATED,
     SONOS_STATE_UPDATED,
 )
 from .speaker import SonosSpeaker
@@ -45,6 +46,13 @@ class SonosEntity(Entity):
             async_dispatcher_connect(
                 self.hass,
                 f"{SONOS_STATE_UPDATED}-{self.soco.uid}",
+                self.async_write_ha_state,
+            )
+        )
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                f"{SONOS_HOUSEHOLD_UPDATED}-{self.soco.household_id}",
                 self.async_write_ha_state,
             )
         )

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -1,0 +1,59 @@
+"""Class representing Sonos favorites."""
+from __future__ import annotations
+
+from collections.abc import Iterator
+import logging
+
+from pysonos.core import SoCo
+from pysonos.data_structures import DidlFavorite
+from pysonos.events_base import Event as SonosEvent
+from pysonos.exceptions import SoCoException
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SonosFavorites:
+    """Storage class for Sonos favorites."""
+
+    def __init__(self, soco: SoCo) -> None:
+        """Initialize the data."""
+        self.soco = soco
+        self._favorites: list[DidlFavorite] = []
+        self._event_version: str | None = None
+        self._poll_version: int | None = None
+
+    def __iter__(self) -> Iterator:
+        """Return an iterator for the known favorites."""
+        return iter(self._favorites)
+
+    def update(self, event: SonosEvent | None = None) -> None:
+        """Update favorites with an event or by polling."""
+        if event and "favorites_update_id" in event.variables:
+            event_id = event.variables["favorites_update_id"]
+            if self._event_version == event_id:
+                _LOGGER.debug("favorites haven't changed (event_id: %s)", event_id)
+                return
+            self._event_version = event_id
+
+        new_favorites = self.soco.music_library.get_sonos_favorites()
+        if self._poll_version == new_favorites.update_id:
+            _LOGGER.debug(
+                "Favorites haven't changed (poll_id: %s)", new_favorites.update_id
+            )
+            return
+        self._poll_version = new_favorites.update_id
+
+        self._favorites = []
+        for fav in new_favorites:
+            try:
+                # exclude non-playable favorites with no linked resources
+                if fav.reference.resources:
+                    self._favorites.append(fav)
+            except SoCoException as ex:
+                # Skip unknown types
+                _LOGGER.error("Unhandled favorite '%s': %s", fav.title, ex)
+        _LOGGER.debug(
+            "Cached %s favorites for household %s",
+            len(self._favorites),
+            self.soco.household_id,
+        )

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -24,8 +24,8 @@ class SonosFavorites:
 
     def __init__(self, hass: HomeAssistant, soco: SoCo) -> None:
         """Initialize the data."""
-        self.hass = hass
-        self.soco = soco
+        self.hass: HomeAssistant = hass
+        self.soco: SoCo = soco
         self._favorites: list[DidlFavorite] = []
         self._event_version: str | None = None
         self._next_update: Callable | None = None

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -32,7 +32,8 @@ class SonosFavorites:
 
     def __iter__(self) -> Iterator:
         """Return an iterator for the known favorites."""
-        return iter(self._favorites)
+        favorites = self._favorites.copy()
+        return iter(favorites)
 
     async def async_delayed_update(self, event: SonosEvent) -> None:
         """Add a delay when triggered by an event.

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -11,7 +11,7 @@ from pysonos.data_structures import DidlFavorite
 from pysonos.events_base import Event as SonosEvent
 from pysonos.exceptions import SoCoException
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import SONOS_HOUSEHOLD_UPDATED
@@ -35,7 +35,8 @@ class SonosFavorites:
         favorites = self._favorites.copy()
         return iter(favorites)
 
-    async def async_delayed_update(self, event: SonosEvent) -> None:
+    @callback
+    def async_delayed_update(self, event: SonosEvent) -> None:
         """Add a delay when triggered by an event.
 
         Updated favorites are not always immediately available.

--- a/homeassistant/components/sonos/favorites.py
+++ b/homeassistant/components/sonos/favorites.py
@@ -23,8 +23,8 @@ class SonosFavorites:
 
     def __init__(self, hass: HomeAssistant, household_id: str) -> None:
         """Initialize the data."""
-        self.hass: HomeAssistant = hass
-        self.household_id: str = household_id
+        self.hass = hass
+        self.household_id = household_id
         self._favorites: list[DidlFavorite] = []
         self._event_version: str | None = None
         self._next_update: Callable | None = None

--- a/homeassistant/components/sonos/media_player.py
+++ b/homeassistant/components/sonos/media_player.py
@@ -439,7 +439,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
         elif source == SOURCE_TV:
             soco.switch_to_tv()
         else:
-            fav = [fav for fav in self.coordinator.favorites if fav.title == source]
+            fav = [fav for fav in self.speaker.favorites if fav.title == source]
             if len(fav) == 1:
                 src = fav.pop()
                 uri = src.reference.get_uri()
@@ -456,7 +456,7 @@ class SonosMediaPlayerEntity(SonosEntity, MediaPlayerEntity):
     @property  # type: ignore[misc]
     def source_list(self) -> list[str]:
         """List of available input sources."""
-        sources = [fav.title for fav in self.coordinator.favorites]
+        sources = [fav.title for fav in self.speaker.favorites]
 
         model = self.coordinator.model_name.upper()
         if "PLAY:5" in model or "CONNECT" in model:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -661,7 +661,7 @@ class SonosSpeaker:
     def async_update_content(self, event: SonosEvent | None = None) -> None:
         """Update information about available content."""
         if event and "favorites_update_id" in event.variables:
-            self.hass.async_add_job(self.favorites.async_delayed_update, event)
+            self.favorites.async_delayed_update(event)
 
     def update_volume(self) -> None:
         """Update information about current volume settings."""

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -129,7 +129,7 @@ class SonosSpeaker:
         """Initialize a SonosSpeaker."""
         self.hass = hass
         self.soco = soco
-        self.household_id = soco.household_id
+        self.household_id: str = soco.household_id
         self.media = SonosMedia(soco)
 
         self._is_ready: bool = False

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -661,8 +661,7 @@ class SonosSpeaker:
     def async_update_content(self, event: SonosEvent | None = None) -> None:
         """Update information about available content."""
         if event and "favorites_update_id" in event.variables:
-            self.hass.async_add_job(self.favorites.update, event)
-            self.async_write_entity_states()
+            self.hass.async_add_job(self.favorites.async_delayed_update, event)
 
     def update_volume(self) -> None:
         """Update information about current volume settings."""

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -11,7 +11,7 @@ from typing import Any, Callable
 
 import async_timeout
 from pysonos.core import MUSIC_SRC_LINE_IN, MUSIC_SRC_RADIO, MUSIC_SRC_TV, SoCo
-from pysonos.data_structures import DidlAudioBroadcast, DidlFavorite
+from pysonos.data_structures import DidlAudioBroadcast
 from pysonos.events_base import Event as SonosEvent, SubscriptionBase
 from pysonos.exceptions import SoCoException
 from pysonos.music_library import MusicLibrary
@@ -48,6 +48,7 @@ from .const import (
     SOURCE_LINEIN,
     SOURCE_TV,
 )
+from .favorites import SonosFavorites
 from .helpers import soco_error
 
 EVENT_CHARGING = {
@@ -128,6 +129,7 @@ class SonosSpeaker:
         """Initialize a SonosSpeaker."""
         self.hass: HomeAssistant = hass
         self.soco: SoCo = soco
+        self.household_id = soco.household_id
         self.media = SonosMedia(soco)
 
         self._is_ready: bool = False
@@ -159,8 +161,6 @@ class SonosSpeaker:
         self.sonos_group_entities: list[str] = []
         self.soco_snapshot: Snapshot | None = None
         self.snapshot_group: list[SonosSpeaker] | None = None
-
-        self.favorites: list[DidlFavorite] = []
 
     def setup(self) -> None:
         """Run initial setup of the speaker."""
@@ -212,7 +212,6 @@ class SonosSpeaker:
         """Set basic information when speaker is reconnected."""
         self.media.play_mode = self.soco.play_mode
         self.update_volume()
-        self.set_favorites()
 
     @property
     def available(self) -> bool:
@@ -653,23 +652,16 @@ class SonosSpeaker:
         for speaker in hass.data[DATA_SONOS].discovered.values():
             speaker.soco._zgs_cache.clear()  # pylint: disable=protected-access
 
-    def set_favorites(self) -> None:
-        """Set available favorites."""
-        self.favorites = []
-        for fav in self.soco.music_library.get_sonos_favorites():
-            try:
-                # Exclude non-playable favorites with no linked resources
-                if fav.reference.resources:
-                    self.favorites.append(fav)
-            except SoCoException as ex:
-                # Skip unknown types
-                _LOGGER.error("Unhandled favorite '%s': %s", fav.title, ex)
+    @property
+    def favorites(self) -> SonosFavorites:
+        """Return the SonosFavorites instance for this household."""
+        return self.hass.data[DATA_SONOS].favorites[self.household_id]
 
     @callback
     def async_update_content(self, event: SonosEvent | None = None) -> None:
         """Update information about available content."""
         if event and "favorites_update_id" in event.variables:
-            self.hass.async_add_job(self.set_favorites)
+            self.hass.async_add_job(self.favorites.update, event)
             self.async_write_entity_states()
 
     def update_volume(self) -> None:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -127,8 +127,8 @@ class SonosSpeaker:
         self, hass: HomeAssistant, soco: SoCo, speaker_info: dict[str, Any]
     ) -> None:
         """Initialize a SonosSpeaker."""
-        self.hass: HomeAssistant = hass
-        self.soco: SoCo = soco
+        self.hass = hass
+        self.soco = soco
         self.household_id = soco.household_id
         self.media = SonosMedia(soco)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Favorites in Sonos are unique per "household" and do not need to be updated and stored separately for every speaker. They're also tied to update identifiers which we can use to conditionally update our cache when changes actually occur. This should help avoid possible race conditions and eliminate the need for bandaids like in #50495 and #50575.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
