### PR TITLE
Replace wrong domain returned from xbox api revisited

### DIFF
--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -55,7 +55,7 @@ class XboxBaseSensorEntity(CoordinatorEntity):
         # We need to also remove the 'mode=Padding' query because with it, it results in an error 400.
         url = URL(self.data.display_pic)
         if url.host == "images-eds.xboxlive.com":
-            url = url.with_host("images-eds-ssl.xboxlive.com")
+            url = url.with_host("images-eds-ssl.xboxlive.com").with_scheme('https')
         query = dict(url.query)
         query.pop("mode", None)
         return str(url.with_query(query))

--- a/homeassistant/components/xbox/base_sensor.py
+++ b/homeassistant/components/xbox/base_sensor.py
@@ -55,7 +55,7 @@ class XboxBaseSensorEntity(CoordinatorEntity):
         # We need to also remove the 'mode=Padding' query because with it, it results in an error 400.
         url = URL(self.data.display_pic)
         if url.host == "images-eds.xboxlive.com":
-            url = url.with_host("images-eds-ssl.xboxlive.com").with_scheme('https')
+            url = url.with_host("images-eds-ssl.xboxlive.com").with_scheme("https")
         query = dict(url.query)
         query.pop("mode", None)
         return str(url.with_query(query))


### PR DESCRIPTION
Somehow the fix of replacing the domain doesn't work on android, so explicit replacement of http to https protocol is needed.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In a previous PR (#47021) I proposed a change for replacing a domain because the xbox api sometimes returned a domain that's hosted on http instead of https. That meant that profile pictures were not loaded. The fix fixed the issue in browsers, but not in the app. An explicit replacement of http to https is needed. 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #47021
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
