### PR TITLE
Fix zwave_js.set_value schema

### DIFF
--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -124,7 +124,7 @@ class ZWaveServices:
             const.DOMAIN,
             const.SERVICE_SET_VALUE,
             self.async_set_value,
-            schema=vol.Schema(
+            schema=vol.All(
                 {
                     vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
                     vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -67,22 +67,26 @@ class ZWaveServices:
             const.DOMAIN,
             const.SERVICE_SET_CONFIG_PARAMETER,
             self.async_set_config_parameter,
-            schema=vol.All(
-                {
-                    vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-                    vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Any(
-                        vol.Coerce(int), cv.string
-                    ),
-                    vol.Optional(const.ATTR_CONFIG_PARAMETER_BITMASK): vol.Any(
-                        vol.Coerce(int), BITMASK_SCHEMA
-                    ),
-                    vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
-                        vol.Coerce(int), cv.string
-                    ),
-                },
-                cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
-                parameter_name_does_not_need_bitmask,
+            schema=vol.Schema(
+                vol.All(
+                    {
+                        vol.Optional(ATTR_DEVICE_ID): vol.All(
+                            cv.ensure_list, [cv.string]
+                        ),
+                        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                        vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Any(
+                            vol.Coerce(int), cv.string
+                        ),
+                        vol.Optional(const.ATTR_CONFIG_PARAMETER_BITMASK): vol.Any(
+                            vol.Coerce(int), BITMASK_SCHEMA
+                        ),
+                        vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
+                            vol.Coerce(int), cv.string
+                        ),
+                    },
+                    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
+                    parameter_name_does_not_need_bitmask,
+                ),
             ),
         )
 
@@ -90,21 +94,25 @@ class ZWaveServices:
             const.DOMAIN,
             const.SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
             self.async_bulk_set_partial_config_parameters,
-            schema=vol.All(
-                {
-                    vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-                    vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Coerce(int),
-                    vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
-                        vol.Coerce(int),
-                        {
-                            vol.Any(
-                                vol.Coerce(int), BITMASK_SCHEMA, cv.string
-                            ): vol.Any(vol.Coerce(int), cv.string)
-                        },
-                    ),
-                },
-                cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
+            schema=vol.Schema(
+                vol.All(
+                    {
+                        vol.Optional(ATTR_DEVICE_ID): vol.All(
+                            cv.ensure_list, [cv.string]
+                        ),
+                        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                        vol.Required(const.ATTR_CONFIG_PARAMETER): vol.Coerce(int),
+                        vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
+                            vol.Coerce(int),
+                            {
+                                vol.Any(
+                                    vol.Coerce(int), BITMASK_SCHEMA, cv.string
+                                ): vol.Any(vol.Coerce(int), cv.string)
+                            },
+                        ),
+                    },
+                    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
+                ),
             ),
         )
 
@@ -124,22 +132,28 @@ class ZWaveServices:
             const.DOMAIN,
             const.SERVICE_SET_VALUE,
             self.async_set_value,
-            schema=vol.All(
-                {
-                    vol.Optional(ATTR_DEVICE_ID): vol.All(cv.ensure_list, [cv.string]),
-                    vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
-                    vol.Required(const.ATTR_COMMAND_CLASS): vol.Coerce(int),
-                    vol.Required(const.ATTR_PROPERTY): vol.Any(vol.Coerce(int), str),
-                    vol.Optional(const.ATTR_PROPERTY_KEY): vol.Any(
-                        vol.Coerce(int), str
-                    ),
-                    vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
-                    vol.Required(const.ATTR_VALUE): vol.Any(
-                        bool, vol.Coerce(int), vol.Coerce(float), cv.string
-                    ),
-                    vol.Optional(const.ATTR_WAIT_FOR_RESULT): vol.Coerce(bool),
-                },
-                cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
+            schema=vol.Schema(
+                vol.All(
+                    {
+                        vol.Optional(ATTR_DEVICE_ID): vol.All(
+                            cv.ensure_list, [cv.string]
+                        ),
+                        vol.Optional(ATTR_ENTITY_ID): cv.entity_ids,
+                        vol.Required(const.ATTR_COMMAND_CLASS): vol.Coerce(int),
+                        vol.Required(const.ATTR_PROPERTY): vol.Any(
+                            vol.Coerce(int), str
+                        ),
+                        vol.Optional(const.ATTR_PROPERTY_KEY): vol.Any(
+                            vol.Coerce(int), str
+                        ),
+                        vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
+                        vol.Required(const.ATTR_VALUE): vol.Any(
+                            bool, vol.Coerce(int), vol.Coerce(float), cv.string
+                        ),
+                        vol.Optional(const.ATTR_WAIT_FOR_RESULT): vol.Coerce(bool),
+                    },
+                    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
+                ),
             ),
         )
 

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -598,6 +598,29 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
             blocking=True,
         )
 
+    assert len(client.async_send_command.call_args_list) == 1
+
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 5
+    assert args["valueId"] == {
+        "commandClassName": "Protection",
+        "commandClass": 117,
+        "endpoint": 0,
+        "property": "local",
+        "propertyName": "local",
+        "ccVersion": 2,
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "Local protection state",
+            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
+        },
+        "value": 0,
+    }
+    assert args["value"] == 2
+
     # Test missing device and entities keys
     with pytest.raises(vol.MultipleInvalid):
         await hass.services.async_call(

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -598,24 +598,16 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
             blocking=True,
         )
 
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "node.set_value"
-    assert args["nodeId"] == 5
-    assert args["valueId"] == {
-        "commandClassName": "Protection",
-        "commandClass": 117,
-        "endpoint": 0,
-        "property": "local",
-        "propertyName": "local",
-        "ccVersion": 2,
-        "metadata": {
-            "type": "number",
-            "readable": True,
-            "writeable": True,
-            "label": "Local protection state",
-            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
-        },
-        "value": 0,
-    }
-    assert args["value"] == 2
+    # Test missing device and entities keys
+    with pytest.raises(vol.MultipleInvalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_VALUE,
+            {
+                ATTR_COMMAND_CLASS: 117,
+                ATTR_PROPERTY: "local",
+                ATTR_VALUE: 2,
+                ATTR_WAIT_FOR_RESULT: True,
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
## Proposed change
While working on the `zwave_js.multicast_set_value` schema I noticed that the schema for `zwave_js.set_value` was wrong and a test was missing. Here we correct it and add an additional test to catch it 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
