### PR TITLE
Set zwave_js cover device_class for shutters and blinds

### DIFF
--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -77,6 +77,15 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     """Representation of a Z-Wave Cover device."""
 
     @property
+    def device_class(self) -> str | None:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        if self.info.platform_hint == "window_shutter":
+            return DEVICE_CLASS_SHUTTER
+        if self.info.platform_hint == "window_blind":
+            return DEVICE_CLASS_BLIND
+        return DEVICE_CLASS_WINDOW
+
+    @property
     def is_closed(self) -> bool | None:
         """Return true if cover is closed."""
         if self.info.primary_value.value is None:

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -9,7 +9,10 @@ from zwave_js_server.model.value import Value as ZwaveValue
 
 from homeassistant.components.cover import (
     ATTR_POSITION,
+    DEVICE_CLASS_BLIND,
     DEVICE_CLASS_GARAGE,
+    DEVICE_CLASS_SHUTTER,
+    DEVICE_CLASS_WINDOW,
     DOMAIN as COVER_DOMAIN,
     SUPPORT_CLOSE,
     SUPPORT_OPEN,

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -220,6 +220,7 @@ DISCOVERY_SCHEMAS = [
     # Fibaro Shutter Fibaro FGS222
     ZWaveDiscoverySchema(
         platform="cover",
+        hint="window_shutter",
         manufacturer_id={0x010F},
         product_id={0x1000},
         product_type={0x0302},
@@ -228,6 +229,7 @@ DISCOVERY_SCHEMAS = [
     # Qubino flush shutter
     ZWaveDiscoverySchema(
         platform="cover",
+        hint="window_shutter",
         manufacturer_id={0x0159},
         product_id={0x0052},
         product_type={0x0003},
@@ -236,6 +238,7 @@ DISCOVERY_SCHEMAS = [
     # Graber/Bali/Spring Fashion Covers
     ZWaveDiscoverySchema(
         platform="cover",
+        hint="window_blind",
         manufacturer_id={0x026E},
         product_id={0x5A31},
         product_type={0x4353},
@@ -244,6 +247,7 @@ DISCOVERY_SCHEMAS = [
     # iBlinds v2 window blind motor
     ZWaveDiscoverySchema(
         platform="cover",
+        hint="window_blind",
         manufacturer_id={0x0287},
         product_id={0x000D},
         product_type={0x0003},

--- a/homeassistant/components/zwave_js/discovery.py
+++ b/homeassistant/components/zwave_js/discovery.py
@@ -231,7 +231,7 @@ DISCOVERY_SCHEMAS = [
         platform="cover",
         hint="window_shutter",
         manufacturer_id={0x0159},
-        product_id={0x0052},
+        product_id={0x0052, 0x0053},
         product_type={0x0003},
         primary_value=SWITCH_MULTILEVEL_CURRENT_VALUE_SCHEMA,
     ),

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -282,6 +282,12 @@ def iblinds_v2_state_fixture():
     return json.loads(load_fixture("zwave_js/cover_iblinds_v2_state.json"))
 
 
+@pytest.fixture(name="qubino_shutter_state", scope="session")
+def qubino_shutter_state_fixture():
+    """Load the Qubino Shutter node state fixture data."""
+    return json.loads(load_fixture("zwave_js/cover_qubino_shutter_state.json"))
+
+
 @pytest.fixture(name="aeon_smart_switch_6_state", scope="session")
 def aeon_smart_switch_6_state_fixture():
     """Load the AEON Labs (ZW096) Smart Switch 6 node state fixture data."""
@@ -599,6 +605,14 @@ def motorized_barrier_cover_fixture(client, gdc_zw062_state):
 def iblinds_cover_fixture(client, iblinds_v2_state):
     """Mock an iBlinds v2.0 window cover node."""
     node = Node(client, copy.deepcopy(iblinds_v2_state))
+    client.driver.controller.nodes[node.node_id] = node
+    return node
+
+
+@pytest.fixture(name="qubino_shutter")
+def qubino_shutter_cover_fixture(client, qubino_shutter_state):
+    """Mock a Qubino flush shutter node."""
+    node = Node(client, copy.deepcopy(qubino_shutter_state))
     client.driver.controller.nodes[node.node_id] = node
     return node
 

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -308,7 +308,6 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
 
 async def test_blind_cover(hass, client, iblinds_v2, integration):
     """Test a blind cover entity."""
-    node = iblinds_v2
     state = hass.states.get(BLIND_COVER_ENTITY)
 
     assert state
@@ -317,7 +316,6 @@ async def test_blind_cover(hass, client, iblinds_v2, integration):
 
 async def test_shutter_cover(hass, client, qubino_shutter, integration):
     """Test a shutter cover entity."""
-    node = qubino_shutter
     state = hass.states.get(SHUTTER_COVER_ENTITY)
 
     assert state

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -306,8 +306,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     assert state.state == "closed"
 
 
-async def test_shutter_cover(hass, client, iblinds_v2, integration):
-    """Test the cover entity."""
+async def test_blind_cover(hass, client, iblinds_v2, integration):
+    """Test a blind cover entity."""
     node = iblinds_v2
     state = hass.states.get(BLIND_COVER_ENTITY)
 
@@ -316,7 +316,7 @@ async def test_shutter_cover(hass, client, iblinds_v2, integration):
 
 
 async def test_shutter_cover(hass, client, qubino_shutter, integration):
-    """Test the cover entity."""
+    """Test a shutter cover entity."""
     node = qubino_shutter
     state = hass.states.get(SHUTTER_COVER_ENTITY)
 

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -3,7 +3,10 @@ from zwave_js_server.event import Event
 
 from homeassistant.components.cover import (
     ATTR_CURRENT_POSITION,
+    DEVICE_CLASS_BLIND,
     DEVICE_CLASS_GARAGE,
+    DEVICE_CLASS_SHUTTER,
+    DEVICE_CLASS_WINDOW,
     DOMAIN,
     SERVICE_CLOSE_COVER,
     SERVICE_OPEN_COVER,
@@ -19,6 +22,8 @@ from homeassistant.const import (
 
 WINDOW_COVER_ENTITY = "cover.zws_12"
 GDC_COVER_ENTITY = "cover.aeon_labs_garage_door_controller_gen5"
+BLIND_COVER_ENTITY = "cover.window_blind_controller"
+SHUTTER_COVER_ENTITY = "cover.window_shutter"
 
 
 async def test_window_cover(hass, client, chain_actuator_zws12, integration):
@@ -27,6 +32,8 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
     state = hass.states.get(WINDOW_COVER_ENTITY)
 
     assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_WINDOW
+
     assert state.state == "closed"
     assert state.attributes[ATTR_CURRENT_POSITION] == 0
 
@@ -297,6 +304,24 @@ async def test_window_cover(hass, client, chain_actuator_zws12, integration):
 
     state = hass.states.get(WINDOW_COVER_ENTITY)
     assert state.state == "closed"
+
+
+async def test_shutter_cover(hass, client, iblinds_v2, integration):
+    """Test the cover entity."""
+    node = iblinds_v2
+    state = hass.states.get(BLIND_COVER_ENTITY)
+
+    assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_BLIND
+
+
+async def test_shutter_cover(hass, client, qubino_shutter, integration):
+    """Test the cover entity."""
+    node = qubino_shutter
+    state = hass.states.get(SHUTTER_COVER_ENTITY)
+
+    assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == DEVICE_CLASS_SHUTTER
 
 
 async def test_motor_barrier_cover(hass, client, gdc_zw062, integration):

--- a/tests/components/zwave_js/test_cover.py
+++ b/tests/components/zwave_js/test_cover.py
@@ -23,7 +23,7 @@ from homeassistant.const import (
 WINDOW_COVER_ENTITY = "cover.zws_12"
 GDC_COVER_ENTITY = "cover.aeon_labs_garage_door_controller_gen5"
 BLIND_COVER_ENTITY = "cover.window_blind_controller"
-SHUTTER_COVER_ENTITY = "cover.window_shutter"
+SHUTTER_COVER_ENTITY = "cover.flush_shutter_dc"
 
 
 async def test_window_cover(hass, client, chain_actuator_zws12, integration):

--- a/tests/fixtures/zwave_js/cover_qubino_shutter_state.json
+++ b/tests/fixtures/zwave_js/cover_qubino_shutter_state.json
@@ -1,0 +1,765 @@
+{
+  "nodeId": 5,
+  "index": 0,
+  "installerIcon": 6656,
+  "userIcon": 6656,
+  "status": 4,
+  "ready": true,
+  "deviceClass": {
+    "basic": { "key": 4, "label": "Routing Slave" },
+    "generic": { "key": 17, "label": "Routing Slave" },
+    "specific": { "key": 7, "label": "Routing Slave" },
+    "mandatorySupportedCCs": [],
+    "mandatoryControlCCs": []
+  },
+  "isListening": true,
+  "isFrequentListening": false,
+  "isRouting": true,
+  "maxBaudRate": 40000,
+  "isSecure": false,
+  "version": 4,
+  "isBeaming": true,
+  "manufacturerId": 345,
+  "productId": 83,
+  "productType": 3,
+  "firmwareVersion": "7.2",
+  "zwavePlusVersion": 1,
+  "nodeType": 0,
+  "roleType": 5,
+  "deviceConfig": {
+    "manufacturerId": 345,
+    "manufacturer": "Qubino",
+    "label": "ZMNHOD",
+    "description": "Flush Shutter DC",
+    "devices": [{ "productType": "0x0003", "productId": "0x0053" }],
+    "firmwareVersion": { "min": "0.0", "max": "255.255" },
+    "paramInformation": { "_map": {} }
+  },
+  "label": "ZMNHOD",
+  "neighbors": [1, 2],
+  "interviewAttempts": 1,
+  "endpoints": [
+    { "nodeId": 5, "index": 0, "installerIcon": 6656, "userIcon": 6656 }
+  ],
+  "commandClasses": [],
+  "values": [
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "min": 0,
+        "max": 99,
+        "label": "Target value"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "duration",
+      "propertyName": "duration",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "duration",
+        "readable": true,
+        "writeable": true,
+        "label": "Transition duration"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 99,
+        "label": "Current value"
+      },
+      "value": "unknown"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "Up",
+      "propertyName": "Up",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Perform a level change (Up)",
+        "ccSpecific": { "switchType": 2 }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 38,
+      "commandClassName": "Multilevel Switch",
+      "property": "Down",
+      "propertyName": "Down",
+      "ccVersion": 3,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Perform a level change (Down)",
+        "ccSpecific": { "switchType": 2 }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "currentValue",
+      "propertyName": "currentValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": false,
+        "label": "Current value"
+      },
+      "value": "unknown"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 37,
+      "commandClassName": "Binary Switch",
+      "property": "targetValue",
+      "propertyName": "targetValue",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "boolean",
+        "readable": true,
+        "writeable": true,
+        "label": "Target value"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "manufacturerId",
+      "propertyName": "manufacturerId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Manufacturer ID"
+      },
+      "value": 345
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productType",
+      "propertyName": "productType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Product type"
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 114,
+      "commandClassName": "Manufacturer Specific",
+      "property": "productId",
+      "propertyName": "productId",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 65535,
+        "label": "Product ID"
+      },
+      "value": 83
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "libraryType",
+      "propertyName": "libraryType",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Library type"
+      },
+      "value": 3
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "protocolVersion",
+      "propertyName": "protocolVersion",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave protocol version"
+      },
+      "value": "4.38"
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "firmwareVersions",
+      "propertyName": "firmwareVersions",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip firmware versions"
+      },
+      "value": ["7.2"]
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 134,
+      "commandClassName": "Version",
+      "property": "hardwareVersion",
+      "propertyName": "hardwareVersion",
+      "ccVersion": 2,
+      "metadata": {
+        "type": "any",
+        "readable": true,
+        "writeable": false,
+        "label": "Z-Wave chip hardware version"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "value",
+      "propertyKey": 65537,
+      "propertyName": "value",
+      "propertyKeyName": "Electric_kWh_Consumed",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Electric Consumed [kWh]",
+        "unit": "kWh",
+        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "deltaTime",
+      "propertyKey": 65537,
+      "propertyName": "deltaTime",
+      "propertyKeyName": "Electric_kWh_Consumed",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Electric Consumed [kWh] (prev. time delta)",
+        "unit": "s",
+        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "value",
+      "propertyKey": 66049,
+      "propertyName": "value",
+      "propertyKeyName": "Electric_W_Consumed",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Electric Consumed [W]",
+        "unit": "W",
+        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "deltaTime",
+      "propertyKey": 66049,
+      "propertyName": "deltaTime",
+      "propertyKeyName": "Electric_W_Consumed",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Electric Consumed [W] (prev. time delta)",
+        "unit": "s",
+        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "reset",
+      "propertyName": "reset",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "boolean",
+        "readable": false,
+        "writeable": true,
+        "label": "Reset accumulated values"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "previousValue",
+      "propertyKey": 65537,
+      "propertyName": "previousValue",
+      "propertyKeyName": "Electric_kWh_Consumed",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Electric Consumed [kWh] (prev. value)",
+        "unit": "kWh",
+        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 0 }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 50,
+      "commandClassName": "Meter",
+      "property": "previousValue",
+      "propertyKey": 66049,
+      "propertyName": "previousValue",
+      "propertyKeyName": "Electric_W_Consumed",
+      "ccVersion": 4,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "label": "Electric Consumed [W] (prev. value)",
+        "unit": "W",
+        "ccSpecific": { "meterType": 1, "rateType": 1, "scale": 2 }
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "alarmType",
+      "propertyName": "alarmType",
+      "ccVersion": 5,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 255,
+        "label": "Alarm Type"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "alarmLevel",
+      "propertyName": "alarmLevel",
+      "ccVersion": 5,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 255,
+        "label": "Alarm Level"
+      }
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 113,
+      "commandClassName": "Notification",
+      "property": "Power Management",
+      "propertyKey": "Over-load status",
+      "propertyName": "Power Management",
+      "propertyKeyName": "Over-load status",
+      "ccVersion": 5,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": false,
+        "min": 0,
+        "max": 255,
+        "label": "Over-load status",
+        "states": { "0": "idle", "8": "Over-load detected" },
+        "ccSpecific": { "notificationType": 8 }
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 10,
+      "propertyName": "Activate/deactivate functions ALL ON / ALL OFF",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 2,
+        "min": 0,
+        "max": 65535,
+        "default": 255,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": {
+          "0": "ALL ON is not active, ALL OFF is not active",
+          "1": "ALL ON is not active ALL OFF active",
+          "2": "ALL ON is not active ALL OFF is not active",
+          "255": "ALL ON active, ALL OFF active"
+        },
+        "label": "Activate/deactivate functions ALL ON / ALL OFF",
+        "isFromConfig": true
+      },
+      "value": 255
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 40,
+      "propertyName": "Power report (Watts) on power change for Q1 or Q2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 100,
+        "default": 1,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Power report (Watts) on power change for Q1 or Q2",
+        "isFromConfig": true
+      },
+      "value": 10
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 42,
+      "propertyName": "Power report (Watts) by time interval for Q1 or Q2",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 2,
+        "min": 0,
+        "max": 32767,
+        "default": 300,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Power report (Watts) by time interval for Q1 or Q2",
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 71,
+      "propertyName": "Operating modes",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 255,
+        "default": 0,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Shutter mode.",
+          "1": "Venetian mode (up/down and slate rotation)"
+        },
+        "label": "Operating modes",
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 72,
+      "propertyName": "Slats tilting full turn time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 2,
+        "min": 0,
+        "max": 32767,
+        "default": 150,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Slats tilting full turn time",
+        "isFromConfig": true
+      },
+      "value": 630
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 73,
+      "propertyName": "Slats position",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 255,
+        "default": 1,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": {
+          "0": "Return to previous position only with Z-wave",
+          "1": "Return to previous position with Z-wave or button"
+        },
+        "label": "Slats position",
+        "isFromConfig": true
+      },
+      "value": 1
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 74,
+      "propertyName": "Motor moving up/down time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 2,
+        "min": 0,
+        "max": 32767,
+        "default": 0,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Motor moving up/down time",
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 76,
+      "propertyName": "Motor operation detection",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 100,
+        "default": 6,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Motor operation detection",
+        "isFromConfig": true
+      },
+      "value": 10
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 78,
+      "propertyName": "Forced Shutter DC calibration",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 255,
+        "default": 0,
+        "format": 1,
+        "allowManualEntry": false,
+        "states": { "0": "Default", "1": "Start calibration process." },
+        "label": "Forced Shutter DC calibration",
+        "isFromConfig": true
+      },
+      "value": 0
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 85,
+      "propertyName": "Power consumption max delay time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 3,
+        "max": 50,
+        "default": 8,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Power consumption max delay time",
+        "isFromConfig": true
+      },
+      "value": 8
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 86,
+      "propertyName": "Power consumption at limit switch delay time",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 3,
+        "max": 50,
+        "default": 8,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Power consumption at limit switch delay time",
+        "isFromConfig": true
+      },
+      "value": 8
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 90,
+      "propertyName": "Time delay for next motor movement",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 1,
+        "max": 30,
+        "default": 5,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Time delay for next motor movement",
+        "isFromConfig": true
+      },
+      "value": 5
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 110,
+      "propertyName": "Temperature sensor offset settings",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 2,
+        "min": 1,
+        "max": 32536,
+        "default": 32536,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Temperature sensor offset settings",
+        "isFromConfig": true
+      },
+      "value": 32536
+    },
+    {
+      "endpoint": 0,
+      "commandClass": 112,
+      "commandClassName": "Configuration",
+      "property": 120,
+      "propertyName": "Digital temperature sensor reporting",
+      "ccVersion": 1,
+      "metadata": {
+        "type": "number",
+        "readable": true,
+        "writeable": true,
+        "valueSize": 1,
+        "min": 0,
+        "max": 127,
+        "default": 5,
+        "format": 0,
+        "allowManualEntry": true,
+        "label": "Digital temperature sensor reporting",
+        "isFromConfig": true
+      },
+      "value": 5
+    }
+  ]
+}


### PR DESCRIPTION
## Proposed change
Sets the device_class for known flush shutters and blinds. This is. required for proper treatment in HA and in Google Assistant. Currently the treatment is different. for Shelly connected shutters and Qubino/Fibaro ones.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
