### PR TITLE
Yeelight: Do not log errors when cannot connect

### DIFF
--- a/homeassistant/components/yeelight/config_flow.py
+++ b/homeassistant/components/yeelight/config_flow.py
@@ -61,7 +61,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if progress.get("context", {}).get(CONF_HOST) == self._discovered_ip:
                 return self.async_abort(reason="already_in_progress")
 
-        self._discovered_model = await self._async_try_connect(self._discovered_ip)
+        try:
+            self._discovered_model = await self._async_try_connect(self._discovered_ip)
+        except CannotConnect:
+            return self.async_abort(reason="cannot_connect")
+
         if not self.unique_id:
             return self.async_abort(reason="cannot_connect")
 

--- a/tests/components/yeelight/test_config_flow.py
+++ b/tests/components/yeelight/test_config_flow.py
@@ -19,6 +19,7 @@ from homeassistant.components.yeelight import (
     DOMAIN,
     NIGHTLIGHT_SWITCH_TYPE_LIGHT,
 )
+from homeassistant.components.yeelight.config_flow import CannotConnect
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_ID, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
@@ -322,6 +323,15 @@ async def test_discovered_by_homekit_and_dhcp(hass):
         )
     assert result3["type"] == RESULT_TYPE_ABORT
     assert result3["reason"] == "already_in_progress"
+
+    with patch(f"{MODULE_CONFIG_FLOW}.yeelight.Bulb", side_effect=CannotConnect):
+        result3 = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data={"ip": "1.2.3.5", "macaddress": "00:00:00:00:00:01"},
+        )
+    assert result3["type"] == RESULT_TYPE_ABORT
+    assert result3["reason"] == "cannot_connect"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
My Xiaomi desk lamp has a host of `yeelink-light-lamp4_miio106`. This triggered the Yeelink DHCP detection but it can't connect. This case wasn't handled and was causing uncaught exceptions. This PR catches the exception and handle it properly.

```
2021-05-13 12:35:25 ERROR (MainThread) [homeassistant] Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/venv/lib/python3.8/site-packages/yeelight/main.py", line 694, in send_command
    self._socket.send((json.dumps(command) + "\r\n").encode("utf8"))
  File "/Users/paulus/dev/hass/core/venv/lib/python3.8/site-packages/yeelight/main.py", line 420, in _socket
    self.__socket.connect((self._ip, self._port))
ConnectionRefusedError: [Errno 61] Connection refused

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/components/yeelight/config_flow.py", line 193, in _async_try_connect
    await self.hass.async_add_executor_job(bulb.get_properties)
  File "/Applications/Xcode.app/Contents/Developer/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/concurrent/futures/thread.py", line 57, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.8/site-packages/yeelight/main.py", line 655, in get_properties
    response = self.send_command("get_prop", requested_properties)
  File "/Users/paulus/dev/hass/core/venv/lib/python3.8/site-packages/yeelight/main.py", line 703, in send_command
    raise_from(
  File "/Users/paulus/dev/hass/core/venv/lib/python3.8/site-packages/future/utils/__init__.py", line 403, in raise_from
    exec(execstr, myglobals, mylocals)
  File "<string>", line 1, in <module>
yeelight.main.BulbException: A socket error occurred when sending the command.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 151, in async_init
    flow, result = await task
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 177, in _async_init
    result = await self._async_handle_step(flow, flow.init_step, data, init_done)
  File "/Users/paulus/dev/hass/core/homeassistant/data_entry_flow.py", line 258, in _async_handle_step
    result: FlowResult = await getattr(flow, method)(user_input)
  File "/Users/paulus/dev/hass/core/homeassistant/components/yeelight/config_flow.py", line 55, in async_step_dhcp
    return await self._async_handle_discovery()
  File "/Users/paulus/dev/hass/core/homeassistant/components/yeelight/config_flow.py", line 64, in _async_handle_discovery
    self._discovered_model = await self._async_try_connect(self._discovered_ip)
  File "/Users/paulus/dev/hass/core/homeassistant/components/yeelight/config_flow.py", line 196, in _async_try_connect
    raise CannotConnect from err
homeassistant.components.yeelight.config_flow.CannotConnect
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
