### PR TITLE
Fix zwave_js api typing

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -142,14 +142,14 @@ def async_register_api(hass: HomeAssistant) -> None:
         hass, websocket_update_data_collection_preference
     )
     websocket_api.async_register_command(hass, websocket_data_collection_status)
-    hass.http.register_view(DumpView)  # type: ignore
+    hass.http.register_view(DumpView())
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {vol.Required(TYPE): "zwave_js/network_status", vol.Required(ENTRY_ID): str}
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_network_status(
     hass: HomeAssistant,
@@ -177,7 +177,6 @@ async def websocket_network_status(
     )
 
 
-@websocket_api.async_response  # type: ignore
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/node_status",
@@ -185,6 +184,7 @@ async def websocket_network_status(
         vol.Required(NODE_ID): int,
     }
 )
+@websocket_api.async_response
 @async_get_node
 async def websocket_node_status(
     hass: HomeAssistant,
@@ -206,8 +206,7 @@ async def websocket_node_status(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/add_node",
@@ -215,6 +214,7 @@ async def websocket_node_status(
         vol.Optional("secure", default=False): bool,
     }
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_add_node(
     hass: HomeAssistant,
@@ -300,14 +300,14 @@ async def websocket_add_node(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/stop_inclusion",
         vol.Required(ENTRY_ID): str,
     }
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_stop_inclusion(
     hass: HomeAssistant,
@@ -325,14 +325,14 @@ async def websocket_stop_inclusion(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/stop_exclusion",
         vol.Required(ENTRY_ID): str,
     }
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_stop_exclusion(
     hass: HomeAssistant,
@@ -350,14 +350,14 @@ async def websocket_stop_exclusion(
     )
 
 
-@websocket_api.require_admin  # type:ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/remove_node",
         vol.Required(ENTRY_ID): str,
     }
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_remove_node(
     hass: HomeAssistant,
@@ -409,8 +409,7 @@ async def websocket_remove_node(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/refresh_node_info",
@@ -418,6 +417,7 @@ async def websocket_remove_node(
         vol.Required(NODE_ID): int,
     },
 )
+@websocket_api.async_response
 @async_get_node
 async def websocket_refresh_node_info(
     hass: HomeAssistant,
@@ -459,8 +459,7 @@ async def websocket_refresh_node_info(
     connection.send_result(msg[ID], result)
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/refresh_node_values",
@@ -468,6 +467,7 @@ async def websocket_refresh_node_info(
         vol.Required(NODE_ID): int,
     },
 )
+@websocket_api.async_response
 @async_get_node
 async def websocket_refresh_node_values(
     hass: HomeAssistant,
@@ -480,8 +480,7 @@ async def websocket_refresh_node_values(
     connection.send_result(msg[ID])
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/refresh_node_cc_values",
@@ -490,6 +489,7 @@ async def websocket_refresh_node_values(
         vol.Required(COMMAND_CLASS_ID): int,
     },
 )
+@websocket_api.async_response
 @async_get_node
 async def websocket_refresh_node_cc_values(
     hass: HomeAssistant,
@@ -512,8 +512,7 @@ async def websocket_refresh_node_cc_values(
     connection.send_result(msg[ID])
 
 
-@websocket_api.require_admin  # type:ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/set_config_parameter",
@@ -524,6 +523,7 @@ async def websocket_refresh_node_cc_values(
         vol.Required(VALUE): int,
     }
 )
+@websocket_api.async_response
 @async_get_node
 async def websocket_set_config_parameter(
     hass: HomeAssistant,
@@ -563,8 +563,7 @@ async def websocket_set_config_parameter(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/get_config_parameters",
@@ -572,6 +571,7 @@ async def websocket_set_config_parameter(
         vol.Required(NODE_ID): int,
     }
 )
+@websocket_api.async_response
 @async_get_node
 async def websocket_get_config_parameters(
     hass: HomeAssistant, connection: ActiveConnection, msg: dict, node: Node
@@ -613,14 +613,14 @@ def filename_is_present_if_logging_to_file(obj: dict) -> dict:
     return obj
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/subscribe_logs",
         vol.Required(ENTRY_ID): str,
     }
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_subscribe_logs(
     hass: HomeAssistant,
@@ -660,8 +660,7 @@ async def websocket_subscribe_logs(
     connection.send_result(msg[ID])
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/update_log_config",
@@ -688,6 +687,7 @@ async def websocket_subscribe_logs(
         ),
     },
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_update_log_config(
     hass: HomeAssistant,
@@ -703,14 +703,14 @@ async def websocket_update_log_config(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/get_log_config",
         vol.Required(ENTRY_ID): str,
     },
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_get_log_config(
     hass: HomeAssistant,
@@ -727,8 +727,7 @@ async def websocket_get_log_config(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/update_data_collection_preference",
@@ -736,6 +735,7 @@ async def websocket_get_log_config(
         vol.Required(OPTED_IN): bool,
     },
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_update_data_collection_preference(
     hass: HomeAssistant,
@@ -758,14 +758,14 @@ async def websocket_update_data_collection_preference(
     )
 
 
-@websocket_api.require_admin  # type: ignore
-@websocket_api.async_response
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "zwave_js/data_collection_status",
         vol.Required(ENTRY_ID): str,
     },
 )
+@websocket_api.async_response
 @async_get_entry
 async def websocket_data_collection_status(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- By changing the order of decorators the typing of the websocket commands will match the expected.
- Instantiate the dump view before registering it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
