### PR TITLE
Add `state_class` to entities coming from battery powered devices in Shelly integration

### DIFF
--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -9,6 +9,13 @@ from typing import Any, Callable
 import aioshelly
 import async_timeout
 
+from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
+from homeassistant.const import (
+    DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_TEMPERATURE,
+)
 from homeassistant.core import callback
 from homeassistant.helpers import (
     device_registry,
@@ -105,6 +112,14 @@ async def async_restore_block_attribute_entities(
             device_class=entry.device_class,
         )
 
+        if description.device_class in [
+            DEVICE_CLASS_BATTERY,
+            DEVICE_CLASS_HUMIDITY,
+            DEVICE_CLASS_TEMPERATURE,
+            DEVICE_CLASS_ILLUMINANCE,
+        ]:
+            description.state_class = STATE_CLASS_MEASUREMENT
+
         entities.append(
             sensor_class(wrapper, None, attribute, description, entry, sensors)
         )
@@ -168,6 +183,7 @@ class RestAttributeDescription:
     unit: str | None = None
     value: Callable[[dict, Any], Any] | None = None
     device_class: str | None = None
+    state_class: str | None = None
     default_enabled: bool = True
     extra_state_attributes: Callable[[dict], dict | None] | None = None
 

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -112,14 +112,6 @@ async def async_restore_block_attribute_entities(
             device_class=entry.device_class,
         )
 
-        # if description.device_class in [
-        #     DEVICE_CLASS_BATTERY,
-        #     DEVICE_CLASS_HUMIDITY,
-        #     DEVICE_CLASS_TEMPERATURE,
-        #     DEVICE_CLASS_ILLUMINANCE,
-        # ]:
-        #     description.state_class = STATE_CLASS_MEASUREMENT
-
         entities.append(
             sensor_class(wrapper, None, attribute, description, entry, sensors)
         )

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -9,13 +9,7 @@ from typing import Any, Callable
 import aioshelly
 import async_timeout
 
-from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_MEASUREMENT
-from homeassistant.const import (
-    DEVICE_CLASS_BATTERY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
-)
+from homeassistant.components.sensor import ATTR_STATE_CLASS
 from homeassistant.core import callback
 from homeassistant.helpers import (
     device_registry,
@@ -438,18 +432,6 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
         if last_state is not None:
             self.last_state = last_state.state
             self.description.state_class = last_state.attributes.get(ATTR_STATE_CLASS)
-
-        if (
-            self.description.device_class
-            in [
-                DEVICE_CLASS_BATTERY,
-                DEVICE_CLASS_HUMIDITY,
-                DEVICE_CLASS_ILLUMINANCE,
-                DEVICE_CLASS_TEMPERATURE,
-            ]
-            and not self.description.state_class
-        ):
-            self.description.state_class = STATE_CLASS_MEASUREMENT
 
     @callback
     def _update_callback(self):

--- a/homeassistant/components/shelly/entity.py
+++ b/homeassistant/components/shelly/entity.py
@@ -9,7 +9,7 @@ from typing import Any, Callable
 import aioshelly
 import async_timeout
 
-from homeassistant.components.sensor import STATE_CLASS_MEASUREMENT
+from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_MEASUREMENT
 from homeassistant.const import (
     DEVICE_CLASS_BATTERY,
     DEVICE_CLASS_HUMIDITY,
@@ -112,13 +112,13 @@ async def async_restore_block_attribute_entities(
             device_class=entry.device_class,
         )
 
-        if description.device_class in [
-            DEVICE_CLASS_BATTERY,
-            DEVICE_CLASS_HUMIDITY,
-            DEVICE_CLASS_TEMPERATURE,
-            DEVICE_CLASS_ILLUMINANCE,
-        ]:
-            description.state_class = STATE_CLASS_MEASUREMENT
+        # if description.device_class in [
+        #     DEVICE_CLASS_BATTERY,
+        #     DEVICE_CLASS_HUMIDITY,
+        #     DEVICE_CLASS_TEMPERATURE,
+        #     DEVICE_CLASS_ILLUMINANCE,
+        # ]:
+        #     description.state_class = STATE_CLASS_MEASUREMENT
 
         entities.append(
             sensor_class(wrapper, None, attribute, description, entry, sensors)
@@ -445,6 +445,19 @@ class ShellySleepingBlockAttributeEntity(ShellyBlockAttributeEntity, RestoreEnti
 
         if last_state is not None:
             self.last_state = last_state.state
+            self.description.state_class = last_state.attributes.get(ATTR_STATE_CLASS)
+
+        if (
+            self.description.device_class
+            in [
+                DEVICE_CLASS_BATTERY,
+                DEVICE_CLASS_HUMIDITY,
+                DEVICE_CLASS_ILLUMINANCE,
+                DEVICE_CLASS_TEMPERATURE,
+            ]
+            and not self.description.state_class
+        ):
+            self.description.state_class = STATE_CLASS_MEASUREMENT
 
     @callback
     def _update_callback(self):

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -30,6 +30,7 @@ SENSORS = {
         name="Battery",
         unit=PERCENTAGE,
         device_class=sensor.DEVICE_CLASS_BATTERY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
         removal_condition=lambda settings, _: settings.get("external_power") == 1,
     ),
     ("device", "deviceTemp"): BlockAttributeDescription(
@@ -37,6 +38,7 @@ SENSORS = {
         unit=temperature_unit,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_TEMPERATURE,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
         default_enabled=False,
     ),
     ("emeter", "current"): BlockAttributeDescription(
@@ -44,12 +46,14 @@ SENSORS = {
         unit=ELECTRICAL_CURRENT_AMPERE,
         value=lambda value: value,
         device_class=sensor.DEVICE_CLASS_CURRENT,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("light", "power"): BlockAttributeDescription(
         name="Power",
         unit=POWER_WATT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_POWER,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
         default_enabled=False,
     ),
     ("device", "power"): BlockAttributeDescription(
@@ -57,60 +61,70 @@ SENSORS = {
         unit=POWER_WATT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_POWER,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("emeter", "power"): BlockAttributeDescription(
         name="Power",
         unit=POWER_WATT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_POWER,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("emeter", "voltage"): BlockAttributeDescription(
         name="Voltage",
         unit=VOLT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_VOLTAGE,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("emeter", "powerFactor"): BlockAttributeDescription(
         name="Power Factor",
         unit=PERCENTAGE,
         value=lambda value: round(value * 100, 1),
         device_class=sensor.DEVICE_CLASS_POWER_FACTOR,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("relay", "power"): BlockAttributeDescription(
         name="Power",
         unit=POWER_WATT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_POWER,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("roller", "rollerPower"): BlockAttributeDescription(
         name="Power",
         unit=POWER_WATT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_POWER,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("device", "energy"): BlockAttributeDescription(
         name="Energy",
         unit=ENERGY_KILO_WATT_HOUR,
         value=lambda value: round(value / 60 / 1000, 2),
         device_class=sensor.DEVICE_CLASS_ENERGY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("emeter", "energy"): BlockAttributeDescription(
         name="Energy",
         unit=ENERGY_KILO_WATT_HOUR,
         value=lambda value: round(value / 1000, 2),
         device_class=sensor.DEVICE_CLASS_ENERGY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("emeter", "energyReturned"): BlockAttributeDescription(
         name="Energy Returned",
         unit=ENERGY_KILO_WATT_HOUR,
         value=lambda value: round(value / 1000, 2),
         device_class=sensor.DEVICE_CLASS_ENERGY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("light", "energy"): BlockAttributeDescription(
         name="Energy",
         unit=ENERGY_KILO_WATT_HOUR,
         value=lambda value: round(value / 60 / 1000, 2),
         device_class=sensor.DEVICE_CLASS_ENERGY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
         default_enabled=False,
     ),
     ("relay", "energy"): BlockAttributeDescription(
@@ -118,17 +132,20 @@ SENSORS = {
         unit=ENERGY_KILO_WATT_HOUR,
         value=lambda value: round(value / 60 / 1000, 2),
         device_class=sensor.DEVICE_CLASS_ENERGY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("roller", "rollerEnergy"): BlockAttributeDescription(
         name="Energy",
         unit=ENERGY_KILO_WATT_HOUR,
         value=lambda value: round(value / 60 / 1000, 2),
         device_class=sensor.DEVICE_CLASS_ENERGY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("sensor", "concentration"): BlockAttributeDescription(
         name="Gas Concentration",
         unit=CONCENTRATION_PARTS_PER_MILLION,
         icon="mdi:gauge",
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("sensor", "extTemp"): BlockAttributeDescription(
         name="Temperature",
@@ -143,17 +160,20 @@ SENSORS = {
         unit=PERCENTAGE,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_HUMIDITY,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
         available=lambda block: block.extTemp != 999,
     ),
     ("sensor", "luminosity"): BlockAttributeDescription(
         name="Luminosity",
         unit=LIGHT_LUX,
         device_class=sensor.DEVICE_CLASS_ILLUMINANCE,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("sensor", "tilt"): BlockAttributeDescription(
         name="Tilt",
         unit=DEGREE,
         icon="mdi:angle-acute",
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("relay", "totalWorkTime"): BlockAttributeDescription(
         name="Lamp Life",
@@ -163,12 +183,14 @@ SENSORS = {
         extra_state_attributes=lambda block: {
             "Operational hours": round(block.totalWorkTime / 3600, 1)
         },
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("adc", "adc"): BlockAttributeDescription(
         name="ADC",
         unit=VOLT,
         value=lambda value: round(value, 1),
         device_class=sensor.DEVICE_CLASS_VOLTAGE,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("sensor", "sensorOp"): BlockAttributeDescription(
         name="Operation",
@@ -184,6 +206,7 @@ REST_SENSORS = {
         unit=SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
         value=lambda status, _: status["wifi_sta"]["rssi"],
         device_class=sensor.DEVICE_CLASS_SIGNAL_STRENGTH,
+        state_class=sensor.STATE_CLASS_MEASUREMENT,
         default_enabled=False,
     ),
     "uptime": RestAttributeDescription(
@@ -217,6 +240,11 @@ class ShellySensor(ShellyBlockAttributeEntity, SensorEntity):
     def state(self):
         """Return value of sensor."""
         return self.attribute_value
+
+    @property
+    def state_class(self):
+        """State class of sensor."""
+        return self.description.state_class
 
     @property
     def unit_of_measurement(self):
@@ -253,6 +281,11 @@ class ShellySleepingSensor(ShellySleepingBlockAttributeEntity, SensorEntity):
             return self.attribute_value
 
         return self.last_state
+
+    @property
+    def state_class(self):
+        """State class of sensor."""
+        return self.description.state_class
 
     @property
     def unit_of_measurement(self):

--- a/homeassistant/components/shelly/sensor.py
+++ b/homeassistant/components/shelly/sensor.py
@@ -183,7 +183,6 @@ SENSORS = {
         extra_state_attributes=lambda block: {
             "Operational hours": round(block.totalWorkTime / 3600, 1)
         },
-        state_class=sensor.STATE_CLASS_MEASUREMENT,
     ),
     ("adc", "adc"): BlockAttributeDescription(
         name="ADC",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR:
- adds `state_class` to entities coming from battery powered devices
- fixes exception for REST sensors:
```
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 382, in async_add_entities
    await asyncio.gather(*tasks)
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 496, in _async_add_entity
    capabilities=entity.capability_attributes,
  File "/usr/src/homeassistant/homeassistant/components/sensor/__init__.py", line 115, in capability_attributes
    if state_class := self.state_class:
  File "/usr/src/homeassistant/homeassistant/components/shelly/sensor.py", line 238, in state_class
    return self.description.state_class
AttributeError: 'RestAttributeDescription' object has no attribute 'state_class'
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
