### PR TITLE
Define sync hass.create_task function

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -368,10 +368,10 @@ async def _async_start_zeroconf_browser(
                 ):
                     continue
 
-            hass.create_task(
+            hass.add_job(
                 hass.config_entries.flow.async_init(
                     matcher["domain"], context={"source": DOMAIN}, data=info
-                )
+                )  # type: ignore
             )
 
     _LOGGER.debug("Starting Zeroconf browser")
@@ -404,12 +404,12 @@ def handle_homekit(
         ):
             continue
 
-        hass.create_task(
+        hass.add_job(
             hass.config_entries.flow.async_init(
                 homekit_models[test_model],
                 context={"source": config_entries.SOURCE_HOMEKIT},
                 data=info,
-            )
+            )  # type: ignore
         )
         return True
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -368,10 +368,10 @@ async def _async_start_zeroconf_browser(
                 ):
                     continue
 
-            hass.add_job(
+            hass.create_task(
                 hass.config_entries.flow.async_init(
                     matcher["domain"], context={"source": DOMAIN}, data=info
-                )  # type: ignore
+                )
             )
 
     _LOGGER.debug("Starting Zeroconf browser")
@@ -404,12 +404,12 @@ def handle_homekit(
         ):
             continue
 
-        hass.add_job(
+        hass.create_task(
             hass.config_entries.flow.async_init(
                 homekit_models[test_model],
                 context={"source": config_entries.SOURCE_HOMEKIT},
                 data=info,
-            )  # type: ignore
+            )
         )
         return True
 

--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -373,6 +373,13 @@ class HomeAssistant:
 
         return task
 
+    def create_task(self, target: Coroutine) -> None:
+        """Add task to the executor pool.
+
+        target: target to call.
+        """
+        self.loop.call_soon_threadsafe(self.async_create_task, target)
+
     @callback
     def async_create_task(self, target: Coroutine) -> asyncio.tasks.Task:
         """Create a task from within the eventloop.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -233,6 +233,29 @@ async def test_async_add_job_pending_tasks_coro(hass):
     assert len(call_count) == 2
 
 
+async def test_async_create_task_pending_tasks_coro(hass):
+    """Add a coro to pending tasks."""
+    call_count = []
+
+    async def test_coro():
+        """Test Coro."""
+        call_count.append("call")
+
+    for _ in range(2):
+        hass.create_task(test_coro())
+
+    async def wait_finish_callback():
+        """Wait until all stuff is scheduled."""
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+
+    await wait_finish_callback()
+
+    assert len(hass._pending_tasks) == 2
+    await hass.async_block_till_done()
+    assert len(call_count) == 2
+
+
 async def test_async_add_job_pending_tasks_executor(hass):
     """Run an executor in pending tasks."""
     call_count = []


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For `async_add_job` which expects `Callable` there's a sync counterpart: `add_job`. But there's no sync counterpart for `async_create_task` which expects `Coroutine`, although it's needed sometimes.

Right now `add_job` is used for that but this bypasses type safety. Here is how it's being used:
```python
def add_job(self, target: Callable[..., Any], *args: Any) -> None:

...

 self.loop.call_soon_threadsafe(self.async_add_job, target, *args)

...

def async_add_job(
        self, target: Callable[..., Any], *args: Any
    ) -> asyncio.Future | None:

...

  if asyncio.iscoroutine(target):
      return self.async_create_task(cast(Coroutine, target))
```

Define `create_task` function which streamlines this and enables type safety.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
