### PR TITLE
Ensure startup can proceed if async_get_integration raises

### DIFF
--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -523,8 +523,8 @@ async def _async_get_integration(hass: HomeAssistant, domain: str) -> Integratio
     # Instead of using resolve_from_root we use the cache of custom
     # components to find the integration.
     if integration := (await async_get_custom_components(hass)).get(domain):
-        _LOGGER.warning(CUSTOM_WARNING, integration.domain)
         validate_custom_integration_version(integration)
+        _LOGGER.warning(CUSTOM_WARNING, integration.domain)
         return integration
 
     from homeassistant import components  # pylint: disable=import-outside-toplevel

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -508,7 +508,7 @@ async def async_get_integration(hass: HomeAssistant, domain: str) -> Integration
 
     try:
         integration = await _async_get_integration(hass, domain)
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         # Remove event from cache.
         cache.pop(domain)
         event.set()

--- a/homeassistant/loader.py
+++ b/homeassistant/loader.py
@@ -506,31 +506,35 @@ async def async_get_integration(hass: HomeAssistant, domain: str) -> Integration
 
     event = cache[domain] = asyncio.Event()
 
+    try:
+        integration = await _async_get_integration(hass, domain)
+    except Exception:
+        # Remove event from cache.
+        cache.pop(domain)
+        event.set()
+        raise
+
+    cache[domain] = integration
+    event.set()
+    return integration
+
+
+async def _async_get_integration(hass: HomeAssistant, domain: str) -> Integration:
     # Instead of using resolve_from_root we use the cache of custom
     # components to find the integration.
-    integration = (await async_get_custom_components(hass)).get(domain)
-    if integration is not None:
-        validate_custom_integration_version(integration)
+    if integration := (await async_get_custom_components(hass)).get(domain):
         _LOGGER.warning(CUSTOM_WARNING, integration.domain)
-        cache[domain] = integration
-        event.set()
+        validate_custom_integration_version(integration)
         return integration
 
     from homeassistant import components  # pylint: disable=import-outside-toplevel
 
-    integration = await hass.async_add_executor_job(
+    if integration := await hass.async_add_executor_job(
         Integration.resolve_from_root, hass, components, domain
-    )
-    event.set()
+    ):
+        return integration
 
-    if not integration:
-        # Remove event from cache.
-        cache.pop(domain)
-        raise IntegrationNotFound(domain)
-
-    cache[domain] = integration
-
-    return integration
+    raise IntegrationNotFound(domain)
 
 
 class LoaderError(Exception):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Ensure startup can proceed if async_get_integration raises

There were cases where the event would never get set and
startup would deadlock because the second attempt to load
the integration would block forever

I saw this when `validate_custom_integration_version` raises and then
I went to manually deleted the integration and it raised in another spot so
I moved all the code that can raise into a new function and wrapped it with
a try to ensure the event always gets set when something goes wrong.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
