### PR TITLE
Add gui config option consider device unavailable

### DIFF
--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -137,10 +137,17 @@ CONF_RADIO_TYPE = "radio_type"
 CONF_USB_PATH = "usb_path"
 CONF_ZIGPY = "zigpy_config"
 
+CONF_CONSIDER_UNAVAILABLE_MAINS = "consider_unavailable_mains"
+CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS = 60 * 60 * 2 # 2 hours
+CONF_CONSIDER_UNAVAILABLE_BATTERY = "consider_unavailable_battery"
+CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY = 60 * 60 * 6  # 6 hours
+
 CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
+        vol.Optional(CONF_CONSIDER_UNAVAILABLE_MAINS, default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS): cv.positive_int,
+        vol.Optional(CONF_CONSIDER_UNAVAILABLE_BATTERY, default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY): cv.positive_int
     }
 )
 

--- a/homeassistant/components/zha/core/const.py
+++ b/homeassistant/components/zha/core/const.py
@@ -138,7 +138,7 @@ CONF_USB_PATH = "usb_path"
 CONF_ZIGPY = "zigpy_config"
 
 CONF_CONSIDER_UNAVAILABLE_MAINS = "consider_unavailable_mains"
-CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS = 60 * 60 * 2 # 2 hours
+CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS = 60 * 60 * 2  # 2 hours
 CONF_CONSIDER_UNAVAILABLE_BATTERY = "consider_unavailable_battery"
 CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY = 60 * 60 * 6  # 6 hours
 
@@ -146,8 +146,14 @@ CONF_ZHA_OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(CONF_DEFAULT_LIGHT_TRANSITION): cv.positive_int,
         vol.Required(CONF_ENABLE_IDENTIFY_ON_JOIN, default=True): cv.boolean,
-        vol.Optional(CONF_CONSIDER_UNAVAILABLE_MAINS, default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS): cv.positive_int,
-        vol.Optional(CONF_CONSIDER_UNAVAILABLE_BATTERY, default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY): cv.positive_int
+        vol.Optional(
+            CONF_CONSIDER_UNAVAILABLE_MAINS,
+            default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
+        ): cv.positive_int,
+        vol.Optional(
+            CONF_CONSIDER_UNAVAILABLE_BATTERY,
+            default=CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
+        ): cv.positive_int,
     }
 )
 

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -56,6 +56,10 @@ from .const import (
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
     CONF_ENABLE_IDENTIFY_ON_JOIN,
+    CONF_CONSIDER_UNAVAILABLE_MAINS,
+    CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
+    CONF_CONSIDER_UNAVAILABLE_BATTERY,
+    CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
     EFFECT_DEFAULT_VARIANT,
     EFFECT_OKAY,
     POWER_BATTERY_OR_UNKNOWN,
@@ -70,8 +74,6 @@ from .const import (
 from .helpers import LogMixin, async_get_zha_config_value
 
 _LOGGER = logging.getLogger(__name__)
-CONSIDER_UNAVAILABLE_MAINS = 60 * 60 * 2  # 2 hours
-CONSIDER_UNAVAILABLE_BATTERY = 60 * 60 * 6  # 6 hours
 _UPDATE_ALIVE_INTERVAL = (60, 90)
 _CHECKIN_GRACE_PERIODS = 2
 
@@ -107,9 +109,20 @@ class ZHADevice(LogMixin):
         )
 
         if self.is_mains_powered:
-            self._consider_unavailable_time = CONSIDER_UNAVAILABLE_MAINS
+            self.consider_unavailable_time = async_get_zha_config_value(
+                    self._zha_gateway.config_entry,
+                    ZHA_OPTIONS,
+                    CONF_CONSIDER_UNAVAILABLE_MAINS,
+                    CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
+                )
         else:
-            self._consider_unavailable_time = CONSIDER_UNAVAILABLE_BATTERY
+            self.consider_unavailable_time = async_get_zha_config_value(
+                    self._zha_gateway.config_entry,
+                    ZHA_OPTIONS,
+                    CONF_CONSIDER_UNAVAILABLE_BATTERY,
+                    CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
+                )
+
         keep_alive_interval = random.randint(*_UPDATE_ALIVE_INTERVAL)
         self.unsubs.append(
             async_track_time_interval(
@@ -320,7 +333,7 @@ class ZHADevice(LogMixin):
             return
 
         difference = time.time() - self.last_seen
-        if difference < self._consider_unavailable_time:
+        if difference < self.consider_unavailable_time:
             self.update_available(True)
             self._checkins_missed_count = 0
             return

--- a/homeassistant/components/zha/core/device.py
+++ b/homeassistant/components/zha/core/device.py
@@ -55,11 +55,11 @@ from .const import (
     CLUSTER_COMMANDS_SERVER,
     CLUSTER_TYPE_IN,
     CLUSTER_TYPE_OUT,
-    CONF_ENABLE_IDENTIFY_ON_JOIN,
-    CONF_CONSIDER_UNAVAILABLE_MAINS,
-    CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
     CONF_CONSIDER_UNAVAILABLE_BATTERY,
+    CONF_CONSIDER_UNAVAILABLE_MAINS,
     CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
+    CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
+    CONF_ENABLE_IDENTIFY_ON_JOIN,
     EFFECT_DEFAULT_VARIANT,
     EFFECT_OKAY,
     POWER_BATTERY_OR_UNKNOWN,
@@ -110,18 +110,18 @@ class ZHADevice(LogMixin):
 
         if self.is_mains_powered:
             self.consider_unavailable_time = async_get_zha_config_value(
-                    self._zha_gateway.config_entry,
-                    ZHA_OPTIONS,
-                    CONF_CONSIDER_UNAVAILABLE_MAINS,
-                    CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
-                )
+                self._zha_gateway.config_entry,
+                ZHA_OPTIONS,
+                CONF_CONSIDER_UNAVAILABLE_MAINS,
+                CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
+            )
         else:
             self.consider_unavailable_time = async_get_zha_config_value(
-                    self._zha_gateway.config_entry,
-                    ZHA_OPTIONS,
-                    CONF_CONSIDER_UNAVAILABLE_BATTERY,
-                    CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
-                )
+                self._zha_gateway.config_entry,
+                ZHA_OPTIONS,
+                CONF_CONSIDER_UNAVAILABLE_BATTERY,
+                CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
+            )
 
         keep_alive_interval = random.randint(*_UPDATE_ALIVE_INTERVAL)
         self.unsubs.append(

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -78,8 +78,6 @@ from .const import (
     RadioType,
 )
 from .device import (
-    CONSIDER_UNAVAILABLE_BATTERY,
-    CONSIDER_UNAVAILABLE_MAINS,
     DeviceStatus,
     ZHADevice,
 )
@@ -185,17 +183,15 @@ class ZHAGateway:
             delta_msg = "not known"
             if zha_dev_entry and zha_dev_entry.last_seen is not None:
                 delta = round(time.time() - zha_dev_entry.last_seen)
-                if zha_device.is_mains_powered:
-                    zha_device.available = delta < CONSIDER_UNAVAILABLE_MAINS
-                else:
-                    zha_device.available = delta < CONSIDER_UNAVAILABLE_BATTERY
+                zha_device.available = delta < zha_device.consider_unavailable_time
                 delta_msg = f"{str(timedelta(seconds=delta))} ago"
             _LOGGER.debug(
-                "[%s](%s) restored as '%s', last seen: %s",
+                "[%s](%s) restored as '%s', last seen: %s, consider_unavailable_time: %s seconds",
                 zha_device.nwk,
                 zha_device.name,
                 "available" if zha_device.available else "unavailable",
                 delta_msg,
+                zha_device.consider_unavailable_time,
             )
         # update the last seen time for devices every 10 minutes to avoid thrashing
         # writes and shutdown issues where storage isn't updated

--- a/homeassistant/components/zha/core/gateway.py
+++ b/homeassistant/components/zha/core/gateway.py
@@ -77,10 +77,7 @@ from .const import (
     ZHA_GW_MSG_RAW_INIT,
     RadioType,
 )
-from .device import (
-    DeviceStatus,
-    ZHADevice,
-)
+from .device import DeviceStatus, ZHADevice
 from .group import GroupMember, ZHAGroup
 from .registries import GROUP_ENTITY_DOMAINS
 from .store import async_get_registry

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -33,7 +33,9 @@
     "zha_options": {
       "title": "Global Options",
       "enable_identify_on_join": "Enable identify effect when devices join the network",
-      "default_light_transition": "Default light transition time (seconds)"
+      "default_light_transition": "Default light transition time (seconds)",
+      "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",
+      "consider_unavailable_battery": "Consider battery powered devices unavailable after (seconds)"
     },
     "zha_alarm_options": {
       "title": "Alarm Control Panel Options",

--- a/homeassistant/components/zha/translations/en.json
+++ b/homeassistant/components/zha/translations/en.json
@@ -43,6 +43,8 @@
         "zha_options": {
             "default_light_transition": "Default light transition time (seconds)",
             "enable_identify_on_join": "Enable identify effect when devices join the network",
+            "consider_unavailable_mains": "Consider mains powered devices unavailable after (seconds)",
+            "consider_unavailable_battery": "Consider battery powered devices unavailable after (seconds)",      
             "title": "Global Options"
         }
     },

--- a/tests/components/zha/test_device.py
+++ b/tests/components/zha/test_device.py
@@ -8,7 +8,10 @@ import pytest
 import zigpy.profiles.zha
 import zigpy.zcl.clusters.general as general
 
-import homeassistant.components.zha.core.device as zha_core_device
+from homeassistant.components.zha.core.const import (
+    CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY,
+    CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS,
+)
 from homeassistant.const import STATE_OFF, STATE_UNAVAILABLE
 import homeassistant.helpers.device_registry as dr
 import homeassistant.util.dt as dt_util
@@ -117,13 +120,13 @@ async def test_check_available_success(
     basic_ch.read_attributes.reset_mock()
     device_with_basic_channel.last_seen = None
     assert zha_device.available is True
-    _send_time_changed(hass, zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2)
+    _send_time_changed(hass, zha_device.consider_unavailable_time + 2)
     await hass.async_block_till_done()
     assert zha_device.available is False
     assert basic_ch.read_attributes.await_count == 0
 
     device_with_basic_channel.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2
+        time.time() - zha_device.consider_unavailable_time - 2
     )
     _seens = [time.time(), device_with_basic_channel.last_seen]
 
@@ -172,7 +175,7 @@ async def test_check_available_unsuccessful(
     assert basic_ch.read_attributes.await_count == 0
 
     device_with_basic_channel.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2
+        time.time() - zha_device.consider_unavailable_time - 2
     )
 
     # unsuccessfuly ping zigpy device, but zha_device is still available
@@ -213,7 +216,7 @@ async def test_check_available_no_basic_channel(
     assert zha_device.available is True
 
     device_without_basic_channel.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2
+        time.time() - zha_device.consider_unavailable_time - 2
     )
 
     assert "does not have a mandatory basic cluster" not in caplog.text
@@ -246,38 +249,38 @@ async def test_ota_sw_version(hass, ota_zha_device):
         ("zigpy_device", 0, True),
         (
             "zigpy_device",
-            zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS + 2,
             True,
         ),
         (
             "zigpy_device",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY - 2,
             True,
         ),
         (
             "zigpy_device",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY + 2,
             False,
         ),
         ("zigpy_device_mains", 0, True),
         (
             "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_MAINS - 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS - 2,
             True,
         ),
         (
             "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_MAINS + 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_MAINS + 2,
             False,
         ),
         (
             "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY - 2,
             False,
         ),
         (
             "zigpy_device_mains",
-            zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 2,
+            CONF_DEFAULT_CONSIDER_UNAVAILABLE_BATTERY + 2,
             False,
         ),
     ),

--- a/tests/components/zha/test_device_trigger.py
+++ b/tests/components/zha/test_device_trigger.py
@@ -7,7 +7,6 @@ import zigpy.profiles.zha
 import zigpy.zcl.clusters.general as general
 
 import homeassistant.components.automation as automation
-import homeassistant.components.zha.core.device as zha_core_device
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
@@ -252,9 +251,7 @@ async def test_device_offline_fires(
     await hass.async_block_till_done()
     assert zha_device.available is True
 
-    zigpy_device.last_seen = (
-        time.time() - zha_core_device.CONSIDER_UNAVAILABLE_BATTERY - 2
-    )
+    zigpy_device.last_seen = time.time() - zha_device.consider_unavailable_time - 2
 
     # there are 3 checkins to perform before marking the device unavailable
     future = dt_util.utcnow() + timedelta(seconds=90)
@@ -266,7 +263,7 @@ async def test_device_offline_fires(
     await hass.async_block_till_done()
 
     future = dt_util.utcnow() + timedelta(
-        seconds=zha_core_device.CONSIDER_UNAVAILABLE_BATTERY + 100
+        seconds=zha_device.consider_unavailable_time + 100
     )
     async_fire_time_changed(hass, future)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds two options in de GUI configuration for ZHA:
- Consider mains powered devices unavailable after (seconds)
- Consider battery powered devices unavailable after (seconds)
![image](https://user-images.githubusercontent.com/3670848/120072055-209f4880-c092-11eb-8f68-fd861528b4d5.png)

These settings determine after how long a device should be considered unavailable. This can happen for instance when power is cut to mains powered devices, or the battery has run empty. Before this PR, these settings were hard coded in core\device.py (not const.py)

For some users it is useful to change these values. For example when using mains/switch operated smart light bulbs: lowering the default 2 hours to 5 minutes helps in determining whether lights are on or off. Other coordinators like deCONZ and Zigbee2mqtt use lower values than 2 hours.

The default values remain the same and thus it has no impact on existing configurations.




## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
