### PR TITLE
Use constants with TypedDict in Airly integration

### DIFF
--- a/homeassistant/components/airly/const.py
+++ b/homeassistant/components/airly/const.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 from typing import Final
 
 from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_PRESSURE,
@@ -20,15 +22,17 @@ ATTR_API_CAQI: Final = "CAQI"
 ATTR_API_CAQI_DESCRIPTION: Final = "DESCRIPTION"
 ATTR_API_CAQI_LEVEL: Final = "LEVEL"
 ATTR_API_HUMIDITY: Final = "HUMIDITY"
-ATTR_API_PM1: Final = "PM1"
 ATTR_API_PM10: Final = "PM10"
 ATTR_API_PM10_LIMIT: Final = "PM10_LIMIT"
 ATTR_API_PM10_PERCENT: Final = "PM10_PERCENT"
+ATTR_API_PM1: Final = "PM1"
 ATTR_API_PM25: Final = "PM25"
 ATTR_API_PM25_LIMIT: Final = "PM25_LIMIT"
 ATTR_API_PM25_PERCENT: Final = "PM25_PERCENT"
 ATTR_API_PRESSURE: Final = "PRESSURE"
 ATTR_API_TEMPERATURE: Final = "TEMPERATURE"
+ATTR_LABEL: Final = "label"
+ATTR_UNIT: Final = "unit"
 
 ATTRIBUTION: Final = "Data provided by Airly"
 CONF_USE_NEAREST: Final = "use_nearest"
@@ -42,27 +46,27 @@ NO_AIRLY_SENSORS: Final = "There are no Airly sensors in this area yet."
 
 SENSOR_TYPES: dict[str, SensorDescription] = {
     ATTR_API_PM1: {
-        "device_class": None,
-        "icon": "mdi:blur",
-        "label": ATTR_API_PM1,
-        "unit": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+        ATTR_DEVICE_CLASS: None,
+        ATTR_ICON: "mdi:blur",
+        ATTR_LABEL: ATTR_API_PM1,
+        ATTR_UNIT: CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
     },
     ATTR_API_HUMIDITY: {
-        "device_class": DEVICE_CLASS_HUMIDITY,
-        "icon": None,
-        "label": ATTR_API_HUMIDITY.capitalize(),
-        "unit": PERCENTAGE,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
+        ATTR_ICON: None,
+        ATTR_LABEL: ATTR_API_HUMIDITY.capitalize(),
+        ATTR_UNIT: PERCENTAGE,
     },
     ATTR_API_PRESSURE: {
-        "device_class": DEVICE_CLASS_PRESSURE,
-        "icon": None,
-        "label": ATTR_API_PRESSURE.capitalize(),
-        "unit": PRESSURE_HPA,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
+        ATTR_ICON: None,
+        ATTR_LABEL: ATTR_API_PRESSURE.capitalize(),
+        ATTR_UNIT: PRESSURE_HPA,
     },
     ATTR_API_TEMPERATURE: {
-        "device_class": DEVICE_CLASS_TEMPERATURE,
-        "icon": None,
-        "label": ATTR_API_TEMPERATURE.capitalize(),
-        "unit": TEMP_CELSIUS,
+        ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
+        ATTR_ICON: None,
+        ATTR_LABEL: ATTR_API_TEMPERATURE.capitalize(),
+        ATTR_UNIT: TEMP_CELSIUS,
     },
 }

--- a/homeassistant/components/airly/sensor.py
+++ b/homeassistant/components/airly/sensor.py
@@ -5,7 +5,12 @@ from typing import Any, cast
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_NAME
+from homeassistant.const import (
+    ATTR_ATTRIBUTION,
+    ATTR_DEVICE_CLASS,
+    ATTR_ICON,
+    CONF_NAME,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -16,6 +21,8 @@ from . import AirlyDataUpdateCoordinator
 from .const import (
     ATTR_API_PM1,
     ATTR_API_PRESSURE,
+    ATTR_LABEL,
+    ATTR_UNIT,
     ATTRIBUTION,
     DEFAULT_NAME,
     DOMAIN,
@@ -63,7 +70,7 @@ class AirlySensor(CoordinatorEntity, SensorEntity):
     @property
     def name(self) -> str:
         """Return the name."""
-        return f"{self._name} {self._description['label']}"
+        return f"{self._name} {self._description[ATTR_LABEL]}"
 
     @property
     def state(self) -> StateType:
@@ -81,12 +88,12 @@ class AirlySensor(CoordinatorEntity, SensorEntity):
     @property
     def icon(self) -> str | None:
         """Return the icon."""
-        return self._description["icon"]
+        return self._description[ATTR_ICON]
 
     @property
     def device_class(self) -> str | None:
         """Return the device_class."""
-        return self._description["device_class"]
+        return self._description[ATTR_DEVICE_CLASS]
 
     @property
     def unique_id(self) -> str:
@@ -111,4 +118,4 @@ class AirlySensor(CoordinatorEntity, SensorEntity):
     @property
     def unit_of_measurement(self) -> str | None:
         """Return the unit the value is expressed in."""
-        return self._description["unit"]
+        return self._description[ATTR_UNIT]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR reverts to using constants with `TypedDict` class.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
