### PR TITLE
Simplify calls to pymodbus

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -151,12 +151,9 @@ class ModbusBinarySensor(BinarySensorEntity):
         """Update the state of the sensor."""
         # remark "now" is a dummy parameter to avoid problems with
         # async_track_time_interval
-        if self._input_type == CALL_TYPE_COIL:
-            result = await self._hub.async_read_coils(self._slave, self._address, 1)
-        else:
-            result = await self._hub.async_read_discrete_inputs(
-                self._slave, self._address, 1
-            )
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._address, 1, self._input_type
+        )
         if result is None:
             self._available = False
             self.async_write_ha_state()

--- a/homeassistant/components/modbus/const.py
+++ b/homeassistant/components/modbus/const.py
@@ -75,6 +75,10 @@ CALL_TYPE_COIL = "coil"
 CALL_TYPE_DISCRETE = "discrete_input"
 CALL_TYPE_REGISTER_HOLDING = "holding"
 CALL_TYPE_REGISTER_INPUT = "input"
+CALL_TYPE_WRITE_COIL = "write_coil"
+CALL_TYPE_WRITE_COILS = "write_coils"
+CALL_TYPE_WRITE_REGISTER = "write_register"
+CALL_TYPE_WRITE_REGISTERS = "write_registers"
 
 # service calls
 SERVICE_WRITE_COIL = "write_coil"

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -27,6 +27,14 @@ from .const import (
     ATTR_STATE,
     ATTR_UNIT,
     ATTR_VALUE,
+    CALL_TYPE_COIL,
+    CALL_TYPE_DISCRETE,
+    CALL_TYPE_REGISTER_HOLDING,
+    CALL_TYPE_REGISTER_INPUT,
+    CALL_TYPE_WRITE_COIL,
+    CALL_TYPE_WRITE_COILS,
+    CALL_TYPE_WRITE_REGISTER,
+    CALL_TYPE_WRITE_REGISTERS,
     CONF_BAUDRATE,
     CONF_BYTESIZE,
     CONF_CLOSE_COMM_ON_ERROR,
@@ -38,6 +46,9 @@ from .const import (
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
 )
+
+ENTRY_FUNC = "func"
+ENTRY_ATTR = "attr"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -202,6 +213,41 @@ class ModbusHub:
         async with self._lock:
             await self.hass.async_add_executor_job(self._pymodbus_connect)
 
+        self._call_type = {
+            CALL_TYPE_COIL: {
+                ENTRY_ATTR: "bits",
+                ENTRY_FUNC: self._client.read_coils,
+            },
+            CALL_TYPE_DISCRETE: {
+                ENTRY_ATTR: "bits",
+                ENTRY_FUNC: self._client.read_discrete_inputs,
+            },
+            CALL_TYPE_REGISTER_HOLDING: {
+                ENTRY_ATTR: "registers",
+                ENTRY_FUNC: self._client.read_holding_registers,
+            },
+            CALL_TYPE_REGISTER_INPUT: {
+                ENTRY_ATTR: "registers",
+                ENTRY_FUNC: self._client.read_input_registers,
+            },
+            CALL_TYPE_WRITE_COIL: {
+                ENTRY_ATTR: "value",
+                ENTRY_FUNC: self._client.write_coil,
+            },
+            CALL_TYPE_WRITE_COILS: {
+                ENTRY_ATTR: "count",
+                ENTRY_FUNC: self._client.write_coils,
+            },
+            CALL_TYPE_WRITE_REGISTER: {
+                ENTRY_ATTR: "value",
+                ENTRY_FUNC: self._client.write_register,
+            },
+            CALL_TYPE_WRITE_REGISTERS: {
+                ENTRY_ATTR: "count",
+                ENTRY_FUNC: self._client.write_registers,
+            },
+        }
+
         # Start counting down to allow modbus requests.
         if self._config_delay:
             self._async_cancel_listener = async_call_later(
@@ -239,73 +285,69 @@ class ModbusHub:
         except ModbusException as exception_error:
             self._log_error(exception_error, error_state=False)
 
-    def _pymodbus_call(self, unit, address, value, check_attr, func):
+    def _pymodbus_call(self, unit, address, value, use_call):
         """Call sync. pymodbus."""
         kwargs = {"unit": unit} if unit else {}
         try:
-            result = func(address, value, **kwargs)
+            result = self._call_type[use_call][ENTRY_FUNC](address, value, **kwargs)
         except ModbusException as exception_error:
             self._log_error(exception_error)
             result = exception_error
-        if not hasattr(result, check_attr):
+        if not hasattr(result, self._call_type[use_call][ENTRY_ATTR]):
             self._log_error(result)
             return None
         self._in_error = False
         return result
 
-    async def async_pymodbus_call(self, unit, address, value, check_attr, func):
+    async def async_pymodbus_call(self, unit, address, value, use_call):
         """Convert async to sync pymodbus call."""
         if self._config_delay:
             return None
         async with self._lock:
             return await self.hass.async_add_executor_job(
-                self._pymodbus_call, unit, address, value, check_attr, func
+                self._pymodbus_call, unit, address, value, use_call
             )
 
     async def async_read_coils(self, unit, address, count):
         """Read coils."""
-        return await self.async_pymodbus_call(
-            unit, address, count, "bits", self._client.read_coils
-        )
+        return await self.async_pymodbus_call(unit, address, count, CALL_TYPE_COIL)
 
     async def async_read_discrete_inputs(self, unit, address, count):
         """Read discrete inputs."""
-        return await self.async_pymodbus_call(
-            unit, address, count, "bits", self._client.read_discrete_inputs
-        )
+        return await self.async_pymodbus_call(unit, address, count, CALL_TYPE_DISCRETE)
 
     async def async_read_input_registers(self, unit, address, count):
         """Read input registers."""
         return await self.async_pymodbus_call(
-            unit, address, count, "registers", self._client.read_input_registers
+            unit, address, count, CALL_TYPE_REGISTER_INPUT
         )
 
     async def async_read_holding_registers(self, unit, address, count):
         """Read holding registers."""
         return await self.async_pymodbus_call(
-            unit, address, count, "registers", self._client.read_holding_registers
+            unit, address, count, CALL_TYPE_REGISTER_HOLDING
         )
 
     async def async_write_coil(self, unit, address, value) -> bool:
         """Write coil."""
         return await self.async_pymodbus_call(
-            unit, address, value, "value", self._client.write_coil
+            unit, address, value, CALL_TYPE_WRITE_COIL
         )
 
     async def async_write_coils(self, unit, address, values) -> bool:
         """Write coil."""
         return await self.async_pymodbus_call(
-            unit, address, values, "count", self._client.write_coils
+            unit, address, values, CALL_TYPE_WRITE_COILS
         )
 
     async def async_write_register(self, unit, address, value) -> bool:
         """Write register."""
         return await self.async_pymodbus_call(
-            unit, address, value, "value", self._client.write_register
+            unit, address, value, CALL_TYPE_WRITE_REGISTER
         )
 
     async def async_write_registers(self, unit, address, values) -> bool:
         """Write registers."""
         return await self.async_pymodbus_call(
-            unit, address, values, "count", self._client.write_registers
+            unit, address, values, CALL_TYPE_WRITE_REGISTERS
         )

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -156,6 +156,41 @@ class ModbusHub:
             # network configuration
             self._config_host = client_config[CONF_HOST]
 
+        self._call_type = {
+            CALL_TYPE_COIL: {
+                ENTRY_ATTR: "bits",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_DISCRETE: {
+                ENTRY_ATTR: "bits",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_REGISTER_HOLDING: {
+                ENTRY_ATTR: "registers",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_REGISTER_INPUT: {
+                ENTRY_ATTR: "registers",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_WRITE_COIL: {
+                ENTRY_ATTR: "value",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_WRITE_COILS: {
+                ENTRY_ATTR: "count",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_WRITE_REGISTER: {
+                ENTRY_ATTR: "value",
+                ENTRY_FUNC: None,
+            },
+            CALL_TYPE_WRITE_REGISTERS: {
+                ENTRY_ATTR: "count",
+                ENTRY_FUNC: None,
+            },
+        }
+
     @property
     def name(self):
         """Return the name of this hub."""
@@ -213,40 +248,24 @@ class ModbusHub:
         async with self._lock:
             await self.hass.async_add_executor_job(self._pymodbus_connect)
 
-        self._call_type = {
-            CALL_TYPE_COIL: {
-                ENTRY_ATTR: "bits",
-                ENTRY_FUNC: self._client.read_coils,
-            },
-            CALL_TYPE_DISCRETE: {
-                ENTRY_ATTR: "bits",
-                ENTRY_FUNC: self._client.read_discrete_inputs,
-            },
-            CALL_TYPE_REGISTER_HOLDING: {
-                ENTRY_ATTR: "registers",
-                ENTRY_FUNC: self._client.read_holding_registers,
-            },
-            CALL_TYPE_REGISTER_INPUT: {
-                ENTRY_ATTR: "registers",
-                ENTRY_FUNC: self._client.read_input_registers,
-            },
-            CALL_TYPE_WRITE_COIL: {
-                ENTRY_ATTR: "value",
-                ENTRY_FUNC: self._client.write_coil,
-            },
-            CALL_TYPE_WRITE_COILS: {
-                ENTRY_ATTR: "count",
-                ENTRY_FUNC: self._client.write_coils,
-            },
-            CALL_TYPE_WRITE_REGISTER: {
-                ENTRY_ATTR: "value",
-                ENTRY_FUNC: self._client.write_register,
-            },
-            CALL_TYPE_WRITE_REGISTERS: {
-                ENTRY_ATTR: "count",
-                ENTRY_FUNC: self._client.write_registers,
-            },
-        }
+        self._call_type[CALL_TYPE_COIL][ENTRY_FUNC] = self._client.read_coils
+        self._call_type[CALL_TYPE_DISCRETE][
+            ENTRY_FUNC
+        ] = self._client.read_discrete_inputs
+        self._call_type[CALL_TYPE_REGISTER_HOLDING][
+            ENTRY_FUNC
+        ] = self._client.read_holding_registers
+        self._call_type[CALL_TYPE_REGISTER_INPUT][
+            ENTRY_FUNC
+        ] = self._client.read_input_registers
+        self._call_type[CALL_TYPE_WRITE_COIL][ENTRY_FUNC] = self._client.write_coil
+        self._call_type[CALL_TYPE_WRITE_COILS][ENTRY_FUNC] = self._client.write_coils
+        self._call_type[CALL_TYPE_WRITE_REGISTER][
+            ENTRY_FUNC
+        ] = self._client.write_register
+        self._call_type[CALL_TYPE_WRITE_REGISTERS][
+            ENTRY_FUNC
+        ] = self._client.write_registers
 
         # Start counting down to allow modbus requests.
         if self._config_delay:

--- a/homeassistant/components/modbus/sensor.py
+++ b/homeassistant/components/modbus/sensor.py
@@ -283,14 +283,9 @@ class ModbusRegisterSensor(RestoreEntity, SensorEntity):
         """Update the state of the sensor."""
         # remark "now" is a dummy parameter to avoid problems with
         # async_track_time_interval
-        if self._register_type == CALL_TYPE_REGISTER_INPUT:
-            result = await self._hub.async_read_input_registers(
-                self._slave, self._register, self._count
-            )
-        else:
-            result = await self._hub.async_read_holding_registers(
-                self._slave, self._register, self._count
-            )
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._register, self._count, self._register_type
+        )
         if result is None:
             self._available = False
             self.async_write_ha_state()

--- a/tests/components/modbus/test_modbus_switch.py
+++ b/tests/components/modbus/test_modbus_switch.py
@@ -3,6 +3,7 @@ import pytest
 
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
+    CALL_TYPE_DISCRETE,
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_REGISTER_INPUT,
     CONF_COILS,
@@ -232,11 +233,11 @@ async def test_service_switch_update(hass, mock_pymodbus):
                 CONF_NAME: "test",
                 CONF_ADDRESS: 1234,
                 CONF_WRITE_TYPE: CALL_TYPE_COIL,
-                CONF_VERIFY: {},
+                CONF_VERIFY: {CONF_INPUT_TYPE: CALL_TYPE_DISCRETE},
             }
         ]
     }
-    mock_pymodbus.read_coils.return_value = ReadResult([0x01])
+    mock_pymodbus.read_discrete_inputs.return_value = ReadResult([0x01])
     await prepare_service_update(
         hass,
         config,
@@ -245,7 +246,7 @@ async def test_service_switch_update(hass, mock_pymodbus):
         "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
     )
     assert hass.states.get(entity_id).state == STATE_ON
-    mock_pymodbus.read_coils.return_value = ReadResult([0x00])
+    mock_pymodbus.read_discrete_inputs.return_value = ReadResult([0x00])
     await hass.services.async_call(
         "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently sensor.py and binary_sensor.py have a:
if <type_a>
   call_type_a
else
   call_type_b

in call_type_a and call_type_b this is again packed to one function call async_pymodbus_call, that seems like waste of program lines (and performance).

Solution:
change async_pymodbus_call to have parameter call_type instead of attr and func.
The relationship call_type -> func, attr is defined once as a dict in async_setup.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Please schedule for 2021.6 not earlier, since it depends on the async PR merged earlier.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
