### PR TITLE
Add "close_comm_on_error" to modbus configuration

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_BAUDRATE,
     CONF_BYTESIZE,
     CONF_CLIMATES,
+    CONF_CLOSE_COMM_ON_ERROR,
     CONF_CURRENT_TEMP,
     CONF_CURRENT_TEMP_REGISTER_TYPE,
     CONF_DATA_COUNT,
@@ -281,6 +282,7 @@ MODBUS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_HUB): cv.string,
         vol.Optional(CONF_TIMEOUT, default=3): cv.socket_timeout,
+        vol.Optional(CONF_CLOSE_COMM_ON_ERROR, default=True): cv.boolean,
         vol.Optional(CONF_DELAY, default=0): cv.positive_int,
         vol.Optional(CONF_BINARY_SENSORS): vol.All(
             cv.ensure_list, [BINARY_SENSOR_SCHEMA]

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
 CONF_BAUDRATE = "baudrate"
 CONF_BYTESIZE = "bytesize"
 CONF_CLIMATES = "climates"
+CONF_CLOSE_COMM_ON_ERROR = "close_comm_on_error"
 CONF_COILS = "coils"
 CONF_CURRENT_TEMP = "current_temp_register"
 CONF_CURRENT_TEMP_REGISTER_TYPE = "current_temp_register_type"

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -28,6 +28,7 @@ from .const import (
     ATTR_VALUE,
     CONF_BAUDRATE,
     CONF_BYTESIZE,
+    CONF_CLOSE_COMM_ON_ERROR,
     CONF_PARITY,
     CONF_STOPBITS,
     DEFAULT_HUB,
@@ -125,6 +126,7 @@ class ModbusHub:
         self._config_port = client_config[CONF_PORT]
         self._config_timeout = client_config[CONF_TIMEOUT]
         self._config_delay = client_config[CONF_DELAY]
+        self._config_reset_socket = client_config[CONF_CLOSE_COMM_ON_ERROR]
         Defaults.Timeout = client_config[CONF_TIMEOUT]
         if self._config_type == "serial":
             # serial configuration
@@ -163,6 +165,7 @@ class ModbusHub:
                     parity=self._config_parity,
                     timeout=self._config_timeout,
                     retry_on_empty=True,
+                    reset_socket=self._config_reset_socket,
                 )
             elif self._config_type == "rtuovertcp":
                 self._client = ModbusTcpClient(
@@ -170,18 +173,21 @@ class ModbusHub:
                     port=self._config_port,
                     framer=ModbusRtuFramer,
                     timeout=self._config_timeout,
+                    reset_socket=self._config_reset_socket,
                 )
             elif self._config_type == "tcp":
                 self._client = ModbusTcpClient(
                     host=self._config_host,
                     port=self._config_port,
                     timeout=self._config_timeout,
+                    reset_socket=self._config_reset_socket,
                 )
             elif self._config_type == "udp":
                 self._client = ModbusUdpClient(
                     host=self._config_host,
                     port=self._config_port,
                     timeout=self._config_timeout,
+                    reset_socket=self._config_reset_socket,
                 )
         except ModbusException as exception_error:
             self._log_error(exception_error, error_state=False)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sometimes a serial-rs485 adapter sends garble to the modbus integration, this causes pymodbus to reset the connection. However modbus integration will reconnect and the problem repeats.

Pymodbus v2.5.2 (see #50282) add the possibility to choose whether to reset the connection in case of errors or not.

This PR adds the possibility for the user to choose whether or not to reset the connection 

Added attribute ""close_comm_on_error" to modbus:
```YAML
modbus:
    ...
    close_comm_on_error: true
```
This is default true, but if a debug log shows messages containing "pymodbus .... cleaning" doing
```YAML
modbus:
    ...
    close_comm_on_error: false
```
However the problem might be caused be a slow device, that sends the response after the timeout have been reached, in this case timeout need to be configured:
```YAML
modbus:
    ...
    timeout: 30
```
Finally sometimes the device disconnect  when receiving the first message, this is caused because the device needs time after connect to prepare its communication element. If this is the case please use:
```YAML
modbus:
    ...
    delay: 20
```

These are all measures to solve the current instability problems, however the biggest that Lovelace becomes unresponsive, is still outstanding and a PR is due later this week.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
This should be part of 2021.6

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
related to #50155 
related to #50139 
related to #49159
related to #48894 

- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/17826

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
