### PR TITLE
Add deprecated backwards compatible history.LazyState

### DIFF
--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -113,10 +113,6 @@ async def async_setup(hass, config):
 class LazyState(history_models.LazyState):
     """A lazy version of core State."""
 
-    def __init__(self, *args, **kwargs):
-        """Init the lazy state."""
-        super().__init__(*args, **kwargs)
-
 
 @websocket_api.websocket_command(
     {

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -13,8 +13,7 @@ import voluptuous as vol
 
 from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView
-from homeassistant.components.recorder import history
-from homeassistant.components.recorder.models import States
+from homeassistant.components.recorder import history, models as history_models
 from homeassistant.components.recorder.statistics import statistics_during_period
 from homeassistant.components.recorder.util import session_scope
 from homeassistant.const import (
@@ -108,6 +107,15 @@ async def async_setup(hass, config):
     )
 
     return True
+
+
+class LazyState(history_models.LazyState):
+    """A lazy version of core State."""
+
+    @deprecated_function("homeassistant.components.recorder.models.LazyState")
+    def __init__(self, *args, **kwargs):
+        """Init the lazy state."""
+        super().__init__(*args, **kwargs)
 
 
 @websocket_api.websocket_command(
@@ -345,17 +353,17 @@ class Filters:
         """Generate the entity filter query."""
         includes = []
         if self.included_domains:
-            includes.append(States.domain.in_(self.included_domains))
+            includes.append(history_models.States.domain.in_(self.included_domains))
         if self.included_entities:
-            includes.append(States.entity_id.in_(self.included_entities))
+            includes.append(history_models.States.entity_id.in_(self.included_entities))
         for glob in self.included_entity_globs:
             includes.append(_glob_to_like(glob))
 
         excludes = []
         if self.excluded_domains:
-            excludes.append(States.domain.in_(self.excluded_domains))
+            excludes.append(history_models.States.domain.in_(self.excluded_domains))
         if self.excluded_entities:
-            excludes.append(States.entity_id.in_(self.excluded_entities))
+            excludes.append(history_models.States.entity_id.in_(self.excluded_entities))
         for glob in self.excluded_entity_globs:
             excludes.append(_glob_to_like(glob))
 
@@ -373,7 +381,7 @@ class Filters:
 
 def _glob_to_like(glob_str):
     """Translate glob to sql."""
-    return States.entity_id.like(glob_str.translate(GLOB_TO_SQL_CHARS))
+    return history_models.States.entity_id.like(glob_str.translate(GLOB_TO_SQL_CHARS))
 
 
 def _entities_may_have_state_changes_after(

--- a/homeassistant/components/history/__init__.py
+++ b/homeassistant/components/history/__init__.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
-from homeassistant.helpers.deprecation import deprecated_function
+from homeassistant.helpers.deprecation import deprecated_class, deprecated_function
 from homeassistant.helpers.entityfilter import (
     CONF_ENTITY_GLOBS,
     INCLUDE_EXCLUDE_BASE_FILTER_SCHEMA,
@@ -109,10 +109,10 @@ async def async_setup(hass, config):
     return True
 
 
+@deprecated_class("homeassistant.components.recorder.models.LazyState")
 class LazyState(history_models.LazyState):
     """A lazy version of core State."""
 
-    @deprecated_function("homeassistant.components.recorder.models.LazyState")
     def __init__(self, *args, **kwargs):
         """Init the lazy state."""
         super().__init__(*args, **kwargs)

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -87,12 +87,12 @@ def deprecated_class(replacement: str) -> Any:
         """Decorate class as deprecated."""
 
         @functools.wraps(cls)
-        def deprecated_class(*args: tuple, **kwargs: dict[str, Any]) -> Any:
+        def deprecated_cls(*args: tuple, **kwargs: dict[str, Any]) -> Any:
             """Wrap for the original class."""
             _print_deprecation_warning(cls, replacement, "class")
             return cls(*args, **kwargs)
 
-        return deprecated_class
+        return deprecated_cls
 
     return deprecated_decorator
 

--- a/homeassistant/helpers/deprecation.py
+++ b/homeassistant/helpers/deprecation.py
@@ -80,6 +80,23 @@ def get_deprecated(
     return config.get(new_name, default)
 
 
+def deprecated_class(replacement: str) -> Any:
+    """Mark class as deprecated and provide a replacement class to be used instead."""
+
+    def deprecated_decorator(cls: Any) -> Any:
+        """Decorate class as deprecated."""
+
+        @functools.wraps(cls)
+        def deprecated_class(*args: tuple, **kwargs: dict[str, Any]) -> Any:
+            """Wrap for the original class."""
+            _print_deprecation_warning(cls, replacement, "class")
+            return cls(*args, **kwargs)
+
+        return deprecated_class
+
+    return deprecated_decorator
+
+
 def deprecated_function(replacement: str) -> Callable[..., Callable]:
     """Mark function as deprecated and provide a replacement function to be used instead."""
 
@@ -89,32 +106,39 @@ def deprecated_function(replacement: str) -> Callable[..., Callable]:
         @functools.wraps(func)
         def deprecated_func(*args: tuple, **kwargs: dict[str, Any]) -> Any:
             """Wrap for the original function."""
-            logger = logging.getLogger(func.__module__)
-            try:
-                _, integration, path = get_integration_frame()
-                if path == "custom_components/":
-                    logger.warning(
-                        "%s was called from %s, this is a deprecated function. Use %s instead, please report this to the maintainer of %s",
-                        func.__name__,
-                        integration,
-                        replacement,
-                        integration,
-                    )
-                else:
-                    logger.warning(
-                        "%s was called from %s, this is a deprecated function. Use %s instead",
-                        func.__name__,
-                        integration,
-                        replacement,
-                    )
-            except MissingIntegrationFrame:
-                logger.warning(
-                    "%s is a deprecated function. Use %s instead",
-                    func.__name__,
-                    replacement,
-                )
+            _print_deprecation_warning(func, replacement, "function")
             return func(*args, **kwargs)
 
         return deprecated_func
 
     return deprecated_decorator
+
+
+def _print_deprecation_warning(obj: Any, replacement: str, description: str) -> None:
+    logger = logging.getLogger(obj.__module__)
+    try:
+        _, integration, path = get_integration_frame()
+        if path == "custom_components/":
+            logger.warning(
+                "%s was called from %s, this is a deprecated %s. Use %s instead, please report this to the maintainer of %s",
+                obj.__name__,
+                integration,
+                description,
+                replacement,
+                integration,
+            )
+        else:
+            logger.warning(
+                "%s was called from %s, this is a deprecated %s. Use %s instead",
+                obj.__name__,
+                integration,
+                description,
+                replacement,
+            )
+    except MissingIntegrationFrame:
+        logger.warning(
+            "%s is a deprecated %s. Use %s instead",
+            obj.__name__,
+            description,
+            replacement,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add deprecated backwards compatible `history.LazyState`

### Background:

PR #50287 did some refactoring of the history component. The intention was to be backwards compatible, but this was forgotten for `homeassistant.components.history.LazyState`

Note: The warning message is not perfect:
```
__init__ is a deprecated function. Use homeassistant.components.recorder.models.LazyState instead
```

Maybe we should add some logic to include the class name if the function is  `__init__`?

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51140
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
