### PR TITLE
Switch to using entity class attributes where possible in zwave_js

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -315,7 +315,7 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
             additional_info=[self.info.primary_value.metadata.states[self.state_key]],
         )
         self._attr_device_class = self._mapping_info.get("device_class")
-        self._attr_unique_id = f"{super()._attr_unique_id}.{self.state_key}"
+        self._attr_unique_id = f"{self._attr_unique_id}.{self.state_key}"
         self._attr_entity_registry_enabled_default = (
             True if not self._mapping_info else self._mapping_info.get("enabled", True)
         )

--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -269,7 +269,20 @@ class ZWaveBooleanBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
     ) -> None:
         """Initialize a ZWaveBooleanBinarySensor entity."""
         super().__init__(config_entry, client, info)
-        self._name = self.generate_name(include_value_name=True)
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(include_value_name=True)
+        self._attr_device_class = (
+            DEVICE_CLASS_BATTERY
+            if self.info.primary_value.command_class == CommandClass.BATTERY
+            else None
+        )
+        # Legacy binary sensors are phased out (replaced by notification sensors)
+        # Disable by default to not confuse users
+        self._attr_entity_registry_enabled_default = bool(
+            self.info.primary_value.command_class != CommandClass.SENSOR_BINARY
+            or self.info.node.device_class.generic.key == 0x20
+        )
 
     @property
     def is_on(self) -> bool | None:
@@ -277,23 +290,6 @@ class ZWaveBooleanBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         if self.info.primary_value.value is None:
             return None
         return bool(self.info.primary_value.value)
-
-    @property
-    def device_class(self) -> str | None:
-        """Return device class."""
-        if self.info.primary_value.command_class == CommandClass.BATTERY:
-            return DEVICE_CLASS_BATTERY
-        return None
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        # Legacy binary sensors are phased out (replaced by notification sensors)
-        # Disable by default to not confuse users
-        return bool(
-            self.info.primary_value.command_class != CommandClass.SENSOR_BINARY
-            or self.info.node.device_class.generic.key == 0x20
-        )
 
 
 class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
@@ -309,13 +305,20 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         """Initialize a ZWaveNotificationBinarySensor entity."""
         super().__init__(config_entry, client, info)
         self.state_key = state_key
-        self._name = self.generate_name(
+        # check if we have a custom mapping for this value
+        self._mapping_info = self._get_sensor_mapping()
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(
             include_value_name=True,
             alternate_value_name=self.info.primary_value.property_name,
             additional_info=[self.info.primary_value.metadata.states[self.state_key]],
         )
-        # check if we have a custom mapping for this value
-        self._mapping_info = self._get_sensor_mapping()
+        self._attr_device_class = self._mapping_info.get("device_class")
+        self._attr_unique_id = f"{super()._attr_unique_id}.{self.state_key}"
+        self._attr_entity_registry_enabled_default = (
+            True if not self._mapping_info else self._mapping_info.get("enabled", True)
+        )
 
     @property
     def is_on(self) -> bool | None:
@@ -323,23 +326,6 @@ class ZWaveNotificationBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         if self.info.primary_value.value is None:
             return None
         return int(self.info.primary_value.value) == int(self.state_key)
-
-    @property
-    def device_class(self) -> str | None:
-        """Return device class."""
-        return self._mapping_info.get("device_class")
-
-    @property
-    def unique_id(self) -> str:
-        """Return unique id for this entity."""
-        return f"{super().unique_id}.{self.state_key}"
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        if not self._mapping_info:
-            return True
-        return self._mapping_info.get("enabled", True)
 
     @callback
     def _get_sensor_mapping(self) -> NotificationSensorMapping:
@@ -366,7 +352,15 @@ class ZWavePropertyBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         super().__init__(config_entry, client, info)
         # check if we have a custom mapping for this value
         self._mapping_info = self._get_sensor_mapping()
-        self._name = self.generate_name(include_value_name=True)
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(include_value_name=True)
+        self._attr_device_class = self._mapping_info.get("device_class")
+        # We hide some more advanced sensors by default to not overwhelm users
+        # unless explicitly stated in a mapping, assume deisabled by default
+        self._attr_entity_registry_enabled_default = self._mapping_info.get(
+            "enabled", False
+        )
 
     @property
     def is_on(self) -> bool | None:
@@ -374,18 +368,6 @@ class ZWavePropertyBinarySensor(ZWaveBaseEntity, BinarySensorEntity):
         if self.info.primary_value.value is None:
             return None
         return self.info.primary_value.value in self._mapping_info["on_states"]
-
-    @property
-    def device_class(self) -> str | None:
-        """Return device class."""
-        return self._mapping_info.get("device_class")
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        # We hide some more advanced sensors by default to not overwhelm users
-        # unless explicitly stated in a mapping, assume deisabled by default
-        return self._mapping_info.get("enabled", False)
 
     @callback
     def _get_sensor_mapping(self) -> PropertySensorMapping:

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -141,6 +141,9 @@ class ZWaveCover(ZWaveBaseEntity, CoverEntity):
 class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
     """Representation of a Z-Wave motorized barrier device."""
 
+    _attr_supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
+    _attr_device_class = DEVICE_CLASS_GARAGE
+
     def __init__(
         self,
         config_entry: ConfigEntry,
@@ -188,13 +191,3 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the garage door."""
         await self.info.node.async_set_value(self._target_state, BARRIER_TARGET_CLOSE)
-
-    @property
-    def supported_features(self) -> int | None:
-        """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE
-
-    @property
-    def device_class(self) -> str | None:
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_GARAGE

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -79,14 +79,21 @@ def percent_to_zwave_position(value: int) -> int:
 class ZWaveCover(ZWaveBaseEntity, CoverEntity):
     """Representation of a Z-Wave Cover device."""
 
-    @property
-    def device_class(self) -> str | None:
-        """Return the class of this device, from component DEVICE_CLASSES."""
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        client: ZwaveClient,
+        info: ZwaveDiscoveryInfo,
+    ) -> None:
+        """Initialize a ZWaveCover entity."""
+        super().__init__(config_entry, client, info)
+
+        # Entity class attributes
+        self._attr_device_class = DEVICE_CLASS_WINDOW
         if self.info.platform_hint == "window_shutter":
-            return DEVICE_CLASS_SHUTTER
+            self._attr_device_class = DEVICE_CLASS_SHUTTER
         if self.info.platform_hint == "window_blind":
-            return DEVICE_CLASS_BLIND
-        return DEVICE_CLASS_WINDOW
+            self._attr_device_class = DEVICE_CLASS_BLIND
 
     @property
     def is_closed(self) -> bool | None:
@@ -146,15 +153,9 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
             "targetState", add_to_watched_value_ids=False
         )
 
-    @property
-    def supported_features(self) -> int | None:
-        """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE
-
-    @property
-    def device_class(self) -> str | None:
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_GARAGE
+        # Entity class attributees
+        self._attr_device_class = DEVICE_CLASS_GARAGE
+        self._attr_supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
 
     @property
     def is_opening(self) -> bool | None:

--- a/homeassistant/components/zwave_js/cover.py
+++ b/homeassistant/components/zwave_js/cover.py
@@ -153,10 +153,6 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
             "targetState", add_to_watched_value_ids=False
         )
 
-        # Entity class attributees
-        self._attr_device_class = DEVICE_CLASS_GARAGE
-        self._attr_supported_features = SUPPORT_OPEN | SUPPORT_CLOSE
-
     @property
     def is_opening(self) -> bool | None:
         """Return if the cover is opening or not."""
@@ -192,3 +188,13 @@ class ZwaveMotorizedBarrier(ZWaveBaseEntity, CoverEntity):
     async def async_close_cover(self, **kwargs: Any) -> None:
         """Close the garage door."""
         await self.info.node.async_set_value(self._target_state, BARRIER_TARGET_CLOSE)
+
+    @property
+    def supported_features(self) -> int | None:
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE
+
+    @property
+    def device_class(self) -> str | None:
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_GARAGE

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -43,7 +43,6 @@ class ZWaveBaseEntity(Entity):
         self._attr_unique_id = get_unique_id(
             self.client.driver.controller.home_id, self.info.primary_value.value_id
         )
-        self._attr_should_poll = False
         self._attr_assumed_state = self.info.assumed_state
         # device is precreated in main handler
         self._attr_device_info = {
@@ -214,3 +213,8 @@ class ZWaveBaseEntity(Entity):
         ):
             self.watched_value_ids.add(return_value.value_id)
         return return_value
+
+    @property
+    def should_poll(self) -> bool:
+        """No polling needed."""
+        return False

--- a/homeassistant/components/zwave_js/entity.py
+++ b/homeassistant/components/zwave_js/entity.py
@@ -9,7 +9,7 @@ from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
 from .discovery import ZwaveDiscoveryInfo
@@ -30,10 +30,6 @@ class ZWaveBaseEntity(Entity):
         self.config_entry = config_entry
         self.client = client
         self.info = info
-        self._name = self.generate_name()
-        self._unique_id = get_unique_id(
-            self.client.driver.controller.home_id, self.info.primary_value.value_id
-        )
         # entities requiring additional values, can add extra ids to this list
         self.watched_value_ids = {self.info.primary_value.value_id}
 
@@ -41,6 +37,18 @@ class ZWaveBaseEntity(Entity):
             self.watched_value_ids = self.watched_value_ids.union(
                 self.info.additional_value_ids_to_watch
             )
+
+        # Entity class attributes
+        self._attr_name = self.generate_name()
+        self._attr_unique_id = get_unique_id(
+            self.client.driver.controller.home_id, self.info.primary_value.value_id
+        )
+        self._attr_should_poll = False
+        self._attr_assumed_state = self.info.assumed_state
+        # device is precreated in main handler
+        self._attr_device_info = {
+            "identifiers": {get_device_id(self.client, self.info.node)},
+        }
 
     @callback
     def on_value_update(self) -> None:
@@ -91,14 +99,6 @@ class ZWaveBaseEntity(Entity):
             )
         )
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device information for the device registry."""
-        # device is precreated in main handler
-        return {
-            "identifiers": {get_device_id(self.client, self.info.node)},
-        }
-
     def generate_name(
         self,
         include_value_name: bool = False,
@@ -132,16 +132,6 @@ class ZWaveBaseEntity(Entity):
             name += f" ({self.info.primary_value.endpoint})"
 
         return name
-
-    @property
-    def name(self) -> str:
-        """Return default name from device name and value name combination."""
-        return self._name
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique_id of the entity."""
-        return self._unique_id
 
     @property
     def available(self) -> bool:
@@ -224,13 +214,3 @@ class ZWaveBaseEntity(Entity):
         ):
             self.watched_value_ids.add(return_value.value_id)
         return return_value
-
-    @property
-    def should_poll(self) -> bool:
-        """No polling needed."""
-        return False
-
-    @property
-    def assumed_state(self) -> bool:
-        """Return True if unable to access real state of the entity."""
-        return self.info.assumed_state

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -118,5 +118,5 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
 
     @property
     def supported_features(self) -> int:
-        """Return supported features."""
+        """Flag supported features."""
         return SUPPORTED_FEATURES

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -66,9 +66,6 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
         """Initialize a ZwaveFan entity."""
         super().__init__(config_entry, client, info)
 
-        # Entity class attributes
-        self._attr_supported_features = SUPPORTED_FEATURES
-
     async def async_set_percentage(self, percentage: int | None) -> None:
         """Set the speed percentage of the fan."""
         target_value = self.get_zwave_value("targetValue")
@@ -118,3 +115,8 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(SPEED_RANGE)
+
+    @property
+    def supported_features(self) -> int:
+        """Return supported features."""
+        return SUPPORTED_FEATURES

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -57,15 +57,6 @@ async def async_setup_entry(
 class ZwaveFan(ZWaveBaseEntity, FanEntity):
     """Representation of a Z-Wave fan."""
 
-    def __init__(
-        self,
-        config_entry: ConfigEntry,
-        client: ZwaveClient,
-        info: ZwaveDiscoveryInfo,
-    ) -> None:
-        """Initialize a ZwaveFan entity."""
-        super().__init__(config_entry, client, info)
-
     async def async_set_percentage(self, percentage: int | None) -> None:
         """Set the speed percentage of the fan."""
         target_value = self.get_zwave_value("targetValue")

--- a/homeassistant/components/zwave_js/fan.py
+++ b/homeassistant/components/zwave_js/fan.py
@@ -57,6 +57,18 @@ async def async_setup_entry(
 class ZwaveFan(ZWaveBaseEntity, FanEntity):
     """Representation of a Z-Wave fan."""
 
+    def __init__(
+        self,
+        config_entry: ConfigEntry,
+        client: ZwaveClient,
+        info: ZwaveDiscoveryInfo,
+    ) -> None:
+        """Initialize a ZwaveFan entity."""
+        super().__init__(config_entry, client, info)
+
+        # Entity class attributes
+        self._attr_supported_features = SUPPORTED_FEATURES
+
     async def async_set_percentage(self, percentage: int | None) -> None:
         """Set the speed percentage of the fan."""
         target_value = self.get_zwave_value("targetValue")
@@ -106,8 +118,3 @@ class ZwaveFan(ZWaveBaseEntity, FanEntity):
     def speed_count(self) -> int:
         """Return the number of speeds the fan supports."""
         return int_states_in_range(SPEED_RANGE)
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        return SUPPORTED_FEATURES

--- a/homeassistant/components/zwave_js/light.py
+++ b/homeassistant/components/zwave_js/light.py
@@ -107,13 +107,10 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             value_property_key=ColorComponent.COLD_WHITE,
         )
         self._supported_color_modes = set()
-        self._supported_features = 0
 
         # get additional (optional) values and set features
         self._target_value = self.get_zwave_value("targetValue")
         self._dimming_duration = self.get_zwave_value("duration")
-        if self._dimming_duration is not None:
-            self._supported_features |= SUPPORT_TRANSITION
         self._calculate_color_values()
         if self._supports_rgbw:
             self._supported_color_modes.add(COLOR_MODE_RGBW)
@@ -123,6 +120,11 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
             self._supported_color_modes.add(COLOR_MODE_COLOR_TEMP)
         if not self._supported_color_modes:
             self._supported_color_modes.add(COLOR_MODE_BRIGHTNESS)
+
+        # Entity class attributes
+        self._attr_supported_features = 0
+        if self._dimming_duration is not None:
+            self._attr_supported_features |= SUPPORT_TRANSITION
 
     @callback
     def on_value_update(self) -> None:
@@ -178,11 +180,6 @@ class ZwaveLight(ZWaveBaseEntity, LightEntity):
     def supported_color_modes(self) -> set | None:
         """Flag supported features."""
         return self._supported_color_modes
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        return self._supported_features
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""

--- a/homeassistant/components/zwave_js/number.py
+++ b/homeassistant/components/zwave_js/number.py
@@ -46,13 +46,15 @@ class ZwaveNumberEntity(ZWaveBaseEntity, NumberEntity):
     ) -> None:
         """Initialize a ZwaveNumberEntity entity."""
         super().__init__(config_entry, client, info)
-        self._name = self.generate_name(
-            include_value_name=True, alternate_value_name=info.platform_hint
-        )
         if self.info.primary_value.metadata.writeable:
             self._target_value = self.info.primary_value
         else:
             self._target_value = self.get_zwave_value("targetValue")
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(
+            include_value_name=True, alternate_value_name=info.platform_hint
+        )
 
     @property
     def min_value(self) -> float:

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -91,7 +91,6 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
         self._attr_name = self.generate_name(include_value_name=True)
         self._attr_device_class = self._get_device_class()
         self._attr_state_class = self._get_state_class()
-        self._attr_force_update = True
         self._attr_entity_registry_enabled_default = True
         # We hide some of the more advanced sensors by default to not overwhelm users
         if self.info.primary_value.command_class in [
@@ -141,6 +140,11 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
             if "humidity" in property_lower or "temperature" in property_lower:
                 return STATE_CLASS_MEASUREMENT
         return None
+
+    @property
+    def force_update(self) -> bool:
+        """Force updates."""
+        return True
 
 
 class ZWaveStringSensor(ZwaveSensorBase):

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -86,9 +86,21 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
     ) -> None:
         """Initialize a ZWaveSensorBase entity."""
         super().__init__(config_entry, client, info)
-        self._name = self.generate_name(include_value_name=True)
-        self._device_class = self._get_device_class()
-        self._state_class = self._get_state_class()
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(include_value_name=True)
+        self._attr_device_class = self._get_device_class()
+        self._attr_state_class = self._get_state_class()
+        self._attr_force_update = True
+        self._attr_entity_registry_enabled_default = True
+        # We hide some of the more advanced sensors by default to not overwhelm users
+        if self.info.primary_value.command_class in [
+            CommandClass.BASIC,
+            CommandClass.CONFIGURATION,
+            CommandClass.INDICATOR,
+            CommandClass.NOTIFICATION,
+        ]:
+            self._attr_entity_registry_enabled_default = False
 
     def _get_device_class(self) -> str | None:
         """
@@ -130,34 +142,6 @@ class ZwaveSensorBase(ZWaveBaseEntity, SensorEntity):
                 return STATE_CLASS_MEASUREMENT
         return None
 
-    @property
-    def device_class(self) -> str | None:
-        """Return the device class of the sensor."""
-        return self._device_class
-
-    @property
-    def state_class(self) -> str | None:
-        """Return the state class of the sensor."""
-        return self._state_class
-
-    @property
-    def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        # We hide some of the more advanced sensors by default to not overwhelm users
-        if self.info.primary_value.command_class in [
-            CommandClass.BASIC,
-            CommandClass.CONFIGURATION,
-            CommandClass.INDICATOR,
-            CommandClass.NOTIFICATION,
-        ]:
-            return False
-        return True
-
-    @property
-    def force_update(self) -> bool:
-        """Force updates."""
-        return True
-
 
 class ZWaveStringSensor(ZwaveSensorBase):
     """Representation of a Z-Wave String sensor."""
@@ -188,8 +172,10 @@ class ZWaveNumericSensor(ZwaveSensorBase):
     ) -> None:
         """Initialize a ZWaveNumericSensor entity."""
         super().__init__(config_entry, client, info)
+
+        # Entity class attributes
         if self.info.primary_value.command_class == CommandClass.BASIC:
-            self._name = self.generate_name(
+            self._attr_name = self.generate_name(
                 include_value_name=True,
                 alternate_value_name=self.info.primary_value.command_class_name,
             )
@@ -225,7 +211,9 @@ class ZWaveListSensor(ZwaveSensorBase):
     ) -> None:
         """Initialize a ZWaveListSensor entity."""
         super().__init__(config_entry, client, info)
-        self._name = self.generate_name(
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(
             include_value_name=True,
             alternate_value_name=self.info.primary_value.property_name,
             additional_info=[self.info.primary_value.property_key_name],
@@ -263,13 +251,15 @@ class ZWaveConfigParameterSensor(ZwaveSensorBase):
     ) -> None:
         """Initialize a ZWaveConfigParameterSensor entity."""
         super().__init__(config_entry, client, info)
-        self._name = self.generate_name(
+        self._primary_value = cast(ConfigurationValue, self.info.primary_value)
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(
             include_value_name=True,
             alternate_value_name=self.info.primary_value.property_name,
             additional_info=[self.info.primary_value.property_key_name],
             name_suffix="Config Parameter",
         )
-        self._primary_value = cast(ConfigurationValue, self.info.primary_value)
 
     @property
     def state(self) -> str | None:

--- a/homeassistant/components/zwave_js/switch.py
+++ b/homeassistant/components/zwave_js/switch.py
@@ -88,20 +88,17 @@ class ZWaveBarrierEventSignalingSwitch(ZWaveBaseEntity, SwitchEntity):
     ) -> None:
         """Initialize a ZWaveBarrierEventSignalingSwitch entity."""
         super().__init__(config_entry, client, info)
-        self._name = self.generate_name(include_value_name=True)
         self._state: bool | None = None
 
         self._update_state()
+
+        # Entity class attributes
+        self._attr_name = self.generate_name(include_value_name=True)
 
     @callback
     def on_value_update(self) -> None:
         """Call when a watched value is added or updated."""
         self._update_state()
-
-    @property
-    def name(self) -> str:
-        """Return default name from device name and value name combination."""
-        return self._name
 
     @property
     def is_on(self) -> bool | None:  # type: ignore


### PR DESCRIPTION
## Proposed change
Switch to using entity class attributes wherever possible instead of properties for brevity. Follow up to review from https://github.com/home-assistant/core/pull/51181


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
