### PR TITLE
Update mill library, fix consumption data

### DIFF
--- a/homeassistant/components/binary_sensor/__init__.py
+++ b/homeassistant/components/binary_sensor/__init__.py
@@ -154,7 +154,7 @@ class BinarySensorEntity(Entity):
     @property
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return None
+        return self._attr_is_on
 
     @property
     def state(self) -> StateType:

--- a/homeassistant/components/coinbase/sensor.py
+++ b/homeassistant/components/coinbase/sensor.py
@@ -81,7 +81,7 @@ class AccountSensor(SensorEntity):
     def update(self):
         """Get the latest state of the sensor."""
         self._coinbase_data.update()
-        for account in self._coinbase_data.accounts["data"]:
+        for account in self._coinbase_data.accounts:
             if self._name == f"Coinbase {account['name']}":
                 self._state = account["balance"]["amount"]
                 self._native_balance = account["native_balance"]["amount"]

--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -570,7 +570,7 @@ class LightEntity(ToggleEntity):
     _attr_rgb_color: tuple[int, int, int] | None = None
     _attr_rgbw_color: tuple[int, int, int, int] | None = None
     _attr_rgbww_color: tuple[int, int, int, int, int] | None = None
-    _attr_supported_color_modes: set | None = None
+    _attr_supported_color_modes: set[str] | None = None
     _attr_supported_features: int = 0
     _attr_xy_color: tuple[float, float] | None = None
 
@@ -821,7 +821,7 @@ class LightEntity(ToggleEntity):
         return supported_color_modes
 
     @property
-    def supported_color_modes(self) -> set | None:
+    def supported_color_modes(self) -> set[str] | None:
         """Flag supported color modes."""
         return self._attr_supported_color_modes
 

--- a/homeassistant/components/mill/manifest.json
+++ b/homeassistant/components/mill/manifest.json
@@ -2,7 +2,7 @@
   "domain": "mill",
   "name": "Mill",
   "documentation": "https://www.home-assistant.io/integrations/mill",
-  "requirements": ["millheater==0.4.0"],
+  "requirements": ["millheater==0.4.1"],
   "codeowners": ["@danielhiversen"],
   "config_flow": true,
   "iot_class": "cloud_polling"

--- a/homeassistant/components/sentry/__init__.py
+++ b/homeassistant/components/sentry/__init__.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import re
+from types import MappingProxyType
+from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.aiohttp import AioHttpIntegration
@@ -120,19 +122,19 @@ def get_channel(version: str) -> str:
 
 def process_before_send(
     hass: HomeAssistant,
-    options,
+    options: MappingProxyType[str, Any],
     channel: str,
     huuid: str,
     system_info: dict[str, bool | str],
     custom_components: dict[str, Integration],
-    event,
-    hint,
+    event: dict[str, Any],
+    hint: dict[str, Any],
 ):
     """Process a Sentry event before sending it to Sentry."""
     # Filter out handled events by default
     if (
         "tags" in event
-        and event.tags.get("handled", "no") == "yes"
+        and event["tags"].get("handled", "no") == "yes"
         and not options.get(CONF_EVENT_HANDLED)
     ):
         return None
@@ -204,7 +206,7 @@ def process_before_send(
                 "channel": channel,
                 "custom_components": "\n".join(sorted(custom_components)),
                 "integrations": "\n".join(sorted(integrations)),
-                **system_info,
+                **system_info,  # type: ignore[arg-type]
             },
         }
     )

--- a/homeassistant/components/tcp/sensor.py
+++ b/homeassistant/components/tcp/sensor.py
@@ -29,7 +29,7 @@ from homeassistant.exceptions import TemplateError
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.template import Template
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.typing import ConfigType, StateType
 
 from .const import (
     CONF_BUFFER_SIZE,
@@ -112,7 +112,7 @@ class TcpSensor(SensorEntity):
         return self._config[CONF_NAME]
 
     @property
-    def state(self) -> str | None:
+    def state(self) -> StateType:
         """Return the state of the device."""
         return self._state
 

--- a/homeassistant/components/vlc_telnet/manifest.json
+++ b/homeassistant/components/vlc_telnet/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "vlc_telnet",
   "name": "VLC media player Telnet",
-  "documentation": "https://www.home-assistant.io/integrations/vlc-telnet",
+  "documentation": "https://www.home-assistant.io/integrations/vlc_telnet",
   "requirements": ["python-telnet-vlc==2.0.1"],
   "codeowners": ["@rodripf", "@dmcc"],
   "iot_class": "local_polling"

--- a/homeassistant/components/volvooncall/binary_sensor.py
+++ b/homeassistant/components/volvooncall/binary_sensor.py
@@ -16,7 +16,9 @@ class VolvoSensor(VolvoEntity, BinarySensorEntity):
 
     @property
     def is_on(self):
-        """Return True if the binary sensor is on."""
+        """Return True if the binary sensor is on, but invert for the 'Door lock'."""
+        if self.instrument.attr == "is_locked":
+            return not self.instrument.is_on
         return self.instrument.is_on
 
     @property

--- a/mypy.ini
+++ b/mypy.ini
@@ -1267,9 +1267,6 @@ ignore_errors = true
 [mypy-homeassistant.components.sense.*]
 ignore_errors = true
 
-[mypy-homeassistant.components.sentry.*]
-ignore_errors = true
-
 [mypy-homeassistant.components.sesame.*]
 ignore_errors = true
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -951,7 +951,7 @@ mficlient==0.3.0
 miflora==0.7.0
 
 # homeassistant.components.mill
-millheater==0.4.0
+millheater==0.4.1
 
 # homeassistant.components.minio
 minio==4.0.9

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -520,7 +520,7 @@ meteofrance-api==1.0.2
 mficlient==0.3.0
 
 # homeassistant.components.mill
-millheater==0.4.0
+millheater==0.4.1
 
 # homeassistant.components.minio
 minio==4.0.9

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -176,7 +176,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.script.*",
     "homeassistant.components.search.*",
     "homeassistant.components.sense.*",
-    "homeassistant.components.sentry.*",
     "homeassistant.components.sesame.*",
     "homeassistant.components.sharkiq.*",
     "homeassistant.components.sma.*",

--- a/tests/components/sentry/conftest.py
+++ b/tests/components/sentry/conftest.py
@@ -1,4 +1,8 @@
-"""Configuration for Sonos tests."""
+"""Configuration for Sentry tests."""
+from __future__ import annotations
+
+from typing import Any
+
 import pytest
 
 from homeassistant.components.sentry import DOMAIN
@@ -7,12 +11,12 @@ from tests.common import MockConfigEntry
 
 
 @pytest.fixture(name="config_entry")
-def config_entry_fixture():
+def config_entry_fixture() -> MockConfigEntry:
     """Create a mock config entry."""
     return MockConfigEntry(domain=DOMAIN, title="Sentry")
 
 
 @pytest.fixture(name="config")
-def config_fixture():
+def config_fixture() -> dict[str, Any]:
     """Create hass config fixture."""
     return {DOMAIN: {"dsn": "http://public@sentry.local/1"}}

--- a/tests/components/sentry/test_config_flow.py
+++ b/tests/components/sentry/test_config_flow.py
@@ -16,20 +16,26 @@ from homeassistant.components.sentry.const import (
     DOMAIN,
 )
 from homeassistant.config_entries import SOURCE_USER
-from homeassistant.data_entry_flow import RESULT_TYPE_ABORT, RESULT_TYPE_FORM
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import (
+    RESULT_TYPE_ABORT,
+    RESULT_TYPE_CREATE_ENTRY,
+    RESULT_TYPE_FORM,
+)
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
 
 
-async def test_full_user_flow_implementation(hass):
+async def test_full_user_flow_implementation(hass: HomeAssistant) -> None:
     """Test we get the form."""
     await async_setup_component(hass, "persistent_notification", {})
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["errors"] == {}
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("errors") == {}
+    assert "flow_id" in result
 
     with patch("homeassistant.components.sentry.config_flow.Dsn"), patch(
         "homeassistant.components.sentry.async_setup_entry",
@@ -40,9 +46,9 @@ async def test_full_user_flow_implementation(hass):
             {"dsn": "http://public@sentry.local/1"},
         )
 
-    assert result2["type"] == "create_entry"
-    assert result2["title"] == "Sentry"
-    assert result2["data"] == {
+    assert result2.get("type") == "create_entry"
+    assert result2.get("title") == "Sentry"
+    assert result2.get("data") == {
         "dsn": "http://public@sentry.local/1",
     }
     await hass.async_block_till_done()
@@ -50,22 +56,23 @@ async def test_full_user_flow_implementation(hass):
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_integration_already_exists(hass):
+async def test_integration_already_exists(hass: HomeAssistant) -> None:
     """Test we only allow a single config flow."""
     MockConfigEntry(domain=DOMAIN).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
-    assert result["type"] == RESULT_TYPE_ABORT
-    assert result["reason"] == "single_instance_allowed"
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "single_instance_allowed"
 
 
-async def test_user_flow_bad_dsn(hass):
+async def test_user_flow_bad_dsn(hass: HomeAssistant) -> None:
     """Test we handle bad dsn error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.sentry.config_flow.Dsn",
@@ -76,15 +83,16 @@ async def test_user_flow_bad_dsn(hass):
             {"dsn": "foo"},
         )
 
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "bad_dsn"}
+    assert result2.get("type") == RESULT_TYPE_FORM
+    assert result2.get("errors") == {"base": "bad_dsn"}
 
 
-async def test_user_flow_unkown_exception(hass):
+async def test_user_flow_unkown_exception(hass: HomeAssistant) -> None:
     """Test we handle any unknown exception error."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": SOURCE_USER}
     )
+    assert "flow_id" in result
 
     with patch(
         "homeassistant.components.sentry.config_flow.Dsn",
@@ -95,11 +103,11 @@ async def test_user_flow_unkown_exception(hass):
             {"dsn": "foo"},
         )
 
-    assert result2["type"] == RESULT_TYPE_FORM
-    assert result2["errors"] == {"base": "unknown"}
+    assert result2.get("type") == RESULT_TYPE_FORM
+    assert result2.get("errors") == {"base": "unknown"}
 
 
-async def test_options_flow(hass):
+async def test_options_flow(hass: HomeAssistant) -> None:
     """Test options config flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -113,8 +121,9 @@ async def test_options_flow(hass):
 
     result = await hass.config_entries.options.async_init(entry.entry_id)
 
-    assert result["type"] == RESULT_TYPE_FORM
-    assert result["step_id"] == "init"
+    assert result.get("type") == RESULT_TYPE_FORM
+    assert result.get("step_id") == "init"
+    assert "flow_id" in result
 
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
@@ -130,8 +139,8 @@ async def test_options_flow(hass):
         },
     )
 
-    assert result["type"] == "create_entry"
-    assert result["data"] == {
+    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result.get("data") == {
         CONF_ENVIRONMENT: "Test",
         CONF_EVENT_CUSTOM_COMPONENTS: True,
         CONF_EVENT_HANDLED: True,

--- a/tests/components/sentry/test_init.py
+++ b/tests/components/sentry/test_init.py
@@ -1,6 +1,6 @@
 """Tests for Sentry integration."""
 import logging
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -112,12 +112,12 @@ async def test_setup_entry_with_tracing(hass: HomeAssistant) -> None:
         ("0.115.0dev0", "dev"),
     ],
 )
-async def test_get_channel(version, channel) -> None:
+async def test_get_channel(version: str, channel: str) -> None:
     """Test if channel detection works from Home Assistant version number."""
     assert get_channel(version) == channel
 
 
-async def test_process_before_send(hass: HomeAssistant):
+async def test_process_before_send(hass: HomeAssistant) -> None:
     """Test regular use of the Sentry process before sending function."""
     hass.config.components.add("puppies")
     hass.config.components.add("a_integration")
@@ -308,12 +308,6 @@ async def test_filter_log_events(hass: HomeAssistant, logger, options, event):
 )
 async def test_filter_handled_events(hass: HomeAssistant, handled, options, event):
     """Tests filtering of handled events based on configuration options."""
-
-    event_mock = MagicMock()
-    event_mock.__iter__ = ["tags"]
-    event_mock.__contains__ = lambda _, val: val == "tags"
-    event_mock.tags = {"handled": handled}
-
     result = process_before_send(
         hass,
         options=options,
@@ -321,7 +315,7 @@ async def test_filter_handled_events(hass: HomeAssistant, handled, options, even
         huuid="12345",
         system_info={"installation_type": "pytest"},
         custom_components=[],
-        event=event_mock,
+        event={"tags": {"handled": handled}},
         hint={},
     )
 


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update mill library, fix consumption data
https://github.com/Danielhiversen/pymill/compare/0.4.0...0.4.1


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
