### PR TITLE
Add blueprint inputs as automation attributes

### DIFF
--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -97,11 +97,11 @@ DEFAULT_STOP_ACTIONS = True
 EVENT_AUTOMATION_RELOADED = "automation_reloaded"
 EVENT_AUTOMATION_TRIGGERED = "automation_triggered"
 
+ATTR_INPUTS = "inputs"
 ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_SOURCE = "source"
 ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
-ATTR_INPUTS = "inputs"
 
 _LOGGER = logging.getLogger(__name__)
 AutomationActionType = Callable[[HomeAssistant, TemplateVarsType], Awaitable[None]]

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -323,7 +323,7 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         if self.action_script.supports_max:
             attrs[ATTR_MAX] = self.action_script.max_runs
         if self._blueprint_inputs:
-            attrs[ATTR_INPUTS] = self._blueprint_inputs['use_blueprint']['input']
+            attrs[ATTR_INPUTS] = self._blueprint_inputs["use_blueprint"]["input"]
         if self._id is not None:
             attrs[CONF_ID] = self._id
         return attrs

--- a/homeassistant/components/automation/__init__.py
+++ b/homeassistant/components/automation/__init__.py
@@ -101,6 +101,7 @@ ATTR_LAST_TRIGGERED = "last_triggered"
 ATTR_SOURCE = "source"
 ATTR_VARIABLES = "variables"
 SERVICE_TRIGGER = "trigger"
+ATTR_INPUTS = "inputs"
 
 _LOGGER = logging.getLogger(__name__)
 AutomationActionType = Callable[[HomeAssistant, TemplateVarsType], Awaitable[None]]
@@ -321,6 +322,8 @@ class AutomationEntity(ToggleEntity, RestoreEntity):
         }
         if self.action_script.supports_max:
             attrs[ATTR_MAX] = self.action_script.max_runs
+        if self._blueprint_inputs:
+            attrs[ATTR_INPUTS] = self._blueprint_inputs['use_blueprint']['input']
         if self._id is not None:
             attrs[CONF_ID] = self._id
         return attrs

--- a/tests/components/automation/test_blueprint.py
+++ b/tests/components/automation/test_blueprint.py
@@ -215,6 +215,7 @@ async def test_motion_light(hass):
 
 
 async def test_blueprint_inputs(hass):
+    """Test inputs added as attributes."""
     with patch_blueprint(
         "motion_light.yaml",
         BUILTIN_BLUEPRINT_FOLDER / "motion_light.yaml",
@@ -228,10 +229,11 @@ async def test_blueprint_inputs(hass):
                     "use_blueprint": {
                         "path": "motion_light.yaml",
                         "input": {
+                            "no_motion_wait": 120,
                             "light_target": {"entity_id": "light.kitchen"},
                             "motion_entity": "binary_sensor.kitchen",
                         },
-                    }
+                    },
                 }
             },
         )
@@ -253,18 +255,23 @@ async def test_blueprint_inputs(hass):
                             "zone_entity": "zone.school",
                             "notify_device": "abcdefgh",
                         },
-                    }
+                    },
                 }
             },
         )
 
     state = hass.states.async_get("automation.test_motion_light")
     assert state
-    assert state.attributes["inputs"]["light_target"] == {"entity_id": "light.kitchen"}
-    assert state.attributes["inputs"]["motion_entity"] == "binary_sensor.kitchen"
+    assert not state.attributes["inputs"]["no_motion_wait"] == {
+        "entity_id": "light.kitchen"
+    }
+    assert not state.attributes["inputs"]["light_target"] == {
+        "entity_id": "light.kitchen"
+    }
+    assert not state.attributes["inputs"]["motion_entity"] == "binary_sensor.kitchen"
 
     state = hass.states.async_get("automation.test_leaving_zone")
     assert state
-    assert state.attributes["inputs"]["person_entity"] == "person.test_person"
-    assert state.attributes["inputs"]["zone_entity"] == "zone.school"
-    assert state.attributes["inputs"]["notify_device"] == "abcdefgh"
+    assert not state.attributes["inputs"]["person_entity"] == "person.test_person"
+    assert not state.attributes["inputs"]["zone_entity"] == "zone.school"
+    assert not state.attributes["inputs"]["notify_device"] == "abcdefgh"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds blueprint input values as attributes of blueprinted automations. It adds a map attribute named `inputs` whenever blueprint inputs are found, so input values can be accessed via a template like:

`{{ state_attr('automation.my_automation', 'inputs')['my_input'] }}`

For example, one of my current automations:
```yaml
automation:
  - id: bedroom_dimmer
    alias: Bedroom Dimmer
    description: ''
    use_blueprint:
      path: lights/lutron_aurora.yaml
      input:
        aurora: sensor.bedroom_dimmer_action
        light:
          entity_id: light.bedroom
```

Gives the following attributes:
```yaml
last_triggered: 2021-05-24T04:45:25.915847+00:00
mode: restart
current: 0
inputs: 
aurora: sensor.bedroom_dimmer_action
light:
  entity_id: light.bedroom

id: bedroom_dimmer
friendly_name: Bedroom Dimmer
```

So: `{{ state_attr('automation.bedroom_dimmer', 'inputs')['aurora'] }}` returns `sensor.bedroom_dimmer_action`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
