### PR TITLE
Add workaround for missing cleaning time in roomba

### DIFF
--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -217,6 +217,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         return state_attrs
 
     def get_cleaning_status(self, state) -> tuple[int, int]:
+        """Return the cleaning time and cleaned area from the device."""
         if not (mission_state := state.get("cleanMissionStatus")):
             return (0, 0)
 

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -220,14 +220,14 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         if not (mission_state := state.get("cleanMissionStatus")):
             return (0, 0)
 
-        if (cleaning_time := mission_state.get("mssnM", 0)) > 0:
+        if cleaning_time := mission_state.get("mssnM", 0):
             pass
         elif start_time := mission_state.get("mssnStrtTm"):
             now = dt_util.as_timestamp(dt_util.utcnow())
             if now > start_time:
                 cleaning_time = (now - start_time) // 60
 
-        if (cleaned_area := mission_state.get("sqft", 0)) > 0:  # Imperial
+        if cleaned_area := mission_state.get("sqft", 0):  # Imperial
             # Convert to m2 if the unit_system is set to metric
             if self.hass.config.units.is_metric:
                 cleaned_area = round(cleaned_area * 0.0929)

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -22,6 +22,7 @@ from homeassistant.components.vacuum import (
     StateVacuumEntity,
 )
 import homeassistant.helpers.device_registry as dr
+import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
 
 from . import roomba_reported_state
@@ -192,7 +193,13 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
         if self.state == STATE_CLEANING:
             # Get clean mission status
             mission_state = state.get("cleanMissionStatus", {})
-            cleaning_time = mission_state.get("mssnM")
+            cleaning_time = mission_state.get("mssnM", 0)
+            if cleaning_time == 0:
+                start_time = mission_state.get("mssnStrtTm", 0)
+                if start_time > 0:
+                    cleaning_time = (
+                        dt_util.as_timestamp(dt_util.utcnow()) - start_time
+                    ) // 60
             cleaned_area = mission_state.get("sqft")  # Imperial
             # Convert to m2 if the unit_system is set to metric
             if cleaned_area and self.hass.config.units.is_metric:

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -22,8 +22,8 @@ from homeassistant.components.vacuum import (
     StateVacuumEntity,
 )
 import homeassistant.helpers.device_registry as dr
-import homeassistant.util.dt as dt_util
 from homeassistant.helpers.entity import Entity
+import homeassistant.util.dt as dt_util
 
 from . import roomba_reported_state
 from .const import DOMAIN

--- a/homeassistant/components/roomba/irobot_base.py
+++ b/homeassistant/components/roomba/irobot_base.py
@@ -216,7 +216,7 @@ class IRobotVacuum(IRobotEntity, StateVacuumEntity):
 
         return state_attrs
 
-    def get_cleaning_status(self, state) -> int:
+    def get_cleaning_status(self, state) -> tuple[int, int]:
         if not (mission_state := state.get("cleanMissionStatus")):
             return (0, 0)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a simple "workaround" to calculate `cleaning_time` for robots which no longer report it in their state. This seems to be a due to to a recent change in the response from iRobot's firmware, in which the robot no longer reports "cleaning time" or "cleaned area".

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/50333
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
