### PR TITLE
Add Crownstone integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -171,6 +171,13 @@ omit =
     homeassistant/components/coolmaster/const.py
     homeassistant/components/cppm_tracker/device_tracker.py
     homeassistant/components/cpuspeed/sensor.py
+    homeassistant/components/crownstone/__init__.py
+    homeassistant/components/crownstone/const.py
+    homeassistant/components/crownstone/listeners.py
+    homeassistant/components/crownstone/helpers.py
+    homeassistant/components/crownstone/devices.py
+    homeassistant/components/crownstone/entry_manager.py
+    homeassistant/components/crownstone/light.py
     homeassistant/components/cups/sensor.py
     homeassistant/components/currencylayer/sensor.py
     homeassistant/components/daikin/*

--- a/.strict-typing
+++ b/.strict-typing
@@ -27,6 +27,7 @@ homeassistant.components.calendar.*
 homeassistant.components.camera.*
 homeassistant.components.canary.*
 homeassistant.components.cover.*
+homeassistant.components.crownstone.*
 homeassistant.components.device_automation.*
 homeassistant.components.device_tracker.*
 homeassistant.components.devolo_home_control.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -104,6 +104,7 @@ homeassistant/components/coronavirus/* @home-assistant/core
 homeassistant/components/counter/* @fabaff
 homeassistant/components/cover/* @home-assistant/core
 homeassistant/components/cpuspeed/* @fabaff
+homeassistant/components/crownstone/* @Crownstone @RicArch97
 homeassistant/components/cups/* @fabaff
 homeassistant/components/daikin/* @fredrike
 homeassistant/components/darksky/* @fabaff

--- a/homeassistant/components/crownstone/__init__.py
+++ b/homeassistant/components/crownstone/__init__.py
@@ -15,9 +15,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not await manager.async_setup():
         return False
 
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = manager
-
     return True
 
 

--- a/homeassistant/components/crownstone/__init__.py
+++ b/homeassistant/components/crownstone/__init__.py
@@ -1,0 +1,27 @@
+"""Integration for Crownstone."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+from .entry_manager import CrownstoneEntryManager
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Initiate setup for a Crownstone config entry."""
+    manager = CrownstoneEntryManager(hass, entry)
+
+    if not await manager.async_setup():
+        return False
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry.entry_id] = manager
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    manager: CrownstoneEntryManager = hass.data[DOMAIN].pop(entry.entry_id)
+    return await manager.async_unload()

--- a/homeassistant/components/crownstone/__init__.py
+++ b/homeassistant/components/crownstone/__init__.py
@@ -23,5 +23,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    manager: CrownstoneEntryManager = hass.data[DOMAIN].pop(entry.entry_id)
-    return await manager.async_unload()
+    unload_ok: bool = await hass.data[DOMAIN][entry.entry_id].async_unload()
+    if len(hass.data[DOMAIN]) == 0:
+        hass.data.pop(DOMAIN)
+    return unload_ok

--- a/homeassistant/components/crownstone/__init__.py
+++ b/homeassistant/components/crownstone/__init__.py
@@ -12,10 +12,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Initiate setup for a Crownstone config entry."""
     manager = CrownstoneEntryManager(hass, entry)
 
-    if not await manager.async_setup():
-        return False
-
-    return True
+    return await manager.async_setup()
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -52,7 +52,7 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     def __init__(self) -> None:
         """Initialize the flow."""
         self.cloud = cast(CrownstoneCloud, None)
-        self.login_info = cast(dict[str, Any], None)
+        self.login_info = cast("dict[str, Any]", None)
         self.usb_path: str | None = None
         self.existing_entry_id: str | None = None
 

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -151,16 +151,21 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Select a Crownstone sphere that the USB operates in."""
         spheres = {sphere.name: sphere.cloud_id for sphere in self.cloud.cloud_data}
         # no need to select if there's only 1 option
+        sphere_id: str | None = None
         if len(spheres) == 1:
-            user_input = {CONF_USB_SPHERE: next(iter(spheres.keys()))}
+            sphere_id = next(iter(spheres.values()))
 
-        if user_input is None:
+        if user_input is None and sphere_id is None:
             return self.async_show_form(
                 step_id="usb_sphere_config",
                 data_schema=vol.Schema({CONF_USB_SPHERE: vol.In(spheres.keys())}),
             )
 
-        self.usb_sphere_id = spheres[user_input[CONF_USB_SPHERE]]
+        if sphere_id:
+            self.usb_sphere_id = sphere_id
+        elif user_input:
+            self.usb_sphere_id = spheres[user_input[CONF_USB_SPHERE]]
+
         return self.async_create_new_entry()
 
     def async_create_new_entry(self) -> FlowResult:
@@ -280,17 +285,21 @@ class CrownstoneOptionsFlowHandler(OptionsFlow):
     ) -> FlowResult:
         """Select a Crownstone sphere that the USB operates in."""
         # no need to select if there's only 1 option
+        sphere_id: str | None = None
         if len(self.spheres) == 1:
-            user_input = {CONF_USB_SPHERE: next(iter(self.spheres.keys()))}
+            sphere_id = next(iter(self.spheres.values()))
 
-        if user_input is None:
+        if user_input is None and sphere_id is None:
             return self.async_show_form(
                 step_id="usb_sphere_config_option",
                 data_schema=vol.Schema({CONF_USB_SPHERE: vol.In(self.spheres.keys())}),
             )
 
-        self.updated_entry_data[CONF_USB_SPHERE] = self.spheres[
-            user_input[CONF_USB_SPHERE]
-        ]
+        if sphere_id:
+            self.updated_entry_data[CONF_USB_SPHERE] = sphere_id
+        elif user_input:
+            self.updated_entry_data[CONF_USB_SPHERE] = self.spheres[
+                user_input[CONF_USB_SPHERE]
+            ]
         self.entry.data = MappingProxyType(self.updated_entry_data)
         return self.async_create_entry(title="", data=self.options_input)

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -12,6 +12,7 @@ import serial.tools.list_ports
 from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 
+from homeassistant.components import usb
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_UNIQUE_ID
 from homeassistant.core import callback
@@ -27,7 +28,6 @@ from .const import (
     MANUAL_PATH,
     REFRESH_LIST,
 )
-from .helpers import get_serial_by_id
 
 
 class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -137,7 +137,7 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                         (ports_as_string.index(selection) - 1)
                     ]
                     self.usb_path = await self.hass.async_add_executor_job(
-                        get_serial_by_id, selected_port.device
+                        usb.get_serial_by_id, selected_port.device
                     )
 
                     # check if we are updating an existing entry

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -1,7 +1,7 @@
 """Flow handler for Crownstone."""
 from __future__ import annotations
 
-from typing import Any, cast
+from typing import Any, Final, cast
 
 from crownstone_cloud import CrownstoneCloud
 from crownstone_cloud.exceptions import (
@@ -27,7 +27,7 @@ from .const import CONF_USB, CONF_USB_PATH, CONF_USE_CROWNSTONE_USB
 from .const import DOMAIN  # pylint: disable=unused-import
 from .helpers import get_serial_by_id
 
-REFRESH_LIST = "Refresh list"
+REFRESH_LIST: Final = "Refresh list"
 
 
 class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -13,7 +13,7 @@ from serial.tools.list_ports_common import ListPortInfo
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
-from homeassistant.const import CONF_EMAIL, CONF_ID, CONF_PASSWORD, CONF_UNIQUE_ID
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_UNIQUE_ID
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import aiohttp_client
@@ -195,7 +195,6 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(
             title=f"Account: {self.unique_id}",
             data={
-                CONF_ID: self.unique_id,
                 CONF_EMAIL: self.login_info[CONF_EMAIL],
                 CONF_PASSWORD: self.login_info[CONF_PASSWORD],
                 CONF_USB_PATH: self.usb_path,

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -1,0 +1,213 @@
+"""Flow handler for Crownstone."""
+from __future__ import annotations
+
+from typing import Any, cast
+
+from crownstone_cloud import CrownstoneCloud
+from crownstone_cloud.exceptions import (
+    CrownstoneAuthenticationError,
+    CrownstoneUnknownError,
+)
+import serial.tools.list_ports
+from serial.tools.list_ports_common import ListPortInfo
+import voluptuous as vol
+
+from homeassistant.config_entries import (
+    CONN_CLASS_CLOUD_POLL,
+    ConfigEntry,
+    ConfigFlow,
+    OptionsFlow,
+)
+from homeassistant.const import CONF_EMAIL, CONF_ID, CONF_PASSWORD, CONF_UNIQUE_ID
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import aiohttp_client
+
+from .const import CONF_USB, CONF_USB_PATH, CONF_USE_CROWNSTONE_USB
+from .const import DOMAIN  # pylint: disable=unused-import
+from .helpers import get_serial_by_id
+
+REFRESH_LIST = "Refresh list"
+
+
+class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Crownstone."""
+
+    VERSION = 1
+    CONNECTION_CLASS = CONN_CLASS_CLOUD_POLL
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,
+    ) -> CrownstoneOptionsFlowHandler:
+        """Return the Crownstone options."""
+        return CrownstoneOptionsFlowHandler(config_entry)
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        self.cloud = cast(CrownstoneCloud, None)
+        self.login_info = cast(dict[str, Any], None)
+        self.usb_path: str | None = None
+        self.existing_entry_id: str | None = None
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+                ),
+            )
+
+        self.cloud = CrownstoneCloud(
+            email=user_input[CONF_EMAIL],
+            password=user_input[CONF_PASSWORD],
+            clientsession=aiohttp_client.async_get_clientsession(self.hass),
+        )
+
+        try:
+            # get all cloud data for this account
+            await self.cloud.async_initialize()
+
+            # set unique id and abort if already configured
+            await self.async_set_unique_id(user_input[CONF_EMAIL])
+            self._abort_if_unique_id_configured()
+
+            # start next flow
+            self.login_info = user_input
+            return await self.async_step_usb()
+        except CrownstoneAuthenticationError as auth_error:
+            if auth_error.type == "LOGIN_FAILED":
+                errors["base"] = "invalid_auth"
+            if auth_error.type == "LOGIN_FAILED_EMAIL_NOT_VERIFIED":
+                errors["base"] = "account_not_verified"
+        except CrownstoneUnknownError:
+            errors["base"] = "unknown_error"
+
+        # show form again, with the error
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_EMAIL): str, vol.Required(CONF_PASSWORD): str}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_usb(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Select whether a Crownstone USB should be used."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="usb",
+                data_schema=vol.Schema({vol.Optional(CONF_USB, default=False): bool}),
+            )
+
+        if user_input[CONF_USB]:
+            return await self.async_step_usb_config()
+
+        return self.async_return_entry()
+
+    async def async_step_usb_config(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Set up a Crownstone USB Dongle."""
+        # save outside of function in case of refresh
+        list_of_ports = await self.hass.async_add_executor_job(
+            serial.tools.list_ports.comports
+        )
+        ports_as_string = [
+            f"{p}" + f" - {p.manufacturer}" if p.manufacturer else ""
+            for p in list_of_ports
+        ]
+        ports_as_string.append(REFRESH_LIST)
+
+        if user_input is not None:
+            if user_input.get(CONF_UNIQUE_ID) is not None:
+                # provided unique id from entry that needs to be updated
+                self.existing_entry_id = user_input.get(CONF_UNIQUE_ID)
+
+            if user_input.get(CONF_USB_PATH) is not None:
+                selection = user_input[CONF_USB_PATH]
+                # user can refresh the list while in this step
+                if selection != REFRESH_LIST:
+                    # get serial-id info
+                    port: ListPortInfo = list_of_ports[ports_as_string.index(selection)]
+                    self.usb_path = await self.hass.async_add_executor_job(
+                        get_serial_by_id, port.device
+                    )
+
+                    # check if we are updating an existing entry
+                    if self.existing_entry_id is not None:
+                        existing_entry = self.hass.config_entries.async_get_entry(
+                            self.existing_entry_id
+                        )
+                        if existing_entry is not None:
+                            # copy instead of directly changing memory
+                            data = existing_entry.data.copy()
+                            data[CONF_USB_PATH] = self.usb_path
+                            # update entry & reload
+                            self.hass.config_entries.async_update_entry(
+                                existing_entry, data=data
+                            )
+                            await self.hass.config_entries.async_reload(
+                                existing_entry.entry_id
+                            )
+                            # this exits the flow immediately
+                            return self.async_abort(reason="usb_setup_successful")
+
+                        # if we couldn't find the entry, which is unlikely
+                        return self.async_abort(reason="usb_setup_unsuccessful")
+
+                    return self.async_return_entry()
+
+        return self.async_show_form(
+            step_id="usb_config",
+            data_schema=vol.Schema(
+                {vol.Required(CONF_USB_PATH): vol.In(ports_as_string)}
+            ),
+        )
+
+    def async_return_entry(self) -> FlowResult:
+        """Create a new entry."""
+        return self.async_create_entry(
+            title=f"Account: {self.unique_id}",
+            data={
+                CONF_ID: self.unique_id,
+                CONF_EMAIL: self.login_info[CONF_EMAIL],
+                CONF_PASSWORD: self.login_info[CONF_PASSWORD],
+                CONF_USB_PATH: self.usb_path,
+            },
+        )
+
+
+class CrownstoneOptionsFlowHandler(OptionsFlow):
+    """Handle Crownstone options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize Crownstone options."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage Crownstone options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_USE_CROWNSTONE_USB,
+                        default=self.config_entry.data.get(CONF_USB_PATH) is not None,
+                    ): bool
+                }
+            ),
+        )

--- a/homeassistant/components/crownstone/config_flow.py
+++ b/homeassistant/components/crownstone/config_flow.py
@@ -90,7 +90,7 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             )
 
         # set unique id and abort if already configured
-        await self.async_set_unique_id(user_input[CONF_EMAIL])
+        await self.async_set_unique_id(cloud.cloud_data.user_id)
         self._abort_if_unique_id_configured()
 
         # start next flow
@@ -193,7 +193,7 @@ class CrownstoneConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     def async_finish_flow(self) -> FlowResult:
         """Create a new entry."""
         return self.async_create_entry(
-            title=f"Account: {self.unique_id}",
+            title=f"Account: {self.login_info[CONF_EMAIL]}",
             data={
                 CONF_EMAIL: self.login_info[CONF_EMAIL],
                 CONF_PASSWORD: self.login_info[CONF_PASSWORD],

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -6,8 +6,13 @@ DOMAIN: Final = "crownstone"
 PLATFORMS: Final = ["light"]
 
 # Listeners
-SSE: Final = "sse_listeners"
-UART: Final = "uart_listeners"
+SSE_LISTENERS: Final = "sse_listeners"
+UART_LISTENERS: Final = "uart_listeners"
+
+# Class attributes
+ATTR_SSE: Final = "sse"
+ATTR_UART: Final = "uart"
+ATTR_CLOUD: Final = "cloud"
 
 # Unique ID suffixes
 CROWNSTONE_SUFFIX: Final = "crownstone"

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -10,9 +10,7 @@ SSE_LISTENERS: Final = "sse_listeners"
 UART_LISTENERS: Final = "uart_listeners"
 
 # Class attributes
-ATTR_SSE: Final = "sse"
 ATTR_UART: Final = "uart"
-ATTR_CLOUD: Final = "cloud"
 
 # Unique ID suffixes
 CROWNSTONE_SUFFIX: Final = "crownstone"

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -1,0 +1,35 @@
+"""Constants for the crownstone integration."""
+
+# Platforms
+DOMAIN = "crownstone"
+LIGHT_PLATFORM = "light"
+
+# Listeners
+SSE = "sse_listeners"
+UART = "uart_listeners"
+
+# Unique ID suffixes
+CROWNSTONE_SUFFIX = "crownstone"
+
+# Signals (within integration)
+SIG_CROWNSTONE_STATE_UPDATE = "crownstone.crownstone_state_update"
+SIG_CROWNSTONE_UPDATE = "crownstone.crownstone_update"
+SIG_UART_STATE_CHANGE = "crownstone.uart_state_change"
+
+# Abilities state
+ABILITY_STATE = {True: "Enabled", False: "Disabled"}
+
+# Config flow
+CONF_USB = "usb"
+CONF_USB_PATH = "usb_path"
+CONF_USE_CROWNSTONE_USB = "use_crownstone_usb"
+
+# Crownstone entity
+CROWNSTONE_INCLUDE_TYPES = {
+    "PLUG": "Plug",
+    "BUILTIN": "Built-in",
+    "BUILTIN_ONE": "Built-in One",
+}
+
+# Crownstone USB Dongle
+CROWNSTONE_USB = "CROWNSTONE_USB"

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -11,9 +11,6 @@ PLATFORMS: Final[list[str]] = ["light"]
 SSE_LISTENERS: Final = "sse_listeners"
 UART_LISTENERS: Final = "uart_listeners"
 
-# Class attributes
-ATTR_UART: Final = "uart"
-
 # Unique ID suffixes
 CROWNSTONE_SUFFIX: Final = "crownstone"
 

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -1,9 +1,11 @@
 """Constants for the crownstone integration."""
+from __future__ import annotations
+
 from typing import Final
 
 # Platforms
 DOMAIN: Final = "crownstone"
-PLATFORMS: Final = ["light"]
+PLATFORMS: Final[list[str]] = ["light"]
 
 # Listeners
 SSE_LISTENERS: Final = "sse_listeners"
@@ -21,19 +23,22 @@ SIG_CROWNSTONE_UPDATE: Final = "crownstone.crownstone_update"
 SIG_UART_STATE_CHANGE: Final = "crownstone.uart_state_change"
 
 # Abilities state
-ABILITY_STATE: Final = {True: "Enabled", False: "Disabled"}
+ABILITY_STATE: Final[dict[bool, str]] = {True: "Enabled", False: "Disabled"}
 
 # Config flow
 CONF_USB_PATH: Final = "usb_path"
 CONF_USB_MANUAL_PATH: Final = "usb_manual_path"
-CONF_USE_CROWNSTONE_USB: Final = "use_crownstone_usb"
+CONF_USB_SPHERE: Final = "usb_sphere"
+# Options flow
+CONF_USE_USB_OPTION: Final = "use_usb_option"
+CONF_USB_SPHERE_OPTION: Final = "usb_sphere_option"
 # USB config list entries
 DONT_USE_USB: Final = "Don't use USB"
 REFRESH_LIST: Final = "Refresh list"
 MANUAL_PATH: Final = "Enter manually"
 
 # Crownstone entity
-CROWNSTONE_INCLUDE_TYPES: Final = {
+CROWNSTONE_INCLUDE_TYPES: Final[dict[str, str]] = {
     "PLUG": "Plug",
     "BUILTIN": "Built-in",
     "BUILTIN_ONE": "Built-in One",

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -2,7 +2,7 @@
 
 # Platforms
 DOMAIN = "crownstone"
-LIGHT_PLATFORM = "light"
+PLATFORMS = ["light"]
 
 # Listeners
 SSE = "sse_listeners"

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -1,35 +1,36 @@
 """Constants for the crownstone integration."""
+from typing import Final
 
 # Platforms
-DOMAIN = "crownstone"
-PLATFORMS = ["light"]
+DOMAIN: Final = "crownstone"
+PLATFORMS: Final = ["light"]
 
 # Listeners
-SSE = "sse_listeners"
-UART = "uart_listeners"
+SSE: Final = "sse_listeners"
+UART: Final = "uart_listeners"
 
 # Unique ID suffixes
-CROWNSTONE_SUFFIX = "crownstone"
+CROWNSTONE_SUFFIX: Final = "crownstone"
 
 # Signals (within integration)
-SIG_CROWNSTONE_STATE_UPDATE = "crownstone.crownstone_state_update"
-SIG_CROWNSTONE_UPDATE = "crownstone.crownstone_update"
-SIG_UART_STATE_CHANGE = "crownstone.uart_state_change"
+SIG_CROWNSTONE_STATE_UPDATE: Final = "crownstone.crownstone_state_update"
+SIG_CROWNSTONE_UPDATE: Final = "crownstone.crownstone_update"
+SIG_UART_STATE_CHANGE: Final = "crownstone.uart_state_change"
 
 # Abilities state
-ABILITY_STATE = {True: "Enabled", False: "Disabled"}
+ABILITY_STATE: Final = {True: "Enabled", False: "Disabled"}
 
 # Config flow
-CONF_USB = "usb"
-CONF_USB_PATH = "usb_path"
-CONF_USE_CROWNSTONE_USB = "use_crownstone_usb"
+CONF_USB: Final = "usb"
+CONF_USB_PATH: Final = "usb_path"
+CONF_USE_CROWNSTONE_USB: Final = "use_crownstone_usb"
 
 # Crownstone entity
-CROWNSTONE_INCLUDE_TYPES = {
+CROWNSTONE_INCLUDE_TYPES: Final = {
     "PLUG": "Plug",
     "BUILTIN": "Built-in",
     "BUILTIN_ONE": "Built-in One",
 }
 
 # Crownstone USB Dongle
-CROWNSTONE_USB = "CROWNSTONE_USB"
+CROWNSTONE_USB: Final = "CROWNSTONE_USB"

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -23,7 +23,10 @@ ABILITY_STATE: Final = {True: "Enabled", False: "Disabled"}
 # Config flow
 CONF_USB: Final = "usb"
 CONF_USB_PATH: Final = "usb_path"
+CONF_USB_MANUAL_PATH: Final = "usb_manual_path"
 CONF_USE_CROWNSTONE_USB: Final = "use_crownstone_usb"
+CONF_REFRESH_LIST: Final = "Refresh List"
+CONF_MANUAL_PATH: Final = "Enter Manually"
 
 # Crownstone entity
 CROWNSTONE_INCLUDE_TYPES: Final = {

--- a/homeassistant/components/crownstone/const.py
+++ b/homeassistant/components/crownstone/const.py
@@ -21,12 +21,13 @@ SIG_UART_STATE_CHANGE: Final = "crownstone.uart_state_change"
 ABILITY_STATE: Final = {True: "Enabled", False: "Disabled"}
 
 # Config flow
-CONF_USB: Final = "usb"
 CONF_USB_PATH: Final = "usb_path"
 CONF_USB_MANUAL_PATH: Final = "usb_manual_path"
 CONF_USE_CROWNSTONE_USB: Final = "use_crownstone_usb"
-CONF_REFRESH_LIST: Final = "Refresh List"
-CONF_MANUAL_PATH: Final = "Enter Manually"
+# USB config list entries
+DONT_USE_USB: Final = "Don't use USB"
+REFRESH_LIST: Final = "Refresh list"
+MANUAL_PATH: Final = "Enter manually"
 
 # Crownstone entity
 CROWNSTONE_INCLUDE_TYPES: Final = {

--- a/homeassistant/components/crownstone/devices.py
+++ b/homeassistant/components/crownstone/devices.py
@@ -38,6 +38,6 @@ class CrownstoneDevice:
             ATTR_IDENTIFIERS: {(DOMAIN, self.cloud_id)},
             ATTR_NAME: self.device.name,
             ATTR_MANUFACTURER: "Crownstone",
-            ATTR_MODEL: str(CROWNSTONE_INCLUDE_TYPES.get(self.device.type)),
+            ATTR_MODEL: CROWNSTONE_INCLUDE_TYPES[self.device.type],
             ATTR_SW_VERSION: self.device.sw_version,
         }

--- a/homeassistant/components/crownstone/devices.py
+++ b/homeassistant/components/crownstone/devices.py
@@ -3,6 +3,13 @@ from __future__ import annotations
 
 from crownstone_cloud.cloud_models.crownstones import Crownstone
 
+from homeassistant.const import (
+    ATTR_IDENTIFIERS,
+    ATTR_MANUFACTURER,
+    ATTR_MODEL,
+    ATTR_NAME,
+    ATTR_SW_VERSION,
+)
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import CROWNSTONE_INCLUDE_TYPES, DOMAIN
@@ -28,9 +35,9 @@ class CrownstoneDevice:
     def device_info(self) -> DeviceInfo:
         """Return device info."""
         return {
-            "identifiers": {(DOMAIN, self.cloud_id)},
-            "name": self.device.name,
-            "manufacturer": "Crownstone",
-            "model": str(CROWNSTONE_INCLUDE_TYPES.get(self.device.type)),
-            "sw_version": self.device.sw_version,
+            ATTR_IDENTIFIERS: {(DOMAIN, self.cloud_id)},
+            ATTR_NAME: self.device.name,
+            ATTR_MANUFACTURER: "Crownstone",
+            ATTR_MODEL: str(CROWNSTONE_INCLUDE_TYPES.get(self.device.type)),
+            ATTR_SW_VERSION: self.device.sw_version,
         }

--- a/homeassistant/components/crownstone/devices.py
+++ b/homeassistant/components/crownstone/devices.py
@@ -1,9 +1,9 @@
 """Base classes for Crownstone devices."""
 from __future__ import annotations
 
-from typing import Any
-
 from crownstone_cloud.cloud_models.crownstones import Crownstone
+
+from homeassistant.helpers.entity import DeviceInfo
 
 from .const import CROWNSTONE_INCLUDE_TYPES, DOMAIN
 
@@ -25,12 +25,12 @@ class CrownstoneDevice:
         return str(self.device.cloud_id)
 
     @property
-    def device_info(self) -> dict[str, Any] | None:
+    def device_info(self) -> DeviceInfo:
         """Return device info."""
         return {
             "identifiers": {(DOMAIN, self.cloud_id)},
             "name": self.device.name,
             "manufacturer": "Crownstone",
-            "model": CROWNSTONE_INCLUDE_TYPES.get(self.device.type),
+            "model": str(CROWNSTONE_INCLUDE_TYPES.get(self.device.type)),
             "sw_version": self.device.sw_version,
         }

--- a/homeassistant/components/crownstone/devices.py
+++ b/homeassistant/components/crownstone/devices.py
@@ -1,0 +1,36 @@
+"""Base classes for Crownstone devices."""
+from __future__ import annotations
+
+from typing import Any
+
+from crownstone_cloud.cloud_models.crownstones import Crownstone
+
+from .const import CROWNSTONE_INCLUDE_TYPES, DOMAIN
+
+
+class CrownstoneDevice:
+    """Representation of a Crownstone device."""
+
+    def __init__(self, device: Crownstone) -> None:
+        """Initialize the device."""
+        self.device = device
+
+    @property
+    def cloud_id(self) -> str:
+        """
+        Return the unique identifier for this device.
+
+        Used as device ID and to generate unique entity ID's.
+        """
+        return str(self.device.cloud_id)
+
+    @property
+    def device_info(self) -> dict[str, Any] | None:
+        """Return device info."""
+        return {
+            "identifiers": {(DOMAIN, self.cloud_id)},
+            "name": self.device.name,
+            "manufacturer": "Crownstone",
+            "model": CROWNSTONE_INCLUDE_TYPES.get(self.device.type),
+            "sw_version": self.device.sw_version,
+        }

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -104,7 +104,9 @@ class CrownstoneEntryManager:
         self.config_entry.async_on_unload(
             self.config_entry.add_update_listener(_async_update_listener)
         )
-        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_shutdown)
+        self.config_entry.async_on_unload(
+            self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_shutdown)
+        )
 
         return True
 

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -1,0 +1,199 @@
+"""Code to set up all communications with Crownstones."""
+from __future__ import annotations
+
+import asyncio
+from functools import partial
+import logging
+from typing import Any, cast
+
+from crownstone_cloud import CrownstoneCloud
+from crownstone_cloud.exceptions import (
+    CrownstoneAuthenticationError,
+    CrownstoneUnknownError,
+)
+from crownstone_sse import CrownstoneSSEAsync
+from crownstone_uart import CrownstoneUart, UartEventBus
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_EMAIL,
+    CONF_PASSWORD,
+    CONF_UNIQUE_ID,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import aiohttp_client
+
+from .const import (
+    CONF_USB_PATH,
+    CONF_USE_CROWNSTONE_USB,
+    DOMAIN,
+    LIGHT_PLATFORM,
+    SSE,
+    UART,
+)
+from .helpers import get_port
+from .listeners import create_data_listeners
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CrownstoneEntryManager:
+    """Manage a Crownstone config entry."""
+
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry) -> None:
+        """Initialize the hub."""
+        self.hass = hass
+        self.config_entry = config_entry
+        self.uart = cast(CrownstoneUart, None)
+        self.cloud = cast(CrownstoneCloud, None)
+        self.sse = cast(CrownstoneSSEAsync, None)
+        self.listeners: dict[str, Any] = {}
+
+    async def async_setup(self) -> bool:
+        """
+        Set up a Crownstone config entry.
+
+        This class is a combination of Crownstone cloud, Crownstone SSE and Crownstone uart.
+        Returns True if the setup was successful.
+        """
+        # Setup email and password gained from config flow
+        customer_email = self.config_entry.data[CONF_EMAIL]
+        customer_password = self.config_entry.data[CONF_PASSWORD]
+
+        # Add entry listener
+        self.config_entry.async_on_unload(
+            self.config_entry.add_update_listener(options_update_listener)
+        )
+
+        # Create cloud instance
+        self.cloud = CrownstoneCloud(
+            email=customer_email,
+            password=customer_password,
+            clientsession=aiohttp_client.async_get_clientsession(self.hass),
+        )
+        # Login
+        try:
+            await self.cloud.async_initialize()
+        except CrownstoneAuthenticationError as auth_err:
+            _LOGGER.error(
+                "Auth error during login with type: %s and message: %s",
+                auth_err.type,
+                auth_err.message,
+            )
+            return False
+        except CrownstoneUnknownError as unknown_err:
+            _LOGGER.error("Unknown error during login")
+            raise ConfigEntryNotReady from unknown_err
+
+        # Create SSE instance
+        # a new clientsession is created because the default one does not cleanup on unload
+        self.sse = CrownstoneSSEAsync(
+            email=customer_email,
+            password=customer_password,
+            access_token=self.cloud.access_token,
+            websession=aiohttp_client.async_create_clientsession(self.hass),
+        )
+        # Listen for events in the background, without task tracking
+        asyncio.create_task(self.process_events(self.sse))
+
+        # Check if a usb by-id exists, if not use cloud
+        if self.config_entry.data[CONF_USB_PATH] is not None:
+            port = await self.hass.async_add_executor_job(
+                partial(get_port, self.config_entry.data[CONF_USB_PATH])
+            )
+            # port is None when Home Assistant is started without the USB plugged in,
+            # but a setup exists
+            if port is not None:
+                self.uart = CrownstoneUart()
+                # initialize USB, this waits for the usb to be initialized
+                # we do this in the background to avoid blocking, devices depend on the 'is_ready' flag
+                asyncio.create_task(self.uart.initialize_usb(f"/dev/{port}"))
+
+        # Create listeners for SSE and UART
+        create_data_listeners(self.hass, self)
+
+        # create listener for when home assistant is stopped
+        self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_close)
+
+        # register crownstone entities
+        self.hass.async_create_task(
+            self.hass.config_entries.async_forward_entry_setup(
+                self.config_entry, LIGHT_PLATFORM
+            )
+        )
+
+        return True
+
+    async def process_events(self, sse_client: CrownstoneSSEAsync) -> None:
+        """Asynchronous iteration of Crownstone SSE events."""
+        async with sse_client as client:
+            async for event in client:
+                if event is not None:
+                    # make SSE updates, like ability change, available to the user
+                    self.hass.bus.async_fire(f"{DOMAIN}_{event.type}", event.data)
+
+    async def async_unload(self) -> bool:
+        """Unload the current config entry."""
+        # stop services
+        if self.uart is not None:
+            self.uart.stop()
+        if self.sse is not None:
+            self.sse.close_client()
+
+        # authentication failed
+        if self.cloud.cloud_data is None:
+            return True
+
+        # Unsubscribe from listeners
+        for sse_unsub in self.listeners[SSE]:
+            sse_unsub()
+        for subscription_id in self.listeners[UART]:
+            UartEventBus.unsubscribe(subscription_id)
+
+        # unload all platform entities
+        unload_ok = await self.hass.config_entries.async_forward_entry_unload(
+            self.config_entry, LIGHT_PLATFORM
+        )
+
+        return unload_ok
+
+    @callback
+    def on_close(self, event: Event) -> None:
+        """Close SSE client and uart bridge."""
+        _LOGGER.debug(event.data)
+        if self.sse is not None:
+            self.sse.close_client()
+        if self.uart is not None:
+            self.uart.stop()
+
+
+async def options_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Handle options update."""
+    entry_data = entry.data.copy()
+    # USB was configured at setup & user wants to remove config
+    if (
+        not entry.options.get(CONF_USE_CROWNSTONE_USB)
+        and entry.data.get(CONF_USB_PATH) is not None
+    ):
+        entry_data[CONF_USB_PATH] = None
+
+        # update and reload
+        # USB connection is closed and entry will be created without USB connection
+        hass.config_entries.async_update_entry(entry, data=entry_data)
+        await hass.config_entries.async_reload(entry.entry_id)
+
+    # USB was not configured at setup & user wants to configure
+    # Init config flow on USB configuration step
+    elif (
+        entry.options.get(CONF_USE_CROWNSTONE_USB)
+        and entry.data.get(CONF_USB_PATH) is None
+    ):
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": "usb_config"},
+                data={CONF_UNIQUE_ID: entry.entry_id},
+            )
+        )

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -117,6 +117,7 @@ class CrownstoneEntryManager:
                 try:
                     await self.uart.initialize_usb(port)
                 except UartException:
+                    delattr(self, ATTR_UART)
                     # remove usb path to make usb setup available from options
                     entry_data = self.config_entry.data.copy()
                     entry_data[CONF_USB_PATH] = None

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -90,12 +90,12 @@ class CrownstoneEntryManager:
         setup_sse_listeners(self)
 
         # Set up a Crownstone USB only if path exists
-        if self.config_entry.data[CONF_USB_PATH] is not None:
+        if self.config_entry.options[CONF_USB_PATH] is not None:
             await self.async_setup_usb()
 
         # Save the sphere where the USB is located
         # Makes HA aware of the Crownstone environment HA is placed in, a user can have multiple
-        self.usb_sphere_id = self.config_entry.data[CONF_USB_SPHERE]
+        self.usb_sphere_id = self.config_entry.options[CONF_USB_SPHERE]
 
         self.hass.data.setdefault(DOMAIN, {})[self.config_entry.entry_id] = self
         self.hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)
@@ -122,7 +122,7 @@ class CrownstoneEntryManager:
         """Attempt setup of a Crownstone usb dongle."""
         # Trace by-id symlink back to the serial port
         serial_port = await self.hass.async_add_executor_job(
-            get_port, self.config_entry.data[CONF_USB_PATH]
+            get_port, self.config_entry.options[CONF_USB_PATH]
         )
         if serial_port is None:
             return
@@ -133,13 +133,13 @@ class CrownstoneEntryManager:
             await self.uart.initialize_usb(serial_port)
         except UartException:
             self.uart = None
-            # Set entry data for usb to null
-            updated_entry_data = self.config_entry.data.copy()
-            updated_entry_data[CONF_USB_PATH] = None
-            updated_entry_data[CONF_USB_SPHERE] = None
+            # Set entry options for usb to null
+            updated_options = self.config_entry.options.copy()
+            updated_options[CONF_USB_PATH] = None
+            updated_options[CONF_USB_SPHERE] = None
             # Ensure that the user can configure an USB again from options
             self.hass.config_entries.async_update_entry(
-                self.config_entry, data=updated_entry_data, options={}
+                self.config_entry, options=updated_options
             )
             # Show notification to ensure the user knows the cloud is now used
             persistent_notification.async_create(

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -25,14 +25,7 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import aiohttp_client
 
-from .const import (
-    CONF_USB_PATH,
-    CONF_USE_CROWNSTONE_USB,
-    DOMAIN,
-    LIGHT_PLATFORM,
-    SSE,
-    UART,
-)
+from .const import CONF_USB_PATH, CONF_USE_CROWNSTONE_USB, DOMAIN, PLATFORMS, SSE, UART
 from .helpers import get_port
 from .listeners import create_data_listeners
 
@@ -125,12 +118,8 @@ class CrownstoneEntryManager:
         # create listener for when home assistant is stopped
         self.hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, self.on_close)
 
-        # register crownstone entities
-        self.hass.async_create_task(
-            self.hass.config_entries.async_forward_entry_setup(
-                self.config_entry, LIGHT_PLATFORM
-            )
-        )
+        # register all entities
+        self.hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)
 
         return True
 
@@ -161,8 +150,8 @@ class CrownstoneEntryManager:
             UartEventBus.unsubscribe(subscription_id)
 
         # unload all platform entities
-        unload_ok = await self.hass.config_entries.async_forward_entry_unload(
-            self.config_entry, LIGHT_PLATFORM
+        unload_ok = await self.hass.config_entries.async_unload_platforms(
+            self.config_entry, PLATFORMS
         )
 
         return unload_ok

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -1,4 +1,4 @@
-"""Code to set up all communications with Crownstones."""
+"""Manager to set up IO with Crownstone devices for a config entry."""
 from __future__ import annotations
 
 import asyncio
@@ -53,7 +53,6 @@ class CrownstoneEntryManager:
         """
         Set up a Crownstone config entry.
 
-        This class is a combination of Crownstone cloud, Crownstone SSE and Crownstone uart.
         Returns True if the setup was successful.
         """
         email = self.config_entry.data[CONF_EMAIL]

--- a/homeassistant/components/crownstone/entry_manager.py
+++ b/homeassistant/components/crownstone/entry_manager.py
@@ -188,14 +188,13 @@ class CrownstoneEntryManager:
         return unload_ok
 
     @callback
-    def on_shutdown(self, event: Event) -> None:
+    def on_shutdown(self, _: Event) -> None:
         """Close all IO connections."""
         self.sse.close_client()
         if hasattr(self, ATTR_UART):
             self.uart.stop()
 
 
-@callback
 async def async_update_entry_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Handle options update."""
     entry_data = entry.data.copy()

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -1,0 +1,24 @@
+"""Helper functions for the Crownstone integration."""
+from __future__ import annotations
+
+import os
+
+
+def get_serial_by_id(dev_path: str) -> str:
+    """Return a /dev/serial/by-id match for given device if available."""
+    by_id = "/dev/serial/by-id"
+    if not os.path.isdir(by_id):
+        return dev_path
+
+    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
+        if os.path.realpath(path) == dev_path:
+            return path
+    return dev_path
+
+
+def get_port(by_id: str) -> str | None:
+    """Get the port that the by-id link points to."""
+    try:
+        return os.path.basename(os.readlink(by_id))
+    except FileNotFoundError:
+        return None

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -16,9 +16,14 @@ def get_serial_by_id(dev_path: str) -> str:
     return dev_path
 
 
-def get_port(by_id: str) -> str | None:
+def get_port(dev_path: str) -> str | None:
     """Get the port that the by-id link points to."""
+    # not a by-id link, but just given path
+    by_id = "/dev/serial/by-id"
+    if by_id not in dev_path:
+        return dev_path
+
     try:
-        return os.path.basename(os.readlink(by_id))
+        return f"/dev/{os.path.basename(os.readlink(dev_path))}"
     except FileNotFoundError:
         return None

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -5,6 +5,8 @@ import os
 
 from serial.tools.list_ports_common import ListPortInfo
 
+from homeassistant.components import usb
+
 from .const import DONT_USE_USB, MANUAL_PATH, REFRESH_LIST
 
 
@@ -24,9 +26,14 @@ def list_ports_as_str(
 
     for port in serial_ports:
         ports_as_string.append(
-            f"{port.device}"
-            + f" - {port.product}"
-            + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+            usb.human_readable_device_name(
+                port.device,
+                port.serial_number,
+                port.manufacturer,
+                port.description,
+                port.vid,
+                port.pid,
+            )
         )
     ports_as_string.append(MANUAL_PATH)
     ports_as_string.append(REFRESH_LIST)

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -3,6 +3,36 @@ from __future__ import annotations
 
 import os
 
+from serial.tools.list_ports_common import ListPortInfo
+
+from .const import DONT_USE_USB, MANUAL_PATH, REFRESH_LIST
+
+
+def list_ports_as_str(
+    serial_ports: list[ListPortInfo], no_usb_option: bool = True
+) -> list[str]:
+    """
+    Represent currently available serial ports as string.
+
+    Adds option to not use usb on top of the list,
+    option to use manual path or refresh list at the end.
+    """
+    ports_as_string: list[str] = []
+
+    if no_usb_option:
+        ports_as_string.append(DONT_USE_USB)
+
+    for port in serial_ports:
+        ports_as_string.append(
+            f"{port.device}"
+            + f" - {port.product}"
+            + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+        )
+    ports_as_string.append(MANUAL_PATH)
+    ports_as_string.append(REFRESH_LIST)
+
+    return ports_as_string
+
 
 def get_port(dev_path: str) -> str | None:
     """Get the port that the by-id link points to."""

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -27,3 +27,8 @@ def get_port(dev_path: str) -> str | None:
         return f"/dev/{os.path.basename(os.readlink(dev_path))}"
     except FileNotFoundError:
         return None
+
+
+def map_from_to(val: int, in_min: int, in_max: int, out_min: int, out_max: int) -> int:
+    """Map a value from a range to another."""
+    return int((val - in_min) * (out_max - out_min) / (in_max - in_min) + out_min)

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -31,8 +31,8 @@ def list_ports_as_str(
                 port.serial_number,
                 port.manufacturer,
                 port.description,
-                port.vid,
-                port.pid,
+                f"{hex(port.vid)[2:]:0>4}".upper(),
+                f"{hex(port.pid)[2:]:0>4}".upper(),
             )
         )
     ports_as_string.append(MANUAL_PATH)

--- a/homeassistant/components/crownstone/helpers.py
+++ b/homeassistant/components/crownstone/helpers.py
@@ -4,18 +4,6 @@ from __future__ import annotations
 import os
 
 
-def get_serial_by_id(dev_path: str) -> str:
-    """Return a /dev/serial/by-id match for given device if available."""
-    by_id = "/dev/serial/by-id"
-    if not os.path.isdir(by_id):
-        return dev_path
-
-    for path in (entry.path for entry in os.scandir(by_id) if entry.is_symlink()):
-        if os.path.realpath(path) == dev_path:
-            return path
-    return dev_path
-
-
 def get_port(dev_path: str) -> str | None:
     """Get the port that the by-id link points to."""
     # not a by-id link, but just given path

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -13,7 +13,6 @@ from crownstone_cloud.const import (
 )
 from crownstone_cloud.exceptions import CrownstoneAbilityError
 from crownstone_uart import CrownstoneUart
-import numpy
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -35,6 +34,7 @@ from .const import (
     SIG_UART_STATE_CHANGE,
 )
 from .devices import CrownstoneDevice
+from .helpers import map_from_to
 
 if TYPE_CHECKING:
     from .entry_manager import CrownstoneEntryManager
@@ -75,12 +75,12 @@ async def async_setup_entry(
 
 def crownstone_state_to_hass(value: int) -> int:
     """Crownstone 0..100 to hass 0..255."""
-    return int(numpy.interp(value, [0, 100], [0, 255]))
+    return map_from_to(value, 0, 100, 0, 255)
 
 
 def hass_to_crownstone_state(value: int) -> int:
     """Hass 0..255 to Crownstone 0..100."""
-    return int(numpy.interp(value, [0, 255], [0, 100]))
+    return map_from_to(value, 0, 255, 0, 100)
 
 
 class CrownstoneEntity(CrownstoneDevice, LightEntity):

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -1,6 +1,7 @@
 """Support for Crownstone devices."""
 from __future__ import annotations
 
+from collections.abc import Mapping
 from functools import partial
 import logging
 from typing import TYPE_CHECKING, Any
@@ -49,7 +50,7 @@ async def async_setup_entry(
     """Set up crownstones from a config entry."""
     manager: CrownstoneEntryManager = hass.data[DOMAIN][config_entry.entry_id]
 
-    entities = []
+    entities: list[CrownstoneEntity] = []
 
     # Add Crownstone entities that support switching/dimming
     for sphere in manager.cloud.cloud_data:
@@ -111,7 +112,7 @@ class CrownstoneEntity(CrownstoneDevice, LightEntity):
         return 0
 
     @property
-    def extra_state_attributes(self) -> dict[str, Any]:
+    def extra_state_attributes(self) -> Mapping[str, Any] | None:
         """State attributes for Crownstone devices."""
         attributes: dict[str, Any] = {}
         # switch method

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     ABILITY_STATE,
+    ATTR_UART,
     CROWNSTONE_INCLUDE_TYPES,
     CROWNSTONE_SUFFIX,
     DOMAIN,
@@ -57,7 +58,10 @@ async def async_setup_entry(
         for crownstone in sphere.crownstones:
             if crownstone.type in CROWNSTONE_INCLUDE_TYPES:
                 # Crownstone can communicate with Crownstone USB
-                if sphere.cloud_id == manager.usb_sphere_id:
+                if (
+                    hasattr(manager, ATTR_UART)
+                    and sphere.cloud_id == manager.usb_sphere_id
+                ):
                     entities.append(CrownstoneEntity(crownstone, manager.uart))
                 # Crownstone can't communicate with Crownstone USB
                 else:

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -51,20 +51,20 @@ async def async_setup_entry(
     manager: CrownstoneEntryManager = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = []
-    crownstone_usb_sphere_id = None
+    usb_sphere_id = None
 
     # Look for a Crownstone USB and what sphere it belongs to
     for sphere in manager.cloud.cloud_data:
         for crownstone in sphere.crownstones:
             if crownstone.type == CROWNSTONE_USB:
-                crownstone_usb_sphere_id = sphere.cloud_id
+                usb_sphere_id = sphere.cloud_id
 
     # Add Crownstone entities that support switching/dimming
     for sphere in manager.cloud.cloud_data:
         for crownstone in sphere.crownstones:
             if crownstone.type in CROWNSTONE_INCLUDE_TYPES:
                 # Crownstone can communicate with Crownstone USB
-                if sphere.cloud_id == crownstone_usb_sphere_id:
+                if sphere.cloud_id == usb_sphere_id and hasattr(manager, "uart"):
                     entities.append(CrownstoneEntity(crownstone, manager.uart))
                 # Crownstone can't communicate with Crownstone USB
                 else:

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -122,18 +122,18 @@ class CrownstoneEntity(CrownstoneDevice, LightEntity):
         attributes: dict[str, Any] = {}
         # switch method
         if self.usb_available:
-            attributes["Switch Method"] = "Crownstone USB Dongle"
+            attributes["switch_method"] = "Crownstone USB Dongle"
         else:
-            attributes["Switch Method"] = "Crownstone Cloud"
+            attributes["switch_method"] = "Crownstone Cloud"
 
         # crownstone abilities
-        attributes["Dimming"] = ABILITY_STATE.get(
+        attributes["dimming"] = ABILITY_STATE.get(
             self.device.abilities.get(DIMMING_ABILITY).is_enabled
         )
-        attributes["Tap To Toggle"] = ABILITY_STATE.get(
+        attributes["tap_to_toggle"] = ABILITY_STATE.get(
             self.device.abilities.get(TAP_TO_TOGGLE_ABILITY).is_enabled
         )
-        attributes["Switchcraft"] = ABILITY_STATE.get(
+        attributes["switchcraft"] = ABILITY_STATE.get(
             self.device.abilities.get(SWITCHCRAFT_ABILITY).is_enabled
         )
 

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -28,7 +28,6 @@ from .const import (
     ABILITY_STATE,
     CROWNSTONE_INCLUDE_TYPES,
     CROWNSTONE_SUFFIX,
-    CROWNSTONE_USB,
     DOMAIN,
     SIG_CROWNSTONE_STATE_UPDATE,
     SIG_UART_STATE_CHANGE,
@@ -51,20 +50,13 @@ async def async_setup_entry(
     manager: CrownstoneEntryManager = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = []
-    usb_sphere_id = None
-
-    # Look for a Crownstone USB and what sphere it belongs to
-    for sphere in manager.cloud.cloud_data:
-        for crownstone in sphere.crownstones:
-            if crownstone.type == CROWNSTONE_USB:
-                usb_sphere_id = sphere.cloud_id
 
     # Add Crownstone entities that support switching/dimming
     for sphere in manager.cloud.cloud_data:
         for crownstone in sphere.crownstones:
             if crownstone.type in CROWNSTONE_INCLUDE_TYPES:
                 # Crownstone can communicate with Crownstone USB
-                if sphere.cloud_id == usb_sphere_id and hasattr(manager, "uart"):
+                if sphere.cloud_id == manager.usb_sphere_id:
                     entities.append(CrownstoneEntity(crownstone, manager.uart))
                 # Crownstone can't communicate with Crownstone USB
                 else:

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -1,0 +1,223 @@
+"""Support for Crownstone devices."""
+from __future__ import annotations
+
+from functools import partial
+import logging
+from typing import TYPE_CHECKING, Any
+
+from crownstone_cloud.cloud_models.crownstones import Crownstone
+from crownstone_cloud.const import (
+    DIMMING_ABILITY,
+    SWITCHCRAFT_ABILITY,
+    TAP_TO_TOGGLE_ABILITY,
+)
+from crownstone_cloud.exceptions import CrownstoneAbilityError
+from crownstone_uart import CrownstoneUart
+import numpy
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    SUPPORT_BRIGHTNESS,
+    LightEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import (
+    ABILITY_STATE,
+    CROWNSTONE_INCLUDE_TYPES,
+    CROWNSTONE_SUFFIX,
+    CROWNSTONE_USB,
+    DOMAIN,
+    SIG_CROWNSTONE_STATE_UPDATE,
+    SIG_UART_STATE_CHANGE,
+)
+from .devices import CrownstoneDevice
+
+if TYPE_CHECKING:
+    from .entry_manager import CrownstoneEntryManager
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up crownstones from a config entry."""
+    manager: CrownstoneEntryManager = hass.data[DOMAIN][config_entry.entry_id]
+
+    entities = []
+    crownstone_usb_sphere_id = None
+
+    # Look for a Crownstone USB and what sphere it belongs to
+    for sphere in manager.cloud.cloud_data:
+        for crownstone in sphere.crownstones:
+            if crownstone.type == CROWNSTONE_USB:
+                crownstone_usb_sphere_id = sphere.cloud_id
+
+    # Add Crownstone entities that support switching/dimming
+    for sphere in manager.cloud.cloud_data:
+        for crownstone in sphere.crownstones:
+            if crownstone.type in CROWNSTONE_INCLUDE_TYPES:
+                # Crownstone can communicate with Crownstone USB
+                if sphere.cloud_id == crownstone_usb_sphere_id:
+                    entities.append(CrownstoneEntity(crownstone, manager.uart))
+                # Crownstone can't communicate with Crownstone USB
+                else:
+                    entities.append(CrownstoneEntity(crownstone))
+
+    async_add_entities(entities)
+
+
+def crownstone_state_to_hass(value: int) -> int:
+    """Crownstone 0..100 to hass 0..255."""
+    return int(numpy.interp(value, [0, 100], [0, 255]))
+
+
+def hass_to_crownstone_state(value: int) -> int:
+    """Hass 0..255 to Crownstone 0..100."""
+    return int(numpy.interp(value, [0, 255], [0, 100]))
+
+
+class CrownstoneEntity(CrownstoneDevice, LightEntity):
+    """
+    Representation of a crownstone.
+
+    Light platform is used to support dimming.
+    """
+
+    def __init__(self, crownstone_data: Crownstone, usb: CrownstoneUart = None) -> None:
+        """Initialize the crownstone."""
+        super().__init__(crownstone_data)
+        self.usb = usb
+
+    @property
+    def name(self) -> str:
+        """Return the name of this presence holder."""
+        return str(self.device.name)
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique id of this entity."""
+        return f"{self.cloud_id}-{CROWNSTONE_SUFFIX}"
+
+    @property
+    def icon(self) -> str:
+        """Return the icon."""
+        return "mdi:power-socket-de"
+
+    @property
+    def brightness(self) -> int:
+        """Return the brightness if dimming enabled."""
+        return crownstone_state_to_hass(self.device.state)
+
+    @property
+    def is_on(self) -> bool:
+        """Return if the device is on."""
+        return crownstone_state_to_hass(self.device.state) > 0
+
+    @property
+    def supported_features(self) -> int:
+        """Return the supported features of this Crownstone."""
+        if self.device.abilities.get(DIMMING_ABILITY).is_enabled:
+            return SUPPORT_BRIGHTNESS
+        return 0
+
+    @property
+    def should_poll(self) -> bool:
+        """Return if polling is required after switching."""
+        return False
+
+    async def async_added_to_hass(self) -> None:
+        """Set up a listener when this entity is added to HA."""
+        # new state received
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIG_CROWNSTONE_STATE_UPDATE, self.async_write_ha_state
+            )
+        )
+        # updates state attributes when usb connects/disconnects
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIG_UART_STATE_CHANGE, self.async_write_ha_state
+            )
+        )
+
+    @property
+    def device_state_attributes(self) -> dict[str, Any]:
+        """State attributes for Crownstone devices."""
+        attributes: dict[str, Any] = {}
+        # switch method
+        if self.usb is not None and self.usb.is_ready():
+            attributes["Switch Method"] = "Crownstone USB Dongle"
+        else:
+            attributes["Switch Method"] = "Crownstone Cloud"
+
+        # crownstone abilities
+        attributes["Dimming"] = ABILITY_STATE.get(
+            self.device.abilities.get(DIMMING_ABILITY).is_enabled
+        )
+        attributes["Tap To Toggle"] = ABILITY_STATE.get(
+            self.device.abilities.get(TAP_TO_TOGGLE_ABILITY).is_enabled
+        )
+        attributes["Switchcraft"] = ABILITY_STATE.get(
+            self.device.abilities.get(SWITCHCRAFT_ABILITY).is_enabled
+        )
+
+        return attributes
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on this light via dongle or cloud."""
+        if ATTR_BRIGHTNESS in kwargs:
+            try:
+                # UART instance is not None when a USB is set up and in the same sphere
+                # UART instance is ready when USB is set up and plugged in
+                if self.usb is not None and self.usb.is_ready():
+                    await self.hass.async_add_executor_job(
+                        partial(
+                            self.usb.dim_crownstone,
+                            self.device.unique_id,
+                            hass_to_crownstone_state(kwargs[ATTR_BRIGHTNESS]),
+                        )
+                    )
+                else:
+                    await self.device.async_set_brightness(
+                        hass_to_crownstone_state(kwargs[ATTR_BRIGHTNESS])
+                    )
+                # set brightness
+                self.device.state = hass_to_crownstone_state(kwargs[ATTR_BRIGHTNESS])
+                self.async_write_ha_state()
+            except CrownstoneAbilityError as ability_error:
+                _LOGGER.error(ability_error)
+
+        elif self.usb is not None and self.usb.is_ready():
+            await self.hass.async_add_executor_job(
+                partial(self.usb.switch_crownstone, self.device.unique_id, on=True)
+            )
+            # set state (in case the updates never comes in)
+            self.device.state = 100
+            self.async_write_ha_state()
+
+        else:
+            await self.device.async_turn_on()
+            # set state (in case the updates never comes in)
+            self.device.state = 100
+            self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off this device via dongle or cloud."""
+        if self.usb is not None and self.usb.is_ready():
+            await self.hass.async_add_executor_job(
+                partial(self.usb.switch_crownstone, self.device.unique_id, on=False)
+            )
+
+        else:
+            await self.device.async_turn_off()
+
+        # set state (in case the updates never comes in)
+        self.device.state = 0
+        self.async_write_ha_state()

--- a/homeassistant/components/crownstone/light.py
+++ b/homeassistant/components/crownstone/light.py
@@ -27,7 +27,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
     ABILITY_STATE,
-    ATTR_UART,
     CROWNSTONE_INCLUDE_TYPES,
     CROWNSTONE_SUFFIX,
     DOMAIN,
@@ -58,10 +57,7 @@ async def async_setup_entry(
         for crownstone in sphere.crownstones:
             if crownstone.type in CROWNSTONE_INCLUDE_TYPES:
                 # Crownstone can communicate with Crownstone USB
-                if (
-                    hasattr(manager, ATTR_UART)
-                    and sphere.cloud_id == manager.usb_sphere_id
-                ):
+                if manager.uart and sphere.cloud_id == manager.usb_sphere_id:
                     entities.append(CrownstoneEntity(crownstone, manager.uart))
                 # Crownstone can't communicate with Crownstone USB
                 else:

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -67,17 +67,19 @@ def update_crwn_ability(manager: CrownstoneEntryManager, ha_event: Event) -> Non
     ability_type = ability_event.ability_type
     ability_enabled = ability_event.ability_enabled
     # only update on a change in state
-    if updated_crownstone.abilities[ability_type].is_enabled != ability_enabled:
-        # write the change to the crownstone entity.
-        updated_crownstone.abilities[ability_type].is_enabled = ability_enabled
+    if updated_crownstone.abilities[ability_type].is_enabled == ability_enabled:
+        return
 
-        if ability_event.sub_type == EVENT_ABILITY_CHANGE_DIMMING:
-            # reload the config entry because dimming is part of supported features
-            manager.hass.async_create_task(
-                manager.hass.config_entries.async_reload(manager.config_entry.entry_id)
-            )
-        else:
-            async_dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
+    # write the change to the crownstone entity.
+    updated_crownstone.abilities[ability_type].is_enabled = ability_enabled
+
+    if ability_event.sub_type == EVENT_ABILITY_CHANGE_DIMMING:
+        # reload the config entry because dimming is part of supported features
+        manager.hass.async_create_task(
+            manager.hass.config_entries.async_reload(manager.config_entry.entry_id)
+        )
+    else:
+        async_dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
 
 
 def update_uart_state(manager: CrownstoneEntryManager, _: bool | None) -> None:

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -92,11 +92,11 @@ def update_crwn_state_uart(
     """Update the state of a Crownstone when switched externally."""
     if data.type != AdvType.EXTERNAL_STATE:
         return
-    updated_crownstone = None
-    for sphere in manager.cloud.cloud_data:
-        if sphere.cloud_id == manager.usb_sphere_id:
-            updated_crownstone = sphere.crownstones.find_by_uid(data.crownstoneId)
-    if updated_crownstone is None:
+    try:
+        updated_crownstone = manager.cloud.get_crownstone_by_uid(
+            data.crownstoneId, manager.usb_sphere_id
+        )
+    except KeyError:
         return
 
     # only update on change

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -6,6 +6,7 @@ For fast device switching Local Push is used in form of UART USB with Bluetooth.
 """
 from __future__ import annotations
 
+from functools import partial
 from typing import TYPE_CHECKING, cast
 
 from crownstone_core.packets.serviceDataParsers.containers.AdvExternalCrownstoneState import (
@@ -20,11 +21,12 @@ from crownstone_sse.const import (
     EVENT_ABILITY_CHANGE_DIMMING,
     EVENT_SWITCH_STATE_UPDATE,
 )
+from crownstone_sse.events import AbilityChangeEvent, SwitchStateUpdateEvent
 from crownstone_uart import UartEventBus, UartTopics
 from crownstone_uart.topics.SystemTopics import SystemTopics
 
-from homeassistant.core import Event, HomeAssistant, callback
-from homeassistant.helpers.dispatcher import async_dispatcher_send
+from homeassistant.core import Event, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 
 from .const import (
     DOMAIN,
@@ -38,108 +40,104 @@ if TYPE_CHECKING:
     from .entry_manager import CrownstoneEntryManager
 
 
-def create_data_listeners(hass: HomeAssistant, manager: CrownstoneEntryManager) -> None:
-    """Set up SSE and UART listeners."""
+@callback
+def update_crwn_state_sse(manager: CrownstoneEntryManager, ha_event: Event) -> None:
+    """Update the state of a Crownstone when switched externally."""
+    switch_event = SwitchStateUpdateEvent(ha_event.data)
+    try:
+        updated_crownstone = manager.cloud.get_crownstone_by_id(switch_event.cloud_id)
+    except KeyError:
+        return
 
-    @callback
-    def update_crwn_state_sse(switch_state_event: Event) -> None:
-        """Update the state of a Crownstone when switched from the Crownstone app."""
-        sphere = manager.cloud.cloud_data.find_by_id(
-            switch_state_event.data["sphere"]["id"]
-        )
-        if sphere is None:
-            return
+    # only update on change.
+    if updated_crownstone.state != switch_event.switch_state:
+        updated_crownstone.state = switch_event.switch_state
+        async_dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
 
-        updated_crownstone = sphere.crownstones.find_by_uid(
-            switch_state_event.data["crownstone"]["uid"]
-        )
-        if updated_crownstone is None:
-            return
 
-        # only update on change.
-        # HA sets the state manually when switching to assume switched, only update when necessary.
-        switch_state = int(switch_state_event.data["crownstone"]["percentage"])
-        if updated_crownstone.state != switch_state:
-            updated_crownstone.state = switch_state
+@callback
+def update_crwn_ability(manager: CrownstoneEntryManager, ha_event: Event) -> None:
+    """Update the ability information of a Crownstone."""
+    ability_event = AbilityChangeEvent(ha_event.data)
+    try:
+        updated_crownstone = manager.cloud.get_crownstone_by_id(ability_event.cloud_id)
+    except KeyError:
+        return
 
-            # update the entity state
-            async_dispatcher_send(hass, SIG_CROWNSTONE_STATE_UPDATE)
+    ability_type = ability_event.ability_type
+    ability_enabled = ability_event.ability_enabled
+    # only update on a change in state
+    if updated_crownstone.abilities[ability_type].is_enabled != ability_enabled:
+        # write the change to the crownstone entity.
+        updated_crownstone.abilities[ability_type].is_enabled = ability_enabled
 
-    @callback
-    def update_ability(ability_event: Event) -> None:
-        """
-        Update the ability information.
+        if ability_event.sub_type == EVENT_ABILITY_CHANGE_DIMMING:
+            # reload the config entry because dimming is part of supported features
+            manager.hass.async_create_task(
+                manager.hass.config_entries.async_reload(manager.config_entry.entry_id)
+            )
+        else:
+            async_dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
 
-        This update triggers an entry reload so the entity is re-created with the new data.
-        This is because the change in supported features cannot be done during runtime.
-        """
-        sphere = manager.cloud.cloud_data.find_by_id(ability_event.data["sphere"]["id"])
-        if sphere is None:
-            return
 
-        updated_crownstone = sphere.crownstones.find_by_uid(
-            ability_event.data["stone"]["uid"]
-        )
-        if updated_crownstone is None:
-            return
+def update_uart_state(manager: CrownstoneEntryManager, data: bool | None) -> None:
+    """Update the uart ready state for entities that use USB."""
+    # update availability of power usage entities.
+    dispatcher_send(manager.hass, SIG_UART_STATE_CHANGE)
 
-        ability_type: str = ability_event.data["ability"]["type"]
-        ability_enabled: bool = ability_event.data["ability"]["enabled"]
-        # only update on a change in state
-        if updated_crownstone.abilities[ability_type].is_enabled != ability_enabled:
-            # write the change to the crownstone entity.
-            updated_crownstone.abilities[ability_type].is_enabled = ability_enabled
 
-            if ability_event.data["subType"] == EVENT_ABILITY_CHANGE_DIMMING:
-                # reload the config entry because dimming is part of supported features
-                hass.async_create_task(
-                    hass.config_entries.async_reload(manager.config_entry.entry_id)
-                )
-            else:
-                # notify entity about change in state attributes
-                async_dispatcher_send(hass, SIG_CROWNSTONE_STATE_UPDATE)
-
-    def update_uart_state(data: bool | None) -> None:
-        """Update the UART ready state for the power usage."""
-        # update availability of power usage entities.
-        async_dispatcher_send(hass, SIG_UART_STATE_CHANGE)
-
-    def update_crwn_state_uart(data: AdvExternalCrownstoneState) -> None:
-        """Update the state of a Crownstone when switched from the Crownstone app."""
-        if data.type != AdvType.EXTERNAL_STATE:
-            return
-
-        updated_crownstone = None
-        for sphere in manager.cloud.cloud_data:
+def update_crwn_state_uart(
+    manager: CrownstoneEntryManager, data: AdvExternalCrownstoneState
+) -> None:
+    """Update the state of a Crownstone when switched externally."""
+    if data.type != AdvType.EXTERNAL_STATE:
+        return
+    updated_crownstone = None
+    for sphere in manager.cloud.cloud_data:
+        if sphere.cloud_id == manager.usb_sphere_id:
             updated_crownstone = sphere.crownstones.find_by_uid(data.crownstoneId)
+    if updated_crownstone is None:
+        return
 
-        if updated_crownstone is None:
-            return
+    # only update on change
+    if data.switchState is not None:
+        # this variable is initialized as None in the lib
+        updated_state = cast(SwitchState, data.switchState)
+        if updated_crownstone.state != updated_state.intensity:
+            updated_crownstone.state = updated_state.intensity
 
-        # only update on change
-        # HA sets the state manually when switching to assume switched, only update when necessary.
-        if data.switchState is not None:
-            # this variable is initialized as None in the lib
-            updated_state = cast(SwitchState, data.switchState)
-            if updated_crownstone.state != updated_state.intensity:
-                updated_crownstone.state = updated_state.intensity
+            dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
 
-                # update HA state
-                async_dispatcher_send(hass, SIG_CROWNSTONE_STATE_UPDATE)
 
-    # add SSE listeners to HA eventbus
+def setup_sse_listeners(manager: CrownstoneEntryManager) -> None:
+    """Set up SSE listeners."""
     # save unsub function for when entry removed
     manager.listeners[SSE_LISTENERS] = [
-        hass.bus.async_listen(
-            f"{DOMAIN}_{EVENT_SWITCH_STATE_UPDATE}", update_crwn_state_sse
+        manager.hass.bus.async_listen(
+            f"{DOMAIN}_{EVENT_SWITCH_STATE_UPDATE}",
+            partial(update_crwn_state_sse, manager),
         ),
-        hass.bus.async_listen(f"{DOMAIN}_{EVENT_ABILITY_CHANGE}", update_ability),
+        manager.hass.bus.async_listen(
+            f"{DOMAIN}_{EVENT_ABILITY_CHANGE}",
+            partial(update_crwn_ability, manager),
+        ),
     ]
 
-    # add UART listeners to UART eventbus
-    # save subscription id to unsub, UartEventBus is a singleton
+
+def setup_uart_listeners(manager: CrownstoneEntryManager) -> None:
+    """Set up UART listeners."""
+    # save subscription id to unsub
     manager.listeners[UART_LISTENERS] = [
-        UartEventBus.subscribe(SystemTopics.connectionEstablished, update_uart_state),
-        UartEventBus.subscribe(SystemTopics.connectionClosed, update_uart_state),
-        UartEventBus.subscribe(UartTopics.newDataAvailable, update_crwn_state_uart),
+        UartEventBus.subscribe(
+            SystemTopics.connectionEstablished,
+            partial(update_uart_state, manager),
+        ),
+        UartEventBus.subscribe(
+            SystemTopics.connectionClosed,
+            partial(update_uart_state, manager),
+        ),
+        UartEventBus.subscribe(
+            UartTopics.newDataAvailable,
+            partial(update_crwn_state_uart, manager),
+        ),
     ]

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -99,14 +99,14 @@ def update_crwn_state_uart(
     except KeyError:
         return
 
-    # only update on change
-    if data.switchState is not None:
-        # this variable is initialized as None in the lib
-        updated_state = cast(SwitchState, data.switchState)
-        if updated_crownstone.state != updated_state.intensity:
-            updated_crownstone.state = updated_state.intensity
+    if data.switchState is None:
+        return
+    # update on change
+    updated_state = cast(SwitchState, data.switchState)
+    if updated_crownstone.state != updated_state.intensity:
+        updated_crownstone.state = updated_state.intensity
 
-            dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
+        dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
 
 
 def setup_sse_listeners(manager: CrownstoneEntryManager) -> None:

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -1,0 +1,139 @@
+"""
+Listeners for updating data in the Crownstone integration.
+
+For data updates, Cloud Push is used in form of an SSE server that sends out events.
+For fast device switching Local Push is used in form of UART USB with Bluetooth.
+"""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+from crownstone_core.packets.serviceDataParsers.containers.AdvExternalCrownstoneState import (
+    AdvExternalCrownstoneState,
+)
+from crownstone_core.packets.serviceDataParsers.containers.elements.AdvTypes import (
+    AdvType,
+)
+from crownstone_core.protocol.SwitchState import SwitchState
+from crownstone_sse.const import (
+    EVENT_ABILITY_CHANGE,
+    EVENT_ABILITY_CHANGE_DIMMING,
+    EVENT_SWITCH_STATE_UPDATE,
+)
+from crownstone_uart import UartEventBus, UartTopics
+from crownstone_uart.topics.SystemTopics import SystemTopics
+
+from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import DOMAIN, SIG_CROWNSTONE_STATE_UPDATE, SIG_UART_STATE_CHANGE, SSE, UART
+
+if TYPE_CHECKING:
+    from .entry_manager import CrownstoneEntryManager
+
+
+def create_data_listeners(hass: HomeAssistant, manager: CrownstoneEntryManager) -> None:
+    """Set up SSE and UART listeners."""
+
+    @callback
+    def update_crwn_state_sse(switch_state_event: Event) -> None:
+        """Update the state of a Crownstone when switched from the Crownstone app."""
+        sphere = manager.cloud.cloud_data.find_by_id(
+            switch_state_event.data["sphere"]["id"]
+        )
+        if sphere is None:
+            return
+
+        updated_crownstone = sphere.crownstones.find_by_uid(
+            switch_state_event.data["crownstone"]["uid"]
+        )
+        if updated_crownstone is None:
+            return
+
+        # only update on change.
+        # HA sets the state manually when switching to assume switched, only update when necessary.
+        switch_state = int(switch_state_event.data["crownstone"]["percentage"])
+        if updated_crownstone.state != switch_state:
+            updated_crownstone.state = switch_state
+
+            # update the entity state
+            async_dispatcher_send(hass, SIG_CROWNSTONE_STATE_UPDATE)
+
+    @callback
+    def update_ability(ability_event: Event) -> None:
+        """
+        Update the ability information.
+
+        This update triggers an entry reload so the entity is re-created with the new data.
+        This is because the change in supported features cannot be done during runtime.
+        """
+        sphere = manager.cloud.cloud_data.find_by_id(ability_event.data["sphere"]["id"])
+        if sphere is None:
+            return
+
+        updated_crownstone = sphere.crownstones.find_by_uid(
+            ability_event.data["stone"]["uid"]
+        )
+        if updated_crownstone is None:
+            return
+
+        ability_type: str = ability_event.data["ability"]["type"]
+        ability_enabled: bool = ability_event.data["ability"]["enabled"]
+        # only update on a change in state
+        if updated_crownstone.abilities[ability_type].is_enabled != ability_enabled:
+            # write the change to the crownstone entity.
+            updated_crownstone.abilities[ability_type].is_enabled = ability_enabled
+
+            if ability_event.data["subType"] == EVENT_ABILITY_CHANGE_DIMMING:
+                # reload the config entry because dimming is part of supported features
+                hass.async_create_task(
+                    hass.config_entries.async_reload(manager.config_entry.entry_id)
+                )
+            else:
+                # notify entity about change in state attributes
+                async_dispatcher_send(hass, SIG_CROWNSTONE_STATE_UPDATE)
+
+    def update_uart_state(data: bool | None) -> None:
+        """Update the UART ready state for the power usage."""
+        # update availability of power usage entities.
+        async_dispatcher_send(hass, SIG_UART_STATE_CHANGE)
+
+    def update_crwn_state_uart(data: AdvExternalCrownstoneState) -> None:
+        """Update the state of a Crownstone when switched from the Crownstone app."""
+        if data.type != AdvType.EXTERNAL_STATE:
+            return
+
+        updated_crownstone = None
+        for sphere in manager.cloud.cloud_data:
+            updated_crownstone = sphere.crownstones.find_by_uid(data.crownstoneId)
+
+        if updated_crownstone is None:
+            return
+
+        # only update on change
+        # HA sets the state manually when switching to assume switched, only update when necessary.
+        if data.switchState is not None:
+            # this variable is initialized as None in the lib
+            updated_state = cast(SwitchState, data.switchState)
+            if updated_crownstone.state != updated_state.intensity:
+                updated_crownstone.state = updated_state.intensity
+
+                # update HA state
+                async_dispatcher_send(hass, SIG_CROWNSTONE_STATE_UPDATE)
+
+    # add SSE listeners to HA eventbus
+    # save unsub function for when entry removed
+    manager.listeners[SSE] = [
+        hass.bus.async_listen(
+            f"{DOMAIN}_{EVENT_SWITCH_STATE_UPDATE}", update_crwn_state_sse
+        ),
+        hass.bus.async_listen(f"{DOMAIN}_{EVENT_ABILITY_CHANGE}", update_ability),
+    ]
+
+    # add UART listeners to UART eventbus
+    # save subscription id to unsub, UartEventBus is a singleton
+    manager.listeners[UART] = [
+        UartEventBus.subscribe(SystemTopics.connectionEstablished, update_uart_state),
+        UartEventBus.subscribe(SystemTopics.connectionClosed, update_uart_state),
+        UartEventBus.subscribe(UartTopics.newDataAvailable, update_crwn_state_uart),
+    ]

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -2,7 +2,7 @@
 Listeners for updating data in the Crownstone integration.
 
 For data updates, Cloud Push is used in form of an SSE server that sends out events.
-For fast device switching Local Push is used in form of UART USB with Bluetooth.
+For fast device switching Local Push is used in form of a USB dongle that hooks into a BLE mesh.
 """
 from __future__ import annotations
 
@@ -41,7 +41,9 @@ if TYPE_CHECKING:
 
 
 @callback
-def update_crwn_state_sse(manager: CrownstoneEntryManager, ha_event: Event) -> None:
+def async_update_crwn_state_sse(
+    manager: CrownstoneEntryManager, ha_event: Event
+) -> None:
     """Update the state of a Crownstone when switched externally."""
     switch_event = SwitchStateUpdateEvent(ha_event.data)
     try:
@@ -56,7 +58,7 @@ def update_crwn_state_sse(manager: CrownstoneEntryManager, ha_event: Event) -> N
 
 
 @callback
-def update_crwn_ability(manager: CrownstoneEntryManager, ha_event: Event) -> None:
+def async_update_crwn_ability(manager: CrownstoneEntryManager, ha_event: Event) -> None:
     """Update the ability information of a Crownstone."""
     ability_event = AbilityChangeEvent(ha_event.data)
     try:
@@ -117,11 +119,11 @@ def setup_sse_listeners(manager: CrownstoneEntryManager) -> None:
     manager.listeners[SSE_LISTENERS] = [
         manager.hass.bus.async_listen(
             f"{DOMAIN}_{EVENT_SWITCH_STATE_UPDATE}",
-            partial(update_crwn_state_sse, manager),
+            partial(async_update_crwn_state_sse, manager),
         ),
         manager.hass.bus.async_listen(
             f"{DOMAIN}_{EVENT_ABILITY_CHANGE}",
-            partial(update_crwn_ability, manager),
+            partial(async_update_crwn_ability, manager),
         ),
     ]
 

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -80,7 +80,7 @@ def update_crwn_ability(manager: CrownstoneEntryManager, ha_event: Event) -> Non
             async_dispatcher_send(manager.hass, SIG_CROWNSTONE_STATE_UPDATE)
 
 
-def update_uart_state(manager: CrownstoneEntryManager, data: bool | None) -> None:
+def update_uart_state(manager: CrownstoneEntryManager, _: bool | None) -> None:
     """Update the uart ready state for entities that use USB."""
     # update availability of power usage entities.
     dispatcher_send(manager.hass, SIG_UART_STATE_CHANGE)

--- a/homeassistant/components/crownstone/listeners.py
+++ b/homeassistant/components/crownstone/listeners.py
@@ -26,7 +26,13 @@ from crownstone_uart.topics.SystemTopics import SystemTopics
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import DOMAIN, SIG_CROWNSTONE_STATE_UPDATE, SIG_UART_STATE_CHANGE, SSE, UART
+from .const import (
+    DOMAIN,
+    SIG_CROWNSTONE_STATE_UPDATE,
+    SIG_UART_STATE_CHANGE,
+    SSE_LISTENERS,
+    UART_LISTENERS,
+)
 
 if TYPE_CHECKING:
     from .entry_manager import CrownstoneEntryManager
@@ -123,7 +129,7 @@ def create_data_listeners(hass: HomeAssistant, manager: CrownstoneEntryManager) 
 
     # add SSE listeners to HA eventbus
     # save unsub function for when entry removed
-    manager.listeners[SSE] = [
+    manager.listeners[SSE_LISTENERS] = [
         hass.bus.async_listen(
             f"{DOMAIN}_{EVENT_SWITCH_STATE_UPDATE}", update_crwn_state_sse
         ),
@@ -132,7 +138,7 @@ def create_data_listeners(hass: HomeAssistant, manager: CrownstoneEntryManager) 
 
     # add UART listeners to UART eventbus
     # save subscription id to unsub, UartEventBus is a singleton
-    manager.listeners[UART] = [
+    manager.listeners[UART_LISTENERS] = [
         UartEventBus.subscribe(SystemTopics.connectionEstablished, update_uart_state),
         UartEventBus.subscribe(SystemTopics.connectionClosed, update_uart_state),
         UartEventBus.subscribe(UartTopics.newDataAvailable, update_crwn_state_uart),

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -7,7 +7,7 @@
     "crownstone-cloud==1.4.5",
     "crownstone-sse==2.0.0",
     "crownstone-uart==2.0.0",
-    "numpy==1.20.2",
+    "numpy==1.21.1",
     "pyserial==3.5"
   ],
   "codeowners": [

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -9,9 +9,7 @@
     "crownstone-uart==2.1.0",
     "pyserial==3.5"
   ],
-  "codeowners": [
-    "@Crownstone",
-    "@RicArch97"
-  ],
+  "codeowners": ["@Crownstone", "@RicArch97"],
+  "after_dependencies": ["usb"],
   "iot_class": "cloud_push"
 }

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -4,8 +4,8 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/crownstone",
   "requirements": [
-    "crownstone-cloud==1.4.6",
-    "crownstone-sse==2.0.1",
+    "crownstone-cloud==1.4.7",
+    "crownstone-sse==2.0.2",
     "crownstone-uart==2.1.0",
     "pyserial==3.5"
   ],

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -1,0 +1,18 @@
+{
+  "domain": "crownstone",
+  "name": "Crownstone",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/crownstone",
+  "requirements": [
+    "crownstone-cloud==1.4.5",
+    "crownstone-sse==2.0.0",
+    "crownstone-uart==2.0.0",
+    "numpy==1.20.2",
+    "pyserial==3.5"
+  ],
+  "codeowners": [
+    "@Crownstone",
+    "@RicArch97"
+  ],
+  "iot_class": "cloud_push"
+}

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -7,7 +7,6 @@
     "crownstone-cloud==1.4.5",
     "crownstone-sse==2.0.0",
     "crownstone-uart==2.0.0",
-    "numpy==1.21.1",
     "pyserial==3.5"
   ],
   "codeowners": [

--- a/homeassistant/components/crownstone/manifest.json
+++ b/homeassistant/components/crownstone/manifest.json
@@ -4,9 +4,9 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/crownstone",
   "requirements": [
-    "crownstone-cloud==1.4.5",
-    "crownstone-sse==2.0.0",
-    "crownstone-uart==2.0.0",
+    "crownstone-cloud==1.4.6",
+    "crownstone-sse==2.0.1",
+    "crownstone-uart==2.1.0",
     "pyserial==3.5"
   ],
   "codeowners": [

--- a/homeassistant/components/crownstone/strings.json
+++ b/homeassistant/components/crownstone/strings.json
@@ -31,6 +31,13 @@
         },
         "title": "Crownstone USB dongle manual path",
         "description": "Manually enter the path of a Crownstone USB dongle."
+      },
+      "usb_sphere_config": {
+        "data": {
+          "usb_sphere": "Crownstone Sphere"
+        },
+        "title": "Crownstone USB Sphere",
+        "description": "Select a Crownstone Sphere where the USB is located."
       }
     }
   },
@@ -38,8 +45,30 @@
     "step": {
       "init": {
         "data": {
-          "use_crownstone_usb": "Use a Crownstone USB dongle for local data transmission."
+          "use_usb_option": "Use a Crownstone USB dongle for local data transmission",
+          "usb_sphere_option": "Crownstone Sphere where the USB is located"
         }
+      },
+      "usb_config_option": {
+        "data": {
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Crownstone USB dongle configuration",
+        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60."
+      },
+      "usb_manual_config_option": {
+        "data": {
+          "usb_manual_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Crownstone USB dongle manual path",
+        "description": "Manually enter the path of a Crownstone USB dongle."
+      },
+      "usb_sphere_config_option": {
+        "data": {
+          "usb_sphere": "Crownstone Sphere"
+        },
+        "title": "Crownstone USB Sphere",
+        "description": "Select a Crownstone Sphere where the USB is located."
       }
     }
   }

--- a/homeassistant/components/crownstone/strings.json
+++ b/homeassistant/components/crownstone/strings.json
@@ -23,7 +23,7 @@
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Crownstone USB dongle configuration",
-        "description": "Select the serial port of the Crownstone USB dongle, or select 'Don't use USB' if you don't want to setup a USB dongle.\n\nLook for a device with VID 10c4 and PID ea60."
+        "description": "Select the serial port of the Crownstone USB dongle, or select 'Don't use USB' if you don't want to setup a USB dongle.\n\nLook for a device with VID 10C4 and PID EA60."
       },
       "usb_manual_config": {
         "data": {
@@ -54,7 +54,7 @@
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Crownstone USB dongle configuration",
-        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60."
+        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10C4 and PID EA60."
       },
       "usb_manual_config_option": {
         "data": {

--- a/homeassistant/components/crownstone/strings.json
+++ b/homeassistant/components/crownstone/strings.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "usb_setup_successful": "Crownstone USB setup was successful.",
+      "usb_setup_unsuccessful": "Crownstone USB setup was unsuccessful."
+    },
+    "error": {
+      "account_not_verified": "Account not verified. Please activate your account through the activation email from Crownstone.",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "title": "Crownstone account"
+      },
+      "usb": {
+        "data": {
+          "usb": "Set up a Crownstone USB dongle"
+        },
+        "title": "Crownstone USB dongle"
+      },
+      "usb_config": {
+        "data": {
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Crownstone USB dongle configuration",
+        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with name \"CP2104 USB to UART Bridge Controller\""
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "use_crownstone_usb": "Use a Crownstone USB dongle for local data transmission."
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/crownstone/strings.json
+++ b/homeassistant/components/crownstone/strings.json
@@ -18,18 +18,12 @@
         },
         "title": "Crownstone account"
       },
-      "usb": {
-        "data": {
-          "usb": "Set up a Crownstone USB dongle"
-        },
-        "title": "Crownstone USB dongle"
-      },
       "usb_config": {
         "data": {
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Crownstone USB dongle configuration",
-        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60."
+        "description": "Select the serial port of the Crownstone USB dongle, or select 'Don't use USB' if you don't want to setup a USB dongle.\n\nLook for a device with VID 10c4 and PID ea60."
       },
       "usb_manual_config": {
         "data": {

--- a/homeassistant/components/crownstone/strings.json
+++ b/homeassistant/components/crownstone/strings.json
@@ -2,7 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "usb_setup_successful": "Crownstone USB setup was successful.",
+      "usb_setup_complete": "Crownstone USB setup complete.",
       "usb_setup_unsuccessful": "Crownstone USB setup was unsuccessful."
     },
     "error": {
@@ -29,7 +29,14 @@
           "usb_path": "[%key:common::config_flow::data::usb_path%]"
         },
         "title": "Crownstone USB dongle configuration",
-        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with name \"CP2104 USB to UART Bridge Controller\""
+        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60."
+      },
+      "usb_manual_config": {
+        "data": {
+          "usb_manual_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Crownstone USB dongle manual path",
+        "description": "Manually enter the path of a Crownstone USB dongle."
       }
     }
   },

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -25,6 +25,13 @@
                 "description": "Manually enter the path of a Crownstone USB dongle.",
                 "title": "Crownstone USB dongle manual path"
             },
+            "usb_sphere_config": {
+                "data": {
+                    "usb_sphere": "Crownstone Sphere"
+                },
+                "description": "Select a Crownstone Sphere where the USB is located.",
+                "title": "Crownstone USB Sphere"
+            },
             "user": {
                 "data": {
                     "email": "Email",
@@ -38,8 +45,30 @@
         "step": {
             "init": {
                 "data": {
-                    "use_crownstone_usb": "Use a Crownstone USB dongle for local data transmission."
+                    "usb_sphere_option": "Crownstone Sphere where the USB is located",
+                    "use_usb_option": "Use a Crownstone USB dongle for local data transmission"
                 }
+            },
+            "usb_config_option": {
+                "data": {
+                    "usb_path": "USB Device Path"
+                },
+                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60.",
+                "title": "Crownstone USB dongle configuration"
+            },
+            "usb_manual_config_option": {
+                "data": {
+                    "usb_manual_path": "USB Device Path"
+                },
+                "description": "Manually enter the path of a Crownstone USB dongle.",
+                "title": "Crownstone USB dongle manual path"
+            },
+            "usb_sphere_config_option": {
+                "data": {
+                    "usb_sphere": "Crownstone Sphere"
+                },
+                "description": "Select a Crownstone Sphere where the USB is located.",
+                "title": "Crownstone USB Sphere"
             }
         }
     }

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "abort": {
             "already_configured": "Account is already configured",
-            "usb_setup_successful": "Crownstone USB setup was successful.",
+            "usb_setup_complete": "Crownstone USB setup complete.",
             "usb_setup_unsuccessful": "Crownstone USB setup was unsuccessful."
         },
         "error": {
@@ -21,8 +21,15 @@
                 "data": {
                     "usb_path": "USB Device Path"
                 },
-                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with name \"CP2104 USB to UART Bridge Controller\"",
+                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60.",
                 "title": "Crownstone USB dongle configuration"
+            },
+            "usb_manual_config": {
+                "data": {
+                    "usb_manual_path": "USB Device Path"
+                },
+                "description": "Manually enter the path of a Crownstone USB dongle.",
+                "title": "Crownstone USB dongle manual path"
             },
             "user": {
                 "data": {

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -11,17 +11,11 @@
             "unknown": "Unexpected error"
         },
         "step": {
-            "usb": {
-                "data": {
-                    "usb": "Set up a Crownstone USB dongle"
-                },
-                "title": "Crownstone USB dongle"
-            },
             "usb_config": {
                 "data": {
                     "usb_path": "USB Device Path"
                 },
-                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60.",
+                "description": "Select the serial port of the Crownstone USB dongle, or select 'Don't use USB' if you don't want to setup a USB dongle.\n\nLook for a device with VID 10c4 and PID ea60.",
                 "title": "Crownstone USB dongle configuration"
             },
             "usb_manual_config": {

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -15,7 +15,7 @@
                 "data": {
                     "usb_path": "USB Device Path"
                 },
-                "description": "Select the serial port of the Crownstone USB dongle, or select 'Don't use USB' if you don't want to setup a USB dongle.\n\nLook for a device with VID 10c4 and PID ea60.",
+                "description": "Select the serial port of the Crownstone USB dongle, or select 'Don't use USB' if you don't want to setup a USB dongle.\n\nLook for a device with VID 10C4 and PID EA60.",
                 "title": "Crownstone USB dongle configuration"
             },
             "usb_manual_config": {
@@ -53,7 +53,7 @@
                 "data": {
                     "usb_path": "USB Device Path"
                 },
-                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10c4 and PID ea60.",
+                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with VID 10C4 and PID EA60.",
                 "title": "Crownstone USB dongle configuration"
             },
             "usb_manual_config_option": {

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "usb_setup_successful": "Crownstone USB setup was successful.",
+      "usb_setup_unsuccessful": "Crownstone USB setup was unsuccessful."
+    },
+    "error": {
+      "account_not_verified": "Account not verified. Please activate your account through the activation email from Crownstone.",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "email": "[%key:common::config_flow::data::email%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "title": "Crownstone account"
+      },
+      "usb": {
+        "data": {
+          "usb": "Set up a Crownstone USB dongle"
+        },
+        "title": "Crownstone USB dongle"
+      },
+      "usb_config": {
+        "data": {
+          "usb_path": "[%key:common::config_flow::data::usb_path%]"
+        },
+        "title": "Crownstone USB dongle configuration",
+        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with name \"CP2104 USB to UART Bridge Controller\""
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "use_crownstone_usb": "Use a Crownstone USB dongle for local data transmission."
+        }
+      }
+    }
+  }
+}

--- a/homeassistant/components/crownstone/translations/en.json
+++ b/homeassistant/components/crownstone/translations/en.json
@@ -1,45 +1,45 @@
 {
-  "config": {
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
-      "usb_setup_successful": "Crownstone USB setup was successful.",
-      "usb_setup_unsuccessful": "Crownstone USB setup was unsuccessful."
-    },
-    "error": {
-      "account_not_verified": "Account not verified. Please activate your account through the activation email from Crownstone.",
-      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]"
-    },
-    "step": {
-      "user": {
-        "data": {
-          "email": "[%key:common::config_flow::data::email%]",
-          "password": "[%key:common::config_flow::data::password%]"
+    "config": {
+        "abort": {
+            "already_configured": "Account is already configured",
+            "usb_setup_successful": "Crownstone USB setup was successful.",
+            "usb_setup_unsuccessful": "Crownstone USB setup was unsuccessful."
         },
-        "title": "Crownstone account"
-      },
-      "usb": {
-        "data": {
-          "usb": "Set up a Crownstone USB dongle"
+        "error": {
+            "account_not_verified": "Account not verified. Please activate your account through the activation email from Crownstone.",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
         },
-        "title": "Crownstone USB dongle"
-      },
-      "usb_config": {
-        "data": {
-          "usb_path": "[%key:common::config_flow::data::usb_path%]"
-        },
-        "title": "Crownstone USB dongle configuration",
-        "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with name \"CP2104 USB to UART Bridge Controller\""
-      }
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "use_crownstone_usb": "Use a Crownstone USB dongle for local data transmission."
+        "step": {
+            "usb": {
+                "data": {
+                    "usb": "Set up a Crownstone USB dongle"
+                },
+                "title": "Crownstone USB dongle"
+            },
+            "usb_config": {
+                "data": {
+                    "usb_path": "USB Device Path"
+                },
+                "description": "Select the serial port of the Crownstone USB dongle.\n\nLook for a device with name \"CP2104 USB to UART Bridge Controller\"",
+                "title": "Crownstone USB dongle configuration"
+            },
+            "user": {
+                "data": {
+                    "email": "Email",
+                    "password": "Password"
+                },
+                "title": "Crownstone account"
+            }
         }
-      }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "use_crownstone_usb": "Use a Crownstone USB dongle for local data transmission."
+                }
+            }
+        }
     }
-  }
 }

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -52,6 +52,7 @@ FLOWS = [
     "control4",
     "coolmaster",
     "coronavirus",
+    "crownstone",
     "daikin",
     "deconz",
     "denonavr",

--- a/mypy.ini
+++ b/mypy.ini
@@ -308,6 +308,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.crownstone.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.device_automation.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -490,13 +490,13 @@ coronavirus==1.1.1
 croniter==1.0.6
 
 # homeassistant.components.crownstone
-crownstone-cloud==1.4.5
+crownstone-cloud==1.4.6
 
 # homeassistant.components.crownstone
-crownstone-sse==2.0.0
+crownstone-sse==2.0.1
 
 # homeassistant.components.crownstone
-crownstone-uart==2.0.0
+crownstone-uart==2.1.0
 
 # homeassistant.components.datadog
 datadog==0.15.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -490,10 +490,10 @@ coronavirus==1.1.1
 croniter==1.0.6
 
 # homeassistant.components.crownstone
-crownstone-cloud==1.4.6
+crownstone-cloud==1.4.7
 
 # homeassistant.components.crownstone
-crownstone-sse==2.0.1
+crownstone-sse==2.0.2
 
 # homeassistant.components.crownstone
 crownstone-uart==2.1.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -489,6 +489,15 @@ coronavirus==1.1.1
 # homeassistant.components.utility_meter
 croniter==1.0.6
 
+# homeassistant.components.crownstone
+crownstone-cloud==1.4.5
+
+# homeassistant.components.crownstone
+crownstone-sse==2.0.0
+
+# homeassistant.components.crownstone
+crownstone-uart==2.0.0
+
 # homeassistant.components.datadog
 datadog==0.15.0
 
@@ -1075,6 +1084,7 @@ nuheat==0.3.0
 numato-gpio==0.10.0
 
 # homeassistant.components.compensation
+# homeassistant.components.crownstone
 # homeassistant.components.iqvia
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1090,9 +1090,6 @@ numato-gpio==0.10.0
 # homeassistant.components.trend
 numpy==1.21.1
 
-# homeassistant.components.crownstone
-numpy==1.21.1
-
 # homeassistant.components.oasa_telematics
 oasatelematics==0.3
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1770,6 +1770,7 @@ pysensibo==1.0.3
 pyserial-asyncio==0.5
 
 # homeassistant.components.acer_projector
+# homeassistant.components.crownstone
 # homeassistant.components.usb
 # homeassistant.components.zha
 pyserial==3.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1084,11 +1084,13 @@ nuheat==0.3.0
 numato-gpio==0.10.0
 
 # homeassistant.components.compensation
-# homeassistant.components.crownstone
 # homeassistant.components.iqvia
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
+numpy==1.21.1
+
+# homeassistant.components.crownstone
 numpy==1.21.1
 
 # homeassistant.components.oasa_telematics

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1029,6 +1029,7 @@ pyruckus==0.12
 pyserial-asyncio==0.5
 
 # homeassistant.components.acer_projector
+# homeassistant.components.crownstone
 # homeassistant.components.usb
 # homeassistant.components.zha
 pyserial==3.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -286,10 +286,10 @@ coronavirus==1.1.1
 croniter==1.0.6
 
 # homeassistant.components.crownstone
-crownstone-cloud==1.4.6
+crownstone-cloud==1.4.7
 
 # homeassistant.components.crownstone
-crownstone-sse==2.0.1
+crownstone-sse==2.0.2
 
 # homeassistant.components.crownstone
 crownstone-uart==2.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -286,13 +286,13 @@ coronavirus==1.1.1
 croniter==1.0.6
 
 # homeassistant.components.crownstone
-crownstone-cloud==1.4.5
+crownstone-cloud==1.4.6
 
 # homeassistant.components.crownstone
-crownstone-sse==2.0.0
+crownstone-sse==2.0.1
 
 # homeassistant.components.crownstone
-crownstone-uart==2.0.0
+crownstone-uart==2.1.0
 
 # homeassistant.components.datadog
 datadog==0.15.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -631,9 +631,6 @@ numato-gpio==0.10.0
 # homeassistant.components.trend
 numpy==1.21.1
 
-# homeassistant.components.crownstone
-numpy==1.21.1
-
 # homeassistant.components.google
 oauth2client==4.0.0
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -625,11 +625,13 @@ nuheat==0.3.0
 numato-gpio==0.10.0
 
 # homeassistant.components.compensation
-# homeassistant.components.crownstone
 # homeassistant.components.iqvia
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow
 # homeassistant.components.trend
+numpy==1.21.1
+
+# homeassistant.components.crownstone
 numpy==1.21.1
 
 # homeassistant.components.google

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -285,6 +285,15 @@ coronavirus==1.1.1
 # homeassistant.components.utility_meter
 croniter==1.0.6
 
+# homeassistant.components.crownstone
+crownstone-cloud==1.4.5
+
+# homeassistant.components.crownstone
+crownstone-sse==2.0.0
+
+# homeassistant.components.crownstone
+crownstone-uart==2.0.0
+
 # homeassistant.components.datadog
 datadog==0.15.0
 
@@ -616,6 +625,7 @@ nuheat==0.3.0
 numato-gpio==0.10.0
 
 # homeassistant.components.compensation
+# homeassistant.components.crownstone
 # homeassistant.components.iqvia
 # homeassistant.components.opencv
 # homeassistant.components.tensorflow

--- a/tests/components/crownstone/__init__.py
+++ b/tests/components/crownstone/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Crownstone integration."""

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from crownstone_cloud.cloud_models.spheres import Spheres
 from crownstone_cloud.exceptions import (
     CrownstoneAuthenticationError,
     CrownstoneUnknownError,
@@ -14,12 +15,14 @@ from homeassistant import data_entry_flow
 from homeassistant.components.crownstone.const import (
     CONF_USB_MANUAL_PATH,
     CONF_USB_PATH,
-    CONF_USE_CROWNSTONE_USB,
+    CONF_USB_SPHERE,
+    CONF_USB_SPHERE_OPTION,
+    CONF_USE_USB_OPTION,
     DOMAIN,
     DONT_USE_USB,
     MANUAL_PATH,
 )
-from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_UNIQUE_ID
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -34,14 +37,25 @@ def crownstone_setup():
         yield
 
 
-def get_mocked_crownstone_cloud():
+def get_mocked_crownstone_cloud(spheres: dict[str, MagicMock] | None = None):
     """Return a mocked Crownstone Cloud instance."""
     mock_cloud = MagicMock()
     mock_cloud.async_initialize = AsyncMock()
-    mock_cloud.cloud_data = MagicMock()
-    mock_cloud.cloud_data.user_id = "account_id"
+    mock_cloud.cloud_data = Spheres(MagicMock(), "account_id")
+    mock_cloud.cloud_data.spheres = spheres
 
     return mock_cloud
+
+
+def create_mocked_spheres(amount: int) -> dict[str, MagicMock]:
+    """Return a dict with mocked sphere instances."""
+    spheres: dict[str, MagicMock] = {}
+    for i in range(amount):
+        spheres[f"sphere_id_{i}"] = MagicMock()
+        spheres[f"sphere_id_{i}"].name = f"sphere_name_{i}"
+        spheres[f"sphere_id_{i}"].cloud_id = f"sphere_id_{i}"
+
+    return spheres
 
 
 def get_mocked_com_port():
@@ -55,19 +69,21 @@ def get_mocked_com_port():
     return port
 
 
-def create_mocked_entry_conf(email: str, password: str, usb_path: str | None):
+def create_mocked_entry_conf(
+    email: str, password: str, usb_path: str | None, usb_sphere: str | None
+):
     """Set a result for the entry for comparison."""
     MOCK_CONF: dict[str, str | None] = {}
     MOCK_CONF[CONF_EMAIL] = email
     MOCK_CONF[CONF_PASSWORD] = password
     MOCK_CONF[CONF_USB_PATH] = usb_path
+    MOCK_CONF[CONF_USB_SPHERE] = usb_sphere
 
     return MOCK_CONF
 
 
-async def start_user_flow(hass: HomeAssistant, mocked_cloud: MagicMock):
+async def start_config_flow(hass: HomeAssistant, mocked_cloud: MagicMock):
     """Patch Crownstone Cloud and start the flow."""
-    # mock login
     mocked_login_input = {
         CONF_EMAIL: "example@homeassistant.com",
         CONF_PASSWORD: "homeassistantisawesome",
@@ -82,6 +98,18 @@ async def start_user_flow(hass: HomeAssistant, mocked_cloud: MagicMock):
         )
 
     return result
+
+
+async def start_options_flow(
+    hass: HomeAssistant, entry_id: str, mocked_cloud: MagicMock
+):
+    """Patch CrownstoneEntryManager and start the flow."""
+    mocked_manager = MagicMock()
+    mocked_manager.cloud = mocked_cloud
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN][entry_id] = mocked_manager
+
+    return await hass.config_entries.options.async_init(entry_id)
 
 
 async def test_no_user_input(hass: HomeAssistant):
@@ -102,6 +130,7 @@ async def test_abort_if_configured(hass: HomeAssistant):
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path="/dev/serial/by-id/crownstone-usb",
+        usb_sphere="sphere_id",
     )
 
     # create mocked entry
@@ -111,7 +140,7 @@ async def test_abort_if_configured(hass: HomeAssistant):
         unique_id="account_id",
     ).add_to_hass(hass)
 
-    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    result = await start_config_flow(hass, get_mocked_crownstone_cloud())
 
     # test if we abort if we try to configure the same entry
     assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
@@ -126,7 +155,7 @@ async def test_authentication_errors(hass: HomeAssistant):
         exception_type="LOGIN_FAILED"
     )
 
-    result = await start_user_flow(hass, cloud)
+    result = await start_config_flow(hass, cloud)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "invalid_auth"}
@@ -136,7 +165,7 @@ async def test_authentication_errors(hass: HomeAssistant):
         exception_type="LOGIN_FAILED_EMAIL_NOT_VERIFIED"
     )
 
-    result = await start_user_flow(hass, cloud)
+    result = await start_config_flow(hass, cloud)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "account_not_verified"}
@@ -148,7 +177,7 @@ async def test_unknown_error(hass: HomeAssistant):
     # side effect: unknown error
     cloud.async_initialize.side_effect = CrownstoneUnknownError
 
-    result = await start_user_flow(hass, cloud)
+    result = await start_config_flow(hass, cloud)
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["errors"] == {"base": "unknown_error"}
@@ -160,8 +189,9 @@ async def test_successful_login_no_usb(hass: HomeAssistant):
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path=None,
+        usb_sphere=None,
     )
-    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    result = await start_config_flow(hass, get_mocked_crownstone_cloud())
     # should show usb form
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "usb_config"
@@ -187,8 +217,11 @@ async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssis
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path="/dev/serial/by-id/crownstone-usb",
+        usb_sphere="sphere_id_1",
     )
-    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    result = await start_config_flow(
+        hass, get_mocked_crownstone_cloud(create_mocked_spheres(2))
+    )
     # should show usb form
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "usb_config"
@@ -205,82 +238,16 @@ async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssis
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={CONF_USB_PATH: port_select}
     )
-
-    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["data"] == entry_with_usb
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_sphere_config"
     assert serial_mock.call_count == 1
 
-
-@patch(
-    "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
-)
-@patch(
-    "homeassistant.components.usb.get_serial_by_id",
-    return_value="/dev/serial/by-id/crownstone-usb",
-)
-async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
-    """Tests the update to the USB config triggered by options flow."""
-    # create mock entry conf
-    configured_entry = create_mocked_entry_conf(
-        email="example@homeassistant.com",
-        password="homeassistantisawesome",
-        usb_path=None,
+    # select a sphere
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_SPHERE: "sphere_name_1"}
     )
-
-    # create mocked entry
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data=configured_entry,
-        unique_id="account_id",
-    )
-    entry.add_to_hass(hass)
-
-    # create a mocked port
-    port = get_mocked_com_port()
-    port_select = (
-        f"{port.device}"
-        + f" - {port.product}"
-        + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
-    )
-
-    get = patch(
-        "homeassistant.config_entries.ConfigEntries.async_get_entry", return_value=entry
-    )
-    reload = patch("homeassistant.config_entries.ConfigEntries.async_reload")
-
-    # initialized from options flow callback
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": "usb_config"},
-        data={CONF_UNIQUE_ID: "example@homeassistant.com"},
-    )
-
-    with get as get_mock, reload as reload_mock:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_USB_PATH: port_select}
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "usb_setup_complete"
-        assert entry.data[CONF_USB_PATH] == "/dev/serial/by-id/crownstone-usb"
-        assert get_mock.call_count == 1
-        assert reload_mock.call_count == 1
-
-    get_none = patch(
-        "homeassistant.config_entries.ConfigEntries.async_get_entry", return_value=None
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": "usb_config"},
-        data={CONF_UNIQUE_ID: "example@homeassistant.com"},
-    )
-
-    with get_none as get_mock:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_USB_PATH: port_select}
-        )
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "usb_setup_unsuccessful"
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == entry_with_usb
 
 
 @patch(
@@ -292,8 +259,11 @@ async def test_successful_login_with_manual_usb_path(hass: HomeAssistant):
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path="/dev/crownstone-usb",
+        usb_sphere="sphere_id_0",
     )
-    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    result = await start_config_flow(
+        hass, get_mocked_crownstone_cloud(create_mocked_spheres(1))
+    )
     # should show usb form
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "usb_config"
@@ -312,39 +282,26 @@ async def test_successful_login_with_manual_usb_path(hass: HomeAssistant):
         result["flow_id"], user_input={CONF_USB_MANUAL_PATH: path}
     )
 
+    # since we only have 1 sphere here, test that it's automatically selected and
+    # creating entry without asking for user input
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert result["data"] == entry_with_manual_usb
 
-    # test update existing usb call for manual path
-    ret_val = {
-        "type": data_entry_flow.RESULT_TYPE_ABORT,
-        "reason": "usb_setup_complete",
-    }
-    update_usb = patch(
-        "homeassistant.components.crownstone.config_flow.CrownstoneConfigFlowHandler.async_update_existing_entry_usb_path",
-        return_value=ret_val,
-    )
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": "usb_config"},
-        data={CONF_UNIQUE_ID: "example@homeassistant.com"},
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_USB_PATH: MANUAL_PATH}
-    )
-    with update_usb as update_usb_mock:
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], user_input={CONF_USB_MANUAL_PATH: path}
-        )
-        assert update_usb_mock.call_count == 1
 
-
-async def test_options_flow(hass: HomeAssistant):
-    """Test options flow."""
+@patch(
+    "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
+)
+@patch(
+    "homeassistant.components.usb.get_serial_by_id",
+    return_value="/dev/serial/by-id/crownstone-usb",
+)
+async def test_options_flow_setup_usb(serial_mock: MagicMock, hass: HomeAssistant):
+    """Test options flow init."""
     configured_entry = create_mocked_entry_conf(
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path=None,
+        usb_sphere=None,
     )
 
     # create mocked entry
@@ -355,19 +312,186 @@ async def test_options_flow(hass: HomeAssistant):
     )
     entry.add_to_hass(hass)
 
-    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await start_options_flow(
+        hass, entry.entry_id, get_mocked_crownstone_cloud(create_mocked_spheres(2))
+    )
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == "init"
 
     schema = result["data_schema"].schema
     for schema_key in schema:
-        if schema_key == CONF_USE_CROWNSTONE_USB:
-            # based on existence of a usb-path string
+        if schema_key == CONF_USE_USB_OPTION:
             assert not schema_key.default()
 
+    # USB is not set up, so this should not be in the options
+    assert CONF_USB_SPHERE_OPTION not in schema
+
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={CONF_USE_CROWNSTONE_USB: True}
+        result["flow_id"], user_input={CONF_USE_USB_OPTION: True}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_config_option"
+
+    # create a mocked port
+    port = get_mocked_com_port()
+    port_select = (
+        f"{port.device}"
+        + f" - {port.product}"
+        + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+    )
+
+    # select a port from the list
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: port_select}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_sphere_config_option"
+    assert serial_mock.call_count == 1
+
+    # select a sphere
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_USB_SPHERE: "sphere_name_1"}
     )
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-    assert result["data"] == {CONF_USE_CROWNSTONE_USB: True}
+    assert result["data"] == {CONF_USE_USB_OPTION: True}
+    # check updated entry data
+    assert entry.data[CONF_USB_PATH] == "/dev/serial/by-id/crownstone-usb"
+    assert entry.data[CONF_USB_SPHERE] == "sphere_id_1"
+
+
+async def test_options_flow_remove_usb(hass: HomeAssistant):
+    """Test selecting to set up an USB dongle."""
+    configured_entry = create_mocked_entry_conf(
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path="/dev/serial/by-id/crownstone-usb",
+        usb_sphere="sphere_id_0",
+    )
+
+    # create mocked entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=configured_entry,
+        unique_id="account_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await start_options_flow(
+        hass, entry.entry_id, get_mocked_crownstone_cloud(create_mocked_spheres(2))
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    schema = result["data_schema"].schema
+    for schema_key in schema:
+        if schema_key == CONF_USE_USB_OPTION:
+            assert schema_key.default()
+        if schema_key == CONF_USB_SPHERE_OPTION:
+            assert schema_key.default() == "sphere_name_0"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_USE_USB_OPTION: False,
+            CONF_USB_SPHERE_OPTION: "sphere_name_0",
+        },
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {CONF_USE_USB_OPTION: False}
+    # check updated entry data
+    assert entry.data[CONF_USB_PATH] is None
+    assert entry.data[CONF_USB_SPHERE] is None
+
+
+@patch(
+    "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
+)
+async def test_options_flow_manual_usb_path(hass: HomeAssistant):
+    """Test flow with correct login and usb configuration."""
+    configured_entry = create_mocked_entry_conf(
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path=None,
+        usb_sphere=None,
+    )
+
+    # create mocked entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=configured_entry,
+        unique_id="account_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await start_options_flow(
+        hass, entry.entry_id, get_mocked_crownstone_cloud(create_mocked_spheres(1))
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_USE_USB_OPTION: True}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_config_option"
+
+    # select manual from the list
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: MANUAL_PATH}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_manual_config_option"
+
+    # enter USB path
+    path = "/dev/crownstone-usb"
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_USB_MANUAL_PATH: path}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {CONF_USE_USB_OPTION: True}
+    # check updated entry data
+    assert entry.data[CONF_USB_PATH] == path
+    assert entry.data[CONF_USB_SPHERE] == "sphere_id_0"
+
+
+async def test_options_flow_change_usb_sphere(hass: HomeAssistant):
+    """Test changing the usb sphere in the options."""
+    configured_entry = create_mocked_entry_conf(
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path="/dev/serial/by-id/crownstone-usb",
+        usb_sphere="sphere_id_0",
+    )
+
+    # create mocked entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=configured_entry,
+        unique_id="account_id",
+    )
+    entry.add_to_hass(hass)
+
+    result = await start_options_flow(
+        hass, entry.entry_id, get_mocked_crownstone_cloud(create_mocked_spheres(3))
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_USE_USB_OPTION: True, CONF_USB_SPHERE_OPTION: "sphere_name_2"},
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {
+        CONF_USE_USB_OPTION: True,
+        CONF_USB_SPHERE_OPTION: "sphere_id_2",
+    }
+    # check updated entry data
+    assert entry.data[CONF_USB_PATH] == "/dev/serial/by-id/crownstone-usb"
+    assert entry.data[CONF_USB_SPHERE] == "sphere_id_2"

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -1,4 +1,6 @@
 """Tests for the Crownstone integration."""
+from __future__ import annotations
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from crownstone_cloud.exceptions import (
@@ -10,7 +12,9 @@ from serial.tools.list_ports_common import ListPortInfo
 
 from homeassistant import data_entry_flow
 from homeassistant.components.crownstone.const import (
+    CONF_MANUAL_PATH,
     CONF_USB,
+    CONF_USB_MANUAL_PATH,
     CONF_USB_PATH,
     CONF_USE_CROWNSTONE_USB,
     DOMAIN,
@@ -41,17 +45,19 @@ def get_mocked_crownstone_cloud():
 def get_mocked_com_port():
     """Mock of a serial port."""
     port = ListPortInfo("/dev/ttyUSB1234")
-    port.serial_number = "1234"
-    port.manufacturer = "Crownstone"
     port.device = "/dev/ttyUSB1234"
-    port.description = "Crownstone USB"
+    port.product = "Crownstone dongle"
+    port.vid = 1234
+    port.pid = 5678
 
     return port
 
 
-def create_mocked_entry_conf(unique_id: str, email: str, password: str, usb_path: str):
+def create_mocked_entry_conf(
+    unique_id: str, email: str, password: str, usb_path: str | None
+):
     """Set a result for the entry for comparison."""
-    MOCK_CONF = {}
+    MOCK_CONF: dict[str, str | None] = {}
     MOCK_CONF[CONF_ID] = unique_id
     MOCK_CONF[CONF_EMAIL] = email
     MOCK_CONF[CONF_PASSWORD] = password
@@ -200,7 +206,11 @@ async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssis
 
     # create a mocked port
     port = get_mocked_com_port()
-    port_select = f"{port}" + f" - {port.manufacturer}"
+    port_select = (
+        f"{port.device}"
+        + f" - {port.product}"
+        + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+    )
 
     # select a port from the list
     result = await hass.config_entries.flow.async_configure(
@@ -239,7 +249,11 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
 
     # create a mocked port
     port = get_mocked_com_port()
-    port_select = f"{port}" + f" - {port.manufacturer}"
+    port_select = (
+        f"{port.device}"
+        + f" - {port.product}"
+        + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+    )
 
     get = patch(
         "homeassistant.config_entries.ConfigEntries.async_get_entry", return_value=entry
@@ -258,7 +272,7 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
             result["flow_id"], user_input={CONF_USB_PATH: port_select}
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "usb_setup_successful"
+        assert result["reason"] == "usb_setup_complete"
         assert entry.data[CONF_USB_PATH] == "/dev/serial/by-id/crownstone-usb"
         assert get_mock.call_count == 1
         assert reload_mock.call_count == 1
@@ -279,6 +293,77 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
         )
         assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
         assert result["reason"] == "usb_setup_unsuccessful"
+
+
+@patch(
+    "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
+)
+@patch(
+    "homeassistant.components.crownstone.config_flow.get_serial_by_id",
+    return_value="/dev/crownstone-usb",
+)
+async def test_successful_login_with_manual_usb_path(
+    serial_mock: MagicMock, hass: HomeAssistant
+):
+    """Test flow with correct login and usb configuration."""
+    entry_with_manual_usb = create_mocked_entry_conf(
+        unique_id="example@homeassistant.com",
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path="/dev/crownstone-usb",
+    )
+    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    # should show usb form
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb"
+
+    # should show usb config form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB: True}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_config"
+
+    # select manual from the list
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: CONF_MANUAL_PATH}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_manual_config"
+
+    # enter USB path
+    path = "/dev/crownstone-usb"
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_MANUAL_PATH: path}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == entry_with_manual_usb
+    assert serial_mock.call_count == 1
+
+    # test update existing usb call for manual path
+    ret_val = {
+        "type": data_entry_flow.RESULT_TYPE_ABORT,
+        "reason": "usb_setup_complete",
+    }
+    update_usb = patch(
+        "homeassistant.components.crownstone.config_flow.CrownstoneConfigFlowHandler.async_update_existing_entry_usb_path",
+        return_value=ret_val,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "usb_config"},
+        data={CONF_UNIQUE_ID: "example@homeassistant.com"},
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: CONF_MANUAL_PATH}
+    )
+    with update_usb as update_usb_mock:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USB_MANUAL_PATH: path}
+        )
+        assert update_usb_mock.call_count == 1
 
 
 async def test_options_flow(hass: HomeAssistant):

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -236,8 +236,8 @@ async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssis
         port.serial_number,
         port.manufacturer,
         port.description,
-        port.vid,
-        port.pid,
+        f"{hex(port.vid)[2:]:0>4}".upper(),
+        f"{hex(port.pid)[2:]:0>4}".upper(),
     )
 
     # select a port from the list
@@ -346,8 +346,8 @@ async def test_options_flow_setup_usb(serial_mock: MagicMock, hass: HomeAssistan
         port.serial_number,
         port.manufacturer,
         port.description,
-        port.vid,
-        port.pid,
+        f"{hex(port.vid)[2:]:0>4}".upper(),
+        f"{hex(port.pid)[2:]:0>4}".upper(),
     )
 
     # select a port from the list

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -12,6 +12,7 @@ import pytest
 from serial.tools.list_ports_common import ListPortInfo
 
 from homeassistant import data_entry_flow
+from homeassistant.components import usb
 from homeassistant.components.crownstone.const import (
     CONF_USB_MANUAL_PATH,
     CONF_USB_PATH,
@@ -62,7 +63,9 @@ def get_mocked_com_port():
     """Mock of a serial port."""
     port = ListPortInfo("/dev/ttyUSB1234")
     port.device = "/dev/ttyUSB1234"
-    port.product = "Crownstone dongle"
+    port.serial_number = "1234567"
+    port.manufacturer = "crownstone"
+    port.description = "crownstone dongle - crownstone dongle"
     port.vid = 1234
     port.pid = 5678
 
@@ -228,10 +231,13 @@ async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssis
 
     # create a mocked port
     port = get_mocked_com_port()
-    port_select = (
-        f"{port.device}"
-        + f" - {port.product}"
-        + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+    port_select = usb.human_readable_device_name(
+        port.device,
+        port.serial_number,
+        port.manufacturer,
+        port.description,
+        port.vid,
+        port.pid,
     )
 
     # select a port from the list
@@ -335,10 +341,13 @@ async def test_options_flow_setup_usb(serial_mock: MagicMock, hass: HomeAssistan
 
     # create a mocked port
     port = get_mocked_com_port()
-    port_select = (
-        f"{port.device}"
-        + f" - {port.product}"
-        + f" - {format(port.vid, 'x')}:{format(port.pid, 'x')}"
+    port_select = usb.human_readable_device_name(
+        port.device,
+        port.serial_number,
+        port.manufacturer,
+        port.description,
+        port.vid,
+        port.pid,
     )
 
     # select a port from the list

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -1,0 +1,316 @@
+"""Tests for the Crownstone integration."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from crownstone_cloud.exceptions import (
+    CrownstoneAuthenticationError,
+    CrownstoneUnknownError,
+)
+import pytest
+from serial.tools.list_ports_common import ListPortInfo
+
+from homeassistant import data_entry_flow
+from homeassistant.components.crownstone.const import (
+    CONF_USB,
+    CONF_USB_PATH,
+    CONF_USE_CROWNSTONE_USB,
+    DOMAIN,
+)
+from homeassistant.const import CONF_EMAIL, CONF_ID, CONF_PASSWORD, CONF_UNIQUE_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="crownstone_setup", autouse=True)
+def crownstone_setup():
+    """Mock Crownstone entry setup."""
+    with patch(
+        "homeassistant.components.crownstone.async_setup_entry", return_value=True
+    ):
+        yield
+
+
+def get_mocked_crownstone_cloud():
+    """Return a mocked Crownstone Cloud instance."""
+    mock_cloud = MagicMock()
+    mock_cloud.async_initialize = AsyncMock()
+
+    return mock_cloud
+
+
+def get_mocked_com_port():
+    """Mock of a serial port."""
+    port = ListPortInfo("/dev/ttyUSB1234")
+    port.serial_number = "1234"
+    port.manufacturer = "Crownstone"
+    port.device = "/dev/ttyUSB1234"
+    port.description = "Crownstone USB"
+
+    return port
+
+
+def create_mocked_entry_conf(unique_id: str, email: str, password: str, usb_path: str):
+    """Set a result for the entry for comparison."""
+    MOCK_CONF = {}
+    MOCK_CONF[CONF_ID] = unique_id
+    MOCK_CONF[CONF_EMAIL] = email
+    MOCK_CONF[CONF_PASSWORD] = password
+    MOCK_CONF[CONF_USB_PATH] = usb_path
+
+    return MOCK_CONF
+
+
+async def start_user_flow(hass: HomeAssistant, mocked_cloud: MagicMock):
+    """Patch Crownstone Cloud and start the flow."""
+    # mock login
+    mocked_login_input = {
+        CONF_EMAIL: "example@homeassistant.com",
+        CONF_PASSWORD: "homeassistantisawesome",
+    }
+
+    with patch(
+        "homeassistant.components.crownstone.config_flow.CrownstoneCloud",
+        return_value=mocked_cloud,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}, data=mocked_login_input
+        )
+
+    return result
+
+
+async def test_no_user_input(hass: HomeAssistant):
+    """Test the flow done in the correct way."""
+    # test if a form is returned if no input is provided
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    # show the login form
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+
+async def test_abort_if_configured(hass: HomeAssistant):
+    """Test flow with correct login input and abort if sphere already configured."""
+    # create mock entry conf
+    configured_entry = create_mocked_entry_conf(
+        unique_id="example@homeassistant.com",
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path="/dev/serial/by-id/crownstone-usb",
+    )
+
+    # create mocked entry
+    MockConfigEntry(
+        domain=DOMAIN,
+        data=configured_entry,
+        unique_id=configured_entry[CONF_ID],
+    ).add_to_hass(hass)
+
+    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+
+    # test if we abort if we try to configure the same entry
+    assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_authentication_errors(hass: HomeAssistant):
+    """Test flow with wrong auth errors."""
+    cloud = get_mocked_crownstone_cloud()
+    # side effect: auth error login failed
+    cloud.async_initialize.side_effect = CrownstoneAuthenticationError(
+        exception_type="LOGIN_FAILED"
+    )
+
+    result = await start_user_flow(hass, cloud)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    # side effect: auth error account not verified
+    cloud.async_initialize.side_effect = CrownstoneAuthenticationError(
+        exception_type="LOGIN_FAILED_EMAIL_NOT_VERIFIED"
+    )
+
+    result = await start_user_flow(hass, cloud)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "account_not_verified"}
+
+
+async def test_unknown_error(hass: HomeAssistant):
+    """Test flow with unknown error."""
+    cloud = get_mocked_crownstone_cloud()
+    # side effect: unknown error
+    cloud.async_initialize.side_effect = CrownstoneUnknownError
+
+    result = await start_user_flow(hass, cloud)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["errors"] == {"base": "unknown_error"}
+
+
+async def test_successful_login_no_usb(hass: HomeAssistant):
+    """Test a successful login without configuring a USB."""
+    entry_without_usb = create_mocked_entry_conf(
+        unique_id="example@homeassistant.com",
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path=None,
+    )
+    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    # should show usb form
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb"
+
+    # don't setup USB dongle, create entry
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB: False}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == entry_without_usb
+
+
+@patch(
+    "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
+)
+@patch(
+    "homeassistant.components.crownstone.config_flow.get_serial_by_id",
+    return_value="/dev/serial/by-id/crownstone-usb",
+)
+async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssistant):
+    """Test flow with correct login and usb configuration."""
+    entry_with_usb = create_mocked_entry_conf(
+        unique_id="example@homeassistant.com",
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path="/dev/serial/by-id/crownstone-usb",
+    )
+    result = await start_user_flow(hass, get_mocked_crownstone_cloud())
+    # should show usb form
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb"
+
+    # should show usb config form
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB: True}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "usb_config"
+
+    # create a mocked port
+    port = get_mocked_com_port()
+    port_select = f"{port}" + f" - {port.manufacturer}"
+
+    # select a port from the list
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_USB_PATH: port_select}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == entry_with_usb
+    assert serial_mock.call_count == 1
+
+
+@patch(
+    "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
+)
+@patch(
+    "homeassistant.components.crownstone.config_flow.get_serial_by_id",
+    return_value="/dev/serial/by-id/crownstone-usb",
+)
+async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
+    """Tests the update to the USB config triggered by options flow."""
+    # create mock entry conf
+    configured_entry = create_mocked_entry_conf(
+        unique_id="example@homeassistant.com",
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path=None,
+    )
+
+    # create mocked entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=configured_entry,
+        unique_id=configured_entry[CONF_ID],
+    )
+    entry.add_to_hass(hass)
+
+    # create a mocked port
+    port = get_mocked_com_port()
+    port_select = f"{port}" + f" - {port.manufacturer}"
+
+    get = patch(
+        "homeassistant.config_entries.ConfigEntries.async_get_entry", return_value=entry
+    )
+    reload = patch("homeassistant.config_entries.ConfigEntries.async_reload")
+
+    # initialized from options flow callback
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "usb_config"},
+        data={CONF_UNIQUE_ID: "example@homeassistant.com"},
+    )
+
+    with get as get_mock, reload as reload_mock:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USB_PATH: port_select}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "usb_setup_successful"
+        assert entry.data[CONF_USB_PATH] == "/dev/serial/by-id/crownstone-usb"
+        assert get_mock.call_count == 1
+        assert reload_mock.call_count == 1
+
+    get_none = patch(
+        "homeassistant.config_entries.ConfigEntries.async_get_entry", return_value=None
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": "usb_config"},
+        data={CONF_UNIQUE_ID: "example@homeassistant.com"},
+    )
+
+    with get_none as get_mock:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_USB_PATH: port_select}
+        )
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "usb_setup_unsuccessful"
+
+
+async def test_options_flow(hass: HomeAssistant):
+    """Test options flow."""
+    configured_entry = create_mocked_entry_conf(
+        unique_id="example@homeassistant.com",
+        email="example@homeassistant.com",
+        password="homeassistantisawesome",
+        usb_path=None,
+    )
+
+    # create mocked entry
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=configured_entry,
+        unique_id=configured_entry[CONF_ID],
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    schema = result["data_schema"].schema
+    for schema_key in schema:
+        if schema_key == CONF_USE_CROWNSTONE_USB:
+            # based on existence of a usb-path string
+            assert not schema_key.default()
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_USE_CROWNSTONE_USB: True}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert result["data"] == {CONF_USE_CROWNSTONE_USB: True}

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -176,7 +176,7 @@ async def test_successful_login_no_usb(hass: HomeAssistant):
     "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
 )
 @patch(
-    "homeassistant.components.crownstone.config_flow.get_serial_by_id",
+    "homeassistant.components.usb.get_serial_by_id",
     return_value="/dev/serial/by-id/crownstone-usb",
 )
 async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssistant):
@@ -213,7 +213,7 @@ async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssis
     "serial.tools.list_ports.comports", MagicMock(return_value=[get_mocked_com_port()])
 )
 @patch(
-    "homeassistant.components.crownstone.config_flow.get_serial_by_id",
+    "homeassistant.components.usb.get_serial_by_id",
     return_value="/dev/serial/by-id/crownstone-usb",
 )
 async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -38,6 +38,8 @@ def get_mocked_crownstone_cloud():
     """Return a mocked Crownstone Cloud instance."""
     mock_cloud = MagicMock()
     mock_cloud.async_initialize = AsyncMock()
+    mock_cloud.cloud_data = MagicMock()
+    mock_cloud.cloud_data.user_id = "account_id"
 
     return mock_cloud
 
@@ -106,7 +108,7 @@ async def test_abort_if_configured(hass: HomeAssistant):
     MockConfigEntry(
         domain=DOMAIN,
         data=configured_entry,
-        unique_id=configured_entry[CONF_EMAIL],
+        unique_id="account_id",
     ).add_to_hass(hass)
 
     result = await start_user_flow(hass, get_mocked_crownstone_cloud())
@@ -229,7 +231,7 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=configured_entry,
-        unique_id=configured_entry[CONF_EMAIL],
+        unique_id="account_id",
     )
     entry.add_to_hass(hass)
 
@@ -349,7 +351,7 @@ async def test_options_flow(hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=configured_entry,
-        unique_id=configured_entry[CONF_EMAIL],
+        unique_id="account_id",
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/crownstone/test_config_flow.py
+++ b/tests/components/crownstone/test_config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.components.crownstone.const import (
     DONT_USE_USB,
     MANUAL_PATH,
 )
-from homeassistant.const import CONF_EMAIL, CONF_ID, CONF_PASSWORD, CONF_UNIQUE_ID
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_UNIQUE_ID
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -53,12 +53,9 @@ def get_mocked_com_port():
     return port
 
 
-def create_mocked_entry_conf(
-    unique_id: str, email: str, password: str, usb_path: str | None
-):
+def create_mocked_entry_conf(email: str, password: str, usb_path: str | None):
     """Set a result for the entry for comparison."""
     MOCK_CONF: dict[str, str | None] = {}
-    MOCK_CONF[CONF_ID] = unique_id
     MOCK_CONF[CONF_EMAIL] = email
     MOCK_CONF[CONF_PASSWORD] = password
     MOCK_CONF[CONF_USB_PATH] = usb_path
@@ -100,7 +97,6 @@ async def test_abort_if_configured(hass: HomeAssistant):
     """Test flow with correct login input and abort if sphere already configured."""
     # create mock entry conf
     configured_entry = create_mocked_entry_conf(
-        unique_id="example@homeassistant.com",
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path="/dev/serial/by-id/crownstone-usb",
@@ -110,7 +106,7 @@ async def test_abort_if_configured(hass: HomeAssistant):
     MockConfigEntry(
         domain=DOMAIN,
         data=configured_entry,
-        unique_id=configured_entry[CONF_ID],
+        unique_id=configured_entry[CONF_EMAIL],
     ).add_to_hass(hass)
 
     result = await start_user_flow(hass, get_mocked_crownstone_cloud())
@@ -159,7 +155,6 @@ async def test_unknown_error(hass: HomeAssistant):
 async def test_successful_login_no_usb(hass: HomeAssistant):
     """Test a successful login without configuring a USB."""
     entry_without_usb = create_mocked_entry_conf(
-        unique_id="example@homeassistant.com",
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path=None,
@@ -187,7 +182,6 @@ async def test_successful_login_no_usb(hass: HomeAssistant):
 async def test_successful_login_with_usb(serial_mock: MagicMock, hass: HomeAssistant):
     """Test flow with correct login and usb configuration."""
     entry_with_usb = create_mocked_entry_conf(
-        unique_id="example@homeassistant.com",
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path="/dev/serial/by-id/crownstone-usb",
@@ -226,7 +220,6 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
     """Tests the update to the USB config triggered by options flow."""
     # create mock entry conf
     configured_entry = create_mocked_entry_conf(
-        unique_id="example@homeassistant.com",
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path=None,
@@ -236,7 +229,7 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=configured_entry,
-        unique_id=configured_entry[CONF_ID],
+        unique_id=configured_entry[CONF_EMAIL],
     )
     entry.add_to_hass(hass)
 
@@ -294,7 +287,6 @@ async def test_update_usb_config(serial_mock: MagicMock, hass: HomeAssistant):
 async def test_successful_login_with_manual_usb_path(hass: HomeAssistant):
     """Test flow with correct login and usb configuration."""
     entry_with_manual_usb = create_mocked_entry_conf(
-        unique_id="example@homeassistant.com",
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path="/dev/crownstone-usb",
@@ -348,7 +340,6 @@ async def test_successful_login_with_manual_usb_path(hass: HomeAssistant):
 async def test_options_flow(hass: HomeAssistant):
     """Test options flow."""
     configured_entry = create_mocked_entry_conf(
-        unique_id="example@homeassistant.com",
         email="example@homeassistant.com",
         password="homeassistantisawesome",
         usb_path=None,
@@ -358,7 +349,7 @@ async def test_options_flow(hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=configured_entry,
-        unique_id=configured_entry[CONF_ID],
+        unique_id=configured_entry[CONF_EMAIL],
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR makes it possible for Home Assistant users to control their Crownstone devices in Home Assistant. 

Crownstones are devices that come in 2 forms: Built-ins that can be placed behind a wall socket and Plugs that you can plug into any outlet. Crownstones currently have 3 abilities:
* Dimming (variable brightness)
* Tap-to-toggle (switch device when holding smartphone really close)
* Switchcraft (can switch the Crownstone by using the regular wall switch)

This PR only implements the `light` platform, to make switching and dimming possible with Crownstones.

The integration exists of 3 IoT classes:
* Cloud polling (getting the user data from the cloud when setting up a config entry, switching/dimming Crownstones when using the cloud)
* Cloud push (pushes update events to Home Assistant to notify about updated switch states and ability changes)
* Local push (a Crownstone USB dongle that provides switch state updates, energy usage etc & switching/dimming Crownstones by advertising directly into Crownstone's BLE mesh network)

The Crownstone USB dongle is optional and the user can select whether to set this up.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17841

This PR follows up on this one: https://github.com/home-assistant/core/pull/37005 
All review comments in that PR have been implemented.
This includes:
* Devices from all Spheres are added to Home Assistant
* UART implementation no longer does a handshake with other serial devices. Instead the user manually selects the port, and the symlink string `by-id` is saved. An options flow was added so users can easily set up an USB dongle after a config entry was already created
* SSE Python library was rewritten to be fully async

The code follows strict typing and the domain was added to `.strict-typing`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
