### PR TITLE
Add Rainbird "Delay Irrigation" service

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -55,14 +55,38 @@ CONFIG_SCHEMA = vol.Schema(
     extra=vol.ALLOW_EXTRA,
 )
 
+ATTR_DAYS = "days"
+SERVICE_DELAY_IRRIGATION = "delay_irrigation"
+SERVICE_SCHEMA_DELAY_IRRIGATION = vol.Schema(
+    {
+        vol.Required(ATTR_DAYS): cv.positive_int,
+    }
+)
+
 
 def setup(hass, config):
     """Set up the Rain Bird component."""
 
     hass.data[DATA_RAINBIRD] = []
     success = False
+
     for controller_config in config[DOMAIN]:
         success = success or _setup_controller(hass, controller_config, config)
+
+    controller = None
+    if success:
+        controller = hass.data[DATA_RAINBIRD][0]
+
+    def delay_irrigation(service):
+        days = service.data[ATTR_DAYS]
+        controller.set_rain_delay(days=days)
+
+    hass.services.register(
+        DOMAIN,
+        SERVICE_DELAY_IRRIGATION,
+        delay_irrigation,
+        schema=SERVICE_SCHEMA_DELAY_IRRIGATION,
+    )
 
     return success
 

--- a/homeassistant/components/rainbird/services.yaml
+++ b/homeassistant/components/rainbird/services.yaml
@@ -19,3 +19,16 @@ start_irrigation:
           min: 1
           max: 1440
           unit_of_measurement: "minutes"
+delay_irrigation:
+  name: Delay irrigation
+  description: Delay the irrigation
+  fields:
+    days:
+      name: Days
+      description: Delay duration in days
+      required: true
+      selector:
+        number:
+          min: 1
+          max: 10
+          unit_of_measurement: "days"

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -9,7 +9,6 @@ from homeassistant.helpers import config_validation as cv
 from . import CONF_ZONES, DATA_RAINBIRD, DOMAIN, RAINBIRD_CONTROLLER
 
 ATTR_DURATION = "duration"
-ATTR_DAYS = "days"
 
 SERVICE_START_IRRIGATION = "start_irrigation"
 
@@ -17,14 +16,6 @@ SERVICE_SCHEMA_IRRIGATION = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_id,
         vol.Required(ATTR_DURATION): cv.positive_float,
-    }
-)
-
-SERVICE_DELAY_IRRIGATION = "delay_irrigation"
-
-SERVICE_SCHEMA_DELAY_IRRIGATION = vol.Schema(
-    {
-        vol.Required(ATTR_DAYS): cv.positive_float,
     }
 )
 
@@ -71,18 +62,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         SERVICE_START_IRRIGATION,
         start_irrigation,
         schema=SERVICE_SCHEMA_IRRIGATION,
-    )
-
-    def delay_irrigation(service):
-        days = service.data[ATTR_DAYS]
-
-        controller.set_rain_delay(days=days)
-
-    hass.services.register(
-        DOMAIN,
-        SERVICE_DELAY_IRRIGATION,
-        delay_irrigation,
-        schema=SERVICE_SCHEMA_DELAY_IRRIGATION,
     )
 
 

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import config_validation as cv
 from . import CONF_ZONES, DATA_RAINBIRD, DOMAIN, RAINBIRD_CONTROLLER
 
 ATTR_DURATION = "duration"
+ATTR_DAYS = "days"
 
 SERVICE_START_IRRIGATION = "start_irrigation"
 
@@ -16,6 +17,14 @@ SERVICE_SCHEMA_IRRIGATION = vol.Schema(
     {
         vol.Required(ATTR_ENTITY_ID): cv.entity_id,
         vol.Required(ATTR_DURATION): cv.positive_float,
+    }
+)
+
+SERVICE_DELAY_IRRIGATION = "delay_irrigation"
+
+SERVICE_SCHEMA_DELAY_IRRIGATION = vol.Schema(
+    {
+        vol.Required(ATTR_DAYS): cv.positive_float,
     }
 )
 
@@ -62,6 +71,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
         SERVICE_START_IRRIGATION,
         start_irrigation,
         schema=SERVICE_SCHEMA_IRRIGATION,
+    )
+
+    def delay_irrigation(service):
+        days = service.data[ATTR_DAYS]
+
+        controller.set_rain_delay(days=days)
+
+    hass.services.register(
+        DOMAIN,
+        SERVICE_DELAY_IRRIGATION,
+        delay_irrigation,
+        schema=SERVICE_SCHEMA_DELAY_IRRIGATION,
     )
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rainbird component currently support only **Start Irrigation** service and I suggest to add also  **Delay Irrigation** service to build automation based on meteo information (for example in my case I'd like to use the daily rain metric to decide if delay or not my garden irrigation schedule).

The routine is already implemented in the [pyrainbird function](https://github.com/jbarrancos/pyrainbird/blob/d9fc7b4a1c845277ef6f0b4501e8053ef0556453/pyrainbird/__init__.py#L154).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
