### PR TITLE
Fix unique_id generation for AtwZoneSensors

### DIFF
--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -165,7 +165,8 @@ class AtwZoneSensor(MelDeviceSensor):
 
     def __init__(self, api: MelCloudDevice, zone: Zone, measurement, definition):
         """Initialize the sensor."""
-        super().__init__(api, measurement, definition)
+        full_measurement = f"{measurement}-zone-{zone.zone_index}"
+        super().__init__(api, full_measurement, definition)
         self._zone = zone
         self._name_slug = f"{api.name} {zone.name}"
 

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -165,7 +165,10 @@ class AtwZoneSensor(MelDeviceSensor):
 
     def __init__(self, api: MelCloudDevice, zone: Zone, measurement, definition):
         """Initialize the sensor."""
-        full_measurement = f"{measurement}-zone-{zone.zone_index}"
+        if zone.zone_index == 1:
+            full_measurement = measurement
+        else:
+            full_measurement = f"{measurement}-zone-{zone.zone_index}"
         super().__init__(api, full_measurement, definition)
         self._zone = zone
         self._name_slug = f"{api.name} {zone.name}"

--- a/tests/components/melcloud/test_atw_zone_sensor.py
+++ b/tests/components/melcloud/test_atw_zone_sensor.py
@@ -1,0 +1,41 @@
+"""Test the MELCloud ATW zone sensor."""
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.melcloud.sensor import AtwZoneSensor
+
+
+@pytest.fixture
+def mock_device():
+    """Mock MELCloud device."""
+    with patch("homeassistant.components.melcloud.MelCloudDevice") as mock:
+        mock.name = "name"
+        mock.device.serial = 1234
+        mock.device.mac = "11:11:11:11:11:11"
+        yield mock
+
+
+@pytest.fixture
+def mock_zone_1():
+    """Mock zone 1."""
+    with patch("pymelcloud.atw_device.Zone") as mock:
+        mock.zone_index = 1
+        yield mock
+
+
+@pytest.fixture
+def mock_zone_2():
+    """Mock zone 2."""
+    with patch("pymelcloud.atw_device.Zone") as mock:
+        mock.zone_index = 2
+        yield mock
+
+
+def test_zone_unique_ids(mock_device, mock_zone_1, mock_zone_2):
+    """Test unique id generation correctness."""
+    sensor_1 = AtwZoneSensor(mock_device, mock_zone_1, "room_temperature", {})
+    assert sensor_1.unique_id == "1234-11:11:11:11:11:11-room_temperature-zone-1"
+
+    sensor_2 = AtwZoneSensor(mock_device, mock_zone_2, "room_temperature", {})
+    assert sensor_2.unique_id == "1234-11:11:11:11:11:11-room_temperature-zone-2"

--- a/tests/components/melcloud/test_atw_zone_sensor.py
+++ b/tests/components/melcloud/test_atw_zone_sensor.py
@@ -35,7 +35,7 @@ def mock_zone_2():
 def test_zone_unique_ids(mock_device, mock_zone_1, mock_zone_2):
     """Test unique id generation correctness."""
     sensor_1 = AtwZoneSensor(mock_device, mock_zone_1, "room_temperature", {})
-    assert sensor_1.unique_id == "1234-11:11:11:11:11:11-room_temperature-zone-1"
+    assert sensor_1.unique_id == "1234-11:11:11:11:11:11-room_temperature"
 
     sensor_2 = AtwZoneSensor(mock_device, mock_zone_2, "room_temperature", {})
     assert sensor_2.unique_id == "1234-11:11:11:11:11:11-room_temperature-zone-2"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
This change changes `unique_id` generation for all ATW zone sensors and therefore it will require manual intervention to replace sensor references in existing 1 zone setups.

The existing ID scheme (`{measurement}`) is replaced by `{measurement}-zone-{zone index}`. It would be possible to keep the existing scheme for the first, currently functional zone, but the mixed scheme is just terrible. 2 zone setups would have sensor IDs like these:

* zone 1 -> `{measurement}` 
* zone 2 -> `{measurement}-zone-2`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add zone index to ATW zone sensor `unique_id`s. The current implementation does not generate unique `unique_id`s with 2 zone setups. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
