### PR TITLE
Allow some failures before setting Xiaomi Miio MIOT air purifiers unavailable

### DIFF
--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -552,7 +552,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         if model in MODELS_PURIFIER_MIOT:
             air_purifier = AirPurifierMiot(host, token)
             entity = XiaomiAirPurifierMiot(
-                name, air_purifier, config_entry, unique_id, retries=2
+                name, air_purifier, config_entry, unique_id, allowed_failures=2
             )
         elif model.startswith("zhimi.airpurifier."):
             air_purifier = AirPurifier(host, token)
@@ -771,11 +771,11 @@ class XiaomiGenericDevice(XiaomiMiioEntity, FanEntity):
 class XiaomiAirPurifier(XiaomiGenericDevice):
     """Representation of a Xiaomi Air Purifier."""
 
-    def __init__(self, name, device, entry, unique_id, retries=0):
+    def __init__(self, name, device, entry, unique_id, allowed_failures=0):
         """Initialize the plug switch."""
         super().__init__(name, device, entry, unique_id)
-        self._retries = retries
-        self._retry = 0
+        self._allowed_failures = allowed_failures
+        self._failure = 0
 
         if self._model == MODEL_AIRPURIFIER_PRO:
             self._device_features = FEATURE_FLAGS_AIRPURIFIER_PRO
@@ -826,23 +826,23 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
                 }
             )
 
-            self._retry = 0
+            self._failure = 0
 
         except DeviceException as ex:
-            self._retry += 1
-            if self._retry < self._retries:
+            self._failure += 1
+            if self._failures < self._allowed_failures:
                 _LOGGER.info(
-                    "Got exception while fetching the state: %s, retry: %d",
+                    "Got exception while fetching the state: %s, failure: %d",
                     ex,
-                    self._retry,
+                    self._failure,
                 )
             else:
                 if self._available:
                     self._available = False
                     _LOGGER.error(
-                        "Got exception while fetching the state: %s, retry: %d",
+                        "Got exception while fetching the state: %s, failure: %d",
                         ex,
-                        self._retry,
+                        self._failure,
                     )
 
     @property

--- a/homeassistant/components/xiaomi_miio/fan.py
+++ b/homeassistant/components/xiaomi_miio/fan.py
@@ -830,7 +830,7 @@ class XiaomiAirPurifier(XiaomiGenericDevice):
 
         except DeviceException as ex:
             self._failure += 1
-            if self._failures < self._allowed_failures:
+            if self._failure < self._allowed_failures:
                 _LOGGER.info(
                     "Got exception while fetching the state: %s, failure: %d",
                     ex,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
MIOT air purifiers sometimes return `{'code': -9999, 'message': 'user ack timeout'}` for no reason when retrieving state. This PR adds mechanism to not mark the entity as `unavailable` after the first status update failure.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #36972
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
