### PR TITLE
Return result from ServiceRegistry.async_call

### DIFF
--- a/homeassistant/core.py
+++ b/homeassistant/core.py
@@ -1525,12 +1525,9 @@ class ServiceRegistry:
         """Execute a service."""
         if handler.job.job_type == HassJobType.Coroutinefunction:
             return await handler.job.target(service_call)
-        elif handler.job.job_type == HassJobType.Callback:
+        if handler.job.job_type == HassJobType.Callback:
             return handler.job.target(service_call)
-        else:
-            return await self._hass.async_add_executor_job(
-                handler.job.target, service_call
-            )
+        return await self._hass.async_add_executor_job(handler.job.target, service_call)
 
 
 class Config:

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -208,10 +208,10 @@ class EntityComponent:
         if isinstance(schema, dict):
             schema = cv.make_entity_service_schema(schema)
 
-        async def handle_service(call: Callable) -> None:
+        async def handle_service(call: ServiceCall) -> dict | None:
             """Handle the service."""
-            await self.hass.helpers.service.entity_service_call(
-                self._platforms.values(), func, call, required_features
+            return await service.entity_service_call(
+                self.hass, self._platforms.values(), func, call, required_features
             )
 
         self.hass.services.async_register(self.domain, name, handle_service, schema)

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -658,9 +658,9 @@ class EntityPlatform:
         if isinstance(schema, dict):
             schema = cv.make_entity_service_schema(schema)
 
-        async def handle_service(call: ServiceCall) -> None:
+        async def handle_service(call: ServiceCall) -> dict | None:
             """Handle the service."""
-            await service.entity_service_call(
+            return await service.entity_service_call(
                 self.hass,
                 [
                     plf

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -565,10 +565,12 @@ class _ScriptRun:
         )
         if limit is not None:
             # There is a call limit, so just wait for it to finish.
-            await service_task
+            result = await service_task
+            trace_update_result(service_result=result)
             return
 
-        await self._async_run_long_action(service_task)
+        result = await self._async_run_long_action(service_task)
+        trace_update_result(service_result=result)
 
     async def _async_device_step(self):
         """Perform the device automation specified in the action."""

--- a/tests/helpers/test_script.py
+++ b/tests/helpers/test_script.py
@@ -246,6 +246,7 @@ async def test_calling_service_basic(hass, caplog):
                             "target": {},
                         },
                         "running_script": False,
+                        "service_result": {"completed": True, "result": None},
                     }
                 }
             ],
@@ -299,6 +300,7 @@ async def test_calling_service_template(hass):
                             "target": {},
                         },
                         "running_script": False,
+                        "service_result": {"completed": True, "result": None},
                     }
                 }
             ],
@@ -338,6 +340,7 @@ async def test_data_template_with_templated_key(hass):
                             "target": {},
                         },
                         "running_script": False,
+                        "service_result": {"completed": True, "result": None},
                     }
                 }
             ],
@@ -2794,6 +2797,7 @@ async def test_set_variable(hass, caplog):
                         "target": {},
                     },
                     "running_script": False,
+                    "service_result": {"completed": True, "result": None},
                 },
                 "variables": {"variable": "value"},
             }
@@ -2835,6 +2839,7 @@ async def test_set_redefines_variable(hass, caplog):
                         "target": {},
                     },
                     "running_script": False,
+                    "service_result": {"completed": True, "result": None},
                 },
                 "variables": {"variable": "1"},
             }
@@ -2851,6 +2856,7 @@ async def test_set_redefines_variable(hass, caplog):
                         "target": {},
                     },
                     "running_script": False,
+                    "service_result": {"completed": True, "result": None},
                 },
                 "variables": {"variable": 2},
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Return result from ServiceRegistry.async_call when `blocking=True`

The return value is a dict:
```py
{
    "completed": bool,  # True if the call completed, False if it timed out
    "result": Any,  # Optional result from the service handler
}
```

Update `entity_service_call` to return a dict with missing areas, missing devices, missing entites,, unavailable entities and unsupported entities.

Main driver is to allow services to report when something is not quite right, but not wrong enough to throw.
An example is `entity_service_call` which proceeds if some targetted entities are not found or do not support the requested service.

TODO (in follow-up PRs):
- Update `entity_service_call` to return the result from each entity's service call
- Update `homeassistant.turn_on` etc. to report invalid or unsupported entities
- Update `group` to return the result from each inner service call
- Update `debounce` to return the result from the debounced call
- Update `ReloadServiceHelper` to return the result
- Other?


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
