### PR TITLE
Enable back free-mobile

### DIFF
--- a/homeassistant/components/free_mobile/manifest.json
+++ b/homeassistant/components/free_mobile/manifest.json
@@ -2,8 +2,7 @@
   "domain": "free_mobile",
   "name": "Free Mobile",
   "documentation": "https://www.home-assistant.io/integrations/free_mobile",
-  "requirements": ["freesms==0.1.2"],
+  "requirements": ["freesms==0.2.0"],
   "codeowners": [],
-  "iot_class": "cloud_push",
-  "disabled": "https://github.com/home-assistant/core/pull/50749"
+  "iot_class": "cloud_push"
 }

--- a/homeassistant/components/free_mobile/notify.py
+++ b/homeassistant/components/free_mobile/notify.py
@@ -1,7 +1,7 @@
 """Support for Free Mobile SMS platform."""
 import logging
 
-from freesms import FreeClient  # pylint: disable=import-error
+from freesms import FreeClient
 import voluptuous as vol
 
 from homeassistant.components.notify import PLATFORM_SCHEMA, BaseNotificationService

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -623,6 +623,9 @@ fortiosapi==0.10.8
 # homeassistant.components.freebox
 freebox-api==0.0.10
 
+# homeassistant.components.free_mobile
+freesms==0.2.0
+
 # homeassistant.components.fritz
 # homeassistant.components.fritzbox_callmonitor
 # homeassistant.components.fritzbox_netmonitor


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
free-mobile intergration was disabled due to problem with `setuptools`: https://github.com/home-assistant/core/pull/50749
`freesms` 0.2.0 released which fixe the problem with `setuptools` so it can be re-enabled.
https://github.com/bfontaine/freesms/blob/master/CHANGELOG.md#v020-20210517
### v0.2.0 (2021/05/17)
- Fix license string in setup.py (#7 by @cdce8p)
- Drop official support for Python 2.x. It probably works, but it’s not tested anymore.
- Don’t hide insecure request warning when not using verify=True (this reverts the change in v0.1.2). It’s problematic to hide a warning by default, and the caller should be able to do it by themselves.

Note: I don't use this integration so unable to test

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
