### PR TITLE
Start ServiceBrowser as soon as possible in zeroconf

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -329,6 +329,9 @@ class ZeroconfDiscovery:
         """Start discovery."""
         self.flow_dispatcher = FlowDispatcher(self.hass)
         types = list(self.zeroconf_types)
+        # We want to make sure we know about other HomeAssistant
+        # instances as soon as possible to avoid name conflicts
+        # so we always browse for ZEROCONF_TYPE
         for hk_type in (ZEROCONF_TYPE, *HOMEKIT_TYPES):
             if hk_type not in self.zeroconf_types:
                 types.append(hk_type)

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -329,7 +329,7 @@ class ZeroconfDiscovery:
         """Start discovery."""
         self.flow_dispatcher = FlowDispatcher(self.hass)
         types = list(self.zeroconf_types)
-        for hk_type in HOMEKIT_TYPES:
+        for hk_type in (ZEROCONF_TYPE, *HOMEKIT_TYPES):
             if hk_type not in self.zeroconf_types:
                 types.append(hk_type)
         _LOGGER.debug("Starting Zeroconf browser")

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -289,7 +289,10 @@ class FlowDispatcher:
     def async_start(self) -> None:
         """Start processing pending flows."""
         self.started = True
-        for flow in list(self.pending_flows):
+        self.hass.loop.call_soon(self._async_process_pending_flows)
+
+    def _async_process_pending_flows(self) -> None:
+        for flow in self.pending_flows:
             self.hass.async_create_task(self._init_flow(flow))
         self.pending_flows = []
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -295,7 +295,7 @@ class FlowDispatcher:
     def create(self, flow: ZeroconfFlow) -> None:
         """Create and add or queue a flow."""
         if self.started:
-            self.hass.add_job(self._init_flow(flow))  # type: ignore
+            self.hass.add_job(self._init_flow(flow))  # type: ignore[arg-type]
         else:
             self.pending_flows.append(flow)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -299,7 +299,7 @@ class FlowDispatcher:
         else:
             self.pending_flows.append(flow)
 
-    def _init_flow(self, flow: ZeroconfFlow) -> Coroutine[Any, Any, Any]:
+    def _init_flow(self, flow: ZeroconfFlow) -> Coroutine[None, None, FlowResult]:
         """Create a flow."""
         return self.hass.config_entries.flow.async_init(
             flow["domain"], context=flow["context"], data=flow["data"]

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -2,14 +2,14 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Coroutine, Iterable
 from contextlib import suppress
 import fnmatch
 import ipaddress
 from ipaddress import ip_address
 import logging
 import socket
-from typing import Any, Coroutine, TypedDict, cast
+from typing import Any, TypedDict, cast
 
 from pyroute2 import IPRoute
 import voluptuous as vol
@@ -295,7 +295,7 @@ class FlowDispatcher:
     def create(self, flow: ZeroconfFlow) -> None:
         """Create and add or queue a flow."""
         if self.started:
-            self.hass.add_job(self._init_flow(flow))  # type: ignore[arg-type]
+            self.hass.create_task(self._init_flow(flow))
         else:
             self.pending_flows.append(flow)
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -30,6 +30,7 @@ from homeassistant.const import (
     __version__,
 )
 from homeassistant.core import Event, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.loader import async_get_homekit, async_get_zeroconf, bind_hass

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.30.0","pyroute2==0.5.18"],
+  "requirements": ["zeroconf==0.31.0","pyroute2==0.5.18"],
   "dependencies": ["api"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -34,7 +34,7 @@ sqlalchemy==1.4.13
 voluptuous-serialize==2.4.0
 voluptuous==0.12.1
 yarl==1.6.3
-zeroconf==0.30.0
+zeroconf==0.31.0
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2399,7 +2399,7 @@ zeep[async]==4.0.0
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.30.0
+zeroconf==0.31.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.57

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1290,7 +1290,7 @@ yeelight==0.6.2
 zeep[async]==4.0.0
 
 # homeassistant.components.zeroconf
-zeroconf==0.30.0
+zeroconf==0.31.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.57

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,14 +1,7 @@
 """Test Zeroconf component setup process."""
 from unittest.mock import patch
 
-from zeroconf import (
-    BadTypeInNameException,
-    Error as ZeroconfError,
-    InterfaceChoice,
-    IPVersion,
-    ServiceInfo,
-    ServiceStateChange,
-)
+from zeroconf import InterfaceChoice, IPVersion, ServiceInfo, ServiceStateChange
 
 from homeassistant.components import zeroconf
 from homeassistant.components.zeroconf import CONF_DEFAULT_INTERFACE, CONF_IPV6
@@ -184,8 +177,7 @@ async def test_setup_with_overly_long_url_and_name(hass, mock_zeroconf, caplog):
         "location_name",
         "\u00dcBER \u00dcber German Umlaut long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string",
     ), patch(
-        "homeassistant.components.zeroconf.ServiceInfo",
-        side_effect=get_service_info_mock,
+        "homeassistant.components.zeroconf.ServiceInfo.request",
     ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
@@ -276,22 +268,6 @@ async def test_setup_with_ipv6_default(hass, mock_zeroconf):
     assert mock_zeroconf.called_with()
 
 
-async def test_service_with_invalid_name(hass, mock_zeroconf, caplog):
-    """Test we do not crash on service with an invalid name."""
-    with patch.object(
-        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ) as mock_service_browser, patch(
-        "homeassistant.components.zeroconf.ServiceInfo",
-        side_effect=BadTypeInNameException,
-    ):
-        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-    assert len(mock_service_browser.mock_calls) == 1
-    assert "Failed to get info for device" in caplog.text
-
-
 async def test_zeroconf_match_macaddress(hass, mock_zeroconf):
     """Test configured options for a device are loaded via config entry."""
 
@@ -318,7 +294,7 @@ async def test_zeroconf_match_macaddress(hass, mock_zeroconf):
         zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
     ) as mock_service_browser, patch(
         "homeassistant.components.zeroconf.ServiceInfo",
-        return_value=get_service_info_mock("FFAADDCC11DD"),
+        side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
     ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
@@ -349,10 +325,10 @@ async def test_zeroconf_match_manufacturer(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = (
-            get_zeroconf_info_mock_manufacturer("Samsung Electronics")
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_zeroconf_info_mock_manufacturer("Samsung Electronics"),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -382,10 +358,10 @@ async def test_zeroconf_match_manufacturer_not_present(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_zeroconf_info_mock(
-            "aa:bb:cc:dd:ee:ff"
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_zeroconf_info_mock("aabbccddeeff"),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -414,10 +390,10 @@ async def test_zeroconf_no_match(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_zeroconf_info_mock(
-            "FFAADDCC11DD"
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_zeroconf_info_mock("FFAADDCC11DD"),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -446,10 +422,10 @@ async def test_zeroconf_no_match_manufacturer(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = (
-            get_zeroconf_info_mock_manufacturer("Not Samsung Electronics")
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_zeroconf_info_mock_manufacturer("Not Samsung Electronics"),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -472,10 +448,10 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
         side_effect=lambda *args, **kwargs: service_update_mock(
             *args, **kwargs, limit_service="_hap._tcp.local."
         ),
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
-            "LIFX bulb", HOMEKIT_STATUS_UNPAIRED
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_homekit_info_mock("LIFX bulb", HOMEKIT_STATUS_UNPAIRED),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -499,10 +475,10 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
         side_effect=lambda *args, **kwargs: service_update_mock(
             *args, **kwargs, limit_service="_hap._udp.local."
         ),
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
-            "Rachio-fa46ba", HOMEKIT_STATUS_UNPAIRED
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_homekit_info_mock("Rachio-fa46ba", HOMEKIT_STATUS_UNPAIRED),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -526,10 +502,10 @@ async def test_homekit_match_full(hass, mock_zeroconf):
         side_effect=lambda *args, **kwargs: service_update_mock(
             *args, **kwargs, limit_service="_hap._udp.local."
         ),
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
-            "BSB002", HOMEKIT_STATUS_UNPAIRED
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_homekit_info_mock("BSB002", HOMEKIT_STATUS_UNPAIRED),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -581,10 +557,10 @@ async def test_homekit_invalid_paring_status(hass, mock_zeroconf):
         side_effect=lambda *args, **kwargs: service_update_mock(
             *args, **kwargs, limit_service="_hap._tcp.local."
         ),
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
-            "tado", b"invalid"
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_homekit_info_mock("tado", b"invalid"),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -604,10 +580,12 @@ async def test_homekit_not_paired(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_homekit_info_mock(
             "this_will_not_match_any_integration", HOMEKIT_STATUS_UNPAIRED
-        )
+        ),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -652,34 +630,44 @@ async def test_get_instance(hass, mock_zeroconf):
 
 async def test_removed_ignored(hass, mock_zeroconf):
     """Test we remove it when a zeroconf entry is removed."""
-    mock_zeroconf.get_service_info.side_effect = ZeroconfError
 
     def service_update_mock(zeroconf, services, handlers):
         """Call service update handler."""
         handlers[0](
-            zeroconf, "_service.added", "name._service.added", ServiceStateChange.Added
+            zeroconf,
+            "_service.added.local.",
+            "name._service.added.local.",
+            ServiceStateChange.Added,
         )
         handlers[0](
             zeroconf,
-            "_service.updated",
-            "name._service.updated",
+            "_service.updated.local.",
+            "name._service.updated.local.",
             ServiceStateChange.Updated,
         )
         handlers[0](
             zeroconf,
-            "_service.removed",
-            "name._service.removed",
+            "_service.removed.local.",
+            "name._service.removed.local.",
             ServiceStateChange.Removed,
         )
 
-    with patch.object(zeroconf, "HaServiceBrowser", side_effect=service_update_mock):
+    with patch.object(
+        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
+    ) as mock_service_info:
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert len(mock_zeroconf.get_service_info.mock_calls) == 2
-    assert mock_zeroconf.get_service_info.mock_calls[0][1][0] == "_service.added"
-    assert mock_zeroconf.get_service_info.mock_calls[1][1][0] == "_service.updated"
+    assert len(mock_service_info.mock_calls) == 2
+    import pprint
+
+    pprint.pprint(mock_service_info.mock_calls[0][1])
+    assert mock_service_info.mock_calls[0][1][0] == "_service.added.local."
+    assert mock_service_info.mock_calls[1][1][0] == "_service.updated.local."
 
 
 async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zeroconf):
@@ -689,8 +677,10 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zer
     ), patch(
         "homeassistant.components.zeroconf.IPRoute.route",
         return_value=_ROUTE_NO_LOOPBACK,
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -704,8 +694,10 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, mock_zerocon
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
         "homeassistant.components.zeroconf.IPRoute.route", return_value=_ROUTE_LOOPBACK
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -717,8 +709,10 @@ async def test_async_detect_interfaces_setting_empty_route(hass, mock_zeroconf):
     """Test without default interface config and the route returns nothing."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ), patch("homeassistant.components.zeroconf.IPRoute.route", return_value=[]):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+    ), patch("homeassistant.components.zeroconf.IPRoute.route", return_value=[]), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -732,8 +726,10 @@ async def test_async_detect_interfaces_setting_exception(hass, mock_zeroconf):
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
         "homeassistant.components.zeroconf.IPRoute.route", side_effect=AttributeError
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -149,8 +149,10 @@ async def test_setup(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -181,8 +183,10 @@ async def test_setup_with_overly_long_url_and_name(hass, mock_zeroconf, caplog):
         hass.config,
         "location_name",
         "\u00dcBER \u00dcber German Umlaut long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string long string",
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
         await hass.async_block_till_done()
@@ -195,8 +199,10 @@ async def test_setup_with_default_interface(hass, mock_zeroconf):
     """Test default interface config."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: True}}
         )
@@ -210,8 +216,10 @@ async def test_setup_without_default_interface(hass, mock_zeroconf):
     """Test without default interface config."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: False}}
         )
@@ -223,8 +231,10 @@ async def test_setup_without_ipv6(hass, mock_zeroconf):
     """Test without ipv6."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_IPV6: False}}
         )
@@ -238,8 +248,10 @@ async def test_setup_with_ipv6(hass, mock_zeroconf):
     """Test without ipv6."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_IPV6: True}}
         )
@@ -253,8 +265,10 @@ async def test_setup_with_ipv6_default(hass, mock_zeroconf):
     """Test without ipv6 as default."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
+    ), patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_service_info_mock,
     ):
-        mock_zeroconf.get_service_info.side_effect = get_service_info_mock
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -266,8 +280,10 @@ async def test_service_with_invalid_name(hass, mock_zeroconf, caplog):
     """Test we do not crash on service with an invalid name."""
     with patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = BadTypeInNameException
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=BadTypeInNameException,
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -300,10 +316,10 @@ async def test_zeroconf_match_macaddress(hass, mock_zeroconf):
         hass.config_entries.flow, "async_init"
     ) as mock_config_flow, patch.object(
         zeroconf, "HaServiceBrowser", side_effect=http_only_service_update_mock
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_zeroconf_info_mock(
-            "FFAADDCC11DD"
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        return_value=get_service_info_mock("FFAADDCC11DD"),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
@@ -537,10 +553,10 @@ async def test_homekit_already_paired(hass, mock_zeroconf):
         side_effect=lambda *args, **kwargs: service_update_mock(
             *args, **kwargs, limit_service="_hap._tcp.local."
         ),
-    ) as mock_service_browser:
-        mock_zeroconf.get_service_info.side_effect = get_homekit_info_mock(
-            "tado", HOMEKIT_STATUS_PAIRED
-        )
+    ) as mock_service_browser, patch(
+        "homeassistant.components.zeroconf.ServiceInfo",
+        side_effect=get_homekit_info_mock("tado", HOMEKIT_STATUS_PAIRED),
+    ):
         assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensures the cache is being populated as soon as possible so we don't miss other Home Assistant instances in the short window we check for conflicting names.

May help with #50695 but either way this should be more robust.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
