### PR TITLE
Add battery support for Sonos S1 speakers

### DIFF
--- a/homeassistant/components/sonos/binary_sensor.py
+++ b/homeassistant/components/sonos/binary_sensor.py
@@ -65,3 +65,8 @@ class SonosPowerEntity(SonosEntity, BinarySensorEntity):
         return {
             ATTR_BATTERY_POWER_SOURCE: self.speaker.power_source,
         }
+
+    @property
+    def available(self) -> bool:
+        """Return whether this device is available."""
+        return self.speaker.available and (self.speaker.charging is not None)

--- a/homeassistant/components/sonos/sensor.py
+++ b/homeassistant/components/sonos/sensor.py
@@ -58,3 +58,8 @@ class SonosBatteryEntity(SonosEntity, SensorEntity):
     def state(self) -> int | None:
         """Return the state of the sensor."""
         return self.speaker.battery_info.get("Level")
+
+    @property
+    def available(self) -> bool:
+        """Return whether this device is available."""
+        return self.speaker.available and self.speaker.power_source

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -10,6 +10,18 @@ from homeassistant.const import CONF_HOSTS
 from tests.common import MockConfigEntry
 
 
+class SonosMockEvent:
+    """Mock a sonos Event used in callbacks."""
+
+    def __init__(self, soco, variables):
+        """Initialize the instance."""
+        self.sid = f"{soco.uid}_sub0000000001"
+        self.seq = "0"
+        self.timestamp = 1621000000.0
+        self.service = dummy_soco_service_fixture
+        self.variables = variables
+
+
 @pytest.fixture(name="config_entry")
 def config_entry_fixture():
     """Create a mock Sonos config entry."""
@@ -95,3 +107,13 @@ def battery_info_fixture():
         "Temperature": "NORMAL",
         "PowerSource": "SONOS_CHARGING_RING",
     }
+
+
+@pytest.fixture(name="battery_event")
+def battery_event_fixture(soco):
+    """Create battery_event fixture."""
+    variables = {
+        "zone_name": "Zone A",
+        "more_info": "BattChg:NOT_CHARGING,RawBattPct:100,BattPct:100,BattTmp:25",
+    }
+    return SonosMockEvent(soco, variables)

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -1,9 +1,9 @@
 """Tests for the Sonos battery sensor platform."""
 from pysonos.exceptions import NotSupportedException
 
-from homeassistant.components.sonos import DOMAIN
+from homeassistant.components.sonos import DATA_SONOS, DOMAIN
 from homeassistant.components.sonos.binary_sensor import ATTR_BATTERY_POWER_SOURCE
-from homeassistant.const import STATE_ON
+from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
 from homeassistant.setup import async_setup_component
 
 
@@ -55,3 +55,32 @@ async def test_battery_attributes(hass, config_entry, config, soco):
     assert (
         power_state.attributes.get(ATTR_BATTERY_POWER_SOURCE) == "SONOS_CHARGING_RING"
     )
+
+
+async def test_battery_on_S1(hass, config_entry, config, soco, battery_event):
+    """Test battery state updates on a Sonos S1 device."""
+    soco.get_battery_info.return_value = {}
+
+    await setup_platform(hass, config_entry, config)
+
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+
+    battery = entity_registry.entities["sensor.zone_a_battery"]
+    battery_state = hass.states.get(battery.entity_id)
+    assert battery_state.state == STATE_UNAVAILABLE
+
+    power = entity_registry.entities["binary_sensor.zone_a_power"]
+    power_state = hass.states.get(power.entity_id)
+    assert power_state.state == STATE_UNAVAILABLE
+
+    # Update the speaker with a callback event
+    speaker = hass.data[DATA_SONOS].discovered[soco.uid]
+    speaker.async_dispatch_properties(battery_event)
+    await hass.async_block_till_done()
+
+    battery_state = hass.states.get(battery.entity_id)
+    assert battery_state.state == "100"
+
+    power_state = hass.states.get(power.entity_id)
+    assert power_state.state == STATE_OFF
+    assert power_state.attributes.get(ATTR_BATTERY_POWER_SOURCE) == "BATTERY"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extends battery sensors support to Sonos speakers still on S1 firmware. This should only be possible on Move models.

I do not have an S1 speaker myself, but I've created tests based on how other users have described the behavior. Extra testing would be appreciated.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50169
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17893

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
