### PR TITLE
Add Nettigo Air Monitor uptime sensor

### DIFF
--- a/homeassistant/components/nam/__init__.py
+++ b/homeassistant/components/nam/__init__.py
@@ -31,7 +31,7 @@ PLATFORMS = ["air_quality", "sensor"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Nettigo as config entry."""
-    host = entry.data[CONF_HOST]
+    host: str = entry.data[CONF_HOST]
 
     websession = async_get_clientsession(hass)
 

--- a/homeassistant/components/nam/air_quality.py
+++ b/homeassistant/components/nam/air_quality.py
@@ -19,9 +19,9 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Add a Nettigo Air Monitor entities from a config_entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: NAMDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities = []
+    entities: list[NAMAirQuality] = []
     for sensor in AIR_QUALITY_SENSORS:
         if f"{sensor}{SUFFIX_P1}" in coordinator.data:
             entities.append(NAMAirQuality(coordinator, sensor))

--- a/homeassistant/components/nam/const.py
+++ b/homeassistant/components/nam/const.py
@@ -10,6 +10,7 @@ from homeassistant.const import (
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_TIMESTAMP,
     PERCENTAGE,
     PRESSURE_HPA,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -126,5 +127,12 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         "device_class": DEVICE_CLASS_TEMPERATURE,
         "icon": None,
         "enabled": True,
+    },
+    "uptime": {
+        "label": f"{DEFAULT_NAME} Uptime",
+        "unit": None,
+        "device_class": DEVICE_CLASS_TIMESTAMP,
+        "icon": None,
+        "enabled": False,
     },
 }

--- a/homeassistant/components/nam/manifest.json
+++ b/homeassistant/components/nam/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nettigo Air Monitor",
   "documentation": "https://www.home-assistant.io/integrations/nam",
   "codeowners": ["@bieniu"],
-  "requirements": ["nettigo-air-monitor==0.2.5"],
+  "requirements": ["nettigo-air-monitor==0.2.6"],
   "zeroconf": [{"type": "_http._tcp.local.", "name": "nam-*"}],
   "config_flow": true,
   "quality_scale": "platinum",

--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -22,7 +22,7 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
 ) -> None:
     """Add a Nettigo Air Monitor entities from a config_entry."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: NAMDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
 
     sensors: list[NAMSensor | NAMSensorUptime] = []
     for sensor in SENSORS:

--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -1,6 +1,7 @@
 """Support for the Nettigo Air Monitor service."""
 from __future__ import annotations
 
+from datetime import timedelta
 from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
@@ -9,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util.dt import utcnow
 
 from . import NAMDataUpdateCoordinator
 from .const import DOMAIN, SENSORS
@@ -22,10 +24,13 @@ async def async_setup_entry(
     """Add a Nettigo Air Monitor entities from a config_entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    sensors = []
+    sensors: list[NAMSensor | NAMSensorUptime] = []
     for sensor in SENSORS:
         if sensor in coordinator.data:
-            sensors.append(NAMSensor(coordinator, sensor))
+            if sensor == "uptime":
+                sensors.append(NAMSensorUptime(coordinator, sensor))
+            else:
+                sensors.append(NAMSensor(coordinator, sensor))
 
     async_add_entities(sensors, False)
 
@@ -91,4 +96,18 @@ class NAMSensor(CoordinatorEntity, SensorEntity):
         # unavailable.
         return available and bool(
             getattr(self.coordinator.data, self.sensor_type, None)
+        )
+
+
+class NAMSensorUptime(NAMSensor):
+    """Define an Nettigo Air Monitor uptime sensor."""
+
+    @property
+    def state(self) -> str:
+        """Return the state."""
+        uptime_sec = getattr(self.coordinator.data, self.sensor_type)
+        return (
+            (utcnow() - timedelta(seconds=uptime_sec))
+            .replace(microsecond=0)
+            .isoformat()
         )

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -994,7 +994,7 @@ netdata==0.2.0
 netdisco==2.8.3
 
 # homeassistant.components.nam
-nettigo-air-monitor==0.2.5
+nettigo-air-monitor==0.2.6
 
 # homeassistant.components.neurio_energy
 neurio==0.3.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -551,7 +551,7 @@ nessclient==0.9.15
 netdisco==2.8.3
 
 # homeassistant.components.nam
-nettigo-air-monitor==0.2.5
+nettigo-air-monitor==0.2.6
 
 # homeassistant.components.nexia
 nexia==0.9.7

--- a/tests/components/nam/__init__.py
+++ b/tests/components/nam/__init__.py
@@ -12,6 +12,7 @@ INCOMPLETE_NAM_DATA = {
 
 nam_data = {
     "software_version": "NAMF-2020-36",
+    "uptime": "456987",
     "sensordatavalues": [
         {"value_type": "SDS_P1", "value": "18.65"},
         {"value_type": "SDS_P2", "value": "11.03"},

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -14,6 +14,7 @@ from homeassistant.const import (
     DEVICE_CLASS_PRESSURE,
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_TIMESTAMP,
     PERCENTAGE,
     PRESSURE_HPA,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
@@ -39,6 +40,14 @@ async def test_sensor(hass):
         DOMAIN,
         "aa:bb:cc:dd:ee:ff-signal",
         suggested_object_id="nettigo_air_monitor_signal_strength",
+        disabled_by=None,
+    )
+
+    registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        "aa:bb:cc:dd:ee:ff-uptime",
+        suggested_object_id="nettigo_air_monitor_uptime",
         disabled_by=None,
     )
 
@@ -166,6 +175,18 @@ async def test_sensor(hass):
     entry = registry.async_get("sensor.nettigo_air_monitor_signal_strength")
     assert entry
     assert entry.unique_id == "aa:bb:cc:dd:ee:ff-signal"
+
+    state = hass.states.get("sensor.nettigo_air_monitor_uptime")
+    assert state
+    assert (
+        state.state
+        == (utcnow() - timedelta(seconds=456987)).replace(microsecond=0).isoformat()
+    )
+    assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TIMESTAMP
+
+    entry = registry.async_get("sensor.nettigo_air_monitor_uptime")
+    assert entry
+    assert entry.unique_id == "aa:bb:cc:dd:ee:ff-uptime"
 
 
 async def test_sensor_disabled(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR bumps `nettigo-air-monitor` library to version `0.2.6` to:
- add `uptime` sensor

Changelog: https://github.com/bieniu/nettigo-air-monitor/compare/0.2.5...0.2.6

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
