### PR TITLE
Make confirmable notification blueprint use unique actions

### DIFF
--- a/homeassistant/components/script/blueprints/confirmable_notification.yaml
+++ b/homeassistant/components/script/blueprints/confirmable_notification.yaml
@@ -51,6 +51,10 @@ blueprint:
 mode: restart
 
 sequence:
+  - alias: "Set up variables"
+    variables:
+      action_confirm: "{{ 'CONFIRM_' ~ context.id }}"
+      action_dismiss: "{{ 'DISMISS_' ~ context.id }}"
   - alias: "Send notification"
     domain: mobile_app
     type: notify
@@ -59,16 +63,22 @@ sequence:
     message: !input message
     data:
       actions:
-        - action: "CONFIRM"
+        - action: "{{ action_confirm }}"
           title: !input confirm_text
-        - action: "DISMISS"
+        - action: "{{ action_dismiss }}"
           title: !input dismiss_text
   - alias: "Awaiting response"
     wait_for_trigger:
       - platform: event
         event_type: mobile_app_notification_action
+        event_data:
+          action: "{{ action_confirm }}"
+      - platform: event
+        event_type: mobile_app_notification_action
+        event_data:
+          action: "{{ action_dismiss }}"
   - choose:
-      - conditions: "{{ wait.trigger.event.data.action == 'CONFIRM' }}"
+      - conditions: "{{ wait.trigger.event.data.action == action_confirm }}"
         sequence: !input confirm_action
-      - conditions: "{{ wait.trigger.event.data.action == 'DISMISS' }}"
+      - conditions: "{{ wait.trigger.event.data.action == action_dismiss }}"
         sequence: !input dismiss_action

--- a/tests/components/script/test_blueprint.py
+++ b/tests/components/script/test_blueprint.py
@@ -7,7 +7,8 @@ from unittest.mock import patch
 
 from homeassistant.components import script
 from homeassistant.components.blueprint.models import Blueprint, DomainBlueprints
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.helpers import template
 from homeassistant.setup import async_setup_component
 from homeassistant.util import yaml
 
@@ -70,43 +71,47 @@ async def test_confirmable_notification(hass: HomeAssistant) -> None:
         )
 
     turn_on_calls = async_mock_service(hass, "homeassistant", "turn_on")
+    context = Context()
 
     with patch(
         "homeassistant.components.mobile_app.device_action.async_call_action_from_config"
     ) as mock_call_action:
 
         # Trigger script
-        await hass.services.async_call(script.DOMAIN, "confirm")
+        await hass.services.async_call(script.DOMAIN, "confirm", context=context)
 
         # Give script the time to attach the trigger.
         await asyncio.sleep(0.1)
 
-    hass.bus.async_fire("mobile_app_notification_action", {"action": "CONFIRM"})
+    hass.bus.async_fire("mobile_app_notification_action", {"action": "ANYTHING_ELSE"})
+    hass.bus.async_fire(
+        "mobile_app_notification_action", {"action": "CONFIRM_" + Context().id}
+    )
+    hass.bus.async_fire(
+        "mobile_app_notification_action", {"action": "CONFIRM_" + context.id}
+    )
     await hass.async_block_till_done()
 
     assert len(mock_call_action.mock_calls) == 1
     _hass, config, variables, _context = mock_call_action.mock_calls[0][1]
 
-    title_tpl = config.pop("title")
-    message_tpl = config.pop("message")
-    title_tpl.hass = hass
-    message_tpl.hass = hass
+    template.attach(hass, config)
+    rendered_config = template.render_complex(config, variables)
 
-    assert config == {
+    assert rendered_config == {
+        "title": "Lord of the things",
+        "message": "Throw ring in mountain?",
         "alias": "Send notification",
         "domain": "mobile_app",
         "type": "notify",
         "device_id": "frodo",
         "data": {
             "actions": [
-                {"action": "CONFIRM", "title": "Confirm"},
-                {"action": "DISMISS", "title": "Dismiss"},
+                {"action": "CONFIRM_" + _context.id, "title": "Confirm"},
+                {"action": "DISMISS_" + _context.id, "title": "Dismiss"},
             ]
         },
     }
-
-    assert title_tpl.async_render(variables) == "Lord of the things"
-    assert message_tpl.async_render(variables) == "Throw ring in mountain?"
 
     assert len(turn_on_calls) == 1
     assert turn_on_calls[0].data == {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Updates `confirmable_notification`:
- Uses unique, per-context actions
- Waits explicitly for specific actions so the `wait_for_trigger` doesn't fire for other events

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [PR] #48621
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
