### PR TITLE
Add mobile_app device_id events & device action template support

### DIFF
--- a/homeassistant/components/mobile_app/device_action.py
+++ b/homeassistant/components/mobile_app/device_action.py
@@ -8,7 +8,6 @@ from homeassistant.components.device_automation import InvalidDeviceAutomationCo
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, template
-from homeassistant.helpers.template import Template
 
 from .const import DOMAIN
 from .util import get_notify_service, supports_push, webhook_id_from_device_id
@@ -37,10 +36,7 @@ async def async_call_action_from_config(
     hass: HomeAssistant, config: dict, variables: dict, context: Context | None
 ) -> None:
     """Execute a device action."""
-    device_id = Template(config[CONF_DEVICE_ID], hass).async_render(
-        variables, parse_result=False
-    )
-    webhook_id = webhook_id_from_device_id(hass, device_id)
+    webhook_id = webhook_id_from_device_id(hass, config[CONF_DEVICE_ID])
 
     if webhook_id is None:
         raise InvalidDeviceAutomationConfig(

--- a/homeassistant/components/mobile_app/device_action.py
+++ b/homeassistant/components/mobile_app/device_action.py
@@ -8,6 +8,7 @@ from homeassistant.components.device_automation import InvalidDeviceAutomationCo
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
 from homeassistant.core import Context, HomeAssistant
 from homeassistant.helpers import config_validation as cv, template
+from homeassistant.helpers.template import Template
 
 from .const import DOMAIN
 from .util import get_notify_service, supports_push, webhook_id_from_device_id
@@ -36,7 +37,10 @@ async def async_call_action_from_config(
     hass: HomeAssistant, config: dict, variables: dict, context: Context | None
 ) -> None:
     """Execute a device action."""
-    webhook_id = webhook_id_from_device_id(hass, config[CONF_DEVICE_ID])
+    device_id = Template(config[CONF_DEVICE_ID], hass).async_render(
+        variables, parse_result=False
+    )
+    webhook_id = webhook_id_from_device_id(hass, device_id)
 
     if webhook_id is None:
         raise InvalidDeviceAutomationConfig(

--- a/homeassistant/components/mobile_app/device_action.py
+++ b/homeassistant/components/mobile_app/device_action.py
@@ -7,7 +7,7 @@ from homeassistant.components import notify
 from homeassistant.components.device_automation import InvalidDeviceAutomationConfig
 from homeassistant.const import CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import config_validation as cv, template
+from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
 from .util import get_notify_service, supports_push, webhook_id_from_device_id
@@ -57,15 +57,7 @@ async def async_call_action_from_config(
         if key not in config:
             continue
 
-        value_template = config[key]
-        template.attach(hass, value_template)
-
-        try:
-            service_data[key] = template.render_complex(value_template, variables)
-        except template.TemplateError as err:
-            raise InvalidDeviceAutomationConfig(
-                f"Error rendering {key}: {err}"
-            ) from err
+        service_data[key] = config[key]
 
     await hass.services.async_call(
         notify.DOMAIN, service_name, service_data, blocking=True, context=context

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1125,7 +1125,7 @@ _SCRIPT_WAIT_TEMPLATE_SCHEMA = vol.Schema(
 DEVICE_ACTION_BASE_SCHEMA = vol.Schema(
     {
         **SCRIPT_ACTION_BASE_SCHEMA,
-        vol.Required(CONF_DEVICE_ID): string,
+        vol.Required(CONF_DEVICE_ID): dynamic_template,
         vol.Required(CONF_DOMAIN): str,
     }
 )

--- a/tests/components/mobile_app/test_device_action.py
+++ b/tests/components/mobile_app/test_device_action.py
@@ -36,10 +36,15 @@ async def test_action(hass, push_registration):
                         "event_type": "test_notify",
                     },
                     "action": [
-                        {"variables": {"name": "Paulus"}},
+                        {
+                            "variables": {
+                                "name": "Paulus",
+                                "id": hass.data[DOMAIN]["devices"][webhook_id].id,
+                            }
+                        },
                         {
                             "domain": DOMAIN,
-                            "device_id": hass.data[DOMAIN]["devices"][webhook_id].id,
+                            "device_id": "{{ id }}",
                             "type": "notify",
                             "message": "Hello {{ name }}",
                         },

--- a/tests/components/mobile_app/test_webhook.py
+++ b/tests/components/mobile_app/test_webhook.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.camera import SUPPORT_STREAM as CAMERA_SUPPORT_STREAM
-from homeassistant.components.mobile_app.const import CONF_SECRET
+from homeassistant.components.mobile_app.const import CONF_SECRET, DATA_DEVICES, DOMAIN
 from homeassistant.components.zone import DOMAIN as ZONE_DOMAIN
 from homeassistant.const import CONF_WEBHOOK_ID
 from homeassistant.core import callback
@@ -121,8 +121,13 @@ async def test_webhook_handle_fire_event(hass, create_registrations, webhook_cli
     json = await resp.json()
     assert json == {}
 
+    device_id = hass.data[DOMAIN][DATA_DEVICES][
+        create_registrations[1]["webhook_id"]
+    ].id
+
     assert len(events) == 1
     assert events[0].data["hello"] == "yo world"
+    assert events[0].data["device_id"] == device_id
 
 
 async def test_webhook_update_registration(webhook_client, authed_api_client):
@@ -470,6 +475,10 @@ async def test_webhook_handle_scan_tag(hass, create_registrations, webhook_clien
     json = await resp.json()
     assert json == {}
 
+    device_id = hass.data[DOMAIN][DATA_DEVICES][
+        create_registrations[1]["webhook_id"]
+    ].id
+
     assert len(events) == 1
     assert events[0].data["tag_id"] == "mock-tag-id"
-    assert events[0].data["device_id"] == "mock-device-id"
+    assert events[0].data["device_id"] == device_id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

- `device_id` for tag scans is now a different `device_id`
- `device_id` is now sent for all events from `mobile_app`, overriding any from-app values


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- Adds support for templates in the `device_id` for device automations for notify in mobile_app
- Adds `device_id` parameter to all event fires for `mobile_app` which is equal to the `device_id` for device automations

This allows writing a script which looks like:

```yaml
- service: notify.notify
  data:
    message: "The message to receive"
    data:
      actions:
        - action: test
          title: test
- wait_for_trigger:
    - platform: event
      event_type: mobile_app_notification_action
      event_data:
        action: "test"
- domain: mobile_app
  type: notify
  device_id: "{{ wait.trigger.event.data.device_id }}"
  message: "just to you"
```

Where the response notification is sent only to the device that triggered the action.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
