### PR TITLE
Enable type checks for tplink

### DIFF
--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -1,11 +1,19 @@
 """Config flow for TP-Link."""
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
 from .common import async_get_discoverable_devices
 from .const import DOMAIN
 
+
+async def _async_has_devices(hass: HomeAssistant) -> bool:
+    """Check if there are devices that can be discovered."""
+    devices = await async_get_discoverable_devices(hass)
+    return len(devices) > 0
+
+
 config_entry_flow.register_discovery_flow(
     DOMAIN,
     "TP-Link Smart Home",
-    async_get_discoverable_devices,
+    _async_has_devices,
 )

--- a/homeassistant/components/tplink/light.py
+++ b/homeassistant/components/tplink/light.py
@@ -120,8 +120,7 @@ class LightState(NamedTuple):
     def to_param(self) -> dict[str, Any]:
         """Return a version that we can send to the bulb."""
         color_temp: int | None = None
-        # Color temperature 0 doesn't make sense and can't be converted to kelvin.
-        if self.color_temp:
+        if self.color_temp is not None and self.color_temp != 0:
             color_temp = mired_to_kelvin(self.color_temp)
 
         brightness: int | None = None

--- a/homeassistant/components/tplink/switch.py
+++ b/homeassistant/components/tplink/switch.py
@@ -61,7 +61,6 @@ class SmartPlugSwitch(TPLinkEntity, SwitchEntity):
         """Initialize the switch."""
         super().__init__(smartplug)
         self.smartplug = smartplug
-        # It was already fetched by this point.
         self._sysinfo = smartplug.sys_info
         self._is_available = False
         # Set up emeter cache

--- a/mypy.ini
+++ b/mypy.ini
@@ -1354,9 +1354,6 @@ ignore_errors = true
 [mypy-homeassistant.components.toon.*]
 ignore_errors = true
 
-[mypy-homeassistant.components.tplink.*]
-ignore_errors = true
-
 [mypy-homeassistant.components.trace.*]
 ignore_errors = true
 

--- a/script/hassfest/mypy_config.py
+++ b/script/hassfest/mypy_config.py
@@ -205,7 +205,6 @@ IGNORED_MODULES: Final[list[str]] = [
     "homeassistant.components.timer.*",
     "homeassistant.components.todoist.*",
     "homeassistant.components.toon.*",
-    "homeassistant.components.tplink.*",
     "homeassistant.components.trace.*",
     "homeassistant.components.tradfri.*",
     "homeassistant.components.tuya.*",

--- a/tests/components/tplink/test_light.py
+++ b/tests/components/tplink/test_light.py
@@ -605,10 +605,10 @@ async def test_get_light_state_retry(
         nonlocal get_sysinfo_call_count
         get_sysinfo_call_count += 1
 
-        # Need to fail on the 2nd call because the first call is used to
+        # Need to fail on the 4th call because the first 3 calls are used to
         # determine if the device is online during the light platform's
-        # setup hook.
-        if get_sysinfo_call_count == 2:
+        # setup hook and in smart bulb constructor.
+        if get_sysinfo_call_count == 4:
             raise SmartDeviceException()
 
         return light_mock_data.sys_info


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This was the tricky one.
- The main change was removing delayed entity initialisation because it's not type safe. It should be ok because in case of exception, exception will be caught and entity won't be created.
- For this several methods were converted to static methods to be able to call them from constructor safely.
- Define common interface `TPLinkEntity` for both entities.
- Define `_async_has_devices` which returns `bool` to match expected callback signature.
- Many smaller fixes.

@rytilahti I'd appreciate if you can test if this still works after all changes because I don't have such devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
