### PR TITLE
Store Hue bridge in hass.data before setting up platforms

### DIFF
--- a/homeassistant/components/hue/__init__.py
+++ b/homeassistant/components/hue/__init__.py
@@ -66,7 +66,6 @@ async def async_setup_entry(
 
     _register_services(hass)
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = bridge
     config = bridge.api.config
 
     # For backwards compat
@@ -133,11 +132,11 @@ async def async_setup_entry(
 
 async def async_unload_entry(hass, entry):
     """Unload a config entry."""
-    bridge = hass.data[DOMAIN].pop(entry.entry_id)
+    unload_success = await hass.data[DOMAIN][entry.entry_id].async_reset()
     if len(hass.data[DOMAIN]) == 0:
         hass.data.pop(DOMAIN)
         hass.services.async_remove(DOMAIN, SERVICE_HUE_SCENE)
-    return await bridge.async_reset()
+    return unload_success
 
 
 @core.callback
@@ -172,7 +171,7 @@ def _register_services(hass):
                 group_name,
             )
 
-    if DOMAIN not in hass.data:
+    if not hass.services.has_service(DOMAIN, SERVICE_HUE_SCENE):
         # Register a local handler for scene activation
         hass.services.async_register(
             DOMAIN,

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -108,7 +108,7 @@ class HueBridge:
         if bridge.sensors is not None:
             self.sensor_manager = SensorManager(self)
 
-        hass.data.setdefault(DOMAIN, {})[self.config_entry.entry_id] = bridge
+        hass.data.setdefault(DOMAIN, {})[self.config_entry.entry_id] = self
         hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)
 
         self.parallel_updates_semaphore = asyncio.Semaphore(

--- a/homeassistant/components/hue/bridge.py
+++ b/homeassistant/components/hue/bridge.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_ALLOW_UNREACHABLE,
     DEFAULT_ALLOW_HUE_GROUPS,
     DEFAULT_ALLOW_UNREACHABLE,
+    DOMAIN,
     LOGGER,
 )
 from .errors import AuthenticationRequired, CannotConnect
@@ -107,6 +108,7 @@ class HueBridge:
         if bridge.sensors is not None:
             self.sensor_manager = SensorManager(self)
 
+        hass.data.setdefault(DOMAIN, {})[self.config_entry.entry_id] = bridge
         hass.config_entries.async_setup_platforms(self.config_entry, PLATFORMS)
 
         self.parallel_updates_semaphore = asyncio.Semaphore(
@@ -173,9 +175,14 @@ class HueBridge:
 
         # If setup was successful, we set api variable, forwarded entry and
         # register service
-        return await self.hass.config_entries.async_unload_platforms(
+        unload_success = await self.hass.config_entries.async_unload_platforms(
             self.config_entry, PLATFORMS
         )
+
+        if unload_success:
+            self.hass.data[DOMAIN].pop(self.config_entry.entry_id)
+
+        return unload_success
 
     async def hue_activate_scene(self, data, skip_reload=False, hide_warnings=False):
         """Service to call directly into bridge to set scenes."""

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -32,6 +32,7 @@ def create_mock_bridge(hass):
         allow_unreachable=False,
         allow_groups=False,
         api=create_mock_api(hass),
+        config_entry=None,
         reset_jobs=[],
         spec=hue.HueBridge,
     )
@@ -41,10 +42,25 @@ def create_mock_bridge(hass):
     bridge.mock_group_responses = bridge.api.mock_group_responses
     bridge.mock_sensor_responses = bridge.api.mock_sensor_responses
 
+    async def async_setup():
+        if bridge.config_entry:
+            hass.data.setdefault(hue.DOMAIN, {})[bridge.config_entry.entry_id] = bridge
+        return True
+
+    bridge.async_setup = async_setup
+
     async def async_request_call(task):
         await task()
 
     bridge.async_request_call = async_request_call
+
+    async def async_reset():
+        if bridge.config_entry:
+            hass.data[hue.DOMAIN].pop(bridge.config_entry.entry_id)
+        return True
+
+    bridge.async_reset = async_reset
+
     return bridge
 
 
@@ -80,7 +96,15 @@ def create_mock_api(hass):
 
     logger = logging.getLogger(__name__)
 
-    api.config.apiversion = "9.9.9"
+    api.config = Mock(
+        bridgeid="ff:ff:ff:ff:ff:ff",
+        mac="aa:bb:cc:dd:ee:ff",
+        modelid="BSB002",
+        apiversion="9.9.9",
+        swversion="1935144040",
+    )
+    api.config.name = "Home"
+
     api.lights = Lights(logger, {}, [], mock_request)
     api.groups = Groups(logger, {}, [], mock_request)
     api.sensors = Sensors(logger, {}, [], mock_request)

--- a/tests/components/hue/test_init.py
+++ b/tests/components/hue/test_init.py
@@ -38,9 +38,14 @@ async def test_unload_entry(hass, mock_bridge_setup):
     assert await async_setup_component(hass, hue.DOMAIN, {}) is True
     assert len(mock_bridge_setup.mock_calls) == 1
 
-    mock_bridge_setup.async_reset = AsyncMock(return_value=True)
+    hass.data[hue.DOMAIN] = {entry.entry_id: mock_bridge_setup}
+
+    async def mock_reset():
+        hass.data[hue.DOMAIN].pop(entry.entry_id)
+        return True
+
+    mock_bridge_setup.async_reset = mock_reset
     assert await hue.async_unload_entry(hass, entry)
-    assert len(mock_bridge_setup.async_reset.mock_calls) == 1
     assert hue.DOMAIN not in hass.data
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There was a race condition possible where platform setup would be reached before the Hue bridge was stored in `hass.data`, causing below exceptions:

```
2021-05-13 12:37:19 ERROR (MainThread) [homeassistant.components.light] Error while setting up hue platform for light
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/helpers/entity_platform.py", line 249, in _async_setup_platform
    await asyncio.shield(task)
  File "/Users/paulus/dev/hass/core/homeassistant/components/hue/light.py", line 105, in async_setup_entry
    bridge = hass.data[HUE_DOMAIN][config_entry.entry_id]
KeyError: 'hue'

2021-05-13 12:37:19 ERROR (MainThread) [homeassistant.components.binary_sensor] Error while setting up hue platform for binary_sensor
Traceback (most recent call last):
  File "/Users/paulus/dev/hass/core/homeassistant/helpers/entity_platform.py", line 249, in _async_setup_platform
    await asyncio.shield(task)
  File "/Users/paulus/dev/hass/core/homeassistant/components/hue/binary_sensor.py", line 17, in async_setup_entry
    bridge = hass.data[HUE_DOMAIN][config_entry.entry_id]
KeyError: 'hue'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
