### PR TITLE
Remove device_registry fixture from zwave_js tests

### DIFF
--- a/tests/components/zwave_js/conftest.py
+++ b/tests/components/zwave_js/conftest.py
@@ -10,8 +10,6 @@ from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node
 from zwave_js_server.version import VersionInfo
 
-from homeassistant.helpers.device_registry import async_get as async_get_device_registry
-
 from tests.common import MockConfigEntry, load_fixture
 
 # Add-on fixtures
@@ -135,12 +133,6 @@ def create_snapshot_fixture():
         "homeassistant.components.zwave_js.addon.async_create_snapshot"
     ) as create_shapshot:
         yield create_shapshot
-
-
-@pytest.fixture(name="device_registry")
-async def device_registry_fixture(hass):
-    """Return the device registry."""
-    return async_get_device_registry(hass)
 
 
 @pytest.fixture(name="controller_state", scope="session")

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -128,10 +128,9 @@ async def test_listen_failure(hass, client, error):
     assert entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_on_node_added_ready(
-    hass, multisensor_6_state, client, integration, device_registry
-):
+async def test_on_node_added_ready(hass, multisensor_6_state, client, integration):
     """Test we handle a ready node added event."""
+    dev_reg = dr.async_get(hass)
     node = Node(client, multisensor_6_state)
     event = {"node": node}
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
@@ -139,7 +138,7 @@ async def test_on_node_added_ready(
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert not state  # entity and device not yet added
-    assert not device_registry.async_get_device(
+    assert not dev_reg.async_get_device(
         identifiers={(DOMAIN, air_temperature_device_id)}
     )
 
@@ -150,9 +149,7 @@ async def test_on_node_added_ready(
 
     assert state  # entity and device added
     assert state.state != STATE_UNAVAILABLE
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
-    )
+    assert dev_reg.async_get_device(identifiers={(DOMAIN, air_temperature_device_id)})
 
 
 async def test_unique_id_migration_dupes(
@@ -473,10 +470,9 @@ async def test_old_entity_migration_notification_binary_sensor(
         )
 
 
-async def test_on_node_added_not_ready(
-    hass, multisensor_6_state, client, integration, device_registry
-):
+async def test_on_node_added_not_ready(hass, multisensor_6_state, client, integration):
     """Test we handle a non ready node added event."""
+    dev_reg = dr.async_get(hass)
     node_data = deepcopy(multisensor_6_state)  # Copy to allow modification in tests.
     node = Node(client, node_data)
     node.data["ready"] = False
@@ -486,7 +482,7 @@ async def test_on_node_added_not_ready(
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert not state  # entity and device not yet added
-    assert not device_registry.async_get_device(
+    assert not dev_reg.async_get_device(
         identifiers={(DOMAIN, air_temperature_device_id)}
     )
 
@@ -496,9 +492,7 @@ async def test_on_node_added_not_ready(
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert not state  # entity not yet added but device added in registry
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
-    )
+    assert dev_reg.async_get_device(identifiers={(DOMAIN, air_temperature_device_id)})
 
     node.data["ready"] = True
     node.emit("ready", event)
@@ -510,10 +504,9 @@ async def test_on_node_added_not_ready(
     assert state.state != STATE_UNAVAILABLE
 
 
-async def test_existing_node_ready(
-    hass, client, multisensor_6, integration, device_registry
-):
+async def test_existing_node_ready(hass, client, multisensor_6, integration):
     """Test we handle a ready node that exists during integration setup."""
+    dev_reg = dr.async_get(hass)
     node = multisensor_6
     air_temperature_device_id = f"{client.driver.controller.home_id}-{node.node_id}"
 
@@ -521,9 +514,7 @@ async def test_existing_node_ready(
 
     assert state  # entity and device added
     assert state.state != STATE_UNAVAILABLE
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
-    )
+    assert dev_reg.async_get_device(identifiers={(DOMAIN, air_temperature_device_id)})
 
 
 async def test_null_name(hass, client, null_name_check, integration):
@@ -532,8 +523,9 @@ async def test_null_name(hass, client, null_name_check, integration):
     assert hass.states.get(f"switch.node_{node.node_id}")
 
 
-async def test_existing_node_not_ready(hass, client, multisensor_6, device_registry):
+async def test_existing_node_not_ready(hass, client, multisensor_6):
     """Test we handle a non ready node that exists during integration setup."""
+    dev_reg = dr.async_get(hass)
     node = multisensor_6
     node.data = deepcopy(node.data)  # Copy to allow modification in tests.
     node.data["ready"] = False
@@ -548,7 +540,7 @@ async def test_existing_node_not_ready(hass, client, multisensor_6, device_regis
     state = hass.states.get(AIR_TEMPERATURE_SENSOR)
 
     assert not state  # entity not yet added
-    assert device_registry.async_get_device(  # device should be added
+    assert dev_reg.async_get_device(  # device should be added
         identifiers={(DOMAIN, air_temperature_device_id)}
     )
 
@@ -560,9 +552,7 @@ async def test_existing_node_not_ready(hass, client, multisensor_6, device_regis
 
     assert state  # entity and device added
     assert state.state != STATE_UNAVAILABLE
-    assert device_registry.async_get_device(
-        identifiers={(DOMAIN, air_temperature_device_id)}
-    )
+    assert dev_reg.async_get_device(identifiers={(DOMAIN, air_temperature_device_id)})
 
 
 async def test_start_addon(


### PR DESCRIPTION
## Proposed change
@balloob pointed out a while ago that there was no need for this fixture but I forgot to remove it (until now 😉 ).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
