### PR TITLE
Enable temperature sensor for AVM Fritz!Smarthome devices

### DIFF
--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -33,16 +33,12 @@ async def async_setup_entry(
     coordinator = hass.data[FRITZBOX_DOMAIN][entry.entry_id][CONF_COORDINATOR]
 
     for ain, device in coordinator.data.items():
-        if (
-            device.has_temperature_sensor
-            and not device.has_switch
-            and not device.has_thermostat
-        ):
+        if device.has_temperature_sensor and not device.has_thermostat:
             entities.append(
                 FritzBoxTempSensor(
                     {
-                        ATTR_NAME: f"{device.name}",
-                        ATTR_ENTITY_ID: f"{device.ain}",
+                        ATTR_NAME: f"{device.name} Temperature",
+                        ATTR_ENTITY_ID: f"{device.ain}_temperature",
                         ATTR_UNIT_OF_MEASUREMENT: TEMP_CELSIUS,
                         ATTR_DEVICE_CLASS: None,
                     },

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -5,22 +5,16 @@ from typing import Any
 from unittest.mock import Mock
 
 from homeassistant.components.fritzbox.const import DOMAIN
-from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from .const import (
+    CONF_FAKE_AIN,
+    CONF_FAKE_MANUFACTURER,
+    CONF_FAKE_NAME,
+    CONF_FAKE_PRODUCTNAME,
+)
 
-MOCK_CONFIG = {
-    DOMAIN: {
-        CONF_DEVICES: [
-            {
-                CONF_HOST: "fake_host",
-                CONF_PASSWORD: "fake_pass",
-                CONF_USERNAME: "fake_user",
-            }
-        ]
-    }
-}
+from tests.common import MockConfigEntry
 
 
 async def setup_config_entry(
@@ -45,27 +39,32 @@ async def setup_config_entry(
     return result
 
 
-class FritzDeviceBinarySensorMock(Mock):
+class FritzDeviceBaseMock(Mock):
+    """base mock of a AVM Fritz!Box binary sensor device."""
+
+    ain = CONF_FAKE_AIN
+    manufacturer = CONF_FAKE_MANUFACTURER
+    name = CONF_FAKE_NAME
+    productname = CONF_FAKE_PRODUCTNAME
+
+
+class FritzDeviceBinarySensorMock(FritzDeviceBaseMock):
     """Mock of a AVM Fritz!Box binary sensor device."""
 
-    ain = "fake_ain"
     alert_state = "fake_state"
+    battery_level = 23
     fw_version = "1.2.3"
     has_alarm = True
     has_switch = False
     has_temperature_sensor = False
     has_thermostat = False
-    manufacturer = "fake_manufacturer"
-    name = "fake_name"
     present = True
-    productname = "fake_productname"
 
 
-class FritzDeviceClimateMock(Mock):
+class FritzDeviceClimateMock(FritzDeviceBaseMock):
     """Mock of a AVM Fritz!Box climate device."""
 
     actual_temperature = 18.0
-    ain = "fake_ain"
     alert_state = "fake_state"
     battery_level = 23
     battery_low = True
@@ -79,19 +78,15 @@ class FritzDeviceClimateMock(Mock):
     has_thermostat = True
     holiday_active = "fake_holiday"
     lock = "fake_locked"
-    manufacturer = "fake_manufacturer"
-    name = "fake_name"
     present = True
-    productname = "fake_productname"
     summer_active = "fake_summer"
     target_temperature = 19.5
     window_open = "fake_window"
 
 
-class FritzDeviceSensorMock(Mock):
+class FritzDeviceSensorMock(FritzDeviceBaseMock):
     """Mock of a AVM Fritz!Box sensor device."""
 
-    ain = "fake_ain"
     battery_level = 23
     device_lock = "fake_locked_device"
     fw_version = "1.2.3"
@@ -100,17 +95,14 @@ class FritzDeviceSensorMock(Mock):
     has_temperature_sensor = True
     has_thermostat = False
     lock = "fake_locked"
-    manufacturer = "fake_manufacturer"
-    name = "fake_name"
     present = True
-    productname = "fake_productname"
     temperature = 1.23
 
 
-class FritzDeviceSwitchMock(Mock):
+class FritzDeviceSwitchMock(FritzDeviceBaseMock):
     """Mock of a AVM Fritz!Box switch device."""
 
-    ain = "fake_ain"
+    battery_level = None
     device_lock = "fake_locked_device"
     energy = 1234
     fw_version = "1.2.3"
@@ -120,9 +112,6 @@ class FritzDeviceSwitchMock(Mock):
     has_thermostat = False
     switch_state = "fake_state"
     lock = "fake_locked"
-    manufacturer = "fake_manufacturer"
-    name = "fake_name"
     power = 5678
     present = True
-    productname = "fake_productname"
-    temperature = 135
+    temperature = 1.23

--- a/tests/components/fritzbox/const.py
+++ b/tests/components/fritzbox/const.py
@@ -1,0 +1,20 @@
+"""Constants for fritzbox tests."""
+from homeassistant.components.fritzbox.const import DOMAIN
+from homeassistant.const import CONF_DEVICES, CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+MOCK_CONFIG = {
+    DOMAIN: {
+        CONF_DEVICES: [
+            {
+                CONF_HOST: "fake_host",
+                CONF_PASSWORD: "fake_pass",
+                CONF_USERNAME: "fake_user",
+            }
+        ]
+    }
+}
+
+CONF_FAKE_NAME = "fake_name"
+CONF_FAKE_AIN = "fake_ain"
+CONF_FAKE_MANUFACTURER = "fake_manufacturer"
+CONF_FAKE_PRODUCTNAME = "fake_productname"

--- a/tests/components/fritzbox/test_binary_sensor.py
+++ b/tests/components/fritzbox/test_binary_sensor.py
@@ -7,21 +7,25 @@ from requests.exceptions import HTTPError
 
 from homeassistant.components.binary_sensor import DOMAIN
 from homeassistant.components.fritzbox.const import DOMAIN as FB_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_FRIENDLY_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
+    PERCENTAGE,
     STATE_OFF,
     STATE_ON,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceBinarySensorMock, setup_config_entry
+from . import FritzDeviceBinarySensorMock, setup_config_entry
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
 
-ENTITY_ID = f"{DOMAIN}.fake_name"
+ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
 async def test_setup(hass: HomeAssistant, fritz: Mock):
@@ -34,8 +38,14 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.state == STATE_ON
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == CONF_FAKE_NAME
     assert state.attributes[ATTR_DEVICE_CLASS] == "window"
+
+    state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_battery")
+    assert state
+    assert state.state == "23"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Battery"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 
 async def test_is_off(hass: HomeAssistant, fritz: Mock):

--- a/tests/components/fritzbox/test_climate.py
+++ b/tests/components/fritzbox/test_climate.py
@@ -30,21 +30,25 @@ from homeassistant.components.fritzbox.const import (
     ATTR_STATE_WINDOW_OPEN,
     DOMAIN as FB_DOMAIN,
 )
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_BATTERY_LEVEL,
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_TEMPERATURE,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
+    PERCENTAGE,
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceClimateMock, setup_config_entry
+from . import FritzDeviceClimateMock, setup_config_entry
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
 
-ENTITY_ID = f"{DOMAIN}.fake_name"
+ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
 async def test_setup(hass: HomeAssistant, fritz: Mock):
@@ -58,7 +62,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state
     assert state.attributes[ATTR_BATTERY_LEVEL] == 23
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] == 18
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == CONF_FAKE_NAME
     assert state.attributes[ATTR_HVAC_MODES] == [HVAC_MODE_HEAT, HVAC_MODE_OFF]
     assert state.attributes[ATTR_MAX_TEMP] == 28
     assert state.attributes[ATTR_MIN_TEMP] == 8
@@ -72,6 +76,12 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_STATE_WINDOW_OPEN] == "fake_window"
     assert state.attributes[ATTR_TEMPERATURE] == 19.5
     assert state.state == HVAC_MODE_HEAT
+
+    state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_battery")
+    assert state
+    assert state.state == "23"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Battery"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 
 async def test_target_temperature_on(hass: HomeAssistant, fritz: Mock):

--- a/tests/components/fritzbox/test_config_flow.py
+++ b/tests/components/fritzbox/test_config_flow.py
@@ -21,14 +21,14 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from . import MOCK_CONFIG
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import MockConfigEntry
 
 MOCK_USER_DATA = MOCK_CONFIG[DOMAIN][CONF_DEVICES][0]
 MOCK_SSDP_DATA = {
     ATTR_SSDP_LOCATION: "https://fake_host:12345/test",
-    ATTR_UPNP_FRIENDLY_NAME: "fake_name",
+    ATTR_UPNP_FRIENDLY_NAME: CONF_FAKE_NAME,
     ATTR_UPNP_UDN: "uuid:only-a-test",
 }
 
@@ -192,7 +192,7 @@ async def test_ssdp(hass: HomeAssistant, fritz: Mock):
         user_input={CONF_PASSWORD: "fake_pass", CONF_USERNAME: "fake_user"},
     )
     assert result["type"] == RESULT_TYPE_CREATE_ENTRY
-    assert result["title"] == "fake_name"
+    assert result["title"] == CONF_FAKE_NAME
     assert result["data"][CONF_HOST] == "fake_host"
     assert result["data"][CONF_PASSWORD] == "fake_pass"
     assert result["data"][CONF_USERNAME] == "fake_user"

--- a/tests/components/fritzbox/test_init.py
+++ b/tests/components/fritzbox/test_init.py
@@ -18,7 +18,8 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import MOCK_CONFIG, FritzDeviceSwitchMock, setup_config_entry
+from . import FritzDeviceSwitchMock, setup_config_entry
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import MockConfigEntry
 
@@ -74,7 +75,7 @@ async def test_coordinator_update_after_password_change(
 async def test_unload_remove(hass: HomeAssistant, fritz: Mock):
     """Test unload and remove of integration."""
     fritz().get_devices.return_value = [FritzDeviceSwitchMock()]
-    entity_id = f"{SWITCH_DOMAIN}.fake_name"
+    entity_id = f"{SWITCH_DOMAIN}.{CONF_FAKE_NAME}"
 
     entry = MockConfigEntry(
         domain=FB_DOMAIN,

--- a/tests/components/fritzbox/test_sensor.py
+++ b/tests/components/fritzbox/test_sensor.py
@@ -20,11 +20,12 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceSensorMock, setup_config_entry
+from . import FritzDeviceSensorMock, setup_config_entry
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
 
-ENTITY_ID = f"{DOMAIN}.fake_name"
+ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
 async def test_setup(hass: HomeAssistant, fritz: Mock):
@@ -33,11 +34,12 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert await setup_config_entry(
         hass, MOCK_CONFIG[FB_DOMAIN][CONF_DEVICES][0], ENTITY_ID, device, fritz
     )
+    await hass.async_block_till_done()
 
-    state = hass.states.get(ENTITY_ID)
+    state = hass.states.get(f"{ENTITY_ID}_temperature")
     assert state
     assert state.state == "1.23"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Temperature"
     assert state.attributes[ATTR_STATE_DEVICE_LOCKED] == "fake_locked_device"
     assert state.attributes[ATTR_STATE_LOCKED] == "fake_locked"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
@@ -45,7 +47,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     state = hass.states.get(f"{ENTITY_ID}_battery")
     assert state
     assert state.state == "23"
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name Battery"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Battery"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == PERCENTAGE
 
 

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -12,11 +12,13 @@ from homeassistant.components.fritzbox.const import (
     ATTR_TOTAL_CONSUMPTION_UNIT,
     DOMAIN as FB_DOMAIN,
 )
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import ATTR_CURRENT_POWER_W, DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
     ATTR_TEMPERATURE,
+    ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
     ENERGY_KILO_WATT_HOUR,
     SERVICE_TURN_OFF,
@@ -27,11 +29,12 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 import homeassistant.util.dt as dt_util
 
-from . import MOCK_CONFIG, FritzDeviceSwitchMock, setup_config_entry
+from . import FritzDeviceSwitchMock, setup_config_entry
+from .const import CONF_FAKE_NAME, MOCK_CONFIG
 
 from tests.common import async_fire_time_changed
 
-ENTITY_ID = f"{DOMAIN}.fake_name"
+ENTITY_ID = f"{DOMAIN}.{CONF_FAKE_NAME}"
 
 
 async def test_setup(hass: HomeAssistant, fritz: Mock):
@@ -45,13 +48,21 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state
     assert state.state == STATE_ON
     assert state.attributes[ATTR_CURRENT_POWER_W] == 5.678
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "fake_name"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == CONF_FAKE_NAME
     assert state.attributes[ATTR_STATE_DEVICE_LOCKED] == "fake_locked_device"
     assert state.attributes[ATTR_STATE_LOCKED] == "fake_locked"
-    assert state.attributes[ATTR_TEMPERATURE] == "135"
+    assert state.attributes[ATTR_TEMPERATURE] == "1.23"
     assert state.attributes[ATTR_TEMPERATURE_UNIT] == TEMP_CELSIUS
     assert state.attributes[ATTR_TOTAL_CONSUMPTION] == "1.234"
     assert state.attributes[ATTR_TOTAL_CONSUMPTION_UNIT] == ENERGY_KILO_WATT_HOUR
+
+    state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_temperature")
+    assert state
+    assert state.state == "1.23"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Temperature"
+    assert state.attributes[ATTR_STATE_DEVICE_LOCKED] == "fake_locked_device"
+    assert state.attributes[ATTR_STATE_LOCKED] == "fake_locked"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
 
 
 async def test_turn_on(hass: HomeAssistant, fritz: Mock):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
For temperature sensors, entity id is now suffixed with `_temperature` as well as entity name is suffixed with ` Temperature`.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Unfortunately  `FritzBoxTempSensor` was never used, since only switch devices does have an additional temperature sensor integrated, but were excluded by `not device.has_switch`.
Nevertheless, small refactor of tests was also needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
