### PR TITLE
Allow camera stream to fail safely

### DIFF
--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -544,7 +544,7 @@ class CameraMjpegStream(CameraView):
         interval_str = request.query.get("interval")
         if interval_str is None:
             stream = await camera.handle_async_mjpeg_stream(request)
-            if not stream:
+            if stream is None:
                 raise web.HTTPBadGateway()
             return stream
 

--- a/homeassistant/components/camera/__init__.py
+++ b/homeassistant/components/camera/__init__.py
@@ -160,7 +160,7 @@ async def async_get_stream_source(hass: HomeAssistant, entity_id: str) -> str | 
 @bind_hass
 async def async_get_mjpeg_stream(
     hass: HomeAssistant, request: web.Request, entity_id: str
-) -> web.StreamResponse:
+) -> web.StreamResponse | None:
     """Fetch an mjpeg stream from a camera entity."""
     camera = _get_camera_from_entity_id(hass, entity_id)
 
@@ -399,7 +399,7 @@ class Camera(Entity):
 
     async def handle_async_mjpeg_stream(
         self, request: web.Request
-    ) -> web.StreamResponse:
+    ) -> web.StreamResponse | None:
         """Serve an HTTP MJPEG stream from the camera.
 
         This method can be overridden by camera platforms to proxy
@@ -543,7 +543,10 @@ class CameraMjpegStream(CameraView):
         """Serve camera stream, possibly with interval."""
         interval_str = request.query.get("interval")
         if interval_str is None:
-            return await camera.handle_async_mjpeg_stream(request)
+            stream = await camera.handle_async_mjpeg_stream(request)
+            if not stream:
+                raise web.HTTPBadGateway()
+            return stream
 
         try:
             # Compose camera stream from stills

--- a/tests/components/camera/test_init.py
+++ b/tests/components/camera/test_init.py
@@ -11,7 +11,12 @@ from homeassistant.components.camera.const import DOMAIN, PREF_PRELOAD_STREAM
 from homeassistant.components.camera.prefs import CameraEntityPreferences
 from homeassistant.components.websocket_api.const import TYPE_RESULT
 from homeassistant.config import async_process_ha_core_config
-from homeassistant.const import ATTR_ENTITY_ID, EVENT_HOMEASSISTANT_START
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_START,
+    HTTP_BAD_GATEWAY,
+    HTTP_OK,
+)
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
@@ -354,3 +359,19 @@ async def test_record_service(hass, mock_camera, mock_stream):
         # So long as we call stream.record, the rest should be covered
         # by those tests.
         assert mock_record.called
+
+
+async def test_camera_proxy_stream(hass, mock_camera, hass_client):
+    """Test record service."""
+
+    client = await hass_client()
+
+    response = await client.get("/api/camera_proxy_stream/camera.demo_camera")
+    assert response.status == HTTP_OK
+
+    with patch(
+        "homeassistant.components.demo.camera.DemoCamera.handle_async_mjpeg_stream",
+        return_value=None,
+    ):
+        response = await client.get("/api/camera_proxy_stream/camera.demo_camera")
+        assert response.status == HTTP_BAD_GATEWAY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow handle_async_mjpeg_stream to fail and return `None`, update typing to match. Right now, there isn't a type safe way for this call to fail, except generating an exception -- which may be better done at the outer layer (?). This is brought about by https://github.com/home-assistant/core/pull/50395 which introduced type safety for `camera`.

Key question: Is it better for cameras to just generate (web?) exceptions within their entity, or pass back None?

Example [use-case](https://github.com/home-assistant/core/pull/46516/files#diff-c656a9d2f40f5a2536a3f894fd4acaa9ba6d7ef2a62d6e59a9b19845afdb7882R216).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 50395
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
