### PR TITLE
Fix IQVIA failing to start if any API call fails

### DIFF
--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -56,7 +56,7 @@ async def async_setup_entry(hass, entry):
         try:
             return await api_coro()
         except IQVIAError as err:
-            raise UpdateFailed(err)
+            raise UpdateFailed from err
 
     init_data_update_tasks = []
     for sensor_type, api_coro in [

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -9,6 +9,7 @@ from pyiqvia.errors import IQVIAError
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import ATTR_ATTRIBUTION
 from homeassistant.core import callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
@@ -55,7 +56,7 @@ async def async_setup_entry(hass, entry):
         try:
             return await api_coro()
         except IQVIAError as err:
-            raise UpdateFailed from err
+            raise UpdateFailed(err)
 
     init_data_update_tasks = []
     for sensor_type, api_coro in [
@@ -74,9 +75,11 @@ async def async_setup_entry(hass, entry):
             update_interval=DEFAULT_SCAN_INTERVAL,
             update_method=partial(async_get_data_from_api, api_coro),
         )
-        init_data_update_tasks.append(coordinator.async_config_entry_first_refresh())
+        init_data_update_tasks.append(coordinator.async_refresh())
 
-    await asyncio.gather(*init_data_update_tasks)
+    results = await asyncio.gather(*init_data_update_tasks, return_exceptions=True)
+    if all(isinstance(result, Exception) for result in results):
+        raise ConfigEntryNotReady()
 
     hass.data[DOMAIN].setdefault(DATA_COORDINATOR, {})[entry.entry_id] = coordinators
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/iqvia/__init__.py
+++ b/homeassistant/components/iqvia/__init__.py
@@ -79,6 +79,9 @@ async def async_setup_entry(hass, entry):
 
     results = await asyncio.gather(*init_data_update_tasks, return_exceptions=True)
     if all(isinstance(result, Exception) for result in results):
+        # The IQVIA API can be selectively flaky, meaning that any number of the setup
+        # API calls could fail. We only retry integration setup if *all* of the initial
+        # API calls fail:
         raise ConfigEntryNotReady()
 
     hass.data[DOMAIN].setdefault(DATA_COORDINATOR, {})[entry.entry_id] = coordinators

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -104,6 +104,9 @@ class ForecastSensor(IQVIAEntity):
     @callback
     def update_from_latest_data(self):
         """Update the sensor."""
+        if not self.coordinator.data:
+            return
+
         data = self.coordinator.data.get("Location")
 
         if not data or not data.get("periods"):

--- a/homeassistant/components/iqvia/sensor.py
+++ b/homeassistant/components/iqvia/sensor.py
@@ -107,9 +107,9 @@ class ForecastSensor(IQVIAEntity):
         if not self.coordinator.data:
             return
 
-        data = self.coordinator.data.get("Location")
+        data = self.coordinator.data.get("Location", {})
 
-        if not data or not data.get("periods"):
+        if not data.get("periods"):
             return
 
         indices = [p["Index"] for p in data["periods"]]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Following up on https://github.com/home-assistant/core/pull/49931. If _any_ of the IQVIA setup API calls fail, HASS will abort and retry with an ever-increasing back-off; because of the flakiness of the IQVIA API (in which, say, 2 of 8 API calls may fail at any given moment), this logic may cause the integration to never load.

This PR alters the approach: setup now only enters the retry-with-increasing-back-off cycle if _all_ of the initial API calls fail. If any number succeed, we move forward and merely mark entities belonging to failed API calls as `unavailable`.

Additionally, this PR makes errors related to failed API calls clearer in the logs:

![CleanShot 2021-05-14 at 08 05 18](https://user-images.githubusercontent.com/47216/118283903-17588e00-b48d-11eb-98de-9d2a216646e3.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/50166
- This PR is related to issue: #49905
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
