### PR TITLE
Add restore temperature to modbus climate

### DIFF
--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -135,9 +135,6 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         state = await self.async_get_last_state()
         if state and state.attributes.get(ATTR_TEMPERATURE):
             self._target_temperature = float(state.attributes[ATTR_TEMPERATURE])
-        else:
-            self._target_temperature = None
-            _LOGGER.warning("No previously saved temperature, setting to none")
 
     @property
     def supported_features(self):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     TEMP_FAHRENHEIT,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .base_platform import BasePlatform
@@ -98,7 +99,7 @@ async def async_setup_platform(
     async_add_entities(entities)
 
 
-class ModbusThermostat(BasePlatform, ClimateEntity):
+class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
     """Representation of a Modbus Thermostat."""
 
     def __init__(
@@ -131,6 +132,14 @@ class ModbusThermostat(BasePlatform, ClimateEntity):
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
         await self.async_base_added_to_hass()
+        state = await self.async_get_last_state()
+        if state and state.attributes.get(ATTR_TEMPERATURE):
+            self._target_temp = float(state.attributes[ATTR_TEMPERATURE])
+        else:
+            self._target_temp = self.max_temp
+            _LOGGER.warning(
+                "No previously saved temperature, setting to %s", self._target_temp
+            )
 
     @property
     def supported_features(self):

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -134,12 +134,10 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         await self.async_base_added_to_hass()
         state = await self.async_get_last_state()
         if state and state.attributes.get(ATTR_TEMPERATURE):
-            self._target_temp = float(state.attributes[ATTR_TEMPERATURE])
+            self._target_temperature = float(state.attributes[ATTR_TEMPERATURE])
         else:
-            self._target_temp = self.max_temp
-            _LOGGER.warning(
-                "No previously saved temperature, setting to %s", self._target_temp
-            )
+            self._target_temperature = None
+            _LOGGER.warning("No previously saved temperature, setting to none")
 
     @property
     def supported_features(self):

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -2,15 +2,24 @@
 import pytest
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.climate.const import HVAC_MODE_AUTO
 from homeassistant.components.modbus.const import (
     CONF_CLIMATES,
     CONF_CURRENT_TEMP,
     CONF_DATA_COUNT,
     CONF_TARGET_TEMP,
 )
-from homeassistant.const import CONF_NAME, CONF_SCAN_INTERVAL, CONF_SLAVE
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    CONF_NAME,
+    CONF_SCAN_INTERVAL,
+    CONF_SLAVE,
+)
+from homeassistant.core import State
 
 from .conftest import ReadResult, base_config_test, base_test, prepare_service_update
+
+from tests.common import mock_restore_cache
 
 
 @pytest.mark.parametrize(
@@ -101,3 +110,31 @@ async def test_service_climate_update(hass, mock_pymodbus):
         "homeassistant", "update_entity", {"entity_id": entity_id}, blocking=True
     )
     assert hass.states.get(entity_id).state == "auto"
+
+
+async def test_restore_state_climate(hass):
+    """Run test for sensor restore state."""
+
+    climate_name = "test_climate"
+    entity_id = f"{CLIMATE_DOMAIN}.{climate_name}"
+    test_value = State(entity_id, 35)
+    test_value.attributes = {ATTR_TEMPERATURE: 37}
+    config_sensor = {
+        CONF_NAME: climate_name,
+        CONF_TARGET_TEMP: 117,
+        CONF_CURRENT_TEMP: 117,
+    }
+    mock_restore_cache(
+        hass,
+        (test_value,),
+    )
+    await base_config_test(
+        hass,
+        config_sensor,
+        climate_name,
+        CLIMATE_DOMAIN,
+        CONF_CLIMATES,
+        None,
+        method_discovery=True,
+    )
+    assert hass.states.get(entity_id).state == HVAC_MODE_AUTO

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -116,9 +116,10 @@ async def test_restore_state_climate(hass):
     """Run test for sensor restore state."""
 
     climate_name = "test_climate"
+    test_temp = 37
     entity_id = f"{CLIMATE_DOMAIN}.{climate_name}"
     test_value = State(entity_id, 35)
-    test_value.attributes = {ATTR_TEMPERATURE: 37}
+    test_value.attributes = {ATTR_TEMPERATURE: test_temp}
     config_sensor = {
         CONF_NAME: climate_name,
         CONF_TARGET_TEMP: 117,
@@ -137,4 +138,6 @@ async def test_restore_state_climate(hass):
         None,
         method_discovery=True,
     )
-    assert hass.states.get(entity_id).state == HVAC_MODE_AUTO
+    state = hass.states.get(entity_id)
+    assert state.state == HVAC_MODE_AUTO
+    assert state.attributes[ATTR_TEMPERATURE] == test_temp


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Try to restore target_temperature in climate, unfortunately the climateEntity, do not store all temperatures, so it needs a little bit of coding.

With this PR all modbus platform have restore_last_state active.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
