### PR TITLE
Fix Soundbar exclusion from SamsungTV

### DIFF
--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -134,7 +134,13 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass, self._bridge, self._host
         )
         if not info:
-            if not self._bridge:
+            if not _method:
+                LOGGER.debug(
+                    "Samsung host %s is not supported by either %s or %s methods",
+                    self._host,
+                    METHOD_LEGACY,
+                    METHOD_WEBSOCKET,
+                )
                 raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
             return False
         dev_info = info.get("device", {})

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -134,6 +134,8 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.hass, self._bridge, self._host
         )
         if not info:
+            if not self._bridge:
+                raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
             return False
         dev_info = info.get("device", {})
         device_type = dev_info.get("type")

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -110,6 +110,8 @@ MOCK_WS_ENTRY = {
     CONF_MODEL: "any",
     CONF_NAME: "any",
 }
+MOCK_DEVICE_INFO = {"device": {"type": "Samsung SmartTV"}, "id": "123"}
+
 
 AUTODETECT_LEGACY = {
     "name": "HomeAssistant",
@@ -273,50 +275,57 @@ async def test_user_not_successful_2(hass: HomeAssistant, remotews: Mock):
 
 async def test_ssdp(hass: HomeAssistant, remote: Mock):
     """Test starting a flow from discovery."""
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
+    ):
+        # confirm to add the entry
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "confirm"
 
-    # confirm to add the entry
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
-    )
-    assert result["type"] == "form"
-    assert result["step_id"] == "confirm"
-
-    # entry was added
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input="whatever"
-    )
-    assert result["type"] == "create_entry"
-    assert result["title"] == "fake_model"
-    assert result["data"][CONF_HOST] == "fake_host"
-    assert result["data"][CONF_NAME] == "fake_model"
-    assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
-    assert result["data"][CONF_MODEL] == "fake_model"
-    assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+        # entry was added
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input="whatever"
+        )
+        assert result["type"] == "create_entry"
+        assert result["title"] == "fake_model"
+        assert result["data"][CONF_HOST] == "fake_host"
+        assert result["data"][CONF_NAME] == "fake_model"
+        assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
+        assert result["data"][CONF_MODEL] == "fake_model"
+        assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
 async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock):
     """Test starting a flow from discovery without prefixes."""
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
+    ):
 
-    # confirm to add the entry
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_SSDP},
-        data=MOCK_SSDP_DATA_NOPREFIX,
-    )
-    assert result["type"] == "form"
-    assert result["step_id"] == "confirm"
+        # confirm to add the entry
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=MOCK_SSDP_DATA_NOPREFIX,
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "confirm"
 
-    # entry was added
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input="whatever"
-    )
-    assert result["type"] == "create_entry"
-    assert result["title"] == "fake2_model"
-    assert result["data"][CONF_HOST] == "fake2_host"
-    assert result["data"][CONF_NAME] == "fake2_model"
-    assert result["data"][CONF_MANUFACTURER] == "Samsung fake2_manufacturer"
-    assert result["data"][CONF_MODEL] == "fake2_model"
-    assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
+        # entry was added
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input="whatever"
+        )
+        assert result["type"] == "create_entry"
+        assert result["title"] == "fake2_model"
+        assert result["data"][CONF_HOST] == "fake2_host"
+        assert result["data"][CONF_NAME] == "fake2_model"
+        assert result["data"][CONF_MANUFACTURER] == "Samsung fake2_manufacturer"
+        assert result["data"][CONF_MODEL] == "fake2_model"
+        assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
 
 
 async def test_ssdp_legacy_missing_auth(hass: HomeAssistant, remote: Mock):
@@ -324,6 +333,9 @@ async def test_ssdp_legacy_missing_auth(hass: HomeAssistant, remote: Mock):
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=AccessDenied("Boom"),
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
     ):
 
         # confirm to add the entry
@@ -346,6 +358,9 @@ async def test_ssdp_legacy_not_supported(hass: HomeAssistant, remote: Mock):
     with patch(
         "homeassistant.components.samsungtv.bridge.Remote",
         side_effect=UnhandledResponse("Boom"),
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
     ):
 
         # confirm to add the entry
@@ -394,6 +409,9 @@ async def test_ssdp_websocket_not_supported(hass: HomeAssistant, remote: Mock):
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=WebSocketProtocolException("Boom"),
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
     ):
         # confirm to add the entry
         result = await hass.config_entries.flow.async_init(
@@ -431,6 +449,9 @@ async def test_ssdp_not_successful(hass: HomeAssistant, remote: Mock):
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=OSError("Boom"),
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
     ):
 
         # confirm to add the entry
@@ -456,6 +477,9 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant, remote: Mock):
     ), patch(
         "homeassistant.components.samsungtv.bridge.SamsungTVWS",
         side_effect=ConnectionFailure("Boom"),
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
     ):
 
         # confirm to add the entry
@@ -475,20 +499,23 @@ async def test_ssdp_not_successful_2(hass: HomeAssistant, remote: Mock):
 
 async def test_ssdp_already_in_progress(hass: HomeAssistant, remote: Mock):
     """Test starting a flow from discovery twice."""
+    with patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWSBridge.device_info",
+        return_value=MOCK_DEVICE_INFO,
+    ):
+        # confirm to add the entry
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
+        )
+        assert result["type"] == "form"
+        assert result["step_id"] == "confirm"
 
-    # confirm to add the entry
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
-    )
-    assert result["type"] == "form"
-    assert result["step_id"] == "confirm"
-
-    # failed as already in progress
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
-    )
-    assert result["type"] == "abort"
-    assert result["reason"] == RESULT_ALREADY_IN_PROGRESS
+        # failed as already in progress
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
+        )
+        assert result["type"] == "abort"
+        assert result["reason"] == RESULT_ALREADY_IN_PROGRESS
 
 
 async def test_ssdp_already_configured(hass: HomeAssistant, remote: Mock):

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -110,7 +110,14 @@ MOCK_WS_ENTRY = {
     CONF_MODEL: "any",
     CONF_NAME: "any",
 }
-MOCK_DEVICE_INFO = {"device": {"type": "Samsung SmartTV"}, "id": "123"}
+MOCK_DEVICE_INFO = {
+    "device": {
+        "type": "Samsung SmartTV",
+        "name": "fake_name",
+        "modelName": "fake_model",
+    },
+    "id": "123",
+}
 
 
 AUTODETECT_LEGACY = {
@@ -291,9 +298,9 @@ async def test_ssdp(hass: HomeAssistant, remote: Mock):
             result["flow_id"], user_input="whatever"
         )
         assert result["type"] == "create_entry"
-        assert result["title"] == "fake_model"
+        assert result["title"] == "fake_name (fake_model)"
         assert result["data"][CONF_HOST] == "fake_host"
-        assert result["data"][CONF_NAME] == "fake_model"
+        assert result["data"][CONF_NAME] == "fake_name"
         assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
         assert result["data"][CONF_MODEL] == "fake_model"
         assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
@@ -320,11 +327,11 @@ async def test_ssdp_noprefix(hass: HomeAssistant, remote: Mock):
             result["flow_id"], user_input="whatever"
         )
         assert result["type"] == "create_entry"
-        assert result["title"] == "fake2_model"
+        assert result["title"] == "fake_name (fake_model)"
         assert result["data"][CONF_HOST] == "fake2_host"
-        assert result["data"][CONF_NAME] == "fake2_model"
+        assert result["data"][CONF_NAME] == "fake_name"
         assert result["data"][CONF_MANUFACTURER] == "Samsung fake2_manufacturer"
-        assert result["data"][CONF_MODEL] == "fake2_model"
+        assert result["data"][CONF_MODEL] == "fake_model"
         assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172df"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After latest code rework, Sound bar was again detected by this integration.
This PR fix it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
