### PR TITLE
Change Cover to use address/input_type

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -68,7 +68,6 @@ from .const import (
     CONF_MIN_TEMP,
     CONF_PARITY,
     CONF_PRECISION,
-    CONF_REGISTER,
     CONF_REVERSE_ORDER,
     CONF_SCALE,
     CONF_STATE_CLOSED,
@@ -145,24 +144,26 @@ CLIMATE_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
     }
 )
 
-COVERS_SCHEMA = vol.All(
-    cv.has_at_least_one_key(CALL_TYPE_COIL, CONF_REGISTER),
-    BASE_COMPONENT_SCHEMA.extend(
-        {
-            vol.Optional(CONF_DEVICE_CLASS): COVER_DEVICE_CLASSES_SCHEMA,
-            vol.Optional(CONF_STATE_CLOSED, default=0): cv.positive_int,
-            vol.Optional(CONF_STATE_CLOSING, default=3): cv.positive_int,
-            vol.Optional(CONF_STATE_OPEN, default=1): cv.positive_int,
-            vol.Optional(CONF_STATE_OPENING, default=2): cv.positive_int,
-            vol.Optional(CONF_STATUS_REGISTER): cv.positive_int,
-            vol.Optional(
-                CONF_STATUS_REGISTER_TYPE,
-                default=CALL_TYPE_REGISTER_HOLDING,
-            ): vol.In([CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]),
-            vol.Exclusive(CALL_TYPE_COIL, CONF_INPUT_TYPE): cv.positive_int,
-            vol.Exclusive(CONF_REGISTER, CONF_INPUT_TYPE): cv.positive_int,
-        }
-    ),
+COVERS_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
+    {
+        vol.Required(CONF_ADDRESS): cv.positive_int,
+        vol.Optional(CONF_INPUT_TYPE, default=CALL_TYPE_REGISTER_HOLDING,): vol.In(
+            [
+                CALL_TYPE_REGISTER_HOLDING,
+                CALL_TYPE_COIL,
+            ]
+        ),
+        vol.Optional(CONF_DEVICE_CLASS): COVER_DEVICE_CLASSES_SCHEMA,
+        vol.Optional(CONF_STATE_CLOSED, default=0): cv.positive_int,
+        vol.Optional(CONF_STATE_CLOSING, default=3): cv.positive_int,
+        vol.Optional(CONF_STATE_OPEN, default=1): cv.positive_int,
+        vol.Optional(CONF_STATE_OPENING, default=2): cv.positive_int,
+        vol.Optional(CONF_STATUS_REGISTER): cv.positive_int,
+        vol.Optional(
+            CONF_STATUS_REGISTER_TYPE,
+            default=CALL_TYPE_REGISTER_HOLDING,
+        ): vol.In([CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]),
+    }
 )
 
 SWITCH_SCHEMA = BASE_COMPONENT_SCHEMA.extend(

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -8,7 +8,6 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_REGISTER_HOLDING,
     CONF_INPUT_TYPE,
-    CONF_REGISTER,
     CONF_STATE_CLOSED,
     CONF_STATE_CLOSING,
     CONF_STATE_OPEN,

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -7,6 +7,7 @@ from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.modbus.const import (
     CALL_TYPE_COIL,
     CALL_TYPE_REGISTER_HOLDING,
+    CONF_INPUT_TYPE,
     CONF_REGISTER,
     CONF_STATE_CLOSED,
     CONF_STATE_CLOSING,
@@ -16,6 +17,7 @@ from homeassistant.components.modbus.const import (
     CONF_STATUS_REGISTER_TYPE,
 )
 from homeassistant.const import (
+    CONF_ADDRESS,
     CONF_COVERS,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
@@ -43,13 +45,14 @@ from tests.common import mock_restore_cache
         },
     ],
 )
-@pytest.mark.parametrize("read_type", [CALL_TYPE_COIL, CONF_REGISTER])
+@pytest.mark.parametrize("read_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])
 async def test_config_cover(hass, do_options, read_type):
     """Run test for cover."""
     device_name = "test_cover"
     device_config = {
         CONF_NAME: device_name,
-        read_type: 1234,
+        CONF_ADDRESS: 1234,
+        CONF_INPUT_TYPE: read_type,
         **do_options,
     }
     await base_config_test(
@@ -95,7 +98,8 @@ async def test_coil_cover(hass, regs, expected):
         hass,
         {
             CONF_NAME: cover_name,
-            CALL_TYPE_COIL: 1234,
+            CONF_INPUT_TYPE: CALL_TYPE_COIL,
+            CONF_ADDRESS: 1234,
             CONF_SLAVE: 1,
         },
         cover_name,
@@ -142,7 +146,7 @@ async def test_register_cover(hass, regs, expected):
         hass,
         {
             CONF_NAME: cover_name,
-            CONF_REGISTER: 1234,
+            CONF_ADDRESS: 1234,
             CONF_SLAVE: 1,
         },
         cover_name,
@@ -165,7 +169,7 @@ async def test_service_cover_update(hass, mock_pymodbus):
         CONF_COVERS: [
             {
                 CONF_NAME: "test",
-                CONF_REGISTER: 1234,
+                CONF_ADDRESS: 1234,
                 CONF_STATUS_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
             }
         ]
@@ -196,7 +200,8 @@ async def test_restore_state_cover(hass, state):
     cover_name = "test"
     config = {
         CONF_NAME: cover_name,
-        CALL_TYPE_COIL: 1234,
+        CONF_INPUT_TYPE: CALL_TYPE_COIL,
+        CONF_ADDRESS: 1234,
         CONF_STATE_OPEN: 1,
         CONF_STATE_CLOSED: 0,
         CONF_STATE_OPENING: 2,
@@ -229,12 +234,13 @@ async def test_service_cover_move(hass, mock_pymodbus):
         CONF_COVERS: [
             {
                 CONF_NAME: "test",
-                CONF_REGISTER: 1234,
+                CONF_ADDRESS: 1234,
                 CONF_STATUS_REGISTER_TYPE: CALL_TYPE_REGISTER_HOLDING,
             },
             {
                 CONF_NAME: "test2",
-                CALL_TYPE_COIL: 1234,
+                CONF_INPUT_TYPE: CALL_TYPE_COIL,
+                CONF_ADDRESS: 1234,
             },
         ]
     }
@@ -254,10 +260,12 @@ async def test_service_cover_move(hass, mock_pymodbus):
     )
     assert hass.states.get(entity_id).state == STATE_CLOSED
 
+    mock_pymodbus.reset()
     mock_pymodbus.read_holding_registers.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
         "cover", "close_cover", {"entity_id": entity_id}, blocking=True
     )
+    assert mock_pymodbus.read_holding_registers.called
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
     mock_pymodbus.read_coils.side_effect = ModbusException("fail write_")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The following configuration is no longer valid:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    covers:
      - name: Door1
        coil: 117
      - name: Door2
        register: 131
        state_open: 1
        state_closed: 0
```
The new configuration looks like:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    covers:
      - name: Door1
        input_type: coil
        address: 117
      - name: Door2
        address: 131
        state_open: 1
        state_closed: 0
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
attributes `coil`and `register` are changed to `address`and (if not default) `input_type`

Test cases are changed correspondingly

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/17995

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
