### PR TITLE
Fix AsusWRT sensor test

### DIFF
--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -47,7 +47,7 @@ MOCK_CURRENT_TRANSFER_RATES = [20000000, 10000000]
 class MockDevices:
     """Mock AsusWrt devices."""
 
-    _mock_devices = MOCK_DEVICES
+    _mock_devices = dict(MOCK_DEVICES)
 
     @staticmethod
     def add_device(mac, device):

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.dt import utcnow
+from homeassistant.util.dt import now
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -44,6 +44,11 @@ MOCK_BYTES_TOTAL = [60000000000, 50000000000]
 MOCK_CURRENT_TRANSFER_RATES = [20000000, 10000000]
 
 
+def get_devices():
+    """Return mock devices for test."""
+    return MOCK_DEVICES.copy()
+
+
 @pytest.fixture(name="connect")
 def mock_controller_connect():
     """Mock a successful connection."""
@@ -52,7 +57,7 @@ def mock_controller_connect():
         service_mock.return_value.is_connected = True
         service_mock.return_value.connection.disconnect = Mock()
         service_mock.return_value.async_get_connected_devices = AsyncMock(
-            return_value=MOCK_DEVICES
+            side_effect=get_devices
         )
         service_mock.return_value.async_get_bytes_total = AsyncMock(
             return_value=MOCK_BYTES_TOTAL
@@ -122,7 +127,7 @@ async def test_sensors(hass, connect):
     # initial devices setup
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    async_fire_time_changed(hass, now() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     assert hass.states.get(f"{device_tracker.DOMAIN}.test").state == STATE_HOME
@@ -138,7 +143,7 @@ async def test_sensors(hass, connect):
     MOCK_DEVICES["a3:b3:c3:d3:e3:f3"] = Device(
         "a3:b3:c3:d3:e3:f3", "192.168.1.4", "TestThree"
     )
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    async_fire_time_changed(hass, now() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     # consider home option set, all devices still home
@@ -151,7 +156,7 @@ async def test_sensors(hass, connect):
         config_entry, options={CONF_CONSIDER_HOME: 0}
     )
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
+    async_fire_time_changed(hass, now() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     # consider home option not set, device "test" not home

--- a/tests/components/asuswrt/test_sensor.py
+++ b/tests/components/asuswrt/test_sensor.py
@@ -20,7 +20,7 @@ from homeassistant.const import (
     STATE_NOT_HOME,
 )
 from homeassistant.helpers import entity_registry as er
-from homeassistant.util.dt import now
+from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -127,7 +127,7 @@ async def test_sensors(hass, connect):
     # initial devices setup
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, now() + timedelta(seconds=30))
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     assert hass.states.get(f"{device_tracker.DOMAIN}.test").state == STATE_HOME
@@ -143,7 +143,7 @@ async def test_sensors(hass, connect):
     MOCK_DEVICES["a3:b3:c3:d3:e3:f3"] = Device(
         "a3:b3:c3:d3:e3:f3", "192.168.1.4", "TestThree"
     )
-    async_fire_time_changed(hass, now() + timedelta(seconds=30))
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     # consider home option set, all devices still home
@@ -156,7 +156,7 @@ async def test_sensors(hass, connect):
         config_entry, options={CONF_CONSIDER_HOME: 0}
     )
     await hass.async_block_till_done()
-    async_fire_time_changed(hass, now() + timedelta(seconds=30))
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=30))
     await hass.async_block_till_done()
 
     # consider home option not set, device "test" not home


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

In AsusWRT sensor test there is an error in the use of `utctime` instead of `time` to firing event in the future. Test work only because the content of test mock device is updated, but this do not reflect real behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
