### PR TITLE
Populate upnp devices from ssdp

### DIFF
--- a/homeassistant/components/upnp/config_flow.py
+++ b/homeassistant/components/upnp/config_flow.py
@@ -29,17 +29,7 @@ from .const import (
     DOMAIN_DEVICES,
     LOGGER as _LOGGER,
 )
-from .device import Device
-
-
-def discovery_info_to_discovery(discovery_info: Mapping) -> Mapping:
-    """Convert a SSDP-discovery to 'our' discovery."""
-    return {
-        DISCOVERY_UDN: discovery_info[ssdp.ATTR_UPNP_UDN],
-        DISCOVERY_ST: discovery_info[ssdp.ATTR_SSDP_ST],
-        DISCOVERY_LOCATION: discovery_info[ssdp.ATTR_SSDP_LOCATION],
-        DISCOVERY_USN: discovery_info[ssdp.ATTR_SSDP_USN],
-    }
+from .device import Device, discovery_info_to_discovery
 
 
 class UpnpFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -12,6 +12,7 @@ from async_upnp_client.aiohttp import AiohttpSessionRequester
 from async_upnp_client.device_updater import DeviceUpdater
 from async_upnp_client.profiles.igd import IgdDevice
 
+from homeassistant.components import ssdp
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -37,6 +38,16 @@ from .const import (
 )
 
 
+def discovery_info_to_discovery(discovery_info: Mapping) -> Mapping:
+    """Convert a SSDP-discovery to 'our' discovery."""
+    return {
+        DISCOVERY_UDN: discovery_info[ssdp.ATTR_UPNP_UDN],
+        DISCOVERY_ST: discovery_info[ssdp.ATTR_SSDP_ST],
+        DISCOVERY_LOCATION: discovery_info[ssdp.ATTR_SSDP_LOCATION],
+        DISCOVERY_USN: discovery_info[ssdp.ATTR_SSDP_USN],
+    }
+
+
 def _get_local_ip(hass: HomeAssistant) -> IPv4Address | None:
     """Get the configured local ip."""
     if DOMAIN in hass.data and DOMAIN_CONFIG in hass.data[DOMAIN]:
@@ -59,17 +70,10 @@ class Device:
     async def async_discover(cls, hass: HomeAssistant) -> list[Mapping]:
         """Discover UPnP/IGD devices."""
         _LOGGER.debug("Discovering UPnP/IGD devices")
-        local_ip = _get_local_ip(hass)
-        discoveries = await IgdDevice.async_search(source_ip=local_ip, timeout=10)
-
-        # Supplement/standardize discovery.
-        for discovery in discoveries:
-            discovery[DISCOVERY_UDN] = discovery["_udn"]
-            discovery[DISCOVERY_ST] = discovery["st"]
-            discovery[DISCOVERY_LOCATION] = discovery["location"]
-            discovery[DISCOVERY_USN] = discovery["usn"]
-            _LOGGER.debug("Discovered device: %s", discovery)
-
+        discoveries = []
+        for st in IgdDevice.DEVICE_TYPES:
+            for discovery_info in ssdp.async_get_discovery_info_by_st(hass, st):
+                discoveries.append(discovery_info_to_discovery(discovery_info))
         return discoveries
 
     @classmethod

--- a/homeassistant/components/upnp/device.py
+++ b/homeassistant/components/upnp/device.py
@@ -71,8 +71,8 @@ class Device:
         """Discover UPnP/IGD devices."""
         _LOGGER.debug("Discovering UPnP/IGD devices")
         discoveries = []
-        for st in IgdDevice.DEVICE_TYPES:
-            for discovery_info in ssdp.async_get_discovery_info_by_st(hass, st):
+        for ssdp_st in IgdDevice.DEVICE_TYPES:
+            for discovery_info in ssdp.async_get_discovery_info_by_st(hass, ssdp_st):
                 discoveries.append(discovery_info_to_discovery(discovery_info))
         return discoveries
 

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -4,6 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/upnp",
   "requirements": ["async-upnp-client==0.18.0"],
+  "dependencies": ["ssdp"],
   "codeowners": ["@StevenLooman"],
   "ssdp": [
     {

--- a/tests/components/upnp/test_init.py
+++ b/tests/components/upnp/test_init.py
@@ -1,17 +1,11 @@
 """Test UPnP/IGD setup process."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
+from homeassistant.components import ssdp
 from homeassistant.components.upnp.const import (
     CONFIG_ENTRY_ST,
     CONFIG_ENTRY_UDN,
-    DISCOVERY_HOSTNAME,
-    DISCOVERY_LOCATION,
-    DISCOVERY_NAME,
-    DISCOVERY_ST,
-    DISCOVERY_UDN,
-    DISCOVERY_UNIQUE_ID,
-    DISCOVERY_USN,
     DOMAIN,
 )
 from homeassistant.components.upnp.device import Device
@@ -28,17 +22,12 @@ async def test_async_setup_entry_default(hass: HomeAssistant):
     udn = "uuid:device_1"
     location = "http://192.168.1.1/desc.xml"
     mock_device = MockDevice(udn)
-    discoveries = [
-        {
-            DISCOVERY_LOCATION: location,
-            DISCOVERY_NAME: mock_device.name,
-            DISCOVERY_ST: mock_device.device_type,
-            DISCOVERY_UDN: mock_device.udn,
-            DISCOVERY_UNIQUE_ID: mock_device.unique_id,
-            DISCOVERY_USN: mock_device.usn,
-            DISCOVERY_HOSTNAME: mock_device.hostname,
-        }
-    ]
+    discovery = {
+        ssdp.ATTR_SSDP_LOCATION: location,
+        ssdp.ATTR_SSDP_ST: mock_device.device_type,
+        ssdp.ATTR_UPNP_UDN: mock_device.udn,
+        ssdp.ATTR_SSDP_USN: mock_device.usn,
+    }
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -51,77 +40,19 @@ async def test_async_setup_entry_default(hass: HomeAssistant):
         # no upnp
     }
     async_create_device = AsyncMock(return_value=mock_device)
-    async_discover = AsyncMock()
+    mock_get_discovery = Mock()
     with patch.object(Device, "async_create_device", async_create_device), patch.object(
-        Device, "async_discover", async_discover
+        ssdp, "async_get_discovery_info_by_udn_st", mock_get_discovery
     ):
         # initialisation of component, no device discovered
-        async_discover.return_value = []
+        mock_get_discovery.return_value = None
         await async_setup_component(hass, "upnp", config)
         await hass.async_block_till_done()
 
         # loading of config_entry, device discovered
-        async_discover.return_value = discoveries
+        mock_get_discovery.return_value = discovery
         entry.add_to_hass(hass)
         assert await hass.config_entries.async_setup(entry.entry_id) is True
 
         # ensure device is stored/used
-        async_create_device.assert_called_with(hass, discoveries[0][DISCOVERY_LOCATION])
-
-
-async def test_sync_setup_entry_multiple_discoveries(hass: HomeAssistant):
-    """Test async_setup_entry."""
-    udn_0 = "uuid:device_1"
-    location_0 = "http://192.168.1.1/desc.xml"
-    mock_device_0 = MockDevice(udn_0)
-    udn_1 = "uuid:device_2"
-    location_1 = "http://192.168.1.2/desc.xml"
-    mock_device_1 = MockDevice(udn_1)
-    discoveries = [
-        {
-            DISCOVERY_LOCATION: location_0,
-            DISCOVERY_NAME: mock_device_0.name,
-            DISCOVERY_ST: mock_device_0.device_type,
-            DISCOVERY_UDN: mock_device_0.udn,
-            DISCOVERY_UNIQUE_ID: mock_device_0.unique_id,
-            DISCOVERY_USN: mock_device_0.usn,
-            DISCOVERY_HOSTNAME: mock_device_0.hostname,
-        },
-        {
-            DISCOVERY_LOCATION: location_1,
-            DISCOVERY_NAME: mock_device_1.name,
-            DISCOVERY_ST: mock_device_1.device_type,
-            DISCOVERY_UDN: mock_device_1.udn,
-            DISCOVERY_UNIQUE_ID: mock_device_1.unique_id,
-            DISCOVERY_USN: mock_device_1.usn,
-            DISCOVERY_HOSTNAME: mock_device_1.hostname,
-        },
-    ]
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONFIG_ENTRY_UDN: mock_device_1.udn,
-            CONFIG_ENTRY_ST: mock_device_1.device_type,
-        },
-    )
-
-    config = {
-        # no upnp
-    }
-    async_create_device = AsyncMock(return_value=mock_device_1)
-    async_discover = AsyncMock()
-    with patch.object(Device, "async_create_device", async_create_device), patch.object(
-        Device, "async_discover", async_discover
-    ):
-        # initialisation of component, no device discovered
-        async_discover.return_value = []
-        await async_setup_component(hass, "upnp", config)
-        await hass.async_block_till_done()
-
-        # loading of config_entry, device discovered
-        async_discover.return_value = discoveries
-        entry.add_to_hass(hass)
-        assert await hass.config_entries.async_setup(entry.entry_id) is True
-
-        # ensure device is stored/used
-        async_create_device.assert_called_with(hass, discoveries[1][DISCOVERY_LOCATION])
+        async_create_device.assert_called_with(hass, discovery[ssdp.ATTR_SSDP_LOCATION])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Populate upnp devices from ssdp

Avoids the need to do additional searches since we already have the data in the cache.
UPNP no longer causes a small startup delay on systems that can start in < 10s.

Additionally discovery now appears to be near instant since the ssdp integration
will have already discovered and cached the device by the time the user
goes to set it up

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
