### PR TITLE
Handle threads exiting unexpected during shutdown

### DIFF
--- a/homeassistant/util/executor.py
+++ b/homeassistant/util/executor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
+import contextlib
 import logging
 import queue
 import sys
@@ -49,7 +50,11 @@ def join_or_interrupt_threads(
         if log:
             _log_thread_running_at_shutdown(thread.name, thread.ident)
 
-        async_raise(thread.ident, SystemExit)
+        with contextlib.suppress(SystemError):
+            # SystemError at this stage is usually a race condition
+            # where the thread happens to die right before we force
+            # it to raise the exception
+            async_raise(thread.ident, SystemExit)
 
     return joined
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If a thread exits right when we are trying to force an exception
to shut it down, setting the exception will fail with SystemError.
At this point in the shutdown process we want to move on as this
will cause the shutdown to abort


Fixes
```
2021-05-19 17:09:45 ERROR (MainThread) [root] Uncaught exception
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 322, in <module>
    sys.exit(main())
  File "/usr/src/homeassistant/homeassistant/__main__.py", line 314, in main
    exit_code = runner.run(runtime_conf)
  File "/usr/src/homeassistant/homeassistant/runner.py", line 118, in run
    return asyncio.run(setup_and_run_hass(runtime_config))
  File "/usr/local/lib/python3.8/asyncio/runners.py", line 51, in run
    loop.close()
  File "/usr/src/homeassistant/homeassistant/runner.py", line 81, in close
    executor.logged_shutdown()
  File "/usr/src/homeassistant/homeassistant/util/executor.py", line 90, in logged_shutdown
    self.join_threads_or_timeout()
  File "/usr/src/homeassistant/homeassistant/util/executor.py", line 105, in join_threads_or_timeout
    remaining_threads -= join_or_interrupt_threads(
  File "/usr/src/homeassistant/homeassistant/util/executor.py", line 52, in join_or_interrupt_threads
    async_raise(thread.ident, SystemExit)
  File "/usr/src/homeassistant/homeassistant/util/thread.py", line 51, in async_raise
    raise SystemError("PyThreadState_SetAsyncExc failed")
SystemError: PyThreadState_SetAsyncExc failed



```


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
