### PR TITLE
Hue: unique ID for groups + remote events

### DIFF
--- a/homeassistant/components/hue/hue_event.py
+++ b/homeassistant/components/hue/hue_event.py
@@ -5,7 +5,7 @@ from aiohue.sensors import TYPE_ZGP_SWITCH, TYPE_ZLL_ROTARY, TYPE_ZLL_SWITCH
 
 from homeassistant.const import CONF_EVENT, CONF_ID, CONF_UNIQUE_ID
 from homeassistant.core import callback
-from homeassistant.util import slugify
+from homeassistant.util import dt as dt_util, slugify
 
 from .sensor_device import GenericHueDevice
 
@@ -48,7 +48,13 @@ class HueEvent(GenericHueDevice):
     @callback
     def async_update_callback(self):
         """Fire the event if reason is that state is updated."""
-        if self.sensor.state == self._last_state:
+        if (
+            self.sensor.state == self._last_state
+            or
+            # Filter out old states. Can happen when events fire while refreshing
+            dt_util.parse_datetime(self.sensor.state["lastupdated"])
+            <= dt_util.parse_datetime(self._last_state["lastupdated"])
+        ):
             return
 
         # Extract the press code as state

--- a/homeassistant/components/hue/light.py
+++ b/homeassistant/components/hue/light.py
@@ -306,7 +306,11 @@ class HueLight(CoordinatorEntity, LightEntity):
     @property
     def unique_id(self):
         """Return the unique ID of this Hue light."""
-        return self.light.uniqueid
+        unique_id = self.light.uniqueid
+        if not unique_id and self.is_group and self.light.room:
+            unique_id = self.light.room["id"]
+
+        return unique_id
 
     @property
     def device_id(self):

--- a/homeassistant/components/hue/manifest.json
+++ b/homeassistant/components/hue/manifest.json
@@ -3,7 +3,7 @@
   "name": "Philips Hue",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/hue",
-  "requirements": ["aiohue==2.4.2"],
+  "requirements": ["aiohue==2.5.0"],
   "ssdp": [
     {
       "manufacturer": "Royal Philips Electronics",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -182,7 +182,7 @@ aiohomekit==0.2.61
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==2.4.2
+aiohue==2.5.0
 
 # homeassistant.components.imap
 aioimaplib==0.7.15

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -119,7 +119,7 @@ aiohomekit==0.2.61
 aiohttp_cors==0.7.0
 
 # homeassistant.components.hue
-aiohue==2.4.2
+aiohue==2.5.0
 
 # homeassistant.components.apache_kafka
 aiokafka==0.6.0

--- a/tests/components/hue/conftest.py
+++ b/tests/components/hue/conftest.py
@@ -81,10 +81,10 @@ def create_mock_api(hass):
     logger = logging.getLogger(__name__)
 
     api.config.apiversion = "9.9.9"
-    api.lights = Lights(logger, {}, mock_request)
-    api.groups = Groups(logger, {}, mock_request)
-    api.sensors = Sensors(logger, {}, mock_request)
-    api.scenes = Scenes(logger, {}, mock_request)
+    api.lights = Lights(logger, {}, [], mock_request)
+    api.groups = Groups(logger, {}, [], mock_request)
+    api.sensors = Sensors(logger, {}, [], mock_request)
+    api.scenes = Scenes(logger, {}, [], mock_request)
     return api
 
 

--- a/tests/components/hue/test_bridge.py
+++ b/tests/components/hue/test_bridge.py
@@ -351,12 +351,11 @@ async def test_event_updates(hass, caplog):
     unsub = hue_bridge.listen_updates("lights", "2", obj_updated)
     unsub_false = hue_bridge.listen_updates("lights", "2", obj_updated_false)
 
-    assert "Overwriting update callback" in caplog.text
-
     events.put_nowait(Mock(ITEM_TYPE="lights", id="2"))
 
     await wait_empty_queue()
-    assert len(calls) == 2
+    assert len(calls) == 3
+    assert calls[-2] is True
     assert calls[-1] is False
 
     # Also call multiple times to make sure that works.
@@ -368,7 +367,7 @@ async def test_event_updates(hass, caplog):
     events.put_nowait(Mock(ITEM_TYPE="lights", id="2"))
 
     await wait_empty_queue()
-    assert len(calls) == 2
+    assert len(calls) == 3
 
     events.put_nowait(None)
     await subscription_task

--- a/tests/components/hue/test_light.py
+++ b/tests/components/hue/test_light.py
@@ -269,6 +269,10 @@ async def test_groups(hass, mock_bridge):
     mock_bridge.allow_groups = True
     mock_bridge.mock_light_responses.append({})
     mock_bridge.mock_group_responses.append(GROUP_RESPONSE)
+    mock_bridge.api.groups._v2_resources = [
+        {"id_v1": "/groups/1", "id": "group-1-mock-id", "type": "room"},
+        {"id_v1": "/groups/2", "id": "group-2-mock-id", "type": "room"},
+    ]
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 2
@@ -284,6 +288,10 @@ async def test_groups(hass, mock_bridge):
     lamp_2 = hass.states.get("light.group_2")
     assert lamp_2 is not None
     assert lamp_2.state == "on"
+
+    ent_reg = er.async_get(hass)
+    assert ent_reg.async_get("light.group_1").unique_id == "group-1-mock-id"
+    assert ent_reg.async_get("light.group_2").unique_id == "group-2-mock-id"
 
 
 async def test_new_group_discovered(hass, mock_bridge):

--- a/tests/components/hue/test_sensor_base.py
+++ b/tests/components/hue/test_sensor_base.py
@@ -8,6 +8,8 @@ from homeassistant.components.hue.hue_event import CONF_HUE_EVENT
 
 from .conftest import create_mock_bridge, setup_bridge_for_sensors as setup_bridge
 
+from tests.common import async_capture_events
+
 PRESENCE_SENSOR_1_PRESENT = {
     "state": {"presence": True, "lastupdated": "2019-01-01T01:00:00"},
     "swupdate": {"state": "noupdates", "lastinstall": "2019-01-01T00:00:00"},
@@ -435,18 +437,17 @@ async def test_hue_events(hass, mock_bridge):
     """Test that hue remotes fire events when pressed."""
     mock_bridge.mock_sensor_responses.append(SENSOR_RESPONSE)
 
-    mock_listener = Mock()
-    unsub = hass.bus.async_listen(CONF_HUE_EVENT, mock_listener)
+    events = async_capture_events(hass, CONF_HUE_EVENT)
 
     await setup_bridge(hass, mock_bridge)
     assert len(mock_bridge.mock_requests) == 1
     assert len(hass.states.async_all()) == 7
-    assert len(mock_listener.mock_calls) == 0
+    assert len(events) == 0
 
     new_sensor_response = dict(SENSOR_RESPONSE)
     new_sensor_response["7"]["state"] = {
         "buttonevent": 18,
-        "lastupdated": "2019-12-28T22:58:02",
+        "lastupdated": "2019-12-28T22:58:03",
     }
     mock_bridge.mock_sensor_responses.append(new_sensor_response)
 
@@ -456,18 +457,18 @@ async def test_hue_events(hass, mock_bridge):
 
     assert len(mock_bridge.mock_requests) == 2
     assert len(hass.states.async_all()) == 7
-    assert len(mock_listener.mock_calls) == 1
-    assert mock_listener.mock_calls[0][1][0].data == {
+    assert len(events) == 1
+    assert events[-1].data == {
         "id": "hue_tap",
         "unique_id": "00:00:00:00:00:44:23:08-f2",
         "event": 18,
-        "last_updated": "2019-12-28T22:58:02",
+        "last_updated": "2019-12-28T22:58:03",
     }
 
     new_sensor_response = dict(new_sensor_response)
     new_sensor_response["8"]["state"] = {
         "buttonevent": 3002,
-        "lastupdated": "2019-12-28T22:58:01",
+        "lastupdated": "2019-12-28T22:58:03",
     }
     mock_bridge.mock_sensor_responses.append(new_sensor_response)
 
@@ -477,13 +478,29 @@ async def test_hue_events(hass, mock_bridge):
 
     assert len(mock_bridge.mock_requests) == 3
     assert len(hass.states.async_all()) == 7
-    assert len(mock_listener.mock_calls) == 2
-    assert mock_listener.mock_calls[1][1][0].data == {
+    assert len(events) == 2
+    assert events[-1].data == {
         "id": "hue_dimmer_switch_1",
         "unique_id": "00:17:88:01:10:3e:3a:dc-02-fc00",
         "event": 3002,
-        "last_updated": "2019-12-28T22:58:01",
+        "last_updated": "2019-12-28T22:58:03",
     }
+
+    # Fire old event, it should be ignored
+    new_sensor_response = dict(new_sensor_response)
+    new_sensor_response["8"]["state"] = {
+        "buttonevent": 18,
+        "lastupdated": "2019-12-28T22:58:02",
+    }
+    mock_bridge.mock_sensor_responses.append(new_sensor_response)
+
+    # Force updates to run again
+    await mock_bridge.sensor_manager.coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert len(mock_bridge.mock_requests) == 4
+    assert len(hass.states.async_all()) == 7
+    assert len(events) == 2
 
     # Add a new remote. In discovery the new event is registered **but not fired**
     new_sensor_response = dict(new_sensor_response)
@@ -524,9 +541,9 @@ async def test_hue_events(hass, mock_bridge):
     await mock_bridge.sensor_manager.coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert len(mock_bridge.mock_requests) == 4
+    assert len(mock_bridge.mock_requests) == 5
     assert len(hass.states.async_all()) == 8
-    assert len(mock_listener.mock_calls) == 2
+    assert len(events) == 2
 
     # A new press fires the event
     new_sensor_response["21"]["state"]["lastupdated"] = "2020-01-31T15:57:19"
@@ -536,14 +553,12 @@ async def test_hue_events(hass, mock_bridge):
     await mock_bridge.sensor_manager.coordinator.async_refresh()
     await hass.async_block_till_done()
 
-    assert len(mock_bridge.mock_requests) == 5
+    assert len(mock_bridge.mock_requests) == 6
     assert len(hass.states.async_all()) == 8
-    assert len(mock_listener.mock_calls) == 3
-    assert mock_listener.mock_calls[2][1][0].data == {
+    assert len(events) == 3
+    assert events[-1].data == {
         "id": "lutron_aurora_1",
         "unique_id": "ff:ff:00:0f:e7:fd:bc:b7-01-fc00-0014",
         "event": 2,
         "last_updated": "2020-01-31T15:57:19",
     }
-
-    unsub()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump aiohue to add support for remotes: https://github.com/home-assistant-libs/aiohue/releases/tag/2.5.0 – thanks for the help @bramkragten 

- Add unique ID to groups
- Fire hue_event based on events from the hub

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
