### PR TITLE
Create KNX cover entities directly from config

### DIFF
--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Callable
 
+from xknx import XKNX
 from xknx.devices import Cover as XknxCover, Device as XknxDevice
 from xknx.telegram.address import parse_device_group_address
 
@@ -22,6 +23,7 @@ from homeassistant.components.cover import (
     SUPPORT_STOP_TILT,
     CoverEntity,
 )
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -40,24 +42,26 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up cover(s) for KNX platform."""
-    _async_migrate_unique_id(hass, discovery_info)
+    if not discovery_info or not discovery_info["platform_config"]:
+        return
+    platform_config = discovery_info["platform_config"]
+    _async_migrate_unique_id(hass, platform_config)
+
+    xknx: XKNX = hass.data[DOMAIN].xknx
+
     entities = []
-    for device in hass.data[DOMAIN].xknx.devices:
-        if isinstance(device, XknxCover):
-            entities.append(KNXCover(device))
+    for entity_config in platform_config:
+        entities.append(KNXCover(xknx, entity_config))
+
     async_add_entities(entities)
 
 
 @callback
 def _async_migrate_unique_id(
-    hass: HomeAssistant, discovery_info: DiscoveryInfoType | None
+    hass: HomeAssistant, platform_config: list[ConfigType]
 ) -> None:
     """Change unique_ids used in 2021.4 to include position_target GA."""
     entity_registry = er.async_get(hass)
-    if not discovery_info or not discovery_info["platform_config"]:
-        return
-
-    platform_config = discovery_info["platform_config"]
     for entity_config in platform_config:
         # normalize group address strings - ga_updown was the old uid but is optional
         updown_addresses = entity_config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS)
@@ -82,12 +86,34 @@ def _async_migrate_unique_id(
 class KNXCover(KnxEntity, CoverEntity):
     """Representation of a KNX cover."""
 
-    def __init__(self, device: XknxCover):
+    def __init__(self, xknx: XKNX, config: ConfigType):
         """Initialize the cover."""
         self._device: XknxCover
-        super().__init__(device)
+        super().__init__(
+            device=XknxCover(
+                xknx,
+                name=config[CONF_NAME],
+                group_address_long=config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS),
+                group_address_short=config.get(CoverSchema.CONF_MOVE_SHORT_ADDRESS),
+                group_address_stop=config.get(CoverSchema.CONF_STOP_ADDRESS),
+                group_address_position_state=config.get(
+                    CoverSchema.CONF_POSITION_STATE_ADDRESS
+                ),
+                group_address_angle=config.get(CoverSchema.CONF_ANGLE_ADDRESS),
+                group_address_angle_state=config.get(
+                    CoverSchema.CONF_ANGLE_STATE_ADDRESS
+                ),
+                group_address_position=config.get(CoverSchema.CONF_POSITION_ADDRESS),
+                travel_time_down=config[CoverSchema.CONF_TRAVELLING_TIME_DOWN],
+                travel_time_up=config[CoverSchema.CONF_TRAVELLING_TIME_UP],
+                invert_position=config[CoverSchema.CONF_INVERT_POSITION],
+                invert_angle=config[CoverSchema.CONF_INVERT_ANGLE],
+            )
+        )
+        self._device_class: str | None = config.get(CONF_DEVICE_CLASS)
         self._unique_id = (
-            f"{device.updown.group_address}_{device.position_target.group_address}"
+            f"{self._device.updown.group_address}_"
+            f"{self._device.position_target.group_address}"
         )
         self._unsubscribe_auto_updater: Callable[[], None] | None = None
 
@@ -101,8 +127,8 @@ class KNXCover(KnxEntity, CoverEntity):
     @property
     def device_class(self) -> str | None:
         """Return the class of this device, from component DEVICE_CLASSES."""
-        if self._device.device_class in DEVICE_CLASSES:
-            return self._device.device_class
+        if self._device_class in DEVICE_CLASSES:
+            return self._device_class
         if self._device.supports_angle:
             return DEVICE_CLASS_BLIND
         return None

--- a/homeassistant/components/knx/factory.py
+++ b/homeassistant/components/knx/factory.py
@@ -6,7 +6,6 @@ from xknx.devices import (
     BinarySensor as XknxBinarySensor,
     Climate as XknxClimate,
     ClimateMode as XknxClimateMode,
-    Cover as XknxCover,
     Device as XknxDevice,
     Fan as XknxFan,
     Light as XknxLight,
@@ -23,7 +22,6 @@ from .const import KNX_ADDRESS, ColorTempModes, SupportedPlatforms
 from .schema import (
     BinarySensorSchema,
     ClimateSchema,
-    CoverSchema,
     FanSchema,
     LightSchema,
     SceneSchema,
@@ -40,9 +38,6 @@ def create_knx_device(
     """Return the requested XKNX device."""
     if platform is SupportedPlatforms.LIGHT:
         return _create_light(knx_module, config)
-
-    if platform is SupportedPlatforms.COVER:
-        return _create_cover(knx_module, config)
 
     if platform is SupportedPlatforms.CLIMATE:
         return _create_climate(knx_module, config)
@@ -66,28 +61,6 @@ def create_knx_device(
         return _create_fan(knx_module, config)
 
     return None
-
-
-def _create_cover(knx_module: XKNX, config: ConfigType) -> XknxCover:
-    """Return a KNX Cover device to be used within XKNX."""
-    return XknxCover(
-        knx_module,
-        name=config[CONF_NAME],
-        group_address_long=config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS),
-        group_address_short=config.get(CoverSchema.CONF_MOVE_SHORT_ADDRESS),
-        group_address_stop=config.get(CoverSchema.CONF_STOP_ADDRESS),
-        group_address_position_state=config.get(
-            CoverSchema.CONF_POSITION_STATE_ADDRESS
-        ),
-        group_address_angle=config.get(CoverSchema.CONF_ANGLE_ADDRESS),
-        group_address_angle_state=config.get(CoverSchema.CONF_ANGLE_STATE_ADDRESS),
-        group_address_position=config.get(CoverSchema.CONF_POSITION_ADDRESS),
-        travel_time_down=config[CoverSchema.CONF_TRAVELLING_TIME_DOWN],
-        travel_time_up=config[CoverSchema.CONF_TRAVELLING_TIME_UP],
-        invert_position=config[CoverSchema.CONF_INVERT_POSITION],
-        invert_angle=config[CoverSchema.CONF_INVERT_ANGLE],
-        device_class=config.get(CONF_DEVICE_CLASS),
-    )
 
 
 def _create_light_color(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is one part of #49275 broken into one PR per platform.

This PR applies the exact same schema already done with the switch platform (#49238) for the platform
- cover

Previously we created xknx.Device objects (in the knx lib) and used them to create HA entities from. This was necessary because xknx had its own yaml config - which is now deprecated since 2021.4.

This approach is better readable / cleaner and we do not have to pipe config values only used in HA through xknx (e.g., device_class).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests


## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #49238
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
