### PR TITLE
Skip processed Sonos alarm updates

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections import OrderedDict
+from collections import OrderedDict, deque
 import datetime
 import logging
 import socket
@@ -73,6 +73,7 @@ class SonosData:
         self.discovered: OrderedDict[str, SonosSpeaker] = OrderedDict()
         self.favorites: dict[str, SonosFavorites] = {}
         self.alarms: dict[str, Alarm] = {}
+        self.processed_alarm_events = deque(maxlen=5)
         self.topology_condition = asyncio.Condition()
         self.discovery_thread = None
         self.hosts_heartbeat = None

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -317,6 +317,10 @@ class SonosSpeaker:
     @callback
     def async_dispatch_alarms(self, event: SonosEvent) -> None:
         """Create a task to update alarms from an event."""
+        update_id = event.variables["alarm_list_version"]
+        if update_id in self.processed_alarm_events:
+            return
+        self.processed_alarm_events.append(update_id)
         self.hass.async_add_executor_job(self.update_alarms)
 
     @callback

--- a/tests/components/sonos/conftest.py
+++ b/tests/components/sonos/conftest.py
@@ -21,6 +21,15 @@ class SonosMockEvent:
         self.service = dummy_soco_service_fixture
         self.variables = variables
 
+    def increment_variable(self, var_name):
+        """Increment the value of the var_name key in variables dict attribute.
+
+        Assumes value has a format of <str>:<int>.
+        """
+        base, count = self.variables[var_name].split(":")
+        newcount = int(count) + 1
+        self.variables[var_name] = ":".join([base, str(newcount)])
+
 
 @pytest.fixture(name="config_entry")
 def config_entry_fixture():
@@ -166,7 +175,7 @@ def alarm_event_fixture(soco):
         "time_zone": "ffc40a000503000003000502ffc4",
         "time_server": "0.sonostime.pool.ntp.org,1.sonostime.pool.ntp.org,2.sonostime.pool.ntp.org,3.sonostime.pool.ntp.org",
         "time_generation": "20000001",
-        "alarm_list_version": "RINCON_test",
+        "alarm_list_version": "RINCON_test:1",
         "time_format": "INV",
         "date_format": "INV",
         "daily_index_refresh_time": None,

--- a/tests/components/sonos/test_switch.py
+++ b/tests/components/sonos/test_switch.py
@@ -68,6 +68,7 @@ async def test_alarm_create_delete(
     assert "switch.sonos_alarm_15" in entity_registry.entities
 
     alarm_clock_extended.ListAlarms.return_value = alarm_clock.ListAlarms.return_value
+    alarm_event.increment_variable("alarm_list_version")
 
     sub_callback(event=alarm_event)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Subscriptions were triggering updates of all alarms for each speaker when any alarm was modified. This keeps track of the last 5 alarm event identifiers and skips if it has already been processed.

The alarm events do not have enough information to determine the specific alarm that has changed, so this seems the best we can do for now.

cc: @AaronDavidSchneider 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
