### PR TITLE
Define ToggleEntity entity attributes as class variables

### DIFF
--- a/homeassistant/components/upcloud/__init__.py
+++ b/homeassistant/components/upcloud/__init__.py
@@ -272,17 +272,12 @@ class UpCloudServerEntity(CoordinatorEntity):
         return "mdi:server" if self.is_on else "mdi:server-off"
 
     @property
-    def state(self) -> str | None:
-        """Return state of the server."""
-        try:
-            return STATE_MAP.get(self._server.state, self._server.state)
-        except AttributeError:
-            return None
-
-    @property
     def is_on(self) -> bool:
         """Return true if the server is on."""
-        return self.state == STATE_ON
+        try:
+            return STATE_MAP.get(self._server.state, self._server.state) == STATE_ON
+        except AttributeError:
+            return False
 
     @property
     def device_class(self) -> str:

--- a/homeassistant/components/upcloud/__init__.py
+++ b/homeassistant/components/upcloud/__init__.py
@@ -280,6 +280,13 @@ class UpCloudServerEntity(CoordinatorEntity):
             return False
 
     @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        return super().available and STATE_MAP.get(
+            self._server.state, self._server.state
+        ) in [STATE_ON, STATE_OFF]
+
+    @property
     def device_class(self) -> str:
         """Return the class of this server."""
         return DEFAULT_COMPONENT_DEVICE_CLASS

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -10,7 +10,7 @@ import logging
 import math
 import sys
 from timeit import default_timer as timer
-from typing import Any, TypedDict
+from typing import Any, TypedDict, final
 
 from homeassistant.config import DATA_CUSTOMIZE
 from homeassistant.const import (
@@ -766,7 +766,11 @@ class Entity(ABC):
 class ToggleEntity(Entity):
     """An abstract class for entities that can be turned on and off."""
 
+    _attr_is_on: bool
+    _attr_state: None = None
+
     @property
+    @final
     def state(self) -> str | None:
         """Return the state."""
         return STATE_ON if self.is_on else STATE_OFF
@@ -774,7 +778,7 @@ class ToggleEntity(Entity):
     @property
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        raise NotImplementedError()
+        return self._attr_is_on
 
     def turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Defines `ToggleEntity` entity attributes as class variables,
followup of the implementation started in #50925

For full context #50925 is the best place to take a look.

Additionally:
- Marked the `state` property method as final. This should not be implemented for toggle entities.
- Typed `_attr_state` as `None` only, as it should not be used for toggle entities.
- Fixes an occurrence in the Upcloud integration override the `state` property method for binary sensors & switches.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
