### PR TITLE
Add Z-Wave Parameter and Node Rename Services to ISY994

### DIFF
--- a/homeassistant/components/isy994/entity.py
+++ b/homeassistant/components/isy994/entity.py
@@ -179,6 +179,27 @@ class ISYNodeEntity(ISYEntity):
             )
         await self._node.send_cmd(command, value, unit_of_measurement, parameters)
 
+    async def async_get_zwave_parameter(self, parameter):
+        """Repsond to an entity service command to request a Z-Wave device parameter from the ISY."""
+        if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
+            raise HomeAssistantError(
+                f"Invalid service call: cannot request Z-Wave Parameter for non-Z-Wave device {self.entity_id}"
+            )
+        await self._node.get_zwave_parameter(parameter)
+
+    async def async_set_zwave_parameter(self, parameter, value, size):
+        """Repsond to an entity service command to set a Z-Wave device parameter via the ISY."""
+        if not hasattr(self._node, "protocol") or self._node.protocol != PROTO_ZWAVE:
+            raise HomeAssistantError(
+                f"Invalid service call: cannot set Z-Wave Parameter for non-Z-Wave device {self.entity_id}"
+            )
+        await self._node.set_zwave_parameter(parameter, value, size)
+        await self._node.get_zwave_parameter(parameter)
+
+    async def async_rename_node(self, name):
+        """Repsond to an entity service command to rename a node on the ISY."""
+        await self._node.rename(name)
+
 
 class ISYProgramEntity(ISYEntity):
     """Representation of an ISY994 program base."""

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -86,7 +86,7 @@ VALID_PROGRAM_COMMANDS = [
     "enable_run_at_startup",
     "disable_run_at_startup",
 ]
-VALID_PARAMETER_SIZES = ["1", 1, "2", 2, "4", 4]
+VALID_PARAMETER_SIZES = [1, 2, 4]
 
 
 def valid_isy_commands(value: Any) -> str:
@@ -129,7 +129,7 @@ SERVICE_GET_ZWAVE_PARAMETER_SCHEMA = {vol.Required(CONF_PARAMETER): vol.Coerce(i
 SERVICE_SET_ZWAVE_PARAMETER_SCHEMA = {
     vol.Required(CONF_PARAMETER): vol.Coerce(int),
     vol.Required(CONF_VALUE): vol.Coerce(int),
-    vol.Required(CONF_SIZE): vol.In(VALID_PARAMETER_SIZES),
+    vol.Required(CONF_SIZE): vol.All(vol.Coerce(int), vol.In(VALID_PARAMETER_SIZES)),
 }
 
 SERVICE_SET_VARIABLE_SCHEMA = vol.All(

--- a/homeassistant/components/isy994/services.py
+++ b/homeassistant/components/isy994/services.py
@@ -48,15 +48,20 @@ INTEGRATION_SERVICES = [
 # Entity specific methods (valid for most Groups/ISY Scenes, Lights, Switches, Fans)
 SERVICE_SEND_RAW_NODE_COMMAND = "send_raw_node_command"
 SERVICE_SEND_NODE_COMMAND = "send_node_command"
+SERVICE_GET_ZWAVE_PARAMETER = "get_zwave_parameter"
+SERVICE_SET_ZWAVE_PARAMETER = "set_zwave_parameter"
+SERVICE_RENAME_NODE = "rename_node"
 
 # Services valid only for dimmable lights.
 SERVICE_SET_ON_LEVEL = "set_on_level"
 SERVICE_SET_RAMP_RATE = "set_ramp_rate"
 
+CONF_PARAMETER = "parameter"
 CONF_PARAMETERS = "parameters"
 CONF_VALUE = "value"
 CONF_INIT = "init"
 CONF_ISY = "isy"
+CONF_SIZE = "size"
 
 VALID_NODE_COMMANDS = [
     "beep",
@@ -81,6 +86,7 @@ VALID_PROGRAM_COMMANDS = [
     "enable_run_at_startup",
     "disable_run_at_startup",
 ]
+VALID_PARAMETER_SIZES = ["1", 1, "2", 2, "4", 4]
 
 
 def valid_isy_commands(value: Any) -> str:
@@ -114,6 +120,16 @@ SERVICE_SEND_RAW_NODE_COMMAND_SCHEMA = {
 
 SERVICE_SEND_NODE_COMMAND_SCHEMA = {
     vol.Required(CONF_COMMAND): vol.In(VALID_NODE_COMMANDS)
+}
+
+SERVICE_RENAME_NODE_SCHEMA = {vol.Required(CONF_NAME): cv.string}
+
+SERVICE_GET_ZWAVE_PARAMETER_SCHEMA = {vol.Required(CONF_PARAMETER): vol.Coerce(int)}
+
+SERVICE_SET_ZWAVE_PARAMETER_SCHEMA = {
+    vol.Required(CONF_PARAMETER): vol.Coerce(int),
+    vol.Required(CONF_VALUE): vol.Coerce(int),
+    vol.Required(CONF_SIZE): vol.In(VALID_PARAMETER_SIZES),
 }
 
 SERVICE_SET_VARIABLE_SCHEMA = vol.All(
@@ -375,6 +391,42 @@ def async_setup_services(hass: HomeAssistant):  # noqa: C901
         service=SERVICE_SEND_NODE_COMMAND,
         schema=cv.make_entity_service_schema(SERVICE_SEND_NODE_COMMAND_SCHEMA),
         service_func=_async_send_node_command,
+    )
+
+    async def _async_get_zwave_parameter(call: ServiceCall):
+        await hass.helpers.service.entity_service_call(
+            async_get_platforms(hass, DOMAIN), "async_get_zwave_parameter", call
+        )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_GET_ZWAVE_PARAMETER,
+        schema=cv.make_entity_service_schema(SERVICE_GET_ZWAVE_PARAMETER_SCHEMA),
+        service_func=_async_get_zwave_parameter,
+    )
+
+    async def _async_set_zwave_parameter(call: ServiceCall):
+        await hass.helpers.service.entity_service_call(
+            async_get_platforms(hass, DOMAIN), "async_set_zwave_parameter", call
+        )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_SET_ZWAVE_PARAMETER,
+        schema=cv.make_entity_service_schema(SERVICE_SET_ZWAVE_PARAMETER_SCHEMA),
+        service_func=_async_set_zwave_parameter,
+    )
+
+    async def _async_rename_node(call: ServiceCall):
+        await hass.helpers.service.entity_service_call(
+            async_get_platforms(hass, DOMAIN), "async_rename_node", call
+        )
+
+    hass.services.async_register(
+        domain=DOMAIN,
+        service=SERVICE_RENAME_NODE,
+        schema=cv.make_entity_service_schema(SERVICE_RENAME_NODE_SCHEMA),
+        service_func=_async_rename_node,
     )
 
 

--- a/homeassistant/components/isy994/services.yaml
+++ b/homeassistant/components/isy994/services.yaml
@@ -68,6 +68,76 @@ send_node_command:
             - "fast_off"
             - "fast_on"
             - "query"
+get_zwave_parameter:
+  name: Get Z-Wave Parameter
+  description: >-
+    Request a Z-Wave Device parameter via the ISY. The parameter value will be returned as a entity extra state attribute with the name "ZW_#"
+    where "#" is the parameter number.
+  target:
+    entity:
+      integration: isy994
+  fields:
+    parameter:
+      name: Parameter
+      description: The parameter number to retrieve from the device.
+      example: 8
+      selector:
+        number:
+          min: 1
+          max: 255
+set_zwave_parameter:
+  name: Set Z-Wave Parameter
+  description: >-
+    Update a Z-Wave Device parameter via the ISY. The parameter value will also be returned as a entity extra state attribute with the name "ZW_#"
+    where "#" is the parameter number.
+  target:
+    entity:
+      integration: isy994
+  fields:
+    parameter:
+      name: Parameter
+      description: The parameter number to set on the end device.
+      required: true
+      example: 8
+      selector:
+        number:
+          min: 1
+          max: 255
+    value:
+      name: Value
+      description: The value to set for the parameter. May be an integer or byte string (e.g. "0xFFFF").
+      required: true
+      example: 33491663
+      selector:
+        text:
+    size:
+      name: Size
+      description: The size of the parameter, either 1, 2, or 4 bytes.
+      required: true
+      example: 4
+      selector:
+        select:
+          options:
+            - "1"
+            - "2"
+            - "4"
+rename_node:
+  name: Rename Node on ISY994
+  description: >-
+    Rename a node or group (scene) on the ISY994. Note: this will not automatically change the Home Assistant Entity Name or Entity ID to match.
+    The entity name and ID will only be updated after calling `isy994.reload` or restarting Home Assistant, and ONLY IF you have not already customized the
+    name within Home Assistant.
+  target:
+    entity:
+      integration: isy994
+  fields:
+    name:
+      name: New Name
+      description: The new name to use within the ISY994.
+      required: true
+      example: "Front Door Light"
+      selector:
+        text:
 set_on_level:
   name: Set On Level
   description: Send a ISY set_on_level command to a Node.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add (3) additional services to the ISY994 integration to get/set Z-Wave parameters via the ISY994 and remotely rename nodes on the ISY994 (recently added feature on ISY994). 

These changes have been under development and testing since June 2020 using the [hacs-isy994](https://github.com/shbatm/hacs-isy994) `custom_component` and [PyISY-beta](https://github.com/shbatm/PyISY) module. This is the migration of the custom component code back to the Home Assistant Core code after upgrading PyISY in #50806. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #n/a
- This PR is related to issue: #50806
- Link to documentation pull request: home-assistant/home-assistant.io#17891

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
