### PR TITLE
Add zwave_js heal node and network WS API commands

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -675,7 +675,7 @@ async def websocket_begin_healing_network(
     def forward_event(key: str, event: dict) -> None:
         connection.send_message(
             websocket_api.event_message(
-                msg[ID], {"event": event["event"], "data": event[key]}
+                msg[ID], {"event": event["event"], "heal_node_status": event[key]}
             )
         )
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import dataclasses
-from functools import wraps
+from functools import partial, wraps
 import json
 from typing import Callable
 
@@ -142,18 +142,21 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_ping_node)
     websocket_api.async_register_command(hass, websocket_add_node)
     websocket_api.async_register_command(hass, websocket_stop_inclusion)
+    websocket_api.async_register_command(hass, websocket_stop_exclusion)
     websocket_api.async_register_command(hass, websocket_remove_node)
     websocket_api.async_register_command(hass, websocket_remove_failed_node)
     websocket_api.async_register_command(hass, websocket_replace_failed_node)
-    websocket_api.async_register_command(hass, websocket_stop_exclusion)
+    websocket_api.async_register_command(hass, websocket_begin_healing_network)
+    websocket_api.async_register_command(hass, websocket_stop_healing_network)
     websocket_api.async_register_command(hass, websocket_refresh_node_info)
     websocket_api.async_register_command(hass, websocket_refresh_node_values)
     websocket_api.async_register_command(hass, websocket_refresh_node_cc_values)
+    websocket_api.async_register_command(hass, websocket_heal_node)
+    websocket_api.async_register_command(hass, websocket_set_config_parameter)
+    websocket_api.async_register_command(hass, websocket_get_config_parameters)
     websocket_api.async_register_command(hass, websocket_subscribe_logs)
     websocket_api.async_register_command(hass, websocket_update_log_config)
     websocket_api.async_register_command(hass, websocket_get_log_config)
-    websocket_api.async_register_command(hass, websocket_get_config_parameters)
-    websocket_api.async_register_command(hass, websocket_set_config_parameter)
     websocket_api.async_register_command(
         hass, websocket_update_data_collection_preference
     )
@@ -637,6 +640,104 @@ async def websocket_remove_failed_node(
     unsub = controller.on("node removed", node_removed)
 
     result = await controller.async_remove_failed_node(node_id)
+    connection.send_result(
+        msg[ID],
+        result,
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/begin_healing_network",
+        vol.Required(ENTRY_ID): str,
+    }
+)
+@websocket_api.async_response
+@async_get_entry
+async def websocket_begin_healing_network(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+    entry: ConfigEntry,
+    client: Client,
+) -> None:
+    """Begin healing the Z-Wave network."""
+    controller = client.driver.controller
+
+    @callback
+    def async_cleanup() -> None:
+        """Remove signal listeners."""
+        for unsub in unsubs:
+            unsub()
+
+    @callback
+    def forward_event(key: str, event: dict) -> None:
+        connection.send_message(
+            websocket_api.event_message(
+                msg[ID], {"event": event["event"], "data": event[key]}
+            )
+        )
+
+    connection.subscriptions[msg["id"]] = async_cleanup
+    unsubs = [
+        controller.on("heal network progress", partial(forward_event, "progress")),
+        controller.on("heal network done", partial(forward_event, "result")),
+    ]
+
+    result = await controller.async_begin_healing_network()
+    connection.send_result(
+        msg[ID],
+        result,
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/stop_healing_network",
+        vol.Required(ENTRY_ID): str,
+    }
+)
+@websocket_api.async_response
+@async_get_entry
+async def websocket_stop_healing_network(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+    entry: ConfigEntry,
+    client: Client,
+) -> None:
+    """Stop healing the Z-Wave network."""
+    controller = client.driver.controller
+    result = await controller.async_stop_healing_network()
+    connection.send_result(
+        msg[ID],
+        result,
+    )
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "zwave_js/heal_node",
+        vol.Required(ENTRY_ID): str,
+        vol.Required(NODE_ID): int,
+    }
+)
+@websocket_api.async_response
+@async_get_entry
+async def websocket_heal_node(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict,
+    entry: ConfigEntry,
+    client: Client,
+) -> None:
+    """Heal a node on the Z-Wave network."""
+    controller = client.driver.controller
+    node_id = msg[NODE_ID]
+    result = await controller.async_heal_node(node_id)
     connection.send_result(
         msg[ID],
         result,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -699,6 +699,41 @@ async def test_begin_healing_network(
     assert msg["success"]
     assert msg["result"]
 
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/begin_healing_network",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+async def test_subscribe_heal_network_progress(
+    hass, integration, client, hass_ws_client
+):
+    """Test the subscribe_heal_network_progress command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/subscribe_heal_network_progress",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
     # Fire heal network progress
     event = Event(
         "heal network progress",
@@ -720,7 +755,7 @@ async def test_begin_healing_network(
     await ws_client.send_json(
         {
             ID: 4,
-            TYPE: "zwave_js/begin_healing_network",
+            TYPE: "zwave_js/subscribe_heal_network_progress",
             ENTRY_ID: entry.entry_id,
         }
     )

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -711,7 +711,7 @@ async def test_begin_healing_network(
     client.driver.controller.receive_event(event)
     msg = await ws_client.receive_json()
     assert msg["event"]["event"] == "heal network progress"
-    assert msg["event"]["data"] == {"67": "pending"}
+    assert msg["event"]["heal_node_status"] == {"67": "pending"}
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -496,6 +496,7 @@ async def test_replace_failed_node(
 
     msg = await ws_client.receive_json()
     assert msg["success"]
+    assert msg["result"]
 
     event = Event(
         type="inclusion started",
@@ -664,6 +665,145 @@ async def test_remove_failed_node(
         {
             ID: 4,
             TYPE: "zwave_js/remove_failed_node",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 67,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+async def test_begin_healing_network(
+    hass,
+    integration,
+    client,
+    hass_ws_client,
+):
+    """Test the begin_healing_network websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    client.async_send_command.return_value = {"success": True}
+
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/begin_healing_network",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]
+
+    # Fire heal network progress
+    event = Event(
+        "heal network progress",
+        {
+            "source": "controller",
+            "event": "heal network progress",
+            "progress": {67: "pending"},
+        },
+    )
+    client.driver.controller.receive_event(event)
+    msg = await ws_client.receive_json()
+    assert msg["event"]["event"] == "heal network progress"
+    assert msg["event"]["data"] == {"67": "pending"}
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/begin_healing_network",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+async def test_stop_healing_network(
+    hass,
+    integration,
+    client,
+    hass_ws_client,
+):
+    """Test the stop_healing_network websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    client.async_send_command.return_value = {"success": True}
+
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/stop_healing_network",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/begin_healing_network",
+            ENTRY_ID: entry.entry_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
+
+async def test_heal_node(
+    hass,
+    integration,
+    client,
+    hass_ws_client,
+):
+    """Test the heal_node websocket command."""
+    entry = integration
+    ws_client = await hass_ws_client(hass)
+
+    client.async_send_command.return_value = {"success": True}
+
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/heal_node",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 67,
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+    assert msg["result"]
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 4,
+            TYPE: "zwave_js/heal_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
         }

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -761,7 +761,7 @@ async def test_stop_healing_network(
     await ws_client.send_json(
         {
             ID: 4,
-            TYPE: "zwave_js/begin_healing_network",
+            TYPE: "zwave_js/stop_healing_network",
             ENTRY_ID: entry.entry_id,
         }
     )

--- a/tests/fixtures/zwave_js/controller_state.json
+++ b/tests/fixtures/zwave_js/controller_state.json
@@ -91,7 +91,8 @@
             239
         ],
         "sucNodeId": 1,
-        "supportsTimers": false
+        "supportsTimers": false,
+        "isHealNetworkActive": false
     },
     "nodes": [
     ]


### PR DESCRIPTION
## Proposed change
Part of the UI roadmap.

Note: The WS API apparently forces dictionary keys to be strings. Our heal network status events have the node_id as the key and it's being forced to be a string. The only way I could get around it was to convert the dictionary to a list of dicts. I don't know if that's more desirable but I did not keep it that way. It is easy enough to change if we feel that's a better way to serialize the data.

The way this will work is that there are four commands to use for network healing:
- `zwave_js/network_status` -> on initial load, used to determine whether healing network is active or noot
- `zwave_js/begin_healing_network` -> start healing
- `zwave_js/subscribe_heal_network_progress` -> watch updates
- `zwave_js/stop_healing_network` -> stop healing

and one for nodes: `zwave_js/heal_node`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
