### PR TITLE
Only create discovery/reconfig notification when its not present

### DIFF
--- a/homeassistant/components/persistent_notification/__init__.py
+++ b/homeassistant/components/persistent_notification/__init__.py
@@ -100,6 +100,15 @@ def async_dismiss(hass: HomeAssistant, notification_id: str) -> None:
     hass.async_create_task(hass.services.async_call(DOMAIN, SERVICE_DISMISS, data))
 
 
+@callback
+@bind_hass
+def async_exists(hass: HomeAssistant, notification_id: str) -> bool:
+    """Check if a notification is present."""
+    return (
+        hass.states.get(ENTITY_ID_FORMAT.format(slugify(notification_id))) is not None
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the persistent notification component."""
     persistent_notifications: MutableMapping[str, MutableMapping] = OrderedDict()

--- a/tests/components/persistent_notification/test_init.py
+++ b/tests/components/persistent_notification/test_init.py
@@ -187,3 +187,18 @@ async def test_ws_get_notifications(hass, hass_ws_client):
     msg = await client.receive_json()
     notifications = msg["result"]
     assert len(notifications) == 0
+
+
+async def test_exists(hass):
+    """Test we can check of a notification exists."""
+    await async_setup_component(hass, pn.DOMAIN, {})
+
+    assert hass.components.persistent_notification.async_exists("Beer 2") is False
+    hass.components.persistent_notification.async_create(
+        "test", notification_id="Beer 2"
+    )
+    await hass.async_block_till_done()
+    assert hass.components.persistent_notification.async_exists("Beer 2") is True
+    hass.components.persistent_notification.async_dismiss("Beer 2")
+    await hass.async_block_till_done()
+    assert hass.components.persistent_notification.async_exists("Beer 2") is False

--- a/tests/test_config_entries.py
+++ b/tests/test_config_entries.py
@@ -666,12 +666,20 @@ async def test_discovery_notification(hass):
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_discovery")
         assert state is not None
+        first_notification_updated_time = state.last_updated
 
         # Start a second discovery flow so we can finish the first and assert that
         # the discovery notification persists until the second one is complete
         flow2 = await hass.config_entries.flow.async_init(
             "test", context={"source": config_entries.SOURCE_DISCOVERY}
         )
+
+        await hass.async_block_till_done()
+        state = hass.states.get("persistent_notification.config_entry_discovery")
+        assert state is not None
+        # Ensure we do not fire the exact same notification a second time when
+        # it is already present
+        assert state.last_updated == first_notification_updated_time
 
         flow1 = await hass.config_entries.flow.async_configure(flow1["flow_id"], {})
         assert flow1["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
@@ -734,12 +742,20 @@ async def test_reauth_notification(hass):
         await hass.async_block_till_done()
         state = hass.states.get("persistent_notification.config_entry_reconfigure")
         assert state is not None
+        first_notification_updated_time = state.last_updated
 
         # Start a second reauth flow so we can finish the first and assert that
         # the reconfigure notification persists until the second one is complete
         flow2 = await hass.config_entries.flow.async_init(
             "test", context={"source": config_entries.SOURCE_REAUTH}
         )
+
+        await hass.async_block_till_done()
+        state = hass.states.get("persistent_notification.config_entry_reconfigure")
+        assert state is not None
+        # Ensure we do not fire the exact same notification a second time when
+        # it is already present
+        assert state.last_updated == first_notification_updated_time
 
         flow1 = await hass.config_entries.flow.async_configure(flow1["flow_id"], {})
         assert flow1["type"] == data_entry_flow.RESULT_TYPE_ABORT


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
During startup there can be a storm of discovered device notifications
if there are large amount of esphome/etc devices on the network which
can cause a bit of I/O from all the events.

Solves this storm of events:
```
2021-05-23 15:23:11 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event service_registered[L]: domain=notify, service=persistent_notification>
2021-05-23 15:23:11 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=dismiss, service_data=notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event state_changed[L]: entity_id=persistent_notification.config_entry_discovery, old_state=None, new_state=<state persistent_notification.config_entry_discovery=notifying; title=New devices discovered, friendly_name=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations). @ 2021-05-23T10:23:31.949354-05:00>>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:31 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:33 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:34 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:34 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:34 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:34 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:34 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:35 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:35 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:35 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:35 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:36 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
2021-05-23 15:23:49 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event call_service[L]: domain=persistent_notification, service=create, service_data=title=New devices discovered, message=We have discovered new devices on your network. [Check it out](/config/integrations)., notification_id=config_entry_discovery>
2021-05-23 15:23:49 DEBUG (MainThread) [homeassistant.core] Bus:Handling <Event persistent_notifications_updated[L]>
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
