### PR TITLE
Remove "old" config from modbus binary_sensor

### DIFF
--- a/homeassistant/components/modbus/binary_sensor.py
+++ b/homeassistant/components/modbus/binary_sensor.py
@@ -3,68 +3,17 @@ from __future__ import annotations
 
 import logging
 
-import voluptuous as vol
-
-from homeassistant.components.binary_sensor import (
-    DEVICE_CLASSES_SCHEMA,
-    PLATFORM_SCHEMA,
-    BinarySensorEntity,
-)
-from homeassistant.const import (
-    CONF_ADDRESS,
-    CONF_BINARY_SENSORS,
-    CONF_DEVICE_CLASS,
-    CONF_NAME,
-    CONF_SCAN_INTERVAL,
-    CONF_SLAVE,
-    STATE_ON,
-)
+from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.const import CONF_BINARY_SENSORS, CONF_NAME, STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .base_platform import BasePlatform
-from .const import (
-    CALL_TYPE_COIL,
-    CALL_TYPE_DISCRETE,
-    CONF_COILS,
-    CONF_HUB,
-    CONF_INPUT_TYPE,
-    CONF_INPUTS,
-    DEFAULT_HUB,
-    DEFAULT_SCAN_INTERVAL,
-    MODBUS_DOMAIN,
-)
+from .const import MODBUS_DOMAIN
 
 PARALLEL_UPDATES = 1
 _LOGGER = logging.getLogger(__name__)
-
-
-PLATFORM_SCHEMA = vol.All(
-    cv.deprecated(CONF_COILS, CONF_INPUTS),
-    PLATFORM_SCHEMA.extend(
-        {
-            vol.Required(CONF_INPUTS): [
-                vol.All(
-                    cv.deprecated(CALL_TYPE_COIL, CONF_ADDRESS),
-                    vol.Schema(
-                        {
-                            vol.Required(CONF_ADDRESS): cv.positive_int,
-                            vol.Required(CONF_NAME): cv.string,
-                            vol.Optional(CONF_DEVICE_CLASS): DEVICE_CLASSES_SCHEMA,
-                            vol.Optional(CONF_HUB, default=DEFAULT_HUB): cv.string,
-                            vol.Optional(CONF_SLAVE): cv.positive_int,
-                            vol.Optional(
-                                CONF_INPUT_TYPE, default=CALL_TYPE_COIL
-                            ): vol.In([CALL_TYPE_COIL, CALL_TYPE_DISCRETE]),
-                        }
-                    ),
-                )
-            ]
-        }
-    ),
-)
 
 
 async def async_setup_platform(
@@ -76,23 +25,11 @@ async def async_setup_platform(
     """Set up the Modbus binary sensors."""
     sensors = []
 
-    #  check for old config:
-    if discovery_info is None:
-        _LOGGER.warning(
-            "Binary_sensor configuration is deprecated, will be removed in a future release"
-        )
-        discovery_info = {
-            CONF_NAME: "no name",
-            CONF_BINARY_SENSORS: config[CONF_INPUTS],
-        }
+    if discovery_info is None:  # pragma: no cover
+        return
 
     for entry in discovery_info[CONF_BINARY_SENSORS]:
-        if CONF_HUB in entry:
-            hub = hass.data[MODBUS_DOMAIN][entry[CONF_HUB]]
-        else:
-            hub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
-        if CONF_SCAN_INTERVAL not in entry:
-            entry[CONF_SCAN_INTERVAL] = DEFAULT_SCAN_INTERVAL
+        hub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
         sensors.append(ModbusBinarySensor(hub, entry))
 
     async_add_entities(sensors)

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -6,7 +6,6 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_DISCRETE,
     CONF_INPUT_TYPE,
-    CONF_INPUTS,
 )
 from homeassistant.const import (
     CONF_ADDRESS,
@@ -25,7 +24,6 @@ from .conftest import ReadResult, base_config_test, base_test, prepare_service_u
 from tests.common import mock_restore_cache
 
 
-@pytest.mark.parametrize("do_discovery", [False, True])
 @pytest.mark.parametrize(
     "do_options",
     [
@@ -37,7 +35,7 @@ from tests.common import mock_restore_cache
         },
     ],
 )
-async def test_config_binary_sensor(hass, do_discovery, do_options):
+async def test_config_binary_sensor(hass, do_options):
     """Run test for binary sensor."""
     sensor_name = "test_sensor"
     config_sensor = {
@@ -51,8 +49,8 @@ async def test_config_binary_sensor(hass, do_discovery, do_options):
         sensor_name,
         SENSOR_DOMAIN,
         CONF_BINARY_SENSORS,
-        CONF_INPUTS,
-        method_discovery=do_discovery,
+        None,
+        method_discovery=True,
     )
 
 
@@ -95,7 +93,7 @@ async def test_all_binary_sensor(hass, do_type, regs, expected):
         sensor_name,
         SENSOR_DOMAIN,
         CONF_BINARY_SENSORS,
-        CONF_INPUTS,
+        None,
         regs,
         expected,
         method_discovery=True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
As announced in 2021.4, the “old style” yaml is deprecated and in 2021.7 it is removed:

Example “old style” configuration, that is now invalid:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502

binary_sensor:
  platform: modbus
  registers:
    - name: Sensor1
      hub: hub1
      slave: 1
      register: 100
```

Same configuration in valid new style:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    binary_sensors:
      - name: Sensor1
        slave: 1
        address: 100
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove PLATFORM schema from binary_sensor.py,
Remove "if old style" from code,
Remove "old style" testing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->
Documentation was updated to new style, months ago.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
