### PR TITLE
Adjust modbus climate to use address/input_type

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -58,8 +58,6 @@ from .const import (
     CONF_BYTESIZE,
     CONF_CLIMATES,
     CONF_CLOSE_COMM_ON_ERROR,
-    CONF_CURRENT_TEMP,
-    CONF_CURRENT_TEMP_REGISTER_TYPE,
     CONF_DATA_COUNT,
     CONF_DATA_TYPE,
     CONF_FANS,
@@ -124,12 +122,15 @@ BASE_COMPONENT_SCHEMA = vol.Schema(
 
 CLIMATE_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
     {
-        vol.Required(CONF_CURRENT_TEMP): cv.positive_int,
+        vol.Required(CONF_ADDRESS): cv.positive_int,
+        vol.Optional(CONF_INPUT_TYPE, default=CALL_TYPE_REGISTER_HOLDING): vol.In(
+            [
+                CALL_TYPE_REGISTER_HOLDING,
+                CALL_TYPE_REGISTER_INPUT,
+            ]
+        ),
         vol.Required(CONF_TARGET_TEMP): cv.positive_int,
         vol.Optional(CONF_DATA_COUNT, default=2): cv.positive_int,
-        vol.Optional(
-            CONF_CURRENT_TEMP_REGISTER_TYPE, default=CALL_TYPE_REGISTER_HOLDING
-        ): vol.In([CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT]),
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT): vol.In(
             [DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT, DATA_TYPE_CUSTOM]
         ),

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -11,7 +11,6 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
-    CONF_ADDRESS,
     CONF_NAME,
     CONF_OFFSET,
     CONF_STRUCTURE,
@@ -29,11 +28,8 @@ from .const import (
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_WRITE_REGISTERS,
     CONF_CLIMATES,
-    CONF_CURRENT_TEMP,
-    CONF_CURRENT_TEMP_REGISTER_TYPE,
     CONF_DATA_COUNT,
     CONF_DATA_TYPE,
-    CONF_INPUT_TYPE,
     CONF_MAX_TEMP,
     CONF_MIN_TEMP,
     CONF_PRECISION,
@@ -108,14 +104,8 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         config: dict[str, Any],
     ) -> None:
         """Initialize the modbus thermostat."""
-        config[CONF_ADDRESS] = "0"
-        config[CONF_INPUT_TYPE] = ""
         super().__init__(hub, config)
         self._target_temperature_register = config[CONF_TARGET_TEMP]
-        self._current_temperature_register = config[CONF_CURRENT_TEMP]
-        self._current_temperature_register_type = config[
-            CONF_CURRENT_TEMP_REGISTER_TYPE
-        ]
         self._target_temperature = None
         self._current_temperature = None
         self._data_type = config[CONF_DATA_TYPE]
@@ -212,7 +202,7 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
             CALL_TYPE_REGISTER_HOLDING, self._target_temperature_register
         )
         self._current_temperature = await self._async_read_register(
-            self._current_temperature_register_type, self._current_temperature_register
+            self._input_type, self._address
         )
 
         self.async_write_ha_state()

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -5,12 +5,12 @@ from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.climate.const import HVAC_MODE_AUTO
 from homeassistant.components.modbus.const import (
     CONF_CLIMATES,
-    CONF_CURRENT_TEMP,
     CONF_DATA_COUNT,
     CONF_TARGET_TEMP,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
+    CONF_ADDRESS,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
@@ -38,7 +38,7 @@ async def test_config_climate(hass, do_options):
     device_config = {
         CONF_NAME: device_name,
         CONF_TARGET_TEMP: 117,
-        CONF_CURRENT_TEMP: 117,
+        CONF_ADDRESS: 117,
         CONF_SLAVE: 10,
         **do_options,
     }
@@ -72,7 +72,7 @@ async def test_temperature_climate(hass, regs, expected):
             CONF_NAME: climate_name,
             CONF_SLAVE: 1,
             CONF_TARGET_TEMP: 117,
-            CONF_CURRENT_TEMP: 117,
+            CONF_ADDRESS: 117,
             CONF_DATA_COUNT: 2,
         },
         climate_name,
@@ -96,7 +96,7 @@ async def test_service_climate_update(hass, mock_pymodbus):
             {
                 CONF_NAME: "test",
                 CONF_TARGET_TEMP: 117,
-                CONF_CURRENT_TEMP: 117,
+                CONF_ADDRESS: 117,
                 CONF_SLAVE: 10,
             }
         ]
@@ -123,7 +123,7 @@ async def test_restore_state_climate(hass):
     config_sensor = {
         CONF_NAME: climate_name,
         CONF_TARGET_TEMP: 117,
-        CONF_CURRENT_TEMP: 117,
+        CONF_ADDRESS: 117,
     }
     mock_restore_cache(
         hass,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The attributes `curent_temp_register` and `current_temp_register_type` are changed to
`address` and `input_type` in order for all platforms to have a common attributes.

Before this PR, this was legal:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    climates:
      - name: "Watlow F4T"
        current_temp_register: 27586
        current_temp_register_type: holding
```

This changes to:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    climates:
      - name: "Watlow F4T"
        address: 27586
        input_type: holding
```

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/18005

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
