### PR TITLE
Adjust segment duration calculation in stream

### DIFF
--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -18,8 +18,12 @@ FORMAT_CONTENT_TYPE = {HLS_PROVIDER: "application/vnd.apple.mpegurl"}
 OUTPUT_IDLE_TIMEOUT = 300  # Idle timeout due to inactivity
 
 NUM_PLAYLIST_SEGMENTS = 3  # Number of segments to use in HLS playlist
-MAX_SEGMENTS = 4  # Max number of segments to keep around
-MIN_SEGMENT_DURATION = 1.5  # Each segment is at least this many seconds
+MAX_SEGMENTS = 5  # Max number of segments to keep around
+TARGET_SEGMENT_DURATION = 2.0  # Each segment is about this many seconds
+SEGMENT_DURATION_ADJUSTER = 0.1  # Used to avoid missing keyframe boundaries
+MIN_SEGMENT_DURATION = (
+    TARGET_SEGMENT_DURATION - SEGMENT_DURATION_ADJUSTER
+)  # Each segment is at least this many seconds
 
 PACKETS_TO_WAIT_FOR_AUDIO = 20  # Some streams have an audio stream with no audio
 MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably reasonable

--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -18,7 +18,7 @@ FORMAT_CONTENT_TYPE = {HLS_PROVIDER: "application/vnd.apple.mpegurl"}
 OUTPUT_IDLE_TIMEOUT = 300  # Idle timeout due to inactivity
 
 NUM_PLAYLIST_SEGMENTS = 3  # Number of segments to use in HLS playlist
-MAX_SEGMENTS = 5  # Max number of segments to keep around
+MAX_SEGMENTS = 4  # Max number of segments to keep around
 TARGET_SEGMENT_DURATION = 2.0  # Each segment is about this many seconds
 SEGMENT_DURATION_ADJUSTER = 0.1  # Used to avoid missing keyframe boundaries
 MIN_SEGMENT_DURATION = (

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -105,7 +105,7 @@ class StreamOutput:
         return -1
 
     @property
-    def segments(self) -> list[int]:
+    def sequences(self) -> list[int]:
         """Return current sequence from segments."""
         return [s.sequence for s in self._segments]
 

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -36,7 +36,7 @@ class HlsMasterPlaylistView(StreamView):
         # Need to calculate max bandwidth as input_container.bit_rate doesn't seem to work
         # Calculate file size / duration and use a small multiplier to account for variation
         # hls spec already allows for 25% variation
-        segment = track.get_segment(track.segments[-1])
+        segment = track.get_segment(track.sequences[-1])
         bandwidth = round(
             (len(segment.init) + len(segment.moof_data)) * 8 / segment.duration * 1.2
         )
@@ -53,7 +53,7 @@ class HlsMasterPlaylistView(StreamView):
         track = stream.add_provider(HLS_PROVIDER)
         stream.start()
         # Wait for a segment to be ready
-        if not track.segments and not await track.recv():
+        if not track.sequences and not await track.recv():
             return web.HTTPNotFound()
         headers = {"Content-Type": FORMAT_CONTENT_TYPE[HLS_PROVIDER]}
         return web.Response(body=self.render(track).encode("utf-8"), headers=headers)
@@ -112,7 +112,7 @@ class HlsPlaylistView(StreamView):
         track = stream.add_provider(HLS_PROVIDER)
         stream.start()
         # Wait for a segment to be ready
-        if not track.segments and not await track.recv():
+        if not track.sequences and not await track.recv():
             return web.HTTPNotFound()
         headers = {"Content-Type": FORMAT_CONTENT_TYPE[HLS_PROVIDER]}
         return web.Response(body=self.render(track).encode("utf-8"), headers=headers)

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -254,6 +254,7 @@ async def test_skip_out_of_order_packet(hass):
     if packets[out_of_order_index].is_keyframe:
         out_of_order_index += 1
     # This packet is out of order
+    assert not packets[out_of_order_index].is_keyframe
     packets[out_of_order_index].dts = -9090
 
     decoded_stream = await async_decode_stream(hass, iter(packets))


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#49608 implements LL-HLS in stream, but that PR is too large, making it hard to review. This an intermediate PR which separates `TARGET_SEGMENT_DURATION` from `MIN_SEGMENT_DURATION`. Since keyframes come at a fixed interval, often 1 frame per second, using a whole number for the `MIN_SEGMENT_DURATION` might risk missing the intended keyframe in the event of a small timestamp adjustment. This led us to use decimal number for `MIN_SEGMENT_DURATION`. However, it is more clear to separate these two so that our `TARGET_SEGMENT_DURATION` can be a rounder number. This will be especially useful if we end up exposing these target durations in settings. Along with this change, there were some minor adjustments in `test_worker.py` to more accurately simulate periodic video keyframes.
Also, as an unrelated minor change,  `StreamOutput.segments` was renamed to `StreamOutput.sequences` as it seems more clear.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
