### PR TITLE
Switch wirelesstag to use cloud push

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -550,6 +550,7 @@ homeassistant/components/websocket_api/* @home-assistant/core
 homeassistant/components/wemo/* @esev
 homeassistant/components/wiffi/* @mampfes
 homeassistant/components/wilight/* @leofig-rj
+homeassistant/components/wirelesstag/* @sergeymaysak
 homeassistant/components/withings/* @vangorra
 homeassistant/components/wled/* @frenck
 homeassistant/components/wolflink/* @adamkrol93

--- a/homeassistant/components/wirelesstag/__init__.py
+++ b/homeassistant/components/wirelesstag/__init__.py
@@ -3,9 +3,8 @@ import logging
 
 from requests.exceptions import ConnectTimeout, HTTPError
 import voluptuous as vol
-from wirelesstagpy import NotificationConfig as NC, WirelessTags, WirelessTagsException
+from wirelesstagpy import WirelessTags, WirelessTagsException
 
-from homeassistant import util
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_VOLTAGE,
@@ -67,11 +66,6 @@ class WirelessTagPlatform:
         self.tags = {}
         self._local_base_url = None
 
-    @property
-    def tag_manager_macs(self):
-        """Return list of tag managers mac addresses in user account."""
-        return self.api.mac_addresses
-
     def load_tags(self):
         """Load tags from remote server."""
         self.tags = self.api.load_tags()
@@ -91,97 +85,44 @@ class WirelessTagPlatform:
         if disarm_func is not None:
             disarm_func(switch.tag_id, switch.tag_manager_mac)
 
-    def make_notifications(self, binary_sensors, mac):
-        """Create configurations for push notifications."""
-        _LOGGER.info("Creating configurations for push notifications")
-        configs = []
+    def start_monitoring(self):
+        """Start monitoring push events."""
 
-        bi_url = self.binary_event_callback_url
-        for bi_sensor in binary_sensors:
-            configs.extend(bi_sensor.event.build_notifications(bi_url, mac))
-
-        update_url = self.update_callback_url
-
-        update_config = NC.make_config_for_update_event(update_url, mac)
-
-        configs.append(update_config)
-        return configs
-
-    def install_push_notifications(self, binary_sensors):
-        """Register local push notification from tag manager."""
-        _LOGGER.info("Registering local push notifications")
-        for mac in self.tag_manager_macs:
-            configs = self.make_notifications(binary_sensors, mac)
-            # install notifications for all tags in tag manager
-            # specified by mac
-            result = self.api.install_push_notification(0, configs, True, mac)
-            if not result:
-                self.hass.components.persistent_notification.create(
-                    "Error: failed to install local push notifications <br />",
-                    title="Wireless Sensor Tag Setup Local Push Notifications",
-                    notification_id="wirelesstag_failed_push_notification",
-                )
-            else:
-                _LOGGER.info(
-                    "Installed push notifications for all tags in %s",
-                    mac,
-                )
-
-    @property
-    def local_base_url(self):
-        """Define base url of hass in local network."""
-        if self._local_base_url is None:
-            self._local_base_url = f"http://{util.get_local_ip()}"
-
-            port = self.hass.config.api.port
-            if port is not None:
-                self._local_base_url += f":{port}"
-        return self._local_base_url
-
-    @property
-    def update_callback_url(self):
-        """Return url for local push notifications(update event)."""
-        return f"{self.local_base_url}/api/events/wirelesstag_update_tags"
-
-    @property
-    def binary_event_callback_url(self):
-        """Return url for local push notifications(binary event)."""
-        return f"{self.local_base_url}/api/events/wirelesstag_binary_event"
-
-    def handle_update_tags_event(self, event):
-        """Handle push event from wireless tag manager."""
-        _LOGGER.info("Push notification for update arrived: %s", event)
-        try:
-            tag_id = event.data.get("id")
-            mac = event.data.get("mac")
-            dispatcher_send(self.hass, SIGNAL_TAG_UPDATE.format(tag_id, mac), event)
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.error(
-                "Unable to handle tag update event:\
-                          %s error: %s",
-                str(event),
-                str(ex),
+        def push_callback(tags_spec, event_spec):
+            """Handle push update."""
+            _LOGGER.debug(
+                "Push notification arrived: %s, events: %s", tags_spec, event_spec
             )
+            for uuid, tag in tags_spec.items():
+                try:
+                    tag_id = tag.tag_id
+                    mac = tag.tag_manager_mac
+                    _LOGGER.debug("Push notification for tag update arrived: %s", tag)
+                    dispatcher_send(
+                        self.hass, SIGNAL_TAG_UPDATE.format(tag_id, mac), tag
+                    )
+                    if uuid in event_spec:
+                        events = event_spec[uuid]
+                        for event in events:
+                            _LOGGER.debug(
+                                "Push notification for binary event arrived: %s", event
+                            )
+                            dispatcher_send(
+                                self.hass,
+                                SIGNAL_BINARY_EVENT_UPDATE.format(
+                                    tag_id, event.type, mac
+                                ),
+                                tag,
+                            )
+                except Exception as ex:  # pylint: disable=broad-except
+                    _LOGGER.error(
+                        "Unable to handle tag update:\
+                                %s error: %s",
+                        str(tag),
+                        str(ex),
+                    )
 
-    def handle_binary_event(self, event):
-        """Handle push notifications for binary (on/off) events."""
-        _LOGGER.info("Push notification for binary event arrived: %s", event)
-        try:
-            tag_id = event.data.get("id")
-            event_type = event.data.get("type")
-            mac = event.data.get("mac")
-            dispatcher_send(
-                self.hass,
-                SIGNAL_BINARY_EVENT_UPDATE.format(tag_id, event_type, mac),
-                event,
-            )
-        except Exception as ex:  # pylint: disable=broad-except
-            _LOGGER.error(
-                "Unable to handle tag binary event:\
-                          %s error: %s",
-                str(event),
-                str(ex),
-            )
+        self.api.start_monitoring(push_callback)
 
 
 def setup(hass, config):
@@ -195,6 +136,7 @@ def setup(hass, config):
 
         platform = WirelessTagPlatform(hass, wirelesstags)
         platform.load_tags()
+        platform.start_monitoring()
         hass.data[DOMAIN] = platform
     except (ConnectTimeout, HTTPError, WirelessTagsException) as ex:
         _LOGGER.error("Unable to connect to wirelesstag.net service: %s", str(ex))
@@ -204,12 +146,6 @@ def setup(hass, config):
             notification_id=NOTIFICATION_ID,
         )
         return False
-
-    # listen to custom events
-    hass.bus.listen(
-        "wirelesstag_update_tags", hass.data[DOMAIN].handle_update_tags_event
-    )
-    hass.bus.listen("wirelesstag_binary_event", hass.data[DOMAIN].handle_binary_event)
 
     return True
 

--- a/homeassistant/components/wirelesstag/binary_sensor.py
+++ b/homeassistant/components/wirelesstag/binary_sensor.py
@@ -81,7 +81,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 sensors.append(WirelessTagBinarySensor(platform, tag, sensor_type))
 
     add_entities(sensors, True)
-    hass.add_job(platform.install_push_notifications, sensors)
 
 
 class WirelessTagBinarySensor(WirelessTagBaseSensor, BinarySensorEntity):
@@ -134,8 +133,8 @@ class WirelessTagBinarySensor(WirelessTagBaseSensor, BinarySensorEntity):
         return self.principal_value
 
     @callback
-    def _on_binary_event_callback(self, event):
+    def _on_binary_event_callback(self, new_tag):
         """Update state from arrived push notification."""
-        # state should be 'on' or 'off'
-        self._state = event.data.get("state")
+        self._tag = new_tag
+        self._state = self.updated_state_value()
         self.async_write_ha_state()

--- a/homeassistant/components/wirelesstag/manifest.json
+++ b/homeassistant/components/wirelesstag/manifest.json
@@ -2,7 +2,7 @@
   "domain": "wirelesstag",
   "name": "Wireless Sensor Tags",
   "documentation": "https://www.home-assistant.io/integrations/wirelesstag",
-  "requirements": ["wirelesstagpy==0.4.1"],
-  "codeowners": [],
-  "iot_class": "local_push"
+  "requirements": ["wirelesstagpy==0.5.0"],
+  "codeowners": ["@sergeymaysak"],
+  "iot_class": "cloud_push"
 }

--- a/homeassistant/components/wirelesstag/sensor.py
+++ b/homeassistant/components/wirelesstag/sensor.py
@@ -108,9 +108,9 @@ class WirelessTagSensor(WirelessTagBaseSensor, SensorEntity):
         return self._tag.sensor[self._sensor_type]
 
     @callback
-    def _update_tag_info_callback(self, event):
+    def _update_tag_info_callback(self, new_tag):
         """Handle push notification sent by tag manager."""
-        _LOGGER.debug("Entity to update state: %s event data: %s", self, event.data)
-        new_value = self._sensor.value_from_update_event(event.data)
-        self._state = self.decorate_value(new_value)
+        _LOGGER.debug("Entity to update state: %s with new tag: %s", self, new_tag)
+        self._tag = new_tag
+        self._state = self.updated_state_value()
         self.async_write_ha_state()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2348,7 +2348,7 @@ websocket-client==0.54.0
 wiffi==1.0.1
 
 # homeassistant.components.wirelesstag
-wirelesstagpy==0.4.1
+wirelesstagpy==0.5.0
 
 # homeassistant.components.withings
 withings-api==2.3.2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
-->
This is a response on issue https://github.com/home-assistant/core/issues/42292.
Proposed change resolves the issue with new implementation which replaces local push with cloud push. It appeared that local push was driven by cloud push, so the change makes it working even faster w/o dependencies on specifics of authentication.

https://github.com/sergeymaysak/wirelesstagpy/releases/tag/0.5.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/42292
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
