### PR TITLE
Only run philips_js notify service while TV is turned on

### DIFF
--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -121,7 +121,7 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
         """Return if the notify feature should be active.
 
         We only run it when TV is considered fully on. When powerstate is in standby, the TV
-        will go in low power states and seeminly break the http server in odd ways.
+        will go in low power states and seemingly break the http server in odd ways.
         """
         return (
             self.api.on

--- a/homeassistant/components/philips_js/__init__.py
+++ b/homeassistant/components/philips_js/__init__.py
@@ -116,8 +116,21 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
             ),
         )
 
+    @property
+    def _notify_wanted(self):
+        """Return if the notify feature should be active.
+
+        We only run it when TV is considered fully on. When powerstate is in standby, the TV
+        will go in low power states and seeminly break the http server in odd ways.
+        """
+        return (
+            self.api.on
+            and self.api.powerstate == "On"
+            and self.api.notify_change_supported
+        )
+
     async def _notify_task(self):
-        while self.api.on and self.api.notify_change_supported:
+        while self._notify_wanted:
             res = await self.api.notifyChange(130)
             if res:
                 self.async_set_updated_data(None)
@@ -133,11 +146,10 @@ class PhilipsTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
     @callback
     def _async_notify_schedule(self):
-        if (
-            (self._notify_future is None or self._notify_future.done())
-            and self.api.on
-            and self.api.notify_change_supported
-        ):
+        if self._notify_future and not self._notify_future.done():
+            return
+
+        if self._notify_wanted:
             self._notify_future = asyncio.create_task(self._notify_task())
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Only run the notify event service while TV is considered turned on. The android TV's are notoriously crash prone with the event service while in standby.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #48918 #48839

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
