### PR TITLE
Add state class to Nettigo Air Monitor sensors

### DIFF
--- a/homeassistant/components/nam/const.py
+++ b/homeassistant/components/nam/const.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Final
 
+from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_MEASUREMENT
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ICON,
@@ -59,6 +60,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_BME280_PRESSURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} BME280 Pressure",
@@ -66,6 +68,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_BME280_TEMPERATURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} BME280 Temperature",
@@ -73,6 +76,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_BMP280_PRESSURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} BMP280 Pressure",
@@ -80,6 +84,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_PRESSURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_BMP280_TEMPERATURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} BMP280 Temperature",
@@ -87,6 +92,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_HECA_HUMIDITY: {
         ATTR_LABEL: f"{DEFAULT_NAME} HECA Humidity",
@@ -94,6 +100,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_HECA_TEMPERATURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} HECA Temperature",
@@ -101,6 +108,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_SHT3X_HUMIDITY: {
         ATTR_LABEL: f"{DEFAULT_NAME} SHT3X Humidity",
@@ -108,6 +116,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_SHT3X_TEMPERATURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} SHT3X Temperature",
@@ -115,6 +124,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_SPS30_P0: {
         ATTR_LABEL: f"{DEFAULT_NAME} SPS30 Particulate Matter 1.0",
@@ -122,6 +132,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: None,
         ATTR_ICON: "mdi:blur",
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_SPS30_P4: {
         ATTR_LABEL: f"{DEFAULT_NAME} SPS30 Particulate Matter 4.0",
@@ -129,6 +140,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: None,
         ATTR_ICON: "mdi:blur",
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_DHT22_HUMIDITY: {
         ATTR_LABEL: f"{DEFAULT_NAME} DHT22 Humidity",
@@ -136,6 +148,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_HUMIDITY,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_DHT22_TEMPERATURE: {
         ATTR_LABEL: f"{DEFAULT_NAME} DHT22 Temperature",
@@ -143,6 +156,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
         ATTR_ICON: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_SIGNAL_STRENGTH: {
         ATTR_LABEL: f"{DEFAULT_NAME} Signal Strength",
@@ -150,6 +164,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
         ATTR_ICON: None,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     ATTR_UPTIME: {
         ATTR_LABEL: f"{DEFAULT_NAME} Uptime",
@@ -157,5 +172,6 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TIMESTAMP,
         ATTR_ICON: None,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
 }

--- a/homeassistant/components/nam/const.py
+++ b/homeassistant/components/nam/const.py
@@ -164,7 +164,7 @@ SENSORS: Final[dict[str, SensorDescription]] = {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_SIGNAL_STRENGTH,
         ATTR_ICON: None,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     ATTR_UPTIME: {
         ATTR_LABEL: f"{DEFAULT_NAME} Uptime",

--- a/homeassistant/components/nam/model.py
+++ b/homeassistant/components/nam/model.py
@@ -12,3 +12,4 @@ class SensorDescription(TypedDict):
     device_class: str | None
     icon: str | None
     enabled: bool
+    state_class: str | None

--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_ICON
 from homeassistant.core import HomeAssistant
@@ -56,6 +56,11 @@ class NAMSensor(CoordinatorEntity, SensorEntity):
     def state(self) -> Any:
         """Return the state."""
         return getattr(self.coordinator.data, self.sensor_type)
+
+    @property
+    def state_class(self) -> str | None:
+        """Return the state class of this entity."""
+        return self._description[ATTR_STATE_CLASS]
 
     @property
     def unit_of_measurement(self) -> str | None:

--- a/homeassistant/components/nam/sensor.py
+++ b/homeassistant/components/nam/sensor.py
@@ -45,7 +45,8 @@ class NAMSensor(CoordinatorEntity, SensorEntity):
         """Initialize."""
         super().__init__(coordinator)
         self.sensor_type = sensor_type
-        self._description = SENSORS[self.sensor_type]
+        self._description = SENSORS[sensor_type]
+        self._attr_state_class = SENSORS[sensor_type][ATTR_STATE_CLASS]
 
     @property
     def name(self) -> str:
@@ -56,11 +57,6 @@ class NAMSensor(CoordinatorEntity, SensorEntity):
     def state(self) -> Any:
         """Return the state."""
         return getattr(self.coordinator.data, self.sensor_type)
-
-    @property
-    def state_class(self) -> str | None:
-        """Return the state class of this entity."""
-        return self._description[ATTR_STATE_CLASS]
 
     @property
     def unit_of_measurement(self) -> str | None:

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -182,7 +182,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "-72"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_SIGNAL_STRENGTH
-    assert state.attributes.get(ATTR_STATE_CLASS) is None
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == SIGNAL_STRENGTH_DECIBELS_MILLIWATT

--- a/tests/components/nam/test_sensor.py
+++ b/tests/components/nam/test_sensor.py
@@ -5,7 +5,11 @@ from unittest.mock import patch
 from nettigo_air_monitor import ApiError
 
 from homeassistant.components.nam.const import DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    DOMAIN as SENSOR_DOMAIN,
+    STATE_CLASS_MEASUREMENT,
+)
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
@@ -57,6 +61,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "45.7"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_HUMIDITY
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
     entry = registry.async_get("sensor.nettigo_air_monitor_bme280_humidity")
@@ -67,6 +72,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "7.6"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
     entry = registry.async_get("sensor.nettigo_air_monitor_bme280_temperature")
@@ -77,6 +83,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "1011"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_PRESSURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_HPA
 
     entry = registry.async_get("sensor.nettigo_air_monitor_bme280_pressure")
@@ -87,6 +94,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "5.6"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
     entry = registry.async_get("sensor.nettigo_air_monitor_bmp280_temperature")
@@ -97,6 +105,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "1022"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_PRESSURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PRESSURE_HPA
 
     entry = registry.async_get("sensor.nettigo_air_monitor_bmp280_pressure")
@@ -107,6 +116,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "34.7"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_HUMIDITY
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
     entry = registry.async_get("sensor.nettigo_air_monitor_sht3x_humidity")
@@ -117,6 +127,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "6.3"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
     entry = registry.async_get("sensor.nettigo_air_monitor_sht3x_temperature")
@@ -127,6 +138,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "46.2"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_HUMIDITY
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
     entry = registry.async_get("sensor.nettigo_air_monitor_dht22_humidity")
@@ -137,6 +149,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "6.3"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
     entry = registry.async_get("sensor.nettigo_air_monitor_dht22_temperature")
@@ -147,6 +160,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "50.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_HUMIDITY
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
 
     entry = registry.async_get("sensor.nettigo_air_monitor_heca_humidity")
@@ -157,6 +171,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "8.0"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
 
     entry = registry.async_get("sensor.nettigo_air_monitor_heca_temperature")
@@ -167,6 +182,7 @@ async def test_sensor(hass):
     assert state
     assert state.state == "-72"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_SIGNAL_STRENGTH
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
     assert (
         state.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         == SIGNAL_STRENGTH_DECIBELS_MILLIWATT
@@ -183,6 +199,7 @@ async def test_sensor(hass):
         == (utcnow() - timedelta(seconds=456987)).replace(microsecond=0).isoformat()
     )
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TIMESTAMP
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.nettigo_air_monitor_uptime")
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds `STATE_CLASS_MEASUREMENT` to sensor entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
