### PR TITLE
Update HLS playlist in stream

### DIFF
--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -21,15 +21,19 @@ NUM_PLAYLIST_SEGMENTS = 3  # Number of segments to use in HLS playlist
 MAX_SEGMENTS = 4  # Max number of segments to keep around
 TARGET_SEGMENT_DURATION = 2.0  # Each segment is about this many seconds
 SEGMENT_DURATION_ADJUSTER = 0.1  # Used to avoid missing keyframe boundaries
-MIN_SEGMENT_DURATION = (
-    TARGET_SEGMENT_DURATION - SEGMENT_DURATION_ADJUSTER
-)  # Each segment is at least this many seconds
+# Each segment is at least this many seconds
+MIN_SEGMENT_DURATION = TARGET_SEGMENT_DURATION - SEGMENT_DURATION_ADJUSTER
+
+# Number of target durations to start before the end of the playlist.
+# 1.5 should put us in the middle of the second to last segment even with
+# variable keyframe intervals.
+EXT_X_START = 1.5
 
 PACKETS_TO_WAIT_FOR_AUDIO = 20  # Some streams have an audio stream with no audio
 MAX_TIMESTAMP_GAP = 10000  # seconds - anything from 10 to 50000 is probably reasonable
 
 MAX_MISSING_DTS = 6  # Number of packets missing DTS to allow
-STREAM_TIMEOUT = 30  # Timeout for reading stream
+SOURCE_TIMEOUT = 30  # Timeout for reading stream source
 
 STREAM_RESTART_INCREMENT = 10  # Increase wait_timeout by this amount each retry
 STREAM_RESTART_RESET_TIME = 300  # Reset wait_timeout after this many seconds

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import deque
+import datetime
 from typing import Callable
 
 from aiohttp import web
@@ -30,6 +31,7 @@ class Segment:
     duration: float = attr.ib()
     # For detecting discontinuities across stream restarts
     stream_id: int = attr.ib(default=0)
+    start_time: datetime.datetime = attr.ib(factory=datetime.datetime.utcnow)
 
 
 class IdleTimer:
@@ -83,7 +85,6 @@ class StreamOutput:
         """Initialize a stream output."""
         self._hass = hass
         self._idle_timer = idle_timer
-        self._cursor: int | None = None
         self._event = asyncio.Event()
         self._segments: deque[Segment] = deque(maxlen=deque_maxlen)
 
@@ -110,6 +111,13 @@ class StreamOutput:
         return [s.sequence for s in self._segments]
 
     @property
+    def last_segment(self) -> Segment | None:
+        """Return the last segment without iterating."""
+        if self._segments:
+            return self._segments[-1]
+        return None
+
+    @property
     def target_duration(self) -> int:
         """Return the max duration of any given segment in seconds."""
         segment_length = len(self._segments)
@@ -120,8 +128,6 @@ class StreamOutput:
 
     def get_segment(self, sequence: int) -> Segment | None:
         """Retrieve a specific segment."""
-        self._idle_timer.awake()
-
         for segment in self._segments:
             if segment.sequence == sequence:
                 return segment
@@ -129,20 +135,13 @@ class StreamOutput:
 
     def get_segments(self) -> deque[Segment]:
         """Retrieve all segments."""
-        self._idle_timer.awake()
         return self._segments
 
-    async def recv(self) -> Segment | None:
+    async def recv(self) -> bool:
         """Wait for and retrieve the latest segment."""
-        if self._cursor is None or self._cursor <= self.last_sequence:
-            await self._event.wait()
-
-        if not self._segments:
-            return None
-
-        segment = self.get_segments()[-1]
-        self._cursor = segment.sequence
-        return segment
+        self._idle_timer.awake()
+        await self._event.wait()
+        return self.last_segment is not None
 
     def put(self, segment: Segment) -> None:
         """Store output."""

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -71,7 +71,7 @@ class HlsPlaylistView(StreamView):
     def render_preamble(track):
         """Render preamble."""
         return [
-            "#EXT-X-VERSION:7",
+            "#EXT-X-VERSION:6",
             f"#EXT-X-TARGETDURATION:{track.target_duration}",
             '#EXT-X-MAP:URI="init.mp4"',
         ]

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -16,7 +16,7 @@ from .const import (
     MIN_SEGMENT_DURATION,
     PACKETS_TO_WAIT_FOR_AUDIO,
     SEGMENT_CONTAINER_FORMAT,
-    STREAM_TIMEOUT,
+    SOURCE_TIMEOUT,
 )
 from .core import Segment, StreamOutput
 from .fmp4utils import get_init_and_moof_data
@@ -149,7 +149,7 @@ def stream_worker(source, options, segment_buffer, quit_event):  # noqa: C901
     """Handle consuming streams."""
 
     try:
-        container = av.open(source, options=options, timeout=STREAM_TIMEOUT)
+        container = av.open(source, options=options, timeout=SOURCE_TIMEOUT)
     except av.AVError:
         _LOGGER.error("Error opening stream %s", redact_credentials(str(source)))
         return

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -78,7 +78,7 @@ def make_playlist(sequence, discontinuity_sequence=0, segments=[]):
     """Create a an hls playlist response for tests to assert on."""
     response = [
         "#EXTM3U",
-        "#EXT-X-VERSION:7",
+        "#EXT-X-VERSION:6",
         "#EXT-X-TARGETDURATION:10",
         '#EXT-X-MAP:URI="init.mp4"',
         f"#EXT-X-MEDIA-SEQUENCE:{sequence}",

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -256,8 +256,8 @@ async def test_record_stream_audio(
         recorder = stream.add_provider(RECORDER_PROVIDER)
 
         while True:
-            segment = await recorder.recv()
-            if not segment:
+            await recorder.recv()
+            if not (segment := recorder.last_segment):
                 break
             last_segment = segment
             stream_worker_sync.resume()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#49608 implements LL-HLS in stream, but that PR is too large, making it hard to review. This an intermediate PR which updates the generated HLS playlists to include the EXT-X-PROGRAM-DATE-TIME and the EXT-X-START tags. The EXT-PROGRAM-DATE-TIME tag is not needed now, but it is a requirement for LL-HLS as specified in [B.1 of the RFC](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#appendix-B.1).  This PR also uses gzip compression to serve the playlists as specified in [6.2.1 of the RFC](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-6.2.1), and timeouts were added to the StreamOutput.recv method to avoid awaiting indefinitely.

Note that the EXT-X-START time, as specified in [4.4.2.2 of the RFC](https://datatracker.ietf.org/doc/html/draft-pantos-hls-rfc8216bis#section-4.4.2.2), is not supposed to be within 3 target durations of the end of the playlist, but this is not a hard requirement (SHOULD NOT vs MUST NOT). The reasoning behind setting this value to 1.5 durations from the end of the playlist is that many players seem to be able to play from 2 segments back instead of 3 segments back. This change will reduce latency for most. The use of 1.5 instead of 2 is just because segment durations may be uneven, particularly with certain codecs like H264+. The 0.5 difference is a fudge factor to try to get us somewhere in the second segment. I have tested these settings and they seem to work fine, but we can keep this in mind in case users experience problems.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
