### PR TITLE
Allow user to override insecure setup codes and pair with homekit_controller

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -343,7 +343,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_abort(reason="accessory_not_found_error")
             except InvalidSetupCode:
                 errors["pairing_code"] = "invalid_setup_code"
-                self.finish_pairing = None
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Pairing attempt failed with an unhandled exception")
                 self.finish_pairing = None

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -14,7 +14,8 @@
         "title": "Pair with a device via HomeKit Accessory Protocol",
         "description": "HomeKit Controller communicates with {name} over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",
         "data": {
-          "pairing_code": "Pairing Code"
+          "pairing_code": "Pairing Code",
+          "allow_invalid_setup_codes": "Allow pairing with invalid setup codes."
         }
       },
       "protocol_error": {
@@ -31,6 +32,7 @@
       }
     },
     "error": {
+      "invalid_setup_code": "The requested setup code is invalid and should not be used because of its trival insecure nature. This device fails to meet basic security requirements.",
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",

--- a/homeassistant/components/homekit_controller/strings.json
+++ b/homeassistant/components/homekit_controller/strings.json
@@ -15,7 +15,7 @@
         "description": "HomeKit Controller communicates with {name} over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",
         "data": {
           "pairing_code": "Pairing Code",
-          "allow_invalid_setup_codes": "Allow pairing with invalid setup codes."
+          "allow_insecure_setup_codes": "Allow pairing with insecure setup codes."
         }
       },
       "protocol_error": {
@@ -32,7 +32,7 @@
       }
     },
     "error": {
-      "invalid_setup_code": "The requested setup code is invalid and should not be used because of its trival insecure nature. This device fails to meet basic security requirements.",
+      "insecure_setup_code": "The requested setup code is insecure because of its trivial nature. This accessory fails to meet basic security requirements.",
       "unable_to_pair": "Unable to pair, please try again.",
       "unknown_error": "Device reported an unknown error. Pairing failed.",
       "authentication_error": "Incorrect HomeKit code. Please check it and try again.",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -12,6 +12,7 @@
         },
         "error": {
             "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
+            "invalid_setup_code": "The requested setup code is invalid and should not be used because of its trival insecure nature. This device fails to meet basic security requirements.",
             "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
             "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently.",
             "unable_to_pair": "Unable to pair, please try again.",
@@ -29,6 +30,7 @@
             },
             "pair": {
                 "data": {
+                    "allow_invalid_setup_codes": "Allow pairing with invalid setup codes.",
                     "pairing_code": "Pairing Code"
                 },
                 "description": "HomeKit Controller communicates with {name} over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",

--- a/homeassistant/components/homekit_controller/translations/en.json
+++ b/homeassistant/components/homekit_controller/translations/en.json
@@ -12,7 +12,7 @@
         },
         "error": {
             "authentication_error": "Incorrect HomeKit code. Please check it and try again.",
-            "invalid_setup_code": "The requested setup code is invalid and should not be used because of its trival insecure nature. This device fails to meet basic security requirements.",
+            "insecure_setup_code": "The requested setup code is insecure because of its trivial nature. This accessory fails to meet basic security requirements.",
             "max_peers_error": "Device refused to add pairing as it has no free pairing storage.",
             "pairing_failed": "An unhandled error occurred while attempting to pair with this device. This may be a temporary failure or your device may not be supported currently.",
             "unable_to_pair": "Unable to pair, please try again.",
@@ -30,7 +30,7 @@
             },
             "pair": {
                 "data": {
-                    "allow_invalid_setup_codes": "Allow pairing with invalid setup codes.",
+                    "allow_insecure_setup_codes": "Allow pairing with insecure setup codes.",
                     "pairing_code": "Pairing Code"
                 },
                 "description": "HomeKit Controller communicates with {name} over the local area network using a secure encrypted connection without a separate HomeKit controller or iCloud. Enter your HomeKit pairing code (in the format XXX-XX-XXX) to use this accessory. This code is usually found on the device itself or in the packaging.",

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -43,7 +43,7 @@ PAIRING_FINISH_ABORT_ERRORS = [
 ]
 
 
-BANNED_PAIRING_CODES = [
+INSECURE_PAIRING_CODES = [
     "111-11-111",
     "123-45-678",
     "22222222",
@@ -101,13 +101,13 @@ def test_invalid_pairing_codes(pairing_code):
         config_flow.ensure_pin_format(pairing_code)
 
 
-@pytest.mark.parametrize("pairing_code", BANNED_PAIRING_CODES)
-def test_banned_pairing_codes(pairing_code):
+@pytest.mark.parametrize("pairing_code", INSECURE_PAIRING_CODES)
+def test_insecure_pairing_codes(pairing_code):
     """Test ensure_pin_format raises for an invalid setup code."""
-    with pytest.raises(config_flow.InvalidSetupCode):
+    with pytest.raises(config_flow.InsecureSetupCode):
         config_flow.ensure_pin_format(pairing_code)
 
-    config_flow.ensure_pin_format(pairing_code, allow_invalid_setup_codes=True)
+    config_flow.ensure_pin_format(pairing_code, allow_insecure_setup_codes=True)
 
 
 @pytest.mark.parametrize("pairing_code", VALID_PAIRING_CODES)
@@ -640,7 +640,7 @@ async def test_user_works(hass, controller):
     assert result["title"] == "Koogeek-LS1-20833F"
 
 
-async def test_user_pairing_with_invalid_setup_code(hass, controller):
+async def test_user_pairing_with_insecure_setup_code(hass, controller):
     """Test user initiated disovers devices."""
     device = setup_mock_accessory(controller)
     device.pairing_code = "123-45-678"
@@ -673,11 +673,11 @@ async def test_user_pairing_with_invalid_setup_code(hass, controller):
     )
     assert result["type"] == "form"
     assert result["step_id"] == "pair"
-    assert result["errors"] == {"pairing_code": "invalid_setup_code"}
+    assert result["errors"] == {"pairing_code": "insecure_setup_code"}
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        user_input={"pairing_code": "123-45-678", "allow_invalid_setup_codes": True},
+        user_input={"pairing_code": "123-45-678", "allow_insecure_setup_codes": True},
     )
     assert result["type"] == "create_entry"
     assert result["title"] == "Koogeek-LS1-20833F"

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -42,6 +42,16 @@ PAIRING_FINISH_ABORT_ERRORS = [
     (aiohomekit.AccessoryNotFoundError, "accessory_not_found_error")
 ]
 
+
+BANNED_PAIRING_CODES = [
+    "111-11-111",
+    "123-45-678",
+    "22222222",
+    "111-11-111 ",
+    " 111-11-111",
+]
+
+
 INVALID_PAIRING_CODES = [
     "aaa-aa-aaa",
     "aaa-11-aaa",
@@ -49,11 +59,8 @@ INVALID_PAIRING_CODES = [
     "aaa-aa-111",
     "1111-1-111",
     "a111-11-111",
-    " 111-11-111",
-    "111-11-111 ",
     "111-11-111a",
     "1111111",
-    "22222222",
 ]
 
 
@@ -92,6 +99,15 @@ def test_invalid_pairing_codes(pairing_code):
     """Test ensure_pin_format raises for an invalid pin code."""
     with pytest.raises(aiohomekit.exceptions.MalformedPinError):
         config_flow.ensure_pin_format(pairing_code)
+
+
+@pytest.mark.parametrize("pairing_code", BANNED_PAIRING_CODES)
+def test_banned_pairing_codes(pairing_code):
+    """Test ensure_pin_format raises for an invalid setup code."""
+    with pytest.raises(config_flow.InvalidSetupCode):
+        config_flow.ensure_pin_format(pairing_code)
+
+    config_flow.ensure_pin_format(pairing_code, allow_invalid_setup_codes=True)
 
 
 @pytest.mark.parametrize("pairing_code", VALID_PAIRING_CODES)
@@ -619,6 +635,49 @@ async def test_user_works(hass, controller):
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input={"pairing_code": "111-22-333"}
+    )
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Koogeek-LS1-20833F"
+
+
+async def test_user_pairing_with_invalid_setup_code(hass, controller):
+    """Test user initiated disovers devices."""
+    device = setup_mock_accessory(controller)
+    device.pairing_code = "123-45-678"
+
+    # Device is discovered
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller", context={"source": config_entries.SOURCE_USER}
+    )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "user"
+    assert get_flow_context(hass, result) == {
+        "source": config_entries.SOURCE_USER,
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"device": "TestDevice"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "pair"
+
+    assert get_flow_context(hass, result) == {
+        "source": config_entries.SOURCE_USER,
+        "unique_id": "00:00:00:00:00:00",
+        "title_placeholders": {"name": "TestDevice"},
+    }
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"pairing_code": "123-45-678"}
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"pairing_code": "invalid_setup_code"}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={"pairing_code": "123-45-678", "allow_invalid_setup_codes": True},
     )
     assert result["type"] == "create_entry"
     assert result["title"] == "Koogeek-LS1-20833F"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allow user to override insecure setup codes and pair with homekit_controller

User enters insecure setup code
<img width="585" alt="Screen Shot 2021-05-22 at 10 38 43 PM" src="https://user-images.githubusercontent.com/663432/119247380-864d7b00-bb4e-11eb-8542-ea60525f8f9d.png">

User must re-enter insecure setup code and check the box before they can continue
<img width="595" alt="Screen Shot 2021-05-23 at 9 14 57 AM" src="https://user-images.githubusercontent.com/663432/119264110-6302ea00-bba7-11eb-91d0-de3ab9c8ccd4.png">


Note that I tested this using two different instances thus the light and dark mode

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #49154
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/17937

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
