### PR TITLE
Update remaining modbus platforms to use pymodbus_call

### DIFF
--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -28,7 +28,7 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .const import (
     ATTR_TEMPERATURE,
     CALL_TYPE_REGISTER_HOLDING,
-    CALL_TYPE_REGISTER_INPUT,
+    CALL_TYPE_WRITE_REGISTERS,
     CONF_CLIMATES,
     CONF_CURRENT_TEMP,
     CONF_CURRENT_TEMP_REGISTER_TYPE,
@@ -208,10 +208,11 @@ class ModbusThermostat(ClimateEntity):
         )
         byte_string = struct.pack(self._structure, target_temperature)
         register_value = struct.unpack(">h", byte_string[0:2])[0]
-        self._available = await self._hub.async_write_registers(
+        self._available = await self._hub.async_pymodbus_call(
             self._slave,
             self._target_temperature_register,
             register_value,
+            CALL_TYPE_WRITE_REGISTERS,
         )
         await self.async_update()
 
@@ -235,14 +236,9 @@ class ModbusThermostat(ClimateEntity):
 
     async def _async_read_register(self, register_type, register) -> float | None:
         """Read register using the Modbus hub slave."""
-        if register_type == CALL_TYPE_REGISTER_INPUT:
-            result = await self._hub.async_read_input_registers(
-                self._slave, register, self._count
-            )
-        else:
-            result = await self._hub.async_read_holding_registers(
-                self._slave, register, self._count
-            )
+        result = await self._hub.async_pymodbus_call(
+            self._slave, register, self._count, register_type
+        )
         if result is None:
             self._available = False
             return -1

--- a/homeassistant/components/modbus/cover.py
+++ b/homeassistant/components/modbus/cover.py
@@ -27,7 +27,8 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .const import (
     CALL_TYPE_COIL,
     CALL_TYPE_REGISTER_HOLDING,
-    CALL_TYPE_REGISTER_INPUT,
+    CALL_TYPE_WRITE_COIL,
+    CALL_TYPE_WRITE_REGISTER,
     CONF_REGISTER,
     CONF_STATE_CLOSED,
     CONF_STATE_CLOSING,
@@ -94,18 +95,22 @@ class ModbusCover(CoverEntity, RestoreEntity):
         # If we read cover status from coil, and not from optional status register,
         # we interpret boolean value False as closed cover, and value True as open cover.
         # Intermediate states are not supported in such a setup.
-        if self._coil is not None and self._status_register is None:
-            self._state_closed = False
-            self._state_open = True
-            self._state_closing = None
-            self._state_opening = None
+        if self._coil is not None:
+            self._write_type = CALL_TYPE_WRITE_COIL
+            if self._status_register is None:
+                self._state_closed = False
+                self._state_open = True
+                self._state_closing = None
+                self._state_opening = None
 
         # If we read cover status from the main register (i.e., an optional
         # status register is not specified), we need to make sure the register_type
         # is set to "holding".
-        if self._register is not None and self._status_register is None:
-            self._status_register = self._register
-            self._status_register_type = CALL_TYPE_REGISTER_HOLDING
+        if self._register is not None:
+            self._write_type = CALL_TYPE_WRITE_REGISTER
+            if self._status_register is None:
+                self._status_register = self._register
+                self._status_register_type = CALL_TYPE_REGISTER_HOLDING
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -169,21 +174,17 @@ class ModbusCover(CoverEntity, RestoreEntity):
 
     async def async_open_cover(self, **kwargs: Any) -> None:
         """Open cover."""
-        if self._coil is not None:
-            await self._async_write_coil(True)
-        else:
-            await self._async_write_register(self._state_open)
-
-        await self.async_update()
+        self._available = await self._hub.async_pymodbus_call(
+            self._slave, self._register, self._state_open, self._write_type
+        )
+        self.async_update()
 
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        if self._coil is not None:
-            await self._async_write_coil(False)
-        else:
-            await self._async_write_register(self._state_closed)
-
-        await self.async_update()
+        self._available = await self._hub.async_pymodbus_call(
+            self._slave, self._register, self._state_closed, self._write_type
+        )
+        self.async_update()
 
     async def async_update(self, now=None):
         """Update the state of the cover."""
@@ -198,14 +199,9 @@ class ModbusCover(CoverEntity, RestoreEntity):
 
     async def _async_read_status_register(self) -> int | None:
         """Read status register using the Modbus hub slave."""
-        if self._status_register_type == CALL_TYPE_REGISTER_INPUT:
-            result = await self._hub.async_read_input_registers(
-                self._slave, self._status_register, 1
-            )
-        else:
-            result = await self._hub.async_read_holding_registers(
-                self._slave, self._status_register, 1
-            )
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._status_register, 1, self._status_register_type
+        )
         if result is None:
             self._available = False
             return None
@@ -215,24 +211,14 @@ class ModbusCover(CoverEntity, RestoreEntity):
 
         return value
 
-    async def _async_write_register(self, value):
-        """Write holding register using the Modbus hub slave."""
-        self._available = await self._hub.async_write_register(
-            self._slave, self._register, value
-        )
-
     async def _async_read_coil(self) -> bool | None:
         """Read coil using the Modbus hub slave."""
-        result = await self._hub.async_read_coils(self._slave, self._coil, 1)
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._coil, 1, CALL_TYPE_COIL
+        )
         if result is None:
             self._available = False
             return None
 
         value = bool(result.bits[0] & 1)
         return value
-
-    async def _async_write_coil(self, value):
-        """Write coil using the Modbus hub slave."""
-        self._available = await self._hub.async_write_coil(
-            self._slave, self._coil, value
-        )

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -327,26 +327,6 @@ class ModbusHub:
                 self._pymodbus_call, unit, address, value, use_call
             )
 
-    async def async_read_coils(self, unit, address, count):
-        """Read coils."""
-        return await self.async_pymodbus_call(unit, address, count, CALL_TYPE_COIL)
-
-    async def async_read_discrete_inputs(self, unit, address, count):
-        """Read discrete inputs."""
-        return await self.async_pymodbus_call(unit, address, count, CALL_TYPE_DISCRETE)
-
-    async def async_read_input_registers(self, unit, address, count):
-        """Read input registers."""
-        return await self.async_pymodbus_call(
-            unit, address, count, CALL_TYPE_REGISTER_INPUT
-        )
-
-    async def async_read_holding_registers(self, unit, address, count):
-        """Read holding registers."""
-        return await self.async_pymodbus_call(
-            unit, address, count, CALL_TYPE_REGISTER_HOLDING
-        )
-
     async def async_write_coil(self, unit, address, value) -> bool:
         """Write coil."""
         return await self.async_pymodbus_call(

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -109,7 +109,7 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
         """Set switch on."""
 
         result = await self._hub.async_pymodbus_call(
-            self._slave, self._verify_address, self._command_on, self._write_type
+            self._slave, self._address, self._command_on, self._write_type
         )
         if result is False:
             self._available = False
@@ -125,7 +125,7 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
     async def async_turn_off(self, **kwargs):
         """Set switch off."""
         result = await self._hub.async_pymodbus_call(
-            self._slave, self._verify_address, self._command_off, self._write_type
+            self._slave, self._address, self._command_off, self._write_type
         )
         if result is False:
             self._available = False

--- a/homeassistant/components/modbus/switch.py
+++ b/homeassistant/components/modbus/switch.py
@@ -22,9 +22,6 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     CALL_TYPE_COIL,
-    CALL_TYPE_DISCRETE,
-    CALL_TYPE_REGISTER_HOLDING,
-    CALL_TYPE_REGISTER_INPUT,
     CONF_INPUT_TYPE,
     CONF_STATE_OFF,
     CONF_STATE_ON,
@@ -62,14 +59,9 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
         self._available = True
         self._scan_interval = timedelta(seconds=config[CONF_SCAN_INTERVAL])
         self._address = config[CONF_ADDRESS]
-        if config[CONF_WRITE_TYPE] == CALL_TYPE_COIL:
-            self._async_write_func = self._hub.async_write_coil
-            self._command_on = 0x01
-            self._command_off = 0x00
-        else:
-            self._async_write_func = self._hub.async_write_register
-            self._command_on = config[CONF_COMMAND_ON]
-            self._command_off = config[CONF_COMMAND_OFF]
+        self._write_type = config[CONF_WRITE_TYPE]
+        self._command_on = config[CONF_COMMAND_ON]
+        self._command_off = config[CONF_COMMAND_OFF]
         if CONF_VERIFY in config:
             if config[CONF_VERIFY] is None:
                 config[CONF_VERIFY] = {}
@@ -82,15 +74,6 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
             )
             self._state_on = config[CONF_VERIFY].get(CONF_STATE_ON, self._command_on)
             self._state_off = config[CONF_VERIFY].get(CONF_STATE_OFF, self._command_off)
-
-            if self._verify_type == CALL_TYPE_REGISTER_HOLDING:
-                self._async_read_func = self._hub.async_read_holding_registers
-            elif self._verify_type == CALL_TYPE_DISCRETE:
-                self._async_read_func = self._hub.async_read_discrete_inputs
-            elif self._verify_type == CALL_TYPE_REGISTER_INPUT:
-                self._async_read_func = self._hub.async_read_input_registers
-            else:  # self._verify_type == CALL_TYPE_COIL:
-                self._async_read_func = self._hub.async_read_coils
         else:
             self._verify_active = False
 
@@ -125,8 +108,8 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
     async def async_turn_on(self, **kwargs):
         """Set switch on."""
 
-        result = await self._async_write_func(
-            self._slave, self._address, self._command_on
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._verify_address, self._command_on, self._write_type
         )
         if result is False:
             self._available = False
@@ -141,8 +124,8 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
 
     async def async_turn_off(self, **kwargs):
         """Set switch off."""
-        result = await self._async_write_func(
-            self._slave, self._address, self._command_off
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._verify_address, self._command_off, self._write_type
         )
         if result is False:
             self._available = False
@@ -164,7 +147,9 @@ class ModbusSwitch(SwitchEntity, RestoreEntity):
             self.async_write_ha_state()
             return
 
-        result = await self._async_read_func(self._slave, self._verify_address, 1)
+        result = await self._hub.async_pymodbus_call(
+            self._slave, self._verify_address, 1, self._verify_type
+        )
         if result is None:
             self._available = False
             self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
cover, switch and climate are simplified to use async_pymodbus_call with CALL_TYPE_* as parameter.

With this PR all platforms are updated.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
