### PR TITLE
Add network configuration integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -44,6 +44,7 @@ homeassistant.components.lock.*
 homeassistant.components.mailbox.*
 homeassistant.components.media_player.*
 homeassistant.components.nam.*
+homeassistant.components.network.*
 homeassistant.components.notify.*
 homeassistant.components.number.*
 homeassistant.components.onewire.*

--- a/homeassistant/components/default_config/manifest.json
+++ b/homeassistant/components/default_config/manifest.json
@@ -19,6 +19,7 @@
     "media_source",
     "mobile_app",
     "my",
+    "network",
     "person",
     "scene",
     "script",

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -6,6 +6,7 @@ import logging
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.components.websocket_api.connection import ActiveConnection
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
@@ -46,12 +47,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-@websocket_api.require_admin  # type: ignore[arg-type]
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): "network"})
+@websocket_api.async_response
 async def websocket_network_adapters(
     hass: HomeAssistant,
-    connection: websocket_api.connection.ActiveConnection,
+    connection: ActiveConnection,
     msg: dict,
 ) -> None:
     """Return network preferences."""
@@ -65,17 +66,17 @@ async def websocket_network_adapters(
     )
 
 
-@websocket_api.require_admin  # type: ignore[arg-type]
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required("type"): "network/configure",
         vol.Required("config", default={}): NETWORK_CONFIG_SCHEMA,
     }
 )
+@websocket_api.async_response
 async def websocket_network_adapters_configure(
     hass: HomeAssistant,
-    connection: websocket_api.connection.ActiveConnection,
+    connection: ActiveConnection,
     msg: dict,
 ) -> None:
     """Update network config."""

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -45,8 +45,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
-@websocket_api.require_admin  # type: ignore[arg-type]
 @websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): "network"})
 async def websocket_network_adapters(
     hass: HomeAssistant,

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -1,0 +1,88 @@
+"""The Network Configuration integration."""
+from __future__ import annotations
+
+import logging
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant
+from homeassistant.loader import bind_hass
+
+from .const import (
+    ATTR_ADAPTERS,
+    ATTR_CONFIGURED_ADAPTERS,
+    DOMAIN,
+    NETWORK_CONFIG_SCHEMA,
+)
+from .models import Adapter
+from .network import Network
+
+ZEROCONF_DOMAIN = "zeroconf"  # cannot import from zeroconf due to circular dep
+_LOGGER = logging.getLogger(__name__)
+
+
+@bind_hass
+async def async_get_adapters(hass: HomeAssistant) -> list[Adapter]:
+    """Get the network adapter configuration."""
+    network: Network = hass.data[DOMAIN]
+    return network.adapters
+
+
+async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+    """Set up network for Home Assistant."""
+
+    hass.data[DOMAIN] = network = Network(hass)
+    await network.async_setup()
+    await network.async_migrate_from_zeroconf(config.get(ZEROCONF_DOMAIN, {}))
+    network.async_configure()
+
+    _LOGGER.debug("Adapters: %s", network.adapters)
+
+    websocket_api.async_register_command(hass, websocket_network_adapters)
+    websocket_api.async_register_command(hass, websocket_network_adapters_configure)
+
+    return True
+
+
+@websocket_api.require_admin  # type: ignore[arg-type]
+@websocket_api.async_response
+@websocket_api.websocket_command({vol.Required("type"): "network"})
+async def websocket_network_adapters(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Return network preferences."""
+    network: Network = hass.data[DOMAIN]
+    connection.send_result(
+        msg["id"],
+        {
+            ATTR_ADAPTERS: network.adapters,
+            ATTR_CONFIGURED_ADAPTERS: network.configured_adapters,
+        },
+    )
+
+
+@websocket_api.require_admin  # type: ignore[arg-type]
+@websocket_api.async_response
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "network/configure",
+        vol.Required("config", default={}): NETWORK_CONFIG_SCHEMA,
+    }
+)
+async def websocket_network_adapters_configure(
+    hass: HomeAssistant,
+    connection: websocket_api.connection.ActiveConnection,
+    msg: dict,
+) -> None:
+    """Update network config."""
+    network: Network = hass.data[DOMAIN]
+
+    await network.async_reconfig(msg["config"])
+
+    connection.send_result(
+        msg["id"],
+        {ATTR_CONFIGURED_ADAPTERS: network.configured_adapters},
+    )

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -45,8 +45,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+@websocket_api.require_admin  # type: ignore[arg-type]
 @websocket_api.async_response
-@websocket_api.require_admin
 @websocket_api.websocket_command({vol.Required("type"): "network"})
 async def websocket_network_adapters(
     hass: HomeAssistant,

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -29,7 +29,7 @@ async def async_get_adapters(hass: HomeAssistant) -> list[Adapter]:
     return network.adapters
 
 
-async def async_setup(hass: HomeAssistant, config: dict) -> bool:
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up network for Home Assistant."""
 
     hass.data[DOMAIN] = network = Network(hass)

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -7,6 +7,7 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import bind_hass
 
 from .const import (

--- a/homeassistant/components/network/__init__.py
+++ b/homeassistant/components/network/__init__.py
@@ -36,7 +36,8 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     hass.data[DOMAIN] = network = Network(hass)
     await network.async_setup()
-    await network.async_migrate_from_zeroconf(config.get(ZEROCONF_DOMAIN, {}))
+    if ZEROCONF_DOMAIN in config:
+        await network.async_migrate_from_zeroconf(config[ZEROCONF_DOMAIN])
     network.async_configure()
 
     _LOGGER.debug("Adapters: %s", network.adapters)

--- a/homeassistant/components/network/const.py
+++ b/homeassistant/components/network/const.py
@@ -1,0 +1,22 @@
+"""Constants for the network integration."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+import homeassistant.helpers.config_validation as cv
+
+DOMAIN = "network"
+STORAGE_KEY = "core.network"
+STORAGE_VERSION = 1
+
+ATTR_ADAPTERS = "adapters"
+ATTR_CONFIGURED_ADAPTERS = "configured_adapters"
+DEFAULT_CONFIGURED_ADAPTERS: list[str] = []
+
+NETWORK_CONFIG_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            ATTR_CONFIGURED_ADAPTERS, default=DEFAULT_CONFIGURED_ADAPTERS
+        ): vol.Schema(vol.All(cv.ensure_list, [cv.string])),
+    }
+)

--- a/homeassistant/components/network/const.py
+++ b/homeassistant/components/network/const.py
@@ -1,17 +1,22 @@
 """Constants for the network integration."""
 from __future__ import annotations
 
+from typing import Final
+
 import voluptuous as vol
 
 import homeassistant.helpers.config_validation as cv
 
-DOMAIN = "network"
-STORAGE_KEY = "core.network"
-STORAGE_VERSION = 1
+DOMAIN: Final = "network"
+STORAGE_KEY: Final = "core.network"
+STORAGE_VERSION: Final = 1
 
-ATTR_ADAPTERS = "adapters"
-ATTR_CONFIGURED_ADAPTERS = "configured_adapters"
+ATTR_ADAPTERS: Final = "adapters"
+ATTR_CONFIGURED_ADAPTERS: Final = "configured_adapters"
 DEFAULT_CONFIGURED_ADAPTERS: list[str] = []
+
+MDNS_TARGET_IP: Final = "224.0.0.251"
+
 
 NETWORK_CONFIG_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/network/manifest.json
+++ b/homeassistant/components/network/manifest.json
@@ -2,7 +2,7 @@
   "domain": "network",
   "name": "Network Configuration",
   "documentation": "https://www.home-assistant.io/integrations/network",
-  "requirements": ["pyroute2==0.5.18", "ifaddr==0.1.7"],
+  "requirements": ["ifaddr==0.1.7"],
   "codeowners": [],
   "dependencies": ["websocket_api"],
   "quality_scale": "internal",

--- a/homeassistant/components/network/manifest.json
+++ b/homeassistant/components/network/manifest.json
@@ -2,10 +2,7 @@
   "domain": "network",
   "name": "Network Configuration",
   "documentation": "https://www.home-assistant.io/integrations/network",
-  "requirements": [
-    "pyroute2==0.5.18",
-    "ifaddr==0.1.7"
-  ],
+  "requirements": ["pyroute2==0.5.18", "ifaddr==0.1.7"],
   "codeowners": [],
   "dependencies": ["websocket_api"],
   "quality_scale": "internal",

--- a/homeassistant/components/network/manifest.json
+++ b/homeassistant/components/network/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "network",
+  "name": "Network Configuration",
+  "documentation": "https://www.home-assistant.io/integrations/network",
+  "requirements": [
+    "pyroute2==0.5.18",
+    "ifaddr==0.1.7"
+  ],
+  "codeowners": [],
+  "dependencies": ["websocket_api"],
+  "quality_scale": "internal",
+  "iot_class": "local_push"
+}

--- a/homeassistant/components/network/models.py
+++ b/homeassistant/components/network/models.py
@@ -1,0 +1,30 @@
+"""Models helper class for the network integration."""
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class IPv6ConfiguredAddress(TypedDict):
+    """Represent an IPv6 address."""
+
+    address: str
+    flowinfo: int
+    scope_id: int
+    network_prefix: int
+
+
+class IPv4ConfiguredAddress(TypedDict):
+    """Represent an IPv4 address."""
+
+    address: str
+    network_prefix: int
+
+
+class Adapter(TypedDict):
+    """Configured network adapters."""
+
+    name: str
+    enabled: bool
+    default: bool
+    ipv6: list[IPv6ConfiguredAddress]
+    ipv4: list[IPv4ConfiguredAddress]

--- a/homeassistant/components/network/models.py
+++ b/homeassistant/components/network/models.py
@@ -25,6 +25,7 @@ class Adapter(TypedDict):
 
     name: str
     enabled: bool
+    auto: bool
     default: bool
     ipv6: list[IPv6ConfiguredAddress]
     ipv4: list[IPv4ConfiguredAddress]

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -174,16 +174,10 @@ def _ifaddr_adapter_to_ha(
 
     for ip_config in adapter.ips:
         if ip_config.is_IPv6:
-            try:
-                ip_addr = ip_address(ip_config.ip[0])
-            except ValueError:
-                continue
+            ip_addr = ip_address(ip_config.ip[0])
             ip_v6s.append(_ip_v6_from_adapter(ip_config))
         else:
-            try:
-                ip_addr = ip_address(ip_config.ip)
-            except ValueError:
-                continue
+            ip_addr = ip_address(ip_config.ip)
             ip_v4s.append(_ip_v4_from_adapter(ip_config))
 
         if ip_addr == next_hop_address:

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -50,10 +50,7 @@ class Network:
         if self._data:
             return
 
-        if (
-            ZC_CONF_DEFAULT_INTERFACE in zc_config
-            and not zc_config[ZC_CONF_DEFAULT_INTERFACE]
-        ):
+        if zc_config.get(ZC_CONF_DEFAULT_INTERFACE) is False:
             self._data[ATTR_CONFIGURED_ADAPTERS] = adapters_with_exernal_addresses(
                 self.adapters
             )

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -1,9 +1,10 @@
 """Network helper class for the network integration."""
 from __future__ import annotations
 
+from collections.abc import Iterable
 from ipaddress import IPv4Address, IPv6Address, ip_address
 import logging
-from typing import Any, Iterable, cast
+from typing import Any, cast
 
 import ifaddr
 from pyroute2 import IPRoute

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -52,9 +52,9 @@ class Network:
 
     async def async_setup(self) -> None:
         """Set up the network config."""
-        self._next_broadcast_hop = await async_default_next_broadcast_hop(self.hass)
+        self._next_broadcast_hop = await _async_default_next_broadcast_hop(self.hass)
         await self.async_load()
-        self._adapters = load_adapters(self._next_broadcast_hop)
+        self._adapters = _load_adapters(self._next_broadcast_hop)
 
     async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""
@@ -146,7 +146,7 @@ def _ip_address_is_external(ip_addr: IPv4Address | IPv6Address) -> bool:
     )
 
 
-def load_adapters(next_hop: str | None) -> list[Adapter]:
+def _load_adapters(next_hop: str | None) -> list[Adapter]:
     """Load adapters."""
     adapters = ifaddr.get_adapters()
     next_hop_address = ip_address(next_hop) if next_hop else None
@@ -232,7 +232,7 @@ def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
     return None
 
 
-async def async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
+async def _async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
     """Auto detect the default next broadcast hop."""
     try:
         routes: Iterable = await hass.async_add_executor_job(

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -15,10 +15,9 @@ from .const import (
 from .models import Adapter
 from .util import (
     adapters_with_exernal_addresses,
-    async_default_next_broadcast_hop,
+    async_load_adapters,
     enable_adapters,
     enable_auto_detected_adapters,
-    load_adapters,
 )
 
 ZC_CONF_DEFAULT_INTERFACE = (
@@ -35,7 +34,6 @@ class Network:
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         self._data: dict[str, Any] = {}
         self._adapters: list[Adapter] = []
-        self._next_broadcast_hop: str | None = None
 
     @property
     def adapters(self) -> list[Adapter]:
@@ -49,9 +47,8 @@ class Network:
 
     async def async_setup(self) -> None:
         """Set up the network config."""
-        self._next_broadcast_hop = await async_default_next_broadcast_hop(self.hass)
         await self.async_load()
-        self._adapters = load_adapters(self._next_broadcast_hop)
+        self._adapters = await async_load_adapters(self.hass)
 
     async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -58,7 +58,7 @@ class Network:
         await self.async_load()
         self._adapters = load_adapters(self._next_broadcast_hop)
 
-    async def async_migrate_from_zeroconf(self, zc_config) -> None:
+    async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""
         if self._data:
             return
@@ -212,7 +212,7 @@ def load_adapters(next_hop: str | None) -> list[Adapter]:
 
 def _get_ip_route(dst_ip: str) -> Iterable:
     """Get ip next hop."""
-    return IPRoute().route("get", dst=dst_ip)
+    return cast(Iterable, IPRoute().route("get", dst=dst_ip))
 
 
 def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
@@ -227,21 +227,22 @@ def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
 
 async def async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
     """Auto detect the default next broadcast hop."""
-    routes = []
     try:
-        routes = await hass.async_add_executor_job(_get_ip_route, MDNS_TARGET_IP)
+        routes: Iterable = await hass.async_add_executor_job(
+            _get_ip_route, MDNS_TARGET_IP
+        )
     except Exception as ex:  # pylint: disable=broad-except
         _LOGGER.debug(
             "The system could not auto detect routing data on your operating system",
             exc_info=ex,
         )
         return None
+    else:
+        if not (first_ip := _first_ip_nexthop_from_route(routes)):
+            _LOGGER.debug(
+                "The system could not auto detect the nexthop for %s on your operating system",
+                MDNS_TARGET_IP,
+            )
+            return None
 
-    if not (first_ip := _first_ip_nexthop_from_route(routes)):
-        _LOGGER.debug(
-            "The system could not auto detect the nexthop for %s on your operating system",
-            MDNS_TARGET_IP,
-        )
-        return None
-
-    return first_ip
+        return first_ip

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -80,8 +80,7 @@ class Network:
         """Reconfigure network."""
         config = NETWORK_CONFIG_SCHEMA(config)
         self._data[ATTR_CONFIGURED_ADAPTERS] = config[ATTR_CONFIGURED_ADAPTERS]
-        for adapter in self._adapters:
-            adapter["enabled"] = False
+        _reset_enabled_adapters(self._adapters)
         _enable_adapters(self._adapters, self.configured_adapters)
         await self._async_save()
 
@@ -144,6 +143,11 @@ def _ip_address_is_external(ip_addr: IPv4Address | IPv6Address) -> bool:
         and not ip_addr.is_loopback
         and not ip_addr.is_link_local
     )
+
+
+def _reset_enabled_adapters(adapters: list[Adapter]) -> None:
+    for adapter in adapters:
+        adapter["enabled"] = False
 
 
 def _load_adapters(next_hop: str | None) -> list[Adapter]:

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -9,19 +9,16 @@ import ifaddr
 from pyroute2 import IPRoute
 
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.storage import Store
 
 from .const import (
     ATTR_CONFIGURED_ADAPTERS,
     DEFAULT_CONFIGURED_ADAPTERS,
+    MDNS_TARGET_IP,
     NETWORK_CONFIG_SCHEMA,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
 from .models import Adapter, IPv4ConfiguredAddress, IPv6ConfiguredAddress
-
-MDNS_TARGET_IP = "224.0.0.251"
-
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -26,7 +26,6 @@ class Network:
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the Network class."""
-        self.hass = hass
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         self._data: dict[str, Any] = {}
         self.adapters: list[Adapter] = []
@@ -39,7 +38,7 @@ class Network:
     async def async_setup(self) -> None:
         """Set up the network config."""
         await self.async_load()
-        self.adapters = await async_load_adapters(self.hass)
+        self.adapters = await async_load_adapters()
 
     async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -36,8 +36,8 @@ class Network:
 
     def __init__(self, hass: HomeAssistant) -> None:
         """Initialize the Network class."""
-        self.hass: HomeAssistant = hass
-        self._store: Store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self.hass = hass
+        self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         self._data: dict[str, Any] = {}
         self._adapters: list[Adapter] = []
         self._next_broadcast_hop: str | None = None

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -1,28 +1,25 @@
 """Network helper class for the network integration."""
 from __future__ import annotations
 
-from collections.abc import Iterable
-from ipaddress import IPv4Address, IPv6Address, ip_address
-import logging
 from typing import Any, cast
-
-import ifaddr
-from pyroute2 import IPRoute
 
 from homeassistant.core import HomeAssistant, callback
 
 from .const import (
     ATTR_CONFIGURED_ADAPTERS,
     DEFAULT_CONFIGURED_ADAPTERS,
-    MDNS_TARGET_IP,
     NETWORK_CONFIG_SCHEMA,
     STORAGE_KEY,
     STORAGE_VERSION,
 )
-from .models import Adapter, IPv4ConfiguredAddress, IPv6ConfiguredAddress
-
-_LOGGER = logging.getLogger(__name__)
-
+from .models import Adapter
+from .util import (
+    adapters_with_exernal_addresses,
+    async_default_next_broadcast_hop,
+    enable_adapters,
+    enable_auto_detected_adapters,
+    load_adapters,
+)
 
 ZC_CONF_DEFAULT_INTERFACE = (
     "default_interface"  # cannot import from zeroconf due to circular dep
@@ -52,9 +49,9 @@ class Network:
 
     async def async_setup(self) -> None:
         """Set up the network config."""
-        self._next_broadcast_hop = await _async_default_next_broadcast_hop(self.hass)
+        self._next_broadcast_hop = await async_default_next_broadcast_hop(self.hass)
         await self.async_load()
-        self._adapters = _load_adapters(self._next_broadcast_hop)
+        self._adapters = load_adapters(self._next_broadcast_hop)
 
     async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""
@@ -65,7 +62,7 @@ class Network:
             ZC_CONF_DEFAULT_INTERFACE in zc_config
             and not zc_config[ZC_CONF_DEFAULT_INTERFACE]
         ):
-            self._data[ATTR_CONFIGURED_ADAPTERS] = _adapters_with_exernal_addresses(
+            self._data[ATTR_CONFIGURED_ADAPTERS] = adapters_with_exernal_addresses(
                 self._adapters
             )
             await self._async_save()
@@ -73,14 +70,14 @@ class Network:
     @callback
     def async_configure(self) -> None:
         """Configure from storage."""
-        if not _enable_adapters(self._adapters, self.configured_adapters):
-            _enable_auto_detected_adapters(self._adapters)
+        if not enable_adapters(self._adapters, self.configured_adapters):
+            enable_auto_detected_adapters(self._adapters)
 
     async def async_reconfig(self, config: dict[str, Any]) -> None:
         """Reconfigure network."""
         config = NETWORK_CONFIG_SCHEMA(config)
         self._data[ATTR_CONFIGURED_ADAPTERS] = config[ATTR_CONFIGURED_ADAPTERS]
-        _enable_adapters(self._adapters, self.configured_adapters)
+        enable_adapters(self._adapters, self.configured_adapters)
         await self._async_save()
 
     async def async_load(self) -> None:
@@ -91,164 +88,3 @@ class Network:
     async def _async_save(self) -> None:
         """Save preferences."""
         await self._store.async_save(self._data)
-
-
-def _enable_adapters(adapters: list[Adapter], enabled_interfaces: list[str]) -> bool:
-    """Enable configured adapters."""
-    _reset_enabled_adapters(adapters)
-
-    if not enabled_interfaces:
-        return False
-
-    found_adapter = False
-    for adapter in adapters:
-        if adapter["name"] in enabled_interfaces:
-            adapter["enabled"] = True
-            found_adapter = True
-
-    return found_adapter
-
-
-def _enable_auto_detected_adapters(adapters: list[Adapter]) -> None:
-    """Enable auto detected adapters."""
-    _enable_adapters(
-        adapters, [adapter["name"] for adapter in adapters if adapter["auto"]]
-    )
-
-
-def _adapters_with_exernal_addresses(adapters: list[Adapter]) -> list[str]:
-    """Enable all interfaces with an external address."""
-    return [
-        adapter["name"]
-        for adapter in adapters
-        if _adapter_has_external_address(adapter)
-    ]
-
-
-def _adapter_has_external_address(adapter: Adapter) -> bool:
-    """Adapter has a non-loopback and non-link-local address."""
-    return any(
-        _has_external_address(v4_config["address"]) for v4_config in adapter["ipv4"]
-    ) or any(
-        _has_external_address(v6_config["address"]) for v6_config in adapter["ipv6"]
-    )
-
-
-def _has_external_address(ip_str: str) -> bool:
-    return _ip_address_is_external(ip_address(ip_str))
-
-
-def _ip_address_is_external(ip_addr: IPv4Address | IPv6Address) -> bool:
-    return (
-        not ip_addr.is_multicast
-        and not ip_addr.is_loopback
-        and not ip_addr.is_link_local
-    )
-
-
-def _reset_enabled_adapters(adapters: list[Adapter]) -> None:
-    for adapter in adapters:
-        adapter["enabled"] = False
-
-
-def _load_adapters(next_hop: str | None) -> list[Adapter]:
-    """Load adapters."""
-    next_hop_address = ip_address(next_hop) if next_hop else None
-
-    ha_adapters: list[Adapter] = [
-        _ifaddr_adapter_to_ha(adapter, next_hop_address)
-        for adapter in ifaddr.get_adapters()
-    ]
-
-    if not any(adapter["default"] and adapter["auto"] for adapter in ha_adapters):
-        for adapter in ha_adapters:
-            if _adapter_has_external_address(adapter):
-                adapter["auto"] = True
-
-    return ha_adapters
-
-
-def _ifaddr_adapter_to_ha(
-    adapter: ifaddr.Adapter, next_hop_address: None | IPv4Address | IPv6Address
-) -> Adapter:
-    """Convert an ifaddr adapter to ha."""
-    ip_v4s: list[IPv4ConfiguredAddress] = []
-    ip_v6s: list[IPv6ConfiguredAddress] = []
-    default = False
-    auto = False
-
-    for ip_config in adapter.ips:
-        if ip_config.is_IPv6:
-            ip_addr = ip_address(ip_config.ip[0])
-            ip_v6s.append(_ip_v6_from_adapter(ip_config))
-        else:
-            ip_addr = ip_address(ip_config.ip)
-            ip_v4s.append(_ip_v4_from_adapter(ip_config))
-
-        if ip_addr == next_hop_address:
-            default = True
-            if _ip_address_is_external(ip_addr):
-                auto = True
-
-    return {
-        "name": adapter.nice_name,
-        "enabled": False,
-        "auto": auto,
-        "default": default,
-        "ipv4": ip_v4s,
-        "ipv6": ip_v6s,
-    }
-
-
-def _ip_v6_from_adapter(ip_config: ifaddr.IP) -> IPv6ConfiguredAddress:
-    return {
-        "address": ip_config.ip[0],
-        "flowinfo": ip_config.ip[1],
-        "scope_id": ip_config.ip[2],
-        "network_prefix": ip_config.network_prefix,
-    }
-
-
-def _ip_v4_from_adapter(ip_config: ifaddr.IP) -> IPv4ConfiguredAddress:
-    return {
-        "address": ip_config.ip,
-        "network_prefix": ip_config.network_prefix,
-    }
-
-
-def _get_ip_route(dst_ip: str) -> Iterable:
-    """Get ip next hop."""
-    return cast(Iterable, IPRoute().route("get", dst=dst_ip))
-
-
-def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
-    """Find the first RTA_PREFSRC in the routes."""
-    _LOGGER.debug("Routes: %s", routes)
-    for route in routes:
-        for key, value in route["attrs"]:
-            if key == "RTA_PREFSRC":
-                return cast(str, value)
-    return None
-
-
-async def _async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
-    """Auto detect the default next broadcast hop."""
-    try:
-        routes: Iterable = await hass.async_add_executor_job(
-            _get_ip_route, MDNS_TARGET_IP
-        )
-    except Exception as ex:  # pylint: disable=broad-except
-        _LOGGER.debug(
-            "The system could not auto detect routing data on your operating system",
-            exc_info=ex,
-        )
-        return None
-    else:
-        if first_ip := _first_ip_nexthop_from_route(routes):
-            return first_ip
-
-    _LOGGER.debug(
-        "The system could not auto detect the nexthop for %s on your operating system",
-        MDNS_TARGET_IP,
-    )
-    return None

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -1,0 +1,237 @@
+"""Network helper class for the network integration."""
+from __future__ import annotations
+
+from ipaddress import ip_address
+import logging
+from typing import Any, Iterable, cast
+
+import ifaddr
+from pyroute2 import IPRoute
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.storage import Store
+
+from .const import (
+    ATTR_CONFIGURED_ADAPTERS,
+    DEFAULT_CONFIGURED_ADAPTERS,
+    NETWORK_CONFIG_SCHEMA,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
+from .models import Adapter, IPv4ConfiguredAddress, IPv6ConfiguredAddress
+
+MDNS_TARGET_IP = "224.0.0.251"
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+ZC_CONF_DEFAULT_INTERFACE = (
+    "default_interface"  # cannot import from zeroconf due to circular dep
+)
+
+
+class Network:
+    """Network helper class for the network integration."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the Network class."""
+        self.hass: HomeAssistant = hass
+        self._store: Store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
+        self._data: dict[str, Any] = {}
+        self._adapters: list[Adapter] = []
+        self._next_broadcast_hop: str | None = None
+
+    @property
+    def adapters(self) -> list[Adapter]:
+        """Return the list of adapters."""
+        return self._adapters
+
+    @property
+    def configured_adapters(self) -> list[str]:
+        """Return the configured adapters."""
+        return self._data.get(ATTR_CONFIGURED_ADAPTERS, DEFAULT_CONFIGURED_ADAPTERS)
+
+    async def async_setup(self) -> None:
+        """Set up the network config."""
+        self._next_broadcast_hop = await async_default_next_broadcast_hop(self.hass)
+        await self.async_load()
+        self._adapters = load_adapters(self._next_broadcast_hop)
+
+    async def async_migrate_from_zeroconf(self, zc_config) -> None:
+        """Migrate configuration from zeroconf."""
+        if self._data:
+            return
+
+        if (
+            ZC_CONF_DEFAULT_INTERFACE in zc_config
+            and not zc_config[ZC_CONF_DEFAULT_INTERFACE]
+        ):
+            self._data[ATTR_CONFIGURED_ADAPTERS] = _adapters_with_exernal_addresses(
+                self._adapters
+            )
+            await self._async_save()
+
+    @callback
+    def async_configure(self) -> None:
+        """Configure from storage."""
+        if not _enable_adapters(self._adapters, self.configured_adapters):
+            _auto_detect_adapters(self._adapters)
+
+    async def async_reconfig(self, config: dict[str, Any]) -> None:
+        """Reconfigure network."""
+        config = NETWORK_CONFIG_SCHEMA(config)
+        self._data[ATTR_CONFIGURED_ADAPTERS] = config[ATTR_CONFIGURED_ADAPTERS]
+        for adapter in self._adapters:
+            adapter["enabled"] = False
+        _enable_adapters(self._adapters, self.configured_adapters)
+        await self._async_save()
+
+    async def async_load(self) -> None:
+        """Load config."""
+        if stored := await self._store.async_load():
+            self._data = cast(dict, stored)
+
+    async def _async_save(self) -> None:
+        """Save preferences."""
+        await self._store.async_save(self._data)
+
+
+def _enable_adapters(adapters: list[Adapter], enabled_interfaces: list[str]) -> bool:
+    """Enable configured adapters."""
+    if not enabled_interfaces:
+        return False
+
+    found_adapter = False
+    for adapter in adapters:
+        if adapter["name"] in enabled_interfaces:
+            adapter["enabled"] = True
+            found_adapter = True
+
+    return found_adapter
+
+
+def _auto_detect_adapters(adapters: list[Adapter]) -> None:
+    """Enable the default adapter or all adapters with external addresses."""
+    for adapter in adapters:
+        if adapter["default"] and _adapter_has_external_address(adapter):
+            adapter["enabled"] = True
+            return
+
+    _enable_adapters(adapters, _adapters_with_exernal_addresses(adapters))
+
+
+def _adapters_with_exernal_addresses(adapters: list[Adapter]) -> list[str]:
+    """Enable all interfaces with an external address."""
+    return [
+        adapter["name"]
+        for adapter in adapters
+        if _adapter_has_external_address(adapter)
+    ]
+
+
+def _adapter_has_external_address(adapter: Adapter) -> bool:
+    """Adapter has a non-loopback and non-link-local address."""
+    return any(
+        _has_external_address(v4_config["address"]) for v4_config in adapter["ipv4"]
+    ) or any(
+        _has_external_address(v6_config["address"]) for v6_config in adapter["ipv6"]
+    )
+
+
+def _has_external_address(ip_str: str):
+    ip_addr = ip_address(ip_str)
+    return (
+        not ip_addr.is_multicast
+        and not ip_addr.is_loopback
+        and not ip_addr.is_link_local
+    )
+
+
+def load_adapters(next_hop: str | None) -> list[Adapter]:
+    """Load adapters."""
+    adapters = ifaddr.get_adapters()
+    ha_adapters: list[Adapter] = []
+    if next_hop:
+        next_hop_address = ip_address(next_hop)
+
+    for adapter in adapters:
+        ip_v4s: list[IPv4ConfiguredAddress] = []
+        ip_v6s: list[IPv6ConfiguredAddress] = []
+        default = False
+
+        for ip_config in adapter.ips:
+            if ip_config.is_IPv6:
+                try:
+                    ip_addr = ip_address(ip_config.ip[0])
+                except ValueError:
+                    continue
+                ip_v6: IPv6ConfiguredAddress = {
+                    "address": str(ip_addr),
+                    "flowinfo": ip_config.ip[1],
+                    "scope_id": ip_config.ip[2],
+                    "network_prefix": ip_config.network_prefix,
+                }
+                if next_hop and ip_addr == next_hop_address:
+                    default = True
+                ip_v6s.append(ip_v6)
+            else:
+                try:
+                    ip_addr = ip_address(ip_config.ip)
+                except ValueError:
+                    continue
+                ip_v4: IPv4ConfiguredAddress = {
+                    "address": str(ip_addr),
+                    "network_prefix": ip_config.network_prefix,
+                }
+                if next_hop and ip_addr == next_hop_address:
+                    default = True
+                ip_v4s.append(ip_v4)
+
+        ha_adapter: Adapter = {
+            "name": adapter.nice_name,
+            "enabled": False,
+            "default": default,
+            "ipv4": ip_v4s,
+            "ipv6": ip_v6s,
+        }
+        ha_adapters.append(ha_adapter)
+
+    return ha_adapters
+
+
+def _get_ip_route(dst_ip: str) -> Any:
+    """Get ip next hop."""
+    return IPRoute().route("get", dst=dst_ip)
+
+
+def _first_ip_nexthop_from_route(routes: Iterable) -> None | str:
+    """Find the first RTA_PREFSRC in the routes."""
+    _LOGGER.debug("Routes: %s", routes)
+    for route in routes:
+        for key, value in route["attrs"]:
+            if key == "RTA_PREFSRC":
+                return cast(str, value)
+    return None
+
+
+async def async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
+    """Auto detect the default next broadcast hop."""
+    routes = []
+    try:
+        routes = await hass.async_add_executor_job(_get_ip_route, MDNS_TARGET_IP)
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.debug(
+            "The system could not auto detect routing data on your operating system",
+            exc_info=ex,
+        )
+        return None
+
+    if not (first_ip := _first_ip_nexthop_from_route(routes)):
+        _LOGGER.debug(
+            "The system could not auto detect the nexthop for %s on your operating system",
+            MDNS_TARGET_IP,
+        )
+        return None
+
+    return first_ip

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -166,23 +166,13 @@ def load_adapters(next_hop: str | None) -> list[Adapter]:
                     ip_addr = ip_address(ip_config.ip[0])
                 except ValueError:
                     continue
-                ip_v6: IPv6ConfiguredAddress = {
-                    "address": str(ip_addr),
-                    "flowinfo": ip_config.ip[1],
-                    "scope_id": ip_config.ip[2],
-                    "network_prefix": ip_config.network_prefix,
-                }
-                ip_v6s.append(ip_v6)
+                ip_v6s.append(_ip_v6_from_adapter(ip_config))
             else:
                 try:
                     ip_addr = ip_address(ip_config.ip)
                 except ValueError:
                     continue
-                ip_v4: IPv4ConfiguredAddress = {
-                    "address": str(ip_addr),
-                    "network_prefix": ip_config.network_prefix,
-                }
-                ip_v4s.append(ip_v4)
+                ip_v4s.append(_ip_v4_from_adapter(ip_config))
 
             if next_hop and ip_addr == next_hop_address:
                 default = True
@@ -206,6 +196,22 @@ def load_adapters(next_hop: str | None) -> list[Adapter]:
                 adapter["auto"] = True
 
     return ha_adapters
+
+
+def _ip_v6_from_adapter(ip_config: ifaddr.IP) -> IPv6ConfiguredAddress:
+    return {
+        "address": ip_config.ip[0],
+        "flowinfo": ip_config.ip[1],
+        "scope_id": ip_config.ip[2],
+        "network_prefix": ip_config.network_prefix,
+    }
+
+
+def _ip_v4_from_adapter(ip_config: ifaddr.IP) -> IPv4ConfiguredAddress:
+    return {
+        "address": ip_config.ip,
+        "network_prefix": ip_config.network_prefix,
+    }
 
 
 def _get_ip_route(dst_ip: str) -> Iterable:

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -80,7 +80,6 @@ class Network:
         """Reconfigure network."""
         config = NETWORK_CONFIG_SCHEMA(config)
         self._data[ATTR_CONFIGURED_ADAPTERS] = config[ATTR_CONFIGURED_ADAPTERS]
-        _reset_enabled_adapters(self._adapters)
         _enable_adapters(self._adapters, self.configured_adapters)
         await self._async_save()
 
@@ -96,6 +95,8 @@ class Network:
 
 def _enable_adapters(adapters: list[Adapter], enabled_interfaces: list[str]) -> bool:
     """Enable configured adapters."""
+    _reset_enabled_adapters(adapters)
+
     if not enabled_interfaces:
         return False
 

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -160,6 +160,7 @@ def load_adapters(next_hop: str | None) -> list[Adapter]:
         ip_v4s: list[IPv4ConfiguredAddress] = []
         ip_v6s: list[IPv6ConfiguredAddress] = []
         default = False
+        auto = False
 
         for ip_config in adapter.ips:
             if ip_config.is_IPv6:

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -33,12 +33,7 @@ class Network:
         self.hass = hass
         self._store = hass.helpers.storage.Store(STORAGE_VERSION, STORAGE_KEY)
         self._data: dict[str, Any] = {}
-        self._adapters: list[Adapter] = []
-
-    @property
-    def adapters(self) -> list[Adapter]:
-        """Return the list of adapters."""
-        return self._adapters
+        self.adapters: list[Adapter] = []
 
     @property
     def configured_adapters(self) -> list[str]:
@@ -48,7 +43,7 @@ class Network:
     async def async_setup(self) -> None:
         """Set up the network config."""
         await self.async_load()
-        self._adapters = await async_load_adapters(self.hass)
+        self.adapters = await async_load_adapters(self.hass)
 
     async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""
@@ -60,21 +55,21 @@ class Network:
             and not zc_config[ZC_CONF_DEFAULT_INTERFACE]
         ):
             self._data[ATTR_CONFIGURED_ADAPTERS] = adapters_with_exernal_addresses(
-                self._adapters
+                self.adapters
             )
             await self._async_save()
 
     @callback
     def async_configure(self) -> None:
         """Configure from storage."""
-        if not enable_adapters(self._adapters, self.configured_adapters):
-            enable_auto_detected_adapters(self._adapters)
+        if not enable_adapters(self.adapters, self.configured_adapters):
+            enable_auto_detected_adapters(self.adapters)
 
     async def async_reconfig(self, config: dict[str, Any]) -> None:
         """Reconfigure network."""
         config = NETWORK_CONFIG_SCHEMA(config)
         self._data[ATTR_CONFIGURED_ADAPTERS] = config[ATTR_CONFIGURED_ADAPTERS]
-        enable_adapters(self._adapters, self.configured_adapters)
+        enable_adapters(self.adapters, self.configured_adapters)
         await self._async_save()
 
     async def async_load(self) -> None:

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -20,10 +20,6 @@ from .util import (
     enable_auto_detected_adapters,
 )
 
-ZC_CONF_DEFAULT_INTERFACE = (
-    "default_interface"  # cannot import from zeroconf due to circular dep
-)
-
 
 class Network:
     """Network helper class for the network integration."""
@@ -47,10 +43,14 @@ class Network:
 
     async def async_migrate_from_zeroconf(self, zc_config: dict[str, Any]) -> None:
         """Migrate configuration from zeroconf."""
-        if self._data:
+        if self._data or not zc_config:
             return
 
-        if zc_config.get(ZC_CONF_DEFAULT_INTERFACE) is False:
+        from homeassistant.components.zeroconf import (  # pylint: disable=import-outside-toplevel
+            CONF_DEFAULT_INTERFACE,
+        )
+
+        if zc_config.get(CONF_DEFAULT_INTERFACE) is False:
             self._data[ATTR_CONFIGURED_ADAPTERS] = adapters_with_exernal_addresses(
                 self.adapters
             )

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -148,11 +148,11 @@ def _ip_address_is_external(ip_addr: IPv4Address | IPv6Address) -> bool:
 
 def _load_adapters(next_hop: str | None) -> list[Adapter]:
     """Load adapters."""
-    adapters = ifaddr.get_adapters()
     next_hop_address = ip_address(next_hop) if next_hop else None
 
     ha_adapters: list[Adapter] = [
-        _ifaddr_adapter_to_ha(adapter, next_hop_address) for adapter in adapters
+        _ifaddr_adapter_to_ha(adapter, next_hop_address)
+        for adapter in ifaddr.get_adapters()
     ]
 
     if not any(adapter["default"] and adapter["auto"] for adapter in ha_adapters):

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -66,7 +66,7 @@ class Network:
         """Reconfigure network."""
         config = NETWORK_CONFIG_SCHEMA(config)
         self._data[ATTR_CONFIGURED_ADAPTERS] = config[ATTR_CONFIGURED_ADAPTERS]
-        enable_adapters(self.adapters, self.configured_adapters)
+        self.async_configure()
         await self._async_save()
 
     async def async_load(self) -> None:

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -210,7 +210,7 @@ def load_adapters(next_hop: str | None) -> list[Adapter]:
     return ha_adapters
 
 
-def _get_ip_route(dst_ip: str) -> Any:
+def _get_ip_route(dst_ip: str) -> Iterable:
     """Get ip next hop."""
     return IPRoute().route("get", dst=dst_ip)
 

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -235,11 +235,11 @@ async def async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
         )
         return None
     else:
-        if not (first_ip := _first_ip_nexthop_from_route(routes)):
-            _LOGGER.debug(
-                "The system could not auto detect the nexthop for %s on your operating system",
-                MDNS_TARGET_IP,
-            )
-            return None
+        if first_ip := _first_ip_nexthop_from_route(routes):
+            return first_ip
 
-        return first_ip
+    _LOGGER.debug(
+        "The system could not auto detect the nexthop for %s on your operating system",
+        MDNS_TARGET_IP,
+    )
+    return None

--- a/homeassistant/components/network/network.py
+++ b/homeassistant/components/network/network.py
@@ -215,7 +215,7 @@ def _get_ip_route(dst_ip: str) -> Any:
     return IPRoute().route("get", dst=dst_ip)
 
 
-def _first_ip_nexthop_from_route(routes: Iterable) -> None | str:
+def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
     """Find the first RTA_PREFSRC in the routes."""
     _LOGGER.debug("Routes: %s", routes)
     for route in routes:

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -148,7 +148,7 @@ def async_get_source_ip(target_ip: str) -> None | str:
     try:
         test_sock.connect((target_ip, 1))
         return cast(str, test_sock.getsockname()[0])
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         _LOGGER.debug(
             "The system could not auto detect the source ip for %s on your operating system",
             target_ip,

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -141,7 +141,7 @@ def _ip_v4_from_adapter(ip_config: ifaddr.IP) -> IPv4ConfiguredAddress:
 
 
 @callback
-def async_get_source_ip(target_ip: str) -> None | str:
+def async_get_source_ip(target_ip: str) -> str | None:
     """Return the source ip that will reach target_ip."""
     test_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     test_sock.setblocking(False)  # must be non-blocking for async

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -75,8 +75,9 @@ def _reset_enabled_adapters(adapters: list[Adapter]) -> None:
         adapter["enabled"] = False
 
 
-def load_adapters(next_hop: str | None) -> list[Adapter]:
+async def async_load_adapters(hass: HomeAssistant) -> list[Adapter]:
     """Load adapters."""
+    next_hop = await _async_default_next_broadcast_hop(hass)
     next_hop_address = ip_address(next_hop) if next_hop else None
 
     ha_adapters: list[Adapter] = [
@@ -155,7 +156,7 @@ def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
     return None
 
 
-async def async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
+async def _async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
     """Auto detect the default next broadcast hop."""
     try:
         routes: Iterable = await hass.async_add_executor_job(

--- a/homeassistant/components/network/util.py
+++ b/homeassistant/components/network/util.py
@@ -1,0 +1,178 @@
+"""Network helper class for the network integration."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+from ipaddress import IPv4Address, IPv6Address, ip_address
+import logging
+from typing import cast
+
+import ifaddr
+from pyroute2 import IPRoute
+
+from homeassistant.core import HomeAssistant
+
+from .const import MDNS_TARGET_IP
+from .models import Adapter, IPv4ConfiguredAddress, IPv6ConfiguredAddress
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def enable_adapters(adapters: list[Adapter], enabled_interfaces: list[str]) -> bool:
+    """Enable configured adapters."""
+    _reset_enabled_adapters(adapters)
+
+    if not enabled_interfaces:
+        return False
+
+    found_adapter = False
+    for adapter in adapters:
+        if adapter["name"] in enabled_interfaces:
+            adapter["enabled"] = True
+            found_adapter = True
+
+    return found_adapter
+
+
+def enable_auto_detected_adapters(adapters: list[Adapter]) -> None:
+    """Enable auto detected adapters."""
+    enable_adapters(
+        adapters, [adapter["name"] for adapter in adapters if adapter["auto"]]
+    )
+
+
+def adapters_with_exernal_addresses(adapters: list[Adapter]) -> list[str]:
+    """Enable all interfaces with an external address."""
+    return [
+        adapter["name"]
+        for adapter in adapters
+        if _adapter_has_external_address(adapter)
+    ]
+
+
+def _adapter_has_external_address(adapter: Adapter) -> bool:
+    """Adapter has a non-loopback and non-link-local address."""
+    return any(
+        _has_external_address(v4_config["address"]) for v4_config in adapter["ipv4"]
+    ) or any(
+        _has_external_address(v6_config["address"]) for v6_config in adapter["ipv6"]
+    )
+
+
+def _has_external_address(ip_str: str) -> bool:
+    return _ip_address_is_external(ip_address(ip_str))
+
+
+def _ip_address_is_external(ip_addr: IPv4Address | IPv6Address) -> bool:
+    return (
+        not ip_addr.is_multicast
+        and not ip_addr.is_loopback
+        and not ip_addr.is_link_local
+    )
+
+
+def _reset_enabled_adapters(adapters: list[Adapter]) -> None:
+    for adapter in adapters:
+        adapter["enabled"] = False
+
+
+def load_adapters(next_hop: str | None) -> list[Adapter]:
+    """Load adapters."""
+    next_hop_address = ip_address(next_hop) if next_hop else None
+
+    ha_adapters: list[Adapter] = [
+        _ifaddr_adapter_to_ha(adapter, next_hop_address)
+        for adapter in ifaddr.get_adapters()
+    ]
+
+    if not any(adapter["default"] and adapter["auto"] for adapter in ha_adapters):
+        for adapter in ha_adapters:
+            if _adapter_has_external_address(adapter):
+                adapter["auto"] = True
+
+    return ha_adapters
+
+
+def _ifaddr_adapter_to_ha(
+    adapter: ifaddr.Adapter, next_hop_address: None | IPv4Address | IPv6Address
+) -> Adapter:
+    """Convert an ifaddr adapter to ha."""
+    ip_v4s: list[IPv4ConfiguredAddress] = []
+    ip_v6s: list[IPv6ConfiguredAddress] = []
+    default = False
+    auto = False
+
+    for ip_config in adapter.ips:
+        if ip_config.is_IPv6:
+            ip_addr = ip_address(ip_config.ip[0])
+            ip_v6s.append(_ip_v6_from_adapter(ip_config))
+        else:
+            ip_addr = ip_address(ip_config.ip)
+            ip_v4s.append(_ip_v4_from_adapter(ip_config))
+
+        if ip_addr == next_hop_address:
+            default = True
+            if _ip_address_is_external(ip_addr):
+                auto = True
+
+    return {
+        "name": adapter.nice_name,
+        "enabled": False,
+        "auto": auto,
+        "default": default,
+        "ipv4": ip_v4s,
+        "ipv6": ip_v6s,
+    }
+
+
+def _ip_v6_from_adapter(ip_config: ifaddr.IP) -> IPv6ConfiguredAddress:
+    return {
+        "address": ip_config.ip[0],
+        "flowinfo": ip_config.ip[1],
+        "scope_id": ip_config.ip[2],
+        "network_prefix": ip_config.network_prefix,
+    }
+
+
+def _ip_v4_from_adapter(ip_config: ifaddr.IP) -> IPv4ConfiguredAddress:
+    return {
+        "address": ip_config.ip,
+        "network_prefix": ip_config.network_prefix,
+    }
+
+
+def _get_ip_route(dst_ip: str) -> Iterable:
+    """Get ip next hop."""
+    return cast(Iterable, IPRoute().route("get", dst=dst_ip))
+
+
+def _first_ip_nexthop_from_route(routes: Iterable) -> str | None:
+    """Find the first RTA_PREFSRC in the routes."""
+    _LOGGER.debug("Routes: %s", routes)
+    for route in routes:
+        for key, value in route["attrs"]:
+            if key == "RTA_PREFSRC":
+                return cast(str, value)
+    return None
+
+
+async def async_default_next_broadcast_hop(hass: HomeAssistant) -> None | str:
+    """Auto detect the default next broadcast hop."""
+    try:
+        routes: Iterable = await hass.async_add_executor_job(
+            _get_ip_route, MDNS_TARGET_IP
+        )
+    except Exception as ex:  # pylint: disable=broad-except
+        _LOGGER.debug(
+            "The system could not auto detect routing data on your operating system",
+            exc_info=ex,
+        )
+        return None
+    else:
+        if first_ip := _first_ip_nexthop_from_route(routes):
+            return first_ip
+
+    _LOGGER.debug(
+        "The system could not auto detect the nexthop for %s on your operating system",
+        MDNS_TARGET_IP,
+    )
+    return None

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -161,10 +161,6 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     if not zc_config.get(CONF_IPV6, DEFAULT_IPV6):
         zc_args["ip_version"] = IPVersion.V4Only
 
-    import pprint
-
-    pprint.pprint(zc_args)
-
     aio_zc = await _async_get_instance(hass, **zc_args)
     zeroconf = aio_zc.zeroconf
 

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -161,6 +161,10 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     if not zc_config.get(CONF_IPV6, DEFAULT_IPV6):
         zc_args["ip_version"] = IPVersion.V4Only
 
+    import pprint
+
+    pprint.pprint(zc_args)
+
     aio_zc = await _async_get_instance(hass, **zc_args)
     zeroconf = aio_zc.zeroconf
 

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,8 +2,8 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.31.0","pyroute2==0.5.18"],
-  "dependencies": ["api"],
+  "requirements": ["zeroconf==0.31.0"],
+  "dependencies": ["network", "api"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",
   "iot_class": "local_push"

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -25,7 +25,6 @@ netdisco==2.8.3
 paho-mqtt==1.5.1
 pillow==8.1.2
 pip>=8.0.3,<20.3
-pyroute2==0.5.18
 python-slugify==4.0.1
 pyyaml==5.4.1
 requests==2.25.1

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -19,6 +19,7 @@ emoji==1.2.0
 hass-nabucasa==0.43.0
 home-assistant-frontend==20210518.0
 httpx==0.18.0
+ifaddr==0.1.7
 jinja2>=3.0.1
 netdisco==2.8.3
 paho-mqtt==1.5.1

--- a/mypy.ini
+++ b/mypy.ini
@@ -495,6 +495,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.network.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.notify.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -821,6 +821,9 @@ ibmiotf==0.3.4
 # homeassistant.components.ping
 icmplib==2.1.1
 
+# homeassistant.components.network
+ifaddr==0.1.7
+
 # homeassistant.components.iglo
 iglo==1.2.7
 
@@ -1690,7 +1693,7 @@ pyrisco==0.3.1
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.3
 
-# homeassistant.components.zeroconf
+# homeassistant.components.network
 pyroute2==0.5.18
 
 # homeassistant.components.ruckus_unleashed

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1693,9 +1693,6 @@ pyrisco==0.3.1
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.3
 
-# homeassistant.components.network
-pyroute2==0.5.18
-
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -465,6 +465,9 @@ iaqualink==0.3.4
 # homeassistant.components.ping
 icmplib==2.1.1
 
+# homeassistant.components.network
+ifaddr==0.1.7
+
 # homeassistant.components.influxdb
 influxdb-client==1.14.0
 
@@ -946,6 +949,9 @@ pyrisco==0.3.1
 
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.3
+
+# homeassistant.components.network
+pyroute2==0.5.18
 
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -950,9 +950,6 @@ pyrisco==0.3.1
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.3
 
-# homeassistant.components.network
-pyroute2==0.5.18
-
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -947,9 +947,6 @@ pyrisco==0.3.1
 # homeassistant.components.rituals_perfume_genie
 pyrituals==0.0.3
 
-# homeassistant.components.zeroconf
-pyroute2==0.5.18
-
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12
 

--- a/script/hassfest/dependencies.py
+++ b/script/hassfest/dependencies.py
@@ -136,6 +136,8 @@ IGNORE_VIOLATIONS = {
     ("demo", "openalpr_local"),
     # Migration wizard from zwave to ozw.
     "ozw",
+    # Migration of settings from zeroconf to network
+    ("network", "zeroconf"),
     # This should become a helper method that integrations can submit data to
     ("websocket_api", "lovelace"),
     ("websocket_api", "shopping_list"),

--- a/tests/components/network/__init__.py
+++ b/tests/components/network/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Network Configuration integration."""

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -1,0 +1,464 @@
+"""Test the Network Configuration."""
+from unittest.mock import Mock, patch
+
+import ifaddr
+
+from homeassistant.components import network
+from homeassistant.components.network.const import (
+    ATTR_ADAPTERS,
+    ATTR_CONFIGURED_ADAPTERS,
+    STORAGE_KEY,
+    STORAGE_VERSION,
+)
+from homeassistant.setup import async_setup_component
+
+_ROUTE_NO_LOOPBACK = (
+    {
+        "attrs": [
+            ("RTA_TABLE", 254),
+            ("RTA_DST", "224.0.0.251"),
+            ("RTA_OIF", 4),
+            ("RTA_PREFSRC", "192.168.1.5"),
+        ],
+    },
+)
+_ROUTE_LOOPBACK = (
+    {
+        "attrs": [
+            ("RTA_TABLE", 254),
+            ("RTA_DST", "224.0.0.251"),
+            ("RTA_OIF", 4),
+            ("RTA_PREFSRC", "127.0.0.1"),
+        ],
+    },
+)
+
+
+def _generate_mock_adapters():
+    mock_lo0 = Mock(spec=ifaddr.Adapter)
+    mock_lo0.nice_name = "lo0"
+    mock_lo0.ips = [ifaddr.IP("127.0.0.1", 8, "lo0")]
+    mock_eth0 = Mock(spec=ifaddr.Adapter)
+    mock_eth0.nice_name = "eth0"
+    mock_eth0.ips = [ifaddr.IP(("2001:db8::", 1, 1), 8, "eth0")]
+    mock_eth1 = Mock(spec=ifaddr.Adapter)
+    mock_eth1.nice_name = "eth1"
+    mock_eth1.ips = [ifaddr.IP("192.168.1.5", 23, "eth1")]
+    mock_vtun0 = Mock(spec=ifaddr.Adapter)
+    mock_vtun0.nice_name = "vtun0"
+    mock_vtun0.ips = [ifaddr.IP("169.254.3.2", 16, "vtun0")]
+    return [mock_eth0, mock_lo0, mock_eth1, mock_vtun0]
+
+
+async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_storage):
+    """Test without default interface config and the route returns a non-loopback address."""
+    with patch(
+        "homeassistant.components.network.util.IPRoute.route",
+        return_value=_ROUTE_NO_LOOPBACK,
+    ), patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=_generate_mock_adapters(),
+    ):
+        assert await async_setup_component(hass, network.DOMAIN, {network.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    network_obj = hass.data[network.DOMAIN]
+    assert network_obj.configured_adapters == []
+
+    assert network_obj.adapters == [
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": True,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]
+
+
+async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage):
+    """Test without default interface config and the route returns a loopback address."""
+    with patch(
+        "homeassistant.components.network.util.IPRoute.route",
+        return_value=_ROUTE_LOOPBACK,
+    ), patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=_generate_mock_adapters(),
+    ):
+        assert await async_setup_component(hass, network.DOMAIN, {network.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    network_obj = hass.data[network.DOMAIN]
+    assert network_obj.configured_adapters == []
+    assert network_obj.adapters == [
+        {
+            "auto": True,
+            "default": False,
+            "enabled": True,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": True,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": False,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]
+
+
+async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
+    """Test without default interface config and the route returns nothing."""
+    with patch(
+        "homeassistant.components.network.util.IPRoute.route",
+        return_value=[],
+    ), patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=_generate_mock_adapters(),
+    ):
+        assert await async_setup_component(hass, network.DOMAIN, {network.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    network_obj = hass.data[network.DOMAIN]
+    assert network_obj.configured_adapters == []
+    assert network_obj.adapters == [
+        {
+            "auto": True,
+            "default": False,
+            "enabled": True,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": False,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]
+
+
+async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
+    """Test without default interface config and the route throws an exception."""
+    with patch(
+        "homeassistant.components.network.util.IPRoute.route",
+        side_effect=AttributeError,
+    ), patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=_generate_mock_adapters(),
+    ):
+        assert await async_setup_component(hass, network.DOMAIN, {network.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    network_obj = hass.data[network.DOMAIN]
+    assert network_obj.configured_adapters == []
+    assert network_obj.adapters == [
+        {
+            "auto": True,
+            "default": False,
+            "enabled": True,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": False,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]
+
+
+async def test_interfaces_configured_from_storage(hass, hass_storage):
+    """Test settings from storage are preferred over auto configure."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "key": STORAGE_KEY,
+        "data": {ATTR_CONFIGURED_ADAPTERS: ["eth0", "eth1", "vtun0"]},
+    }
+    with patch(
+        "homeassistant.components.network.util.IPRoute.route",
+        return_value=_ROUTE_NO_LOOPBACK,
+    ), patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=_generate_mock_adapters(),
+    ):
+        assert await async_setup_component(hass, network.DOMAIN, {network.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    network_obj = hass.data[network.DOMAIN]
+    assert network_obj.configured_adapters == ["eth0", "eth1", "vtun0"]
+
+    assert network_obj.adapters == [
+        {
+            "auto": False,
+            "default": False,
+            "enabled": True,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": True,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": True,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]
+
+
+async def test_interfaces_configured_from_storage_websocket_update(
+    hass, hass_ws_client, hass_storage
+):
+    """Test settings from storage can be updated via websocket api."""
+    hass_storage[STORAGE_KEY] = {
+        "version": STORAGE_VERSION,
+        "key": STORAGE_KEY,
+        "data": {ATTR_CONFIGURED_ADAPTERS: ["eth0", "eth1", "vtun0"]},
+    }
+    with patch(
+        "homeassistant.components.network.util.IPRoute.route",
+        return_value=_ROUTE_NO_LOOPBACK,
+    ), patch(
+        "homeassistant.components.network.util.ifaddr.get_adapters",
+        return_value=_generate_mock_adapters(),
+    ):
+        assert await async_setup_component(hass, network.DOMAIN, {network.DOMAIN: {}})
+        await hass.async_block_till_done()
+
+    network_obj = hass.data[network.DOMAIN]
+    assert network_obj.configured_adapters == ["eth0", "eth1", "vtun0"]
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({"id": 1, "type": "network"})
+
+    response = await ws_client.receive_json()
+
+    assert response["success"]
+    assert response["result"][ATTR_CONFIGURED_ADAPTERS] == ["eth0", "eth1", "vtun0"]
+    assert response["result"][ATTR_ADAPTERS] == [
+        {
+            "auto": False,
+            "default": False,
+            "enabled": True,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": True,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": True,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]
+
+    await ws_client.send_json(
+        {"id": 2, "type": "network/configure", "config": {ATTR_CONFIGURED_ADAPTERS: []}}
+    )
+    response = await ws_client.receive_json()
+    assert response["result"][ATTR_CONFIGURED_ADAPTERS] == []
+
+    await ws_client.send_json({"id": 3, "type": "network"})
+    response = await ws_client.receive_json()
+    assert response["result"][ATTR_CONFIGURED_ADAPTERS] == []
+    assert response["result"][ATTR_ADAPTERS] == [
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [],
+            "ipv6": [
+                {
+                    "address": "2001:db8::",
+                    "network_prefix": 8,
+                    "flowinfo": 1,
+                    "scope_id": 1,
+                }
+            ],
+            "name": "eth0",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "127.0.0.1", "network_prefix": 8}],
+            "ipv6": [],
+            "name": "lo0",
+        },
+        {
+            "auto": True,
+            "default": True,
+            "enabled": True,
+            "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+            "ipv6": [],
+            "name": "eth1",
+        },
+        {
+            "auto": False,
+            "default": False,
+            "enabled": False,
+            "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+            "ipv6": [],
+            "name": "vtun0",
+        },
+    ]

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -12,26 +12,8 @@ from homeassistant.components.network.const import (
 )
 from homeassistant.setup import async_setup_component
 
-_ROUTE_NO_LOOPBACK = (
-    {
-        "attrs": [
-            ("RTA_TABLE", 254),
-            ("RTA_DST", "224.0.0.251"),
-            ("RTA_OIF", 4),
-            ("RTA_PREFSRC", "192.168.1.5"),
-        ],
-    },
-)
-_ROUTE_LOOPBACK = (
-    {
-        "attrs": [
-            ("RTA_TABLE", 254),
-            ("RTA_DST", "224.0.0.251"),
-            ("RTA_OIF", 4),
-            ("RTA_PREFSRC", "127.0.0.1"),
-        ],
-    },
-)
+_NO_LOOPBACK_IPADDR = "192.168.1.5"
+_LOOPBACK_IPADDR = "127.0.0.1"
 
 
 def _generate_mock_adapters():
@@ -53,8 +35,8 @@ def _generate_mock_adapters():
 async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_storage):
     """Test without default interface config and the route returns a non-loopback address."""
     with patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        return_value=_ROUTE_NO_LOOPBACK,
+        "homeassistant.components.network.util.socket.socket.getsockname",
+        return_value=[_NO_LOOPBACK_IPADDR],
     ), patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
         return_value=_generate_mock_adapters(),
@@ -111,8 +93,8 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, hass_sto
 async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage):
     """Test without default interface config and the route returns a loopback address."""
     with patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        return_value=_ROUTE_LOOPBACK,
+        "homeassistant.components.network.util.socket.socket.getsockname",
+        return_value=[_LOOPBACK_IPADDR],
     ), patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
         return_value=_generate_mock_adapters(),
@@ -168,7 +150,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, hass_storage
 async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
     """Test without default interface config and the route returns nothing."""
     with patch(
-        "homeassistant.components.network.util.IPRoute.route",
+        "homeassistant.components.network.util.socket.socket.getsockname",
         return_value=[],
     ), patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
@@ -225,7 +207,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, hass_storage):
 async def test_async_detect_interfaces_setting_exception(hass, hass_storage):
     """Test without default interface config and the route throws an exception."""
     with patch(
-        "homeassistant.components.network.util.IPRoute.route",
+        "homeassistant.components.network.util.socket.socket.getsockname",
         side_effect=AttributeError,
     ), patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
@@ -287,8 +269,8 @@ async def test_interfaces_configured_from_storage(hass, hass_storage):
         "data": {ATTR_CONFIGURED_ADAPTERS: ["eth0", "eth1", "vtun0"]},
     }
     with patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        return_value=_ROUTE_NO_LOOPBACK,
+        "homeassistant.components.network.util.socket.socket.getsockname",
+        return_value=[_NO_LOOPBACK_IPADDR],
     ), patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
         return_value=_generate_mock_adapters(),
@@ -352,8 +334,8 @@ async def test_interfaces_configured_from_storage_websocket_update(
         "data": {ATTR_CONFIGURED_ADAPTERS: ["eth0", "eth1", "vtun0"]},
     }
     with patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        return_value=_ROUTE_NO_LOOPBACK,
+        "homeassistant.components.network.util.socket.socket.getsockname",
+        return_value=[_NO_LOOPBACK_IPADDR],
     ), patch(
         "homeassistant.components.network.util.ifaddr.get_adapters",
         return_value=_generate_mock_adapters(),

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -702,7 +702,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zer
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.network.network.IPRoute.route",
+        "homeassistant.components.network.util.IPRoute.route",
         return_value=_ROUTE_NO_LOOPBACK,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
@@ -720,7 +720,7 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, mock_zerocon
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.network.network.IPRoute.route",
+        "homeassistant.components.network.util.IPRoute.route",
         return_value=_ROUTE_LOOPBACK,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
@@ -738,7 +738,7 @@ async def test_async_detect_interfaces_setting_empty_route(hass, mock_zeroconf):
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.network.network.IPRoute.route", return_value=[]
+        "homeassistant.components.network.util.IPRoute.route", return_value=[]
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
         side_effect=get_service_info_mock,
@@ -755,7 +755,7 @@ async def test_async_detect_interfaces_setting_exception(hass, mock_zeroconf):
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.network.network.IPRoute.route",
+        "homeassistant.components.network.util.IPRoute.route",
         side_effect=AttributeError,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,5 +1,5 @@
 """Test Zeroconf component setup process."""
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 from zeroconf import InterfaceChoice, IPVersion, ServiceInfo, ServiceStateChange
 
@@ -697,13 +697,27 @@ async def test_removed_ignored(hass, mock_zeroconf):
     assert mock_service_info.mock_calls[1][1][0] == "_service.updated.local."
 
 
-async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zeroconf):
+_ADAPTER_WITH_DEFAULT_ENABLED = [
+    {
+        "auto": True,
+        "default": True,
+        "enabled": True,
+        "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+        "ipv6": [],
+        "name": "eth1",
+    }
+]
+
+
+async def test_async_detect_interfaces_setting_non_loopback_route(hass):
     """Test without default interface config and the route returns a non-loopback address."""
-    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+    with patch(
+        "homeassistant.components.zeroconf.models.HaZeroconf"
+    ) as mock_zc, patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        return_value=_ROUTE_NO_LOOPBACK,
+        "homeassistant.components.zeroconf.network.async_get_adapters",
+        return_value=_ADAPTER_WITH_DEFAULT_ENABLED,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
         side_effect=get_service_info_mock,
@@ -712,33 +726,53 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zer
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
+    assert mock_zc.mock_calls[0] == call(interfaces=InterfaceChoice.Default)
 
 
-async def test_async_detect_interfaces_setting_loopback_route(hass, mock_zeroconf):
-    """Test without default interface config and the route returns a loopback address."""
-    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
-        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ), patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        return_value=_ROUTE_LOOPBACK,
-    ), patch(
-        "homeassistant.components.zeroconf.ServiceInfo",
-        side_effect=get_service_info_mock,
-    ):
-        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
+_ADAPTERS_WITH_MANUAL_CONFIG = [
+    {
+        "auto": True,
+        "default": False,
+        "enabled": True,
+        "ipv4": [],
+        "ipv6": [
+            {
+                "address": "2001:db8::",
+                "network_prefix": 8,
+                "flowinfo": 1,
+                "scope_id": 1,
+            }
+        ],
+        "name": "eth0",
+    },
+    {
+        "auto": True,
+        "default": False,
+        "enabled": True,
+        "ipv4": [{"address": "192.168.1.5", "network_prefix": 23}],
+        "ipv6": [],
+        "name": "eth1",
+    },
+    {
+        "auto": False,
+        "default": False,
+        "enabled": False,
+        "ipv4": [{"address": "169.254.3.2", "network_prefix": 16}],
+        "ipv6": [],
+        "name": "vtun0",
+    },
+]
 
-    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.All)
 
-
-async def test_async_detect_interfaces_setting_empty_route(hass, mock_zeroconf):
+async def test_async_detect_interfaces_setting_empty_route(hass):
     """Test without default interface config and the route returns nothing."""
-    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
+    with patch(
+        "homeassistant.components.zeroconf.models.HaZeroconf"
+    ) as mock_zc, patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.network.util.IPRoute.route", return_value=[]
+        "homeassistant.components.zeroconf.network.async_get_adapters",
+        return_value=_ADAPTERS_WITH_MANUAL_CONFIG,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
         side_effect=get_service_info_mock,
@@ -747,22 +781,4 @@ async def test_async_detect_interfaces_setting_empty_route(hass, mock_zeroconf):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.All)
-
-
-async def test_async_detect_interfaces_setting_exception(hass, mock_zeroconf):
-    """Test without default interface config and the route throws an exception."""
-    with patch.object(hass.config_entries.flow, "async_init"), patch.object(
-        zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ), patch(
-        "homeassistant.components.network.util.IPRoute.route",
-        side_effect=AttributeError,
-    ), patch(
-        "homeassistant.components.zeroconf.ServiceInfo",
-        side_effect=get_service_info_mock,
-    ):
-        assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
-        await hass.async_block_till_done()
-
-    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.All)
+    assert mock_zc.mock_calls[0] == call(interfaces=[1, "192.168.1.5"])

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -702,7 +702,7 @@ async def test_async_detect_interfaces_setting_non_loopback_route(hass, mock_zer
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.zeroconf.IPRoute.route",
+        "homeassistant.components.network.network.IPRoute.route",
         return_value=_ROUTE_NO_LOOPBACK,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
@@ -720,7 +720,8 @@ async def test_async_detect_interfaces_setting_loopback_route(hass, mock_zerocon
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.zeroconf.IPRoute.route", return_value=_ROUTE_LOOPBACK
+        "homeassistant.components.network.network.IPRoute.route",
+        return_value=_ROUTE_LOOPBACK,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
         side_effect=get_service_info_mock,
@@ -736,7 +737,9 @@ async def test_async_detect_interfaces_setting_empty_route(hass, mock_zeroconf):
     """Test without default interface config and the route returns nothing."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
-    ), patch("homeassistant.components.zeroconf.IPRoute.route", return_value=[]), patch(
+    ), patch(
+        "homeassistant.components.network.network.IPRoute.route", return_value=[]
+    ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
         side_effect=get_service_info_mock,
     ):
@@ -752,7 +755,8 @@ async def test_async_detect_interfaces_setting_exception(hass, mock_zeroconf):
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaServiceBrowser", side_effect=service_update_mock
     ), patch(
-        "homeassistant.components.zeroconf.IPRoute.route", side_effect=AttributeError
+        "homeassistant.components.network.network.IPRoute.route",
+        side_effect=AttributeError,
     ), patch(
         "homeassistant.components.zeroconf.ServiceInfo",
         side_effect=get_service_info_mock,

--- a/tests/test_requirements.py
+++ b/tests/test_requirements.py
@@ -361,7 +361,7 @@ async def test_discovery_requirements_ssdp(hass):
     ) as mock_process:
         await async_get_integration_with_requirements(hass, "ssdp_comp")
 
-    assert len(mock_process.mock_calls) == 3
+    assert len(mock_process.mock_calls) == 4
     assert mock_process.mock_calls[0][1][2] == ssdp.requirements
     # Ensure zeroconf is a dep for ssdp
     assert mock_process.mock_calls[1][1][1] == "zeroconf"
@@ -386,7 +386,7 @@ async def test_discovery_requirements_zeroconf(hass, partial_manifest):
     ) as mock_process:
         await async_get_integration_with_requirements(hass, "comp")
 
-    assert len(mock_process.mock_calls) == 2  # zeroconf also depends on http
+    assert len(mock_process.mock_calls) == 3  # zeroconf also depends on http
     assert mock_process.mock_calls[0][1][2] == zeroconf.requirements
 
 


### PR DESCRIPTION
## Breaking change

Network adapter configuration has moved to the UI. Users that previously used a custom zeroconf interface configuration may need to adjust the settings in the UI.

For more details see https://www.home-assistant.io/integrations/network/

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add intelligent network adapter/interface selection

- If the user manually configured a list of interfaces, these are used

- If we can detect the next hop for broadcast traffic and it has an external address (non-loopback, non-link-local, non-multicast) this interface is used

- Finally, if we cannot detect the next hop for broadcast traffic, all interfaces with a external address (non-loopback, non-link-local, non-multicast) are used


https://github.com/home-assistant/architecture/discussions/509
https://github.com/home-assistant/frontend/pull/9210
Add network configuration integration

Once this is completed, we should be able to replace SSDP discovery threads by providing a way to get callbacks from the `ssdp` integration as this will resolve the inconsistency where some integrations bind to all interfaces (sonos).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17897 and https://github.com/home-assistant/home-assistant.io/pull/17911

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
