### PR TITLE
Make Philips TV notify service optional

### DIFF
--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.core import CALLBACK_TYPE, Context, HassJob, HomeAssistant, c
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
+from .const import CONF_ALLOW_NOTIFY, DOMAIN
 
 PLATFORMS = ["media_player", "remote"]
 
@@ -36,8 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         username=entry.data.get(CONF_USERNAME),
         password=entry.data.get(CONF_PASSWORD),
     )
-
-    coordinator = PhilipsTVDataUpdateCoordinator(hass, tvapi)
+    coordinator = PhilipsTVDataUpdateCoordinator(hass, tvapi, entry.options)
 
     await coordinator.async_refresh()
     hass.data.setdefault(DOMAIN, {})
@@ -45,7 +44,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(async_update_entry))
+
     return True
+
+
+async def async_update_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Update options."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -94,9 +100,10 @@ class PluggableAction:
 class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
     """Coordinator to update data."""
 
-    def __init__(self, hass, api: PhilipsTV) -> None:
+    def __init__(self, hass, api: PhilipsTV, options: dict) -> None:
         """Set up the coordinator."""
         self.api = api
+        self.options = options
         self._notify_future: asyncio.Task | None = None
 
         @callback
@@ -127,6 +134,7 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
             self.api.on
             and self.api.powerstate == "On"
             and self.api.notify_change_supported
+            and self.options.get(CONF_ALLOW_NOTIFY, False)
         )
 
     async def _notify_task(self):

--- a/homeassistant/components/philips_js/config_flow.py
+++ b/homeassistant/components/philips_js/config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
 )
 
 from . import LOGGER
-from .const import CONF_SYSTEM, CONST_APP_ID, CONST_APP_NAME, DOMAIN
+from .const import CONF_ALLOW_NOTIFY, CONF_SYSTEM, CONST_APP_ID, CONST_APP_NAME, DOMAIN
 
 
 async def validate_input(
@@ -154,3 +154,32 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         return self.async_show_form(step_id="user", data_schema=schema, errors=errors)
+
+    @staticmethod
+    @core.callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return OptionsFlowHandler(config_entry)
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle a option flow for AEMET."""
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(self, user_input=None):
+        """Handle options flow."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_ALLOW_NOTIFY,
+                    default=self.config_entry.options.get(CONF_ALLOW_NOTIFY),
+                ): bool,
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/homeassistant/components/philips_js/const.py
+++ b/homeassistant/components/philips_js/const.py
@@ -2,6 +2,7 @@
 
 DOMAIN = "philips_js"
 CONF_SYSTEM = "system"
+CONF_ALLOW_NOTIFY = "allow_notify"
 
 CONST_APP_ID = "homeassistant.io"
 CONST_APP_NAME = "Home Assistant"

--- a/homeassistant/components/philips_js/strings.json
+++ b/homeassistant/components/philips_js/strings.json
@@ -20,9 +20,18 @@
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "pairing_failure": "Unable to pair: {error_id}",
       "invalid_pin": "Invalid PIN"
-},
+    },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "allownotify": "Allow usage of data notification service."
+        }
+      }
     }
   },
   "device_automation": {

--- a/homeassistant/components/philips_js/strings.json
+++ b/homeassistant/components/philips_js/strings.json
@@ -29,7 +29,7 @@
     "step": {
       "init": {
         "data": {
-          "allownotify": "Allow usage of data notification service."
+          "allow_notify": "Allow usage of data notification service."
         }
       }
     }

--- a/homeassistant/components/philips_js/translations/en.json
+++ b/homeassistant/components/philips_js/translations/en.json
@@ -25,6 +25,15 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "allownotify": "Allow usage of data notification service."
+                }
+            }
+        }
+    },
     "device_automation": {
         "trigger_type": {
             "turn_on": "Device is requested to turn on"

--- a/homeassistant/components/philips_js/translations/en.json
+++ b/homeassistant/components/philips_js/translations/en.json
@@ -29,7 +29,7 @@
         "step": {
             "init": {
                 "data": {
-                    "allownotify": "Allow usage of data notification service."
+                    "allow_notify": "Allow usage of data notification service."
                 }
             }
         }

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -4,8 +4,8 @@ from unittest.mock import ANY, patch
 from haphilipsjs import PairingFailure
 from pytest import fixture
 
-from homeassistant import config_entries
-from homeassistant.components.philips_js.const import DOMAIN
+from homeassistant import config_entries, data_entry_flow
+from homeassistant.components.philips_js.const import CONF_ALLOW_NOTIFY, DOMAIN
 
 from . import (
     MOCK_CONFIG,
@@ -17,13 +17,17 @@ from . import (
     MOCK_USERNAME,
 )
 
+from tests.common import MockConfigEntry
 
-@fixture(autouse=True)
-def mock_setup_entry():
+
+@fixture(autouse=True, name="mock_setup_entry")
+def mock_setup_entry_fixture():
     """Disable component setup."""
     with patch(
         "homeassistant.components.philips_js.async_setup_entry", return_value=True
-    ) as mock_setup_entry:
+    ) as mock_setup_entry, patch(
+        "homeassistant.components.philips_js.async_unload_entry", return_value=True
+    ):
         yield mock_setup_entry
 
 
@@ -226,3 +230,32 @@ async def test_pair_grant_failed(hass, mock_tv_pairable, mock_setup_entry):
         "reason": "pairing_failure",
         "type": "abort",
     }
+
+
+async def test_options_flow(hass):
+    """Test config flow options."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="123456",
+        data=MOCK_CONFIG_PAIRED,
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={CONF_ALLOW_NOTIFY: True}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    assert config_entry.options == {CONF_ALLOW_NOTIFY: True}
+
+    await hass.async_block_till_done()
+    assert await hass.config_entries.async_unload(config_entry.entry_id)
+    await hass.async_block_till_done()

--- a/tests/components/philips_js/test_config_flow.py
+++ b/tests/components/philips_js/test_config_flow.py
@@ -255,7 +255,3 @@ async def test_options_flow(hass):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
     assert config_entry.options == {CONF_ALLOW_NOTIFY: True}
-
-    await hass.async_block_till_done()
-    assert await hass.config_entries.async_unload(config_entry.entry_id)
-    await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Change the use of the notifyData service to an optional feature. It seems android TV's have a tendency to crash their https server when taking multiple requests. It's not entirely clear it's the notification service that breaks it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #48918 #48839

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
