### PR TITLE
Add zwave_js node status sensor

### DIFF
--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -15,6 +15,7 @@ from zwave_js_server.model.notification import (
 )
 from zwave_js_server.model.value import Value, ValueNotification
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_DEVICE_ID,
@@ -177,6 +178,14 @@ async def async_setup_entry(  # noqa: C901
             # Capture discovery info for values we want to watch for updates
             if disc_info.assumed_state:
                 value_updates_disc_info.append(disc_info)
+
+        # We need to set up the sensor platform if it hasn't already been setup in
+        # order to create the node status sensor
+        if SENSOR_DOMAIN not in platform_setup_tasks:
+            platform_setup_tasks[SENSOR_DOMAIN] = hass.async_create_task(
+                hass.config_entries.async_forward_entry_setup(entry, SENSOR_DOMAIN)
+            )
+            await platform_setup_tasks[SENSOR_DOMAIN]
 
         # Create a node status sensor for each device
         async_dispatcher_send(

--- a/homeassistant/components/zwave_js/__init__.py
+++ b/homeassistant/components/zwave_js/__init__.py
@@ -178,6 +178,11 @@ async def async_setup_entry(  # noqa: C901
             if disc_info.assumed_state:
                 value_updates_disc_info.append(disc_info)
 
+        # Create a node status sensor for each device
+        async_dispatcher_send(
+            hass, f"{DOMAIN}_{entry.entry_id}_add_node_status_sensor", node
+        )
+
         # add listener for value updated events if necessary
         if value_updates_disc_info:
             unsubscribe_callbacks.append(

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -315,6 +315,9 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
 class ZWaveNodeStatusSensor(SensorEntity):
     """Representation of a node status sensor."""
 
+    _attr_should_poll = False
+    _attr_entity_registry_enabled_default = False
+
     def __init__(
         self, config_entry: ConfigEntry, client: ZwaveClient, node: ZwaveNode
     ) -> None:
@@ -365,13 +368,3 @@ class ZWaveNodeStatusSensor(SensorEntity):
     def available(self) -> bool:
         """Return entity availability."""
         return self.client.connected and bool(self.node.ready)
-
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed."""
-        return False
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        return False

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -315,6 +315,8 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
 class ZWaveNodeStatusSensor(SensorEntity):
     """Representation of a node status sensor."""
 
+    _attr_entity_registry_enabled_default = False
+    _attr_should_poll = False
     def __init__(
         self, config_entry: ConfigEntry, client: ZwaveClient, node: ZwaveNode
     ) -> None:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -334,8 +334,6 @@ class ZWaveNodeStatusSensor(SensorEntity):
         self._attr_unique_id = (
             f"{self.client.driver.controller.home_id}.{node.node_id}.node_status"
         )
-        self._attr_entity_registry_enabled_default = False
-        self._attr_should_poll = False
         # device is precreated in main handler
         self._attr_device_info = {
             "identifiers": {get_device_id(self.client, self.node)},
@@ -369,3 +367,13 @@ class ZWaveNodeStatusSensor(SensorEntity):
     def available(self) -> bool:
         """Return entity availability."""
         return self.client.connected and bool(self.node.ready)
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Return if the entity should be enabled when first added to the entity registry."""
+        return False

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -328,7 +328,7 @@ class ZWaveNodeStatusSensor(SensorEntity):
             or self.node.device_config.description
             or f"Node {self.node.node_id}"
         )
-        self._name = f"{name}: Node Status"
+        self._attr_name = f"{name}: Node Status"
         self._unique_id = (
             f"{self.client.driver.controller.home_id}.{node.node_id}.node_status"
         )
@@ -369,11 +369,6 @@ class ZWaveNodeStatusSensor(SensorEntity):
         return {
             "identifiers": {get_device_id(self.client, self.node)},
         }
-
-    @property
-    def name(self) -> str:
-        """Return default name from device name and value name combination."""
-        return self._name
 
     @property
     def unique_id(self) -> str:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -18,7 +18,6 @@ from homeassistant.components.sensor import (
     STATE_CLASS_MEASUREMENT,
     SensorEntity,
 )
-from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
@@ -34,6 +33,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DATA_CLIENT, DATA_UNSUBSCRIBE, DOMAIN
 from .discovery import ZwaveDiscoveryInfo
 from .entity import ZWaveBaseEntity
+from .helpers import get_device_id
 
 LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -315,8 +315,6 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
 class ZWaveNodeStatusSensor(SensorEntity):
     """Representation of a node status sensor."""
 
-    _attr_entity_registry_enabled_default = False
-    _attr_should_poll = False
     def __init__(
         self, config_entry: ConfigEntry, client: ZwaveClient, node: ZwaveNode
     ) -> None:

--- a/tests/components/zwave_js/test_init.py
+++ b/tests/components/zwave_js/test_init.py
@@ -916,7 +916,7 @@ async def test_removed_device(hass, client, multiple_devices, integration):
     # Check how many entities there are
     ent_reg = er.async_get(hass)
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
-    assert len(entity_entries) == 24
+    assert len(entity_entries) == 26
 
     # Remove a node and reload the entry
     old_node = nodes.pop(13)
@@ -928,7 +928,7 @@ async def test_removed_device(hass, client, multiple_devices, integration):
     device_entries = dr.async_entries_for_config_entry(dev_reg, integration.entry_id)
     assert len(device_entries) == 1
     entity_entries = er.async_entries_for_config_entry(ent_reg, integration.entry_id)
-    assert len(entity_entries) == 15
+    assert len(entity_entries) == 16
     assert dev_reg.async_get_device({get_device_id(client, old_node)}) is None
 
 


### PR DESCRIPTION
## Proposed change
Saw this on the roadmap and it seemed straightforward enough to implement. We can't use thee base entity class because it assumes that `ZwaveDiscoveryInfo` is passed in, which we don't need to do for this sensor since it is not specific to a value.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
