### PR TITLE
Deprecate IPv6 zeroconf setting in favor of the network integration

### DIFF
--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -17,7 +17,7 @@ from zeroconf import (
     NonUniqueNameException,
     ServiceStateChange,
 )
-from zeroconf.aio import AsyncServiceInfo
+from zeroconf.asyncio import AsyncServiceInfo
 
 from homeassistant import config_entries, util
 from homeassistant.components import network

--- a/homeassistant/components/zeroconf/__init__.py
+++ b/homeassistant/components/zeroconf/__init__.py
@@ -15,10 +15,9 @@ from zeroconf import (
     InterfaceChoice,
     IPVersion,
     NonUniqueNameException,
-    ServiceInfo,
     ServiceStateChange,
-    Zeroconf,
 )
+from zeroconf.aio import AsyncServiceInfo
 
 from homeassistant import config_entries, util
 from homeassistant.components import network
@@ -35,7 +34,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.loader import async_get_homekit, async_get_zeroconf, bind_hass
 
-from .models import HaAsyncZeroconf, HaServiceBrowser, HaZeroconf
+from .models import HaAsyncServiceBrowser, HaAsyncZeroconf, HaZeroconf
 from .usage import install_multiple_zeroconf_catcher
 
 _LOGGER = logging.getLogger(__name__)
@@ -70,6 +69,7 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.All(
             cv.deprecated(CONF_DEFAULT_INTERFACE),
+            cv.deprecated(CONF_IPV6),
             vol.Schema(
                 {
                     vol.Optional(CONF_DEFAULT_INTERFACE): cv.boolean,
@@ -119,16 +119,16 @@ async def _async_get_instance(hass: HomeAssistant, **zcargs: Any) -> HaAsyncZero
 
     logging.getLogger("zeroconf").setLevel(logging.NOTSET)
 
-    aio_zc = HaAsyncZeroconf(**zcargs)
-    zeroconf = cast(HaZeroconf, aio_zc.zeroconf)
+    zeroconf = HaZeroconf(**zcargs)
+    aio_zc = HaAsyncZeroconf(zc=zeroconf)
 
     install_multiple_zeroconf_catcher(zeroconf)
 
-    def _stop_zeroconf(_event: Event) -> None:
+    async def _async_stop_zeroconf(_event: Event) -> None:
         """Stop Zeroconf."""
-        zeroconf.ha_close()
+        await aio_zc.ha_async_close()
 
-    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop_zeroconf)
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _async_stop_zeroconf)
     hass.data[DOMAIN] = aio_zc
 
     return aio_zc
@@ -143,7 +143,6 @@ def _async_use_default_interface(adapters: list[Adapter]) -> bool:
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up Zeroconf and make Home Assistant discoverable."""
-    zc_config = config.get(DOMAIN, {})
     zc_args: dict = {}
 
     adapters = await network.async_get_adapters(hass)
@@ -158,16 +157,18 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
                 interfaces.append(ipv4s[0]["address"])
             elif ipv6s := adapter["ipv6"]:
                 interfaces.append(ipv6s[0]["scope_id"])
-    if not zc_config.get(CONF_IPV6, DEFAULT_IPV6):
+
+    ipv6 = True
+    if not any(adapter["enabled"] and adapter["ipv6"] for adapter in adapters):
+        ipv6 = False
         zc_args["ip_version"] = IPVersion.V4Only
 
     aio_zc = await _async_get_instance(hass, **zc_args)
-    zeroconf = aio_zc.zeroconf
-
+    zeroconf = cast(HaZeroconf, aio_zc.zeroconf)
     zeroconf_types, homekit_models = await asyncio.gather(
         async_get_zeroconf(hass), async_get_homekit(hass)
     )
-    discovery = ZeroconfDiscovery(hass, zeroconf, zeroconf_types, homekit_models)
+    discovery = ZeroconfDiscovery(hass, zeroconf, zeroconf_types, homekit_models, ipv6)
     await discovery.async_setup()
 
     async def _async_zeroconf_hass_start(_event: Event) -> None:
@@ -230,7 +231,7 @@ async def _async_register_hass_zc_service(
 
     _suppress_invalid_properties(params)
 
-    info = ServiceInfo(
+    info = AsyncServiceInfo(
         ZEROCONF_TYPE,
         name=f"{valid_location_name}.{ZEROCONF_TYPE}",
         server=f"{uuid}.local.",
@@ -268,10 +269,10 @@ class FlowDispatcher:
             self.hass.async_create_task(self._init_flow(flow))
         self.pending_flows = []
 
-    def create(self, flow: ZeroconfFlow) -> None:
+    def async_create(self, flow: ZeroconfFlow) -> None:
         """Create and add or queue a flow."""
         if self.started:
-            self.hass.create_task(self._init_flow(flow))
+            self.hass.async_create_task(self._init_flow(flow))
         else:
             self.pending_flows.append(flow)
 
@@ -288,18 +289,20 @@ class ZeroconfDiscovery:
     def __init__(
         self,
         hass: HomeAssistant,
-        zeroconf: Zeroconf,
+        zeroconf: HaZeroconf,
         zeroconf_types: dict[str, list[dict[str, str]]],
         homekit_models: dict[str, str],
+        ipv6: bool,
     ) -> None:
         """Init discovery."""
         self.hass = hass
         self.zeroconf = zeroconf
         self.zeroconf_types = zeroconf_types
         self.homekit_models = homekit_models
+        self.ipv6 = ipv6
 
         self.flow_dispatcher: FlowDispatcher | None = None
-        self.service_browser: HaServiceBrowser | None = None
+        self.async_service_browser: HaAsyncServiceBrowser | None = None
 
     async def async_setup(self) -> None:
         """Start discovery."""
@@ -311,15 +314,15 @@ class ZeroconfDiscovery:
         for hk_type in (ZEROCONF_TYPE, *HOMEKIT_TYPES):
             if hk_type not in self.zeroconf_types:
                 types.append(hk_type)
-        _LOGGER.debug("Starting Zeroconf browser")
-        self.service_browser = HaServiceBrowser(
-            self.zeroconf, types, handlers=[self.service_update]
+        _LOGGER.debug("Starting Zeroconf browser for: %s", types)
+        self.async_service_browser = HaAsyncServiceBrowser(
+            self.ipv6, self.zeroconf, types, handlers=[self.async_service_update]
         )
 
     async def async_stop(self) -> None:
         """Cancel the service browser and stop processing the queue."""
-        if self.service_browser:
-            await self.hass.async_add_executor_job(self.service_browser.cancel)
+        if self.async_service_browser:
+            await self.async_service_browser.async_cancel()
 
     @callback
     def async_start(self) -> None:
@@ -327,21 +330,35 @@ class ZeroconfDiscovery:
         assert self.flow_dispatcher is not None
         self.flow_dispatcher.async_start()
 
-    def service_update(
+    @callback
+    def async_service_update(
         self,
-        zeroconf: Zeroconf,
+        zeroconf: HaZeroconf,
         service_type: str,
         name: str,
         state_change: ServiceStateChange,
     ) -> None:
         """Service state changed."""
+        _LOGGER.debug(
+            "service_update: type=%s name=%s state_change=%s",
+            service_type,
+            name,
+            state_change,
+        )
+
         if state_change == ServiceStateChange.Removed:
             return
 
-        service_info = ServiceInfo(service_type, name)
-        service_info.load_from_cache(zeroconf)
+        asyncio.create_task(self._process_service_update(zeroconf, service_type, name))
 
-        info = info_from_service(service_info)
+    async def _process_service_update(
+        self, zeroconf: HaZeroconf, service_type: str, name: str
+    ) -> None:
+        """Process a zeroconf update."""
+        async_service_info = AsyncServiceInfo(service_type, name)
+        await async_service_info.async_request(zeroconf, 3000)
+
+        info = info_from_service(async_service_info)
         if not info:
             # Prevent the browser thread from collapsing
             _LOGGER.debug("Failed to get addresses for device %s", name)
@@ -353,7 +370,7 @@ class ZeroconfDiscovery:
         # If we can handle it as a HomeKit discovery, we do that here.
         if service_type in HOMEKIT_TYPES:
             if pending_flow := handle_homekit(self.hass, self.homekit_models, info):
-                self.flow_dispatcher.create(pending_flow)
+                self.flow_dispatcher.async_create(pending_flow)
             # Continue on here as homekit_controller
             # still needs to get updates on devices
             # so it can see when the 'c#' field is updated.
@@ -415,7 +432,7 @@ class ZeroconfDiscovery:
                 "context": {"source": config_entries.SOURCE_ZEROCONF},
                 "data": info,
             }
-            self.flow_dispatcher.create(flow)
+            self.flow_dispatcher.async_create(flow)
 
 
 def handle_homekit(
@@ -453,7 +470,7 @@ def handle_homekit(
     return None
 
 
-def info_from_service(service: ServiceInfo) -> HaServiceInfo | None:
+def info_from_service(service: AsyncServiceInfo) -> HaServiceInfo | None:
     """Return prepared info from mDNS entries."""
     properties: dict[str, Any] = {"_raw": {}}
 

--- a/homeassistant/components/zeroconf/manifest.json
+++ b/homeassistant/components/zeroconf/manifest.json
@@ -2,7 +2,7 @@
   "domain": "zeroconf",
   "name": "Zero-configuration networking (zeroconf)",
   "documentation": "https://www.home-assistant.io/integrations/zeroconf",
-  "requirements": ["zeroconf==0.31.0"],
+  "requirements": ["zeroconf==0.32.0"],
   "dependencies": ["network", "api"],
   "codeowners": ["@bdraco"],
   "quality_scale": "internal",

--- a/homeassistant/components/zeroconf/models.py
+++ b/homeassistant/components/zeroconf/models.py
@@ -3,7 +3,7 @@
 from typing import Any
 
 from zeroconf import DNSAddress, DNSRecord, Zeroconf
-from zeroconf.aio import AsyncServiceBrowser, AsyncZeroconf
+from zeroconf.asyncio import AsyncServiceBrowser, AsyncZeroconf
 
 TYPE_AAAA = 28
 

--- a/homeassistant/components/zeroconf/models.py
+++ b/homeassistant/components/zeroconf/models.py
@@ -33,7 +33,7 @@ class HaAsyncServiceBrowser(AsyncServiceBrowser):
         """Create service browser that filters ipv6 if it is disabled."""
         self.ipv6 = ipv6
         super().__init__(*args, **kwargs)
-        self.name = "HaServiceBrowser"
+        self.name = self.__class__.__name__
 
     def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
         """Pre-Filter AAAA records if IPv6 is not enabled."""

--- a/homeassistant/components/zeroconf/models.py
+++ b/homeassistant/components/zeroconf/models.py
@@ -33,7 +33,6 @@ class HaAsyncServiceBrowser(AsyncServiceBrowser):
         """Create service browser that filters ipv6 if it is disabled."""
         self.ipv6 = ipv6
         super().__init__(*args, **kwargs)
-        self.name = self.__class__.__name__
 
     def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
         """Pre-Filter AAAA records if IPv6 is not enabled."""

--- a/homeassistant/components/zeroconf/models.py
+++ b/homeassistant/components/zeroconf/models.py
@@ -33,6 +33,7 @@ class HaAsyncServiceBrowser(AsyncServiceBrowser):
         """Create service browser that filters ipv6 if it is disabled."""
         self.ipv6 = ipv6
         super().__init__(*args, **kwargs)
+        self.name = "HaServiceBrowser"
 
     def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
         """Pre-Filter AAAA records if IPv6 is not enabled."""

--- a/homeassistant/components/zeroconf/models.py
+++ b/homeassistant/components/zeroconf/models.py
@@ -1,10 +1,11 @@
 """Models for Zeroconf."""
 
-import asyncio
 from typing import Any
 
-from zeroconf import DNSPointer, DNSRecord, ServiceBrowser, Zeroconf
-from zeroconf.asyncio import AsyncZeroconf
+from zeroconf import DNSAddress, DNSRecord, Zeroconf
+from zeroconf.aio import AsyncServiceBrowser, AsyncZeroconf
+
+TYPE_AAAA = 28
 
 
 class HaZeroconf(Zeroconf):
@@ -19,33 +20,26 @@ class HaZeroconf(Zeroconf):
 class HaAsyncZeroconf(AsyncZeroconf):
     """Home Assistant version of AsyncZeroconf."""
 
-    def __init__(  # pylint: disable=super-init-not-called
-        self, *args: Any, **kwargs: Any
-    ) -> None:
-        """Wrap AsyncZeroconf."""
-        self.zeroconf = HaZeroconf(*args, **kwargs)
-        self.loop = asyncio.get_running_loop()
-
     async def async_close(self) -> None:
         """Fake method to avoid integrations closing it."""
 
+    ha_async_close = AsyncZeroconf.async_close
 
-class HaServiceBrowser(ServiceBrowser):
+
+class HaAsyncServiceBrowser(AsyncServiceBrowser):
     """ServiceBrowser that only consumes DNSPointer records."""
 
-    def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
-        """Pre-Filter update_record to DNSPointers for the configured type."""
+    def __init__(self, ipv6: bool, *args: Any, **kwargs: Any) -> None:
+        """Create service browser that filters ipv6 if it is disabled."""
+        self.ipv6 = ipv6
+        super().__init__(*args, **kwargs)
 
-        #
-        # Each ServerBrowser currently runs in its own thread which
-        # processes every A or AAAA record update per instance.
-        #
-        # As the list of zeroconf names we watch for grows, each additional
-        # ServiceBrowser would process all the A and AAAA updates on the network.
-        #
-        # To avoid overwhelming the system we pre-filter here and only process
-        # DNSPointers for the configured record name (type)
-        #
-        if record.name not in self.types or not isinstance(record, DNSPointer):
+    def update_record(self, zc: Zeroconf, now: float, record: DNSRecord) -> None:
+        """Pre-Filter AAAA records if IPv6 is not enabled."""
+        if (
+            not self.ipv6
+            and isinstance(record, DNSAddress)
+            and record.type == TYPE_AAAA
+        ):
             return
         super().update_record(zc, now, record)

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -33,7 +33,7 @@ sqlalchemy==1.4.17
 voluptuous-serialize==2.4.0
 voluptuous==0.12.1
 yarl==1.6.3
-zeroconf==0.31.0
+zeroconf==0.32.0
 
 pycryptodome>=3.6.6
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2425,7 +2425,7 @@ zeep[async]==4.0.0
 zengge==0.2
 
 # homeassistant.components.zeroconf
-zeroconf==0.31.0
+zeroconf==0.32.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.57

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1328,7 +1328,7 @@ yeelight==0.6.3
 zeep[async]==4.0.0
 
 # homeassistant.components.zeroconf
-zeroconf==0.31.0
+zeroconf==0.32.0
 
 # homeassistant.components.zha
 zha-quirks==0.0.57

--- a/tests/components/zeroconf/conftest.py
+++ b/tests/components/zeroconf/conftest.py
@@ -1,0 +1,15 @@
+"""Tests for the Zeroconf component."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_async_zeroconf():
+    """Mock AsyncZeroconf."""
+    with patch("homeassistant.components.zeroconf.HaAsyncZeroconf") as mock_aiozc:
+        zc = mock_aiozc.return_value
+        zc.async_register_service = AsyncMock()
+        zc.zeroconf.async_wait_for_start = AsyncMock()
+        zc.ha_async_close = AsyncMock()
+        yield zc

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -32,6 +32,7 @@ def mock_async_zeroconf():
     """Mock AsyncZeroconf."""
     with patch("homeassistant.components.zeroconf.HaAsyncZeroconf") as mock_aiozc:
         zc = mock_aiozc.return_value
+        zc.zeroconf.async_wait_for_start = AsyncMock()
         zc.ha_async_close = AsyncMock()
         yield zc
 
@@ -157,7 +158,7 @@ async def test_setup(hass, mock_async_zeroconf):
     )
 
 
-async def test_setup_with_overly_long_url_and_name(hass, mock_zeroconf, caplog):
+async def test_setup_with_overly_long_url_and_name(hass, mock_async_zeroconf, caplog):
     """Test we still setup with long urls and names."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -179,7 +180,7 @@ async def test_setup_with_overly_long_url_and_name(hass, mock_zeroconf, caplog):
     assert "German Umlaut" in caplog.text
 
 
-async def test_setup_with_default_interface(hass, mock_zeroconf):
+async def test_setup_with_default_interface(hass, mock_async_zeroconf):
     """Test default interface config."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -193,10 +194,10 @@ async def test_setup_with_default_interface(hass, mock_zeroconf):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
+    assert mock_async_zeroconf.called_with(interface_choice=InterfaceChoice.Default)
 
 
-async def test_setup_without_default_interface(hass, mock_zeroconf):
+async def test_setup_without_default_interface(hass, mock_async_zeroconf):
     """Test without default interface config."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -208,10 +209,10 @@ async def test_setup_without_default_interface(hass, mock_zeroconf):
             hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {CONF_DEFAULT_INTERFACE: False}}
         )
 
-    assert mock_zeroconf.called_with()
+    assert mock_async_zeroconf.called_with()
 
 
-async def test_setup_without_ipv6(hass, mock_zeroconf):
+async def test_setup_without_ipv6(hass, mock_async_zeroconf):
     """Test without ipv6."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -225,10 +226,10 @@ async def test_setup_without_ipv6(hass, mock_zeroconf):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_zeroconf.called_with(ip_version=IPVersion.V4Only)
+    assert mock_async_zeroconf.called_with(ip_version=IPVersion.V4Only)
 
 
-async def test_setup_with_ipv6(hass, mock_zeroconf):
+async def test_setup_with_ipv6(hass, mock_async_zeroconf):
     """Test without ipv6."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -242,10 +243,10 @@ async def test_setup_with_ipv6(hass, mock_zeroconf):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_zeroconf.called_with()
+    assert mock_async_zeroconf.called_with()
 
 
-async def test_setup_with_ipv6_default(hass, mock_zeroconf):
+async def test_setup_with_ipv6_default(hass, mock_async_zeroconf):
     """Test without ipv6 as default."""
     with patch.object(hass.config_entries.flow, "async_init"), patch.object(
         zeroconf, "HaAsyncServiceBrowser", side_effect=service_update_mock
@@ -257,10 +258,10 @@ async def test_setup_with_ipv6_default(hass, mock_zeroconf):
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
         await hass.async_block_till_done()
 
-    assert mock_zeroconf.called_with()
+    assert mock_async_zeroconf.called_with()
 
 
-async def test_zeroconf_match_macaddress(hass, mock_zeroconf):
+async def test_zeroconf_match_macaddress(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -297,7 +298,7 @@ async def test_zeroconf_match_macaddress(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "shelly"
 
 
-async def test_zeroconf_match_manufacturer(hass, mock_zeroconf):
+async def test_zeroconf_match_manufacturer(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -330,7 +331,7 @@ async def test_zeroconf_match_manufacturer(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "samsungtv"
 
 
-async def test_zeroconf_match_manufacturer_not_present(hass, mock_zeroconf):
+async def test_zeroconf_match_manufacturer_not_present(hass, mock_async_zeroconf):
     """Test matchers reject when a property is missing."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -362,7 +363,7 @@ async def test_zeroconf_match_manufacturer_not_present(hass, mock_zeroconf):
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_zeroconf_no_match(hass, mock_zeroconf):
+async def test_zeroconf_no_match(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -394,7 +395,7 @@ async def test_zeroconf_no_match(hass, mock_zeroconf):
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_zeroconf_no_match_manufacturer(hass, mock_zeroconf):
+async def test_zeroconf_no_match_manufacturer(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
 
     def http_only_service_update_mock(ipv6, zeroconf, services, handlers):
@@ -426,7 +427,7 @@ async def test_zeroconf_no_match_manufacturer(hass, mock_zeroconf):
     assert len(mock_config_flow.mock_calls) == 0
 
 
-async def test_homekit_match_partial_space(hass, mock_zeroconf):
+async def test_homekit_match_partial_space(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -453,7 +454,7 @@ async def test_homekit_match_partial_space(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "lifx"
 
 
-async def test_homekit_match_partial_dash(hass, mock_zeroconf):
+async def test_homekit_match_partial_dash(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -480,7 +481,7 @@ async def test_homekit_match_partial_dash(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "rachio"
 
 
-async def test_homekit_match_partial_fnmatch(hass, mock_zeroconf):
+async def test_homekit_match_partial_fnmatch(hass, mock_async_zeroconf):
     """Test matching homekit devices with fnmatch."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -507,7 +508,7 @@ async def test_homekit_match_partial_fnmatch(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "yeelight"
 
 
-async def test_homekit_match_full(hass, mock_zeroconf):
+async def test_homekit_match_full(hass, mock_async_zeroconf):
     """Test configured options for a device are loaded via config entry."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -534,7 +535,7 @@ async def test_homekit_match_full(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "hue"
 
 
-async def test_homekit_already_paired(hass, mock_zeroconf):
+async def test_homekit_already_paired(hass, mock_async_zeroconf):
     """Test that an already paired device is sent to homekit_controller."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -562,7 +563,7 @@ async def test_homekit_already_paired(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[1][1][0] == "homekit_controller"
 
 
-async def test_homekit_invalid_paring_status(hass, mock_zeroconf):
+async def test_homekit_invalid_paring_status(hass, mock_async_zeroconf):
     """Test that missing paring data is not sent to homekit_controller."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -589,7 +590,7 @@ async def test_homekit_invalid_paring_status(hass, mock_zeroconf):
     assert mock_config_flow.mock_calls[0][1][0] == "tado"
 
 
-async def test_homekit_not_paired(hass, mock_zeroconf):
+async def test_homekit_not_paired(hass, mock_async_zeroconf):
     """Test that an not paired device is sent to homekit_controller."""
     with patch.dict(
         zc_gen.ZEROCONF,
@@ -638,16 +639,18 @@ async def test_info_from_service_with_addresses(hass):
     assert info is None
 
 
-async def test_get_instance(hass, mock_zeroconf):
+async def test_get_instance(hass, mock_async_zeroconf):
     """Test we get an instance."""
     assert await async_setup_component(hass, zeroconf.DOMAIN, {zeroconf.DOMAIN: {}})
-    assert await hass.components.zeroconf.async_get_instance() is mock_zeroconf
+    assert (
+        await hass.components.zeroconf.async_get_async_instance() is mock_async_zeroconf
+    )
     hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
     await hass.async_block_till_done()
-    assert len(mock_zeroconf.ha_close.mock_calls) == 1
+    assert len(mock_async_zeroconf.ha_async_close.mock_calls) == 1
 
 
-async def test_removed_ignored(hass, mock_zeroconf):
+async def test_removed_ignored(hass, mock_async_zeroconf):
     """Test we remove it when a zeroconf entry is removed."""
 
     def service_update_mock(ipv6, zeroconf, services, handlers):
@@ -701,7 +704,9 @@ _ADAPTER_WITH_DEFAULT_ENABLED = [
 ]
 
 
-async def test_async_detect_interfaces_setting_non_loopback_route(hass):
+async def test_async_detect_interfaces_setting_non_loopback_route(
+    hass, mock_async_zeroconf
+):
     """Test without default interface config and the route returns a non-loopback address."""
     with patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc, patch.object(
         hass.config_entries.flow, "async_init"

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -1,7 +1,6 @@
 """Test Zeroconf component setup process."""
-from unittest.mock import AsyncMock, call, patch
+from unittest.mock import call, patch
 
-import pytest
 from zeroconf import InterfaceChoice, IPVersion, ServiceStateChange
 from zeroconf.asyncio import AsyncServiceInfo
 
@@ -25,16 +24,6 @@ PROPERTIES = {
 
 HOMEKIT_STATUS_UNPAIRED = b"1"
 HOMEKIT_STATUS_PAIRED = b"0"
-
-
-@pytest.fixture
-def mock_async_zeroconf():
-    """Mock AsyncZeroconf."""
-    with patch("homeassistant.components.zeroconf.HaAsyncZeroconf") as mock_aiozc:
-        zc = mock_aiozc.return_value
-        zc.zeroconf.async_wait_for_start = AsyncMock()
-        zc.ha_async_close = AsyncMock()
-        yield zc
 
 
 def service_update_mock(ipv6, zeroconf, services, handlers, *, limit_service=None):
@@ -763,7 +752,7 @@ _ADAPTERS_WITH_MANUAL_CONFIG = [
 ]
 
 
-async def test_async_detect_interfaces_setting_empty_route(hass):
+async def test_async_detect_interfaces_setting_empty_route(hass, mock_async_zeroconf):
     """Test without default interface config and the route returns nothing."""
     with patch("homeassistant.components.zeroconf.HaZeroconf") as mock_zc, patch.object(
         hass.config_entries.flow, "async_init"

--- a/tests/components/zeroconf/test_init.py
+++ b/tests/components/zeroconf/test_init.py
@@ -2,7 +2,7 @@
 from unittest.mock import call, patch
 
 from zeroconf import InterfaceChoice, IPVersion, ServiceStateChange
-from zeroconf.aio import AsyncServiceInfo
+from zeroconf.asyncio import AsyncServiceInfo
 
 from homeassistant.components import zeroconf
 from homeassistant.components.zeroconf import CONF_DEFAULT_INTERFACE, CONF_IPV6

--- a/tests/components/zeroconf/test_usage.py
+++ b/tests/components/zeroconf/test_usage.py
@@ -10,7 +10,9 @@ from homeassistant.setup import async_setup_component
 DOMAIN = "zeroconf"
 
 
-async def test_multiple_zeroconf_instances(hass, mock_zeroconf, caplog):
+async def test_multiple_zeroconf_instances(
+    hass, mock_async_zeroconf, mock_zeroconf, caplog
+):
     """Test creating multiple zeroconf throws without an integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 
@@ -24,7 +26,9 @@ async def test_multiple_zeroconf_instances(hass, mock_zeroconf, caplog):
     assert "Zeroconf" in caplog.text
 
 
-async def test_multiple_zeroconf_instances_gives_shared(hass, mock_zeroconf, caplog):
+async def test_multiple_zeroconf_instances_gives_shared(
+    hass, mock_async_zeroconf, mock_zeroconf, caplog
+):
     """Test creating multiple zeroconf gives the shared instance to an integration."""
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Deprecate IPv6 zeroconf setting in favor of the network integration

Requires zeroconf 0.32+

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #45116 fixes #51851
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18350

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
