### PR TITLE
Add zwave_js add-on info dataclass

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -561,7 +561,7 @@ async def async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) ->
     try:
         addon_info = await addon_manager.async_get_addon_info()
     except AddonError as err:
-        LOGGER.error("err")
+        LOGGER.error(err)
         raise ConfigEntryNotReady from err
 
     usb_path: str = entry.data[CONF_USB_PATH]

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -29,7 +29,7 @@ from homeassistant.helpers import device_registry, entity_registry
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .addon import AddonError, AddonManager, get_addon_manager
+from .addon import AddonError, AddonManager, AddonState, get_addon_manager
 from .api import async_register_api
 from .const import (
     ATTR_COMMAND_CLASS,
@@ -559,22 +559,21 @@ async def async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) ->
     if addon_manager.task_in_progress():
         raise ConfigEntryNotReady
     try:
-        addon_is_installed = await addon_manager.async_is_addon_installed()
-        addon_is_running = await addon_manager.async_is_addon_running()
+        addon_state = await addon_manager.async_get_addon_state()
     except AddonError as err:
-        LOGGER.error("Failed to get the Z-Wave JS add-on info")
+        LOGGER.error("Failed to get the Z-Wave JS add-on state")
         raise ConfigEntryNotReady from err
 
     usb_path: str = entry.data[CONF_USB_PATH]
     network_key: str = entry.data[CONF_NETWORK_KEY]
 
-    if not addon_is_installed:
+    if addon_state == AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(
             usb_path, network_key, catch_error=True
         )
         raise ConfigEntryNotReady
 
-    if not addon_is_running:
+    if addon_state == AddonState.NOT_RUNNING:
         addon_manager.async_schedule_setup_addon(
             usb_path, network_key, catch_error=True
         )

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -559,13 +559,14 @@ async def async_ensure_addon_running(hass: HomeAssistant, entry: ConfigEntry) ->
     if addon_manager.task_in_progress():
         raise ConfigEntryNotReady
     try:
-        addon_state = await addon_manager.async_get_addon_state()
+        addon_info = await addon_manager.async_get_addon_info()
     except AddonError as err:
-        LOGGER.error("Failed to get the Z-Wave JS add-on state")
+        LOGGER.error("err")
         raise ConfigEntryNotReady from err
 
     usb_path: str = entry.data[CONF_USB_PATH]
     network_key: str = entry.data[CONF_NETWORK_KEY]
+    addon_state = addon_info.state
 
     if addon_state == AddonState.NOT_INSTALLED:
         addon_manager.async_schedule_install_setup_addon(

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -64,7 +64,7 @@ class AddonInfo:
     options: dict[str, Any]
     state: AddonState
     update_available: bool
-    version: str
+    version: str | None
 
 
 class AddonState(Enum):

--- a/homeassistant/components/zwave_js/addon.py
+++ b/homeassistant/components/zwave_js/addon.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
 from enum import Enum
 from functools import partial
 from typing import Any, Callable, TypeVar, cast
@@ -56,6 +57,16 @@ def api_error(error_message: str) -> Callable[[F], F]:
     return handle_hassio_api_error
 
 
+@dataclass
+class AddonInfo:
+    """Represent the current add-on info state."""
+
+    options: dict[str, Any]
+    state: AddonState
+    update_available: bool
+    version: str
+
+
 class AddonState(Enum):
     """Represent the current state of the add-on."""
 
@@ -104,15 +115,20 @@ class AddonManager:
         return discovery_info_config
 
     @api_error("Failed to get the Z-Wave JS add-on info")
-    async def async_get_addon_info(self) -> dict:
+    async def async_get_addon_info(self) -> AddonInfo:
         """Return and cache Z-Wave JS add-on info."""
         addon_info: dict = await async_get_addon_info(self._hass, ADDON_SLUG)
-        return addon_info
+        addon_state = self.async_get_addon_state(addon_info)
+        return AddonInfo(
+            options=addon_info["options"],
+            state=addon_state,
+            update_available=addon_info["update_available"],
+            version=addon_info["version"],
+        )
 
-    async def async_get_addon_state(self) -> AddonState:
+    @callback
+    def async_get_addon_state(self, addon_info: dict[str, Any]) -> AddonState:
         """Return the current state of the Z-Wave JS add-on."""
-        addon_info = await self.async_get_addon_info()
-
         addon_state = AddonState.NOT_INSTALLED
 
         if addon_info["version"] is not None:
@@ -125,11 +141,6 @@ class AddonManager:
             addon_state = AddonState.UPDATING
 
         return addon_state
-
-    async def async_get_addon_options(self) -> dict:
-        """Get Z-Wave JS add-on options."""
-        addon_info = await self.async_get_addon_info()
-        return cast(dict, addon_info["options"])
 
     @api_error("Failed to set the Z-Wave JS add-on options")
     async def async_set_addon_options(self, config: dict) -> None:
@@ -182,13 +193,11 @@ class AddonManager:
     async def async_update_addon(self) -> None:
         """Update the Z-Wave JS add-on if needed."""
         addon_info = await self.async_get_addon_info()
-        addon_version = addon_info["version"]
-        update_available = addon_info["update_available"]
 
-        if addon_version is None:
+        if addon_info.version is None:
             raise AddonError("Z-Wave JS add-on is not installed")
 
-        if not update_available:
+        if not addon_info.update_available:
             return
 
         await self.async_create_snapshot()
@@ -233,14 +242,14 @@ class AddonManager:
 
     async def async_configure_addon(self, usb_path: str, network_key: str) -> None:
         """Configure and start Z-Wave JS add-on."""
-        addon_options = await self.async_get_addon_options()
+        addon_info = await self.async_get_addon_info()
 
         new_addon_options = {
             CONF_ADDON_DEVICE: usb_path,
             CONF_ADDON_NETWORK_KEY: network_key,
         }
 
-        if new_addon_options != addon_options:
+        if new_addon_options != addon_info.options:
             await self.async_set_addon_options(new_addon_options)
 
     @callback
@@ -264,8 +273,7 @@ class AddonManager:
     async def async_create_snapshot(self) -> None:
         """Create a partial snapshot of the Z-Wave JS add-on."""
         addon_info = await self.async_get_addon_info()
-        addon_version = addon_info["version"]
-        name = f"addon_{ADDON_SLUG}_{addon_version}"
+        name = f"addon_{ADDON_SLUG}_{addon_info.version}"
 
         LOGGER.debug("Creating snapshot: %s", name)
         await async_create_snapshot(

--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -30,7 +30,12 @@ def mock_addon_info(addon_info_side_effect):
         "homeassistant.components.zwave_js.addon.async_get_addon_info",
         side_effect=addon_info_side_effect,
     ) as addon_info:
-        addon_info.return_value = {}
+        addon_info.return_value = {
+            "options": {},
+            "state": None,
+            "update_available": False,
+            "version": None,
+        }
         yield addon_info
 
 
@@ -52,7 +57,6 @@ def mock_addon_installed(addon_info):
 @pytest.fixture(name="addon_options")
 def mock_addon_options(addon_info):
     """Mock add-on options."""
-    addon_info.return_value["options"] = {}
     return addon_info.return_value["options"]
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Consolidate add-on info access in add-on manager by adding an AddonInfo dataclass.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
