### PR TITLE
Adjust zwave_js WS API commands for logging

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1027,10 +1027,12 @@ async def websocket_subscribe_logs(
                 msg[ID],
                 {
                     "type": "log_message",
-                    "timestamp": log_msg.timestamp,
-                    "level": log_msg.level,
-                    "primary_tags": log_msg.primary_tags,
-                    "message": log_msg.formatted_message,
+                    "log_message": {
+                        "timestamp": log_msg.timestamp,
+                        "level": log_msg.level,
+                        "primary_tags": log_msg.primary_tags,
+                        "message": log_msg.formatted_message,
+                    },
                 },
             )
         )
@@ -1043,7 +1045,7 @@ async def websocket_subscribe_logs(
                 msg[ID],
                 {
                     "type": "log_config",
-                    "config": dataclasses.asdict(log_config),
+                    "log_config": dataclasses.asdict(log_config),
                 },
             )
         )

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -157,7 +157,6 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_heal_node)
     websocket_api.async_register_command(hass, websocket_set_config_parameter)
     websocket_api.async_register_command(hass, websocket_get_config_parameters)
-    websocket_api.async_register_command(hass, websocket_subscribe_logs)
     websocket_api.async_register_command(hass, websocket_subscribe_log_updates)
     websocket_api.async_register_command(hass, websocket_update_log_config)
     websocket_api.async_register_command(hass, websocket_get_log_config)

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1408,10 +1408,12 @@ async def test_subscribe_logs(hass, integration, client, hass_ws_client):
     msg = await ws_client.receive_json()
     assert msg["event"] == {
         "type": "log_message",
-        "message": ["test"],
-        "level": "debug",
-        "primary_tags": "tag",
-        "timestamp": "time",
+        "log_message": {
+            "message": ["test"],
+            "level": "debug",
+            "primary_tags": "tag",
+            "timestamp": "time",
+        },
     }
 
     event = Event(
@@ -1433,7 +1435,7 @@ async def test_subscribe_logs(hass, integration, client, hass_ws_client):
     msg = await ws_client.receive_json()
     assert msg["event"] == {
         "type": "log_config",
-        "config": {
+        "log_config": {
             "enabled": False,
             "level": "error",
             "log_to_file": True,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1372,15 +1372,15 @@ async def test_view_invalid_node_id(integration, hass_client, method, url):
     assert resp.status == 404
 
 
-async def test_subscribe_logs(hass, integration, client, hass_ws_client):
-    """Test the subscribe_logs websocket command."""
+async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
+    """Test the subscribe_log_updates websocket command."""
     entry = integration
     ws_client = await hass_ws_client(hass)
 
     client.async_send_command.return_value = {}
 
     await ws_client.send_json(
-        {ID: 1, TYPE: "zwave_js/subscribe_logs", ENTRY_ID: entry.entry_id}
+        {ID: 1, TYPE: "zwave_js/subscribe_log_updates", ENTRY_ID: entry.entry_id}
     )
 
     msg = await ws_client.receive_json()
@@ -1449,7 +1449,7 @@ async def test_subscribe_logs(hass, integration, client, hass_ws_client):
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 2, TYPE: "zwave_js/subscribe_logs", ENTRY_ID: entry.entry_id}
+        {ID: 2, TYPE: "zwave_js/subscribe_log_updates", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 


### PR DESCRIPTION
## Breaking change
The name of the WS API command to subscribe to logs has changed as well as the signature of the payload that gets sent.


## Proposed change
Handle upstream changes to access the log config from the lib instead of requesting it from the server. We will also receive log config updates so that we can update the internal frontend state as needed.

Must be merged in coordination with https://github.com/home-assistant/frontend/pull/9262


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
