### PR TITLE
Move pymodbus test fixtures to test_init

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -57,6 +57,7 @@ async def mock_modbus(hass, mock_pymodbus):
     yield mock_pymodbus
 
 
+# dataclass
 class ReadResult:
     """Storage class for register read results."""
 

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -79,41 +79,14 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
+from .conftest import ReadResult
+
 from tests.common import async_fire_time_changed
 
 TEST_SENSOR_NAME = "testSensor"
 TEST_ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_SENSOR_NAME}"
 TEST_HOST = "modbusTestHost"
 TEST_MODBUS_NAME = "modbusTest"
-
-
-class ReadResult:
-    """Storage class for register read results."""
-
-    def __init__(self, register_words):
-        """Init."""
-        # result read calls
-        self.registers = register_words
-        self.bits = register_words
-
-        # result write calls
-        self.value = register_words
-        self.count = len(register_words)
-
-
-@pytest.fixture
-def mock_pymodbus():
-    """Mock pymodbus."""
-    mock_pb = mock.MagicMock()
-    with mock.patch(
-        "homeassistant.components.modbus.modbus.ModbusTcpClient", return_value=mock_pb
-    ), mock.patch(
-        "homeassistant.components.modbus.modbus.ModbusSerialClient",
-        return_value=mock_pb,
-    ), mock.patch(
-        "homeassistant.components.modbus.modbus.ModbusUdpClient", return_value=mock_pb
-    ):
-        yield mock_pb
 
 
 @pytest.fixture
@@ -179,7 +152,7 @@ async def test_number_validator():
         },
     ],
 )
-async def test_OK_sensor_schema_validator(do_config):
+async def test_ok_sensor_schema_validator(do_config):
     """Test struct validator."""
     try:
         sensor_schema_validator(do_config)

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -5,9 +5,12 @@ This file is responsible for testing:
 - Functionality of class ModbusHub
 - Coverage 100%:
     __init__.py
-    base_platform.py
     const.py
     modbus.py
+    validators.py
+    baseplatform.py (only BasePlatform)
+
+It uses binary_sensors/sensors to do black box testing of the read calls.
 """
 from datetime import timedelta
 import logging
@@ -35,19 +38,31 @@ from homeassistant.components.modbus.const import (
     CALL_TYPE_WRITE_REGISTERS,
     CONF_BAUDRATE,
     CONF_BYTESIZE,
+    CONF_DATA_TYPE,
     CONF_INPUT_TYPE,
     CONF_PARITY,
+    CONF_REVERSE_ORDER,
     CONF_STOPBITS,
+    CONF_SWAP,
+    CONF_SWAP_BYTE,
+    CONF_SWAP_WORD,
+    DATA_TYPE_CUSTOM,
+    DATA_TYPE_INT,
+    DATA_TYPE_STRING,
     DEFAULT_SCAN_INTERVAL,
     MODBUS_DOMAIN as DOMAIN,
     SERVICE_WRITE_COIL,
     SERVICE_WRITE_REGISTER,
 )
-from homeassistant.components.modbus.validators import number_validator
+from homeassistant.components.modbus.validators import (
+    number_validator,
+    sensor_schema_validator,
+)
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     CONF_ADDRESS,
     CONF_BINARY_SENSORS,
+    CONF_COUNT,
     CONF_DELAY,
     CONF_HOST,
     CONF_METHOD,
@@ -55,6 +70,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_SCAN_INTERVAL,
     CONF_SENSORS,
+    CONF_STRUCTURE,
     CONF_TIMEOUT,
     CONF_TYPE,
     STATE_ON,
@@ -63,13 +79,54 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from .conftest import TEST_MODBUS_NAME, ReadResult
-
 from tests.common import async_fire_time_changed
 
 TEST_SENSOR_NAME = "testSensor"
 TEST_ENTITY_ID = f"{SENSOR_DOMAIN}.{TEST_SENSOR_NAME}"
 TEST_HOST = "modbusTestHost"
+TEST_MODBUS_NAME = "modbusTest"
+
+
+class ReadResult:
+    """Storage class for register read results."""
+
+    def __init__(self, register_words):
+        """Init."""
+        # result read calls
+        self.registers = register_words
+        self.bits = register_words
+
+        # result write calls
+        self.value = register_words
+        self.count = len(register_words)
+
+
+@pytest.fixture
+def mock_pymodbus():
+    """Mock pymodbus."""
+    mock_pb = mock.MagicMock()
+    with mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusTcpClient", return_value=mock_pb
+    ), mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusSerialClient",
+        return_value=mock_pb,
+    ), mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusUdpClient", return_value=mock_pb
+    ):
+        yield mock_pb
+
+
+@pytest.fixture
+async def mock_modbus_with_pymodbus(hass, caplog, do_config, mock_pymodbus):
+    """Load integration modbus using mocked pymodbus."""
+    caplog.clear()
+    caplog.set_level(logging.ERROR)
+    config = {DOMAIN: do_config}
+    assert await async_setup_component(hass, DOMAIN, config) is True
+    await hass.async_block_till_done()
+    assert DOMAIN in hass.config.components
+    assert caplog.text == ""
+    yield mock_pymodbus
 
 
 async def test_number_validator():
@@ -92,6 +149,84 @@ async def test_number_validator():
     except (vol.Invalid):
         return
     pytest.fail("Number_validator not throwing exception")
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 2,
+            CONF_DATA_TYPE: DATA_TYPE_STRING,
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 2,
+            CONF_DATA_TYPE: DATA_TYPE_INT,
+            CONF_REVERSE_ORDER: True,
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 2,
+            CONF_DATA_TYPE: DATA_TYPE_INT,
+            CONF_REVERSE_ORDER: False,
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 2,
+            CONF_DATA_TYPE: DATA_TYPE_INT,
+            CONF_SWAP: CONF_SWAP_BYTE,
+        },
+    ],
+)
+async def test_OK_sensor_schema_validator(do_config):
+    """Test struct validator."""
+    try:
+        sensor_schema_validator(do_config)
+    except vol.Invalid:
+        pytest.fail("Sensor_schema_validator unexpected exception")
+
+
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 8,
+            CONF_DATA_TYPE: DATA_TYPE_INT,
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 8,
+            CONF_DATA_TYPE: DATA_TYPE_CUSTOM,
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 8,
+            CONF_DATA_TYPE: DATA_TYPE_CUSTOM,
+            CONF_STRUCTURE: "no good",
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 20,
+            CONF_DATA_TYPE: DATA_TYPE_CUSTOM,
+            CONF_STRUCTURE: ">f",
+        },
+        {
+            CONF_NAME: TEST_SENSOR_NAME,
+            CONF_COUNT: 1,
+            CONF_DATA_TYPE: DATA_TYPE_INT,
+            CONF_SWAP: CONF_SWAP_WORD,
+        },
+    ],
+)
+async def test_exception_sensor_schema_validator(do_config):
+    """Test struct validator."""
+    try:
+        sensor_schema_validator(do_config)
+    except vol.Invalid:
+        return
+    pytest.fail("Sensor_schema_validator missing exception")
 
 
 @pytest.mark.parametrize(
@@ -187,16 +322,23 @@ async def test_number_validator():
                 CONF_NAME: TEST_MODBUS_NAME + "3",
             },
         ],
+        {
+            # Special test for scan_interval validator with scan_interval: 0
+            CONF_TYPE: "tcp",
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: 5501,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: TEST_SENSOR_NAME,
+                    CONF_ADDRESS: 117,
+                    CONF_SCAN_INTERVAL: 0,
+                }
+            ],
+        },
     ],
 )
-async def test_config_modbus(hass, caplog, do_config, mock_pymodbus):
+async def test_config_modbus(hass, caplog, mock_modbus_with_pymodbus):
     """Run configuration test for modbus."""
-    config = {DOMAIN: do_config}
-    caplog.set_level(logging.ERROR)
-    assert await async_setup_component(hass, DOMAIN, config) is True
-    await hass.async_block_till_done()
-    assert DOMAIN in hass.config.components
-    assert len(caplog.records) == 0
 
 
 VALUE = "value"
@@ -205,6 +347,17 @@ DATA = "data"
 SERVICE = "service"
 
 
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_NAME: TEST_MODBUS_NAME,
+            CONF_TYPE: "tcp",
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: 5501,
+        },
+    ],
+)
 @pytest.mark.parametrize(
     "do_write",
     [
@@ -234,14 +387,25 @@ SERVICE = "service"
         },
     ],
 )
-async def test_pb_service_write(hass, do_write, caplog, mock_modbus):
+@pytest.mark.parametrize(
+    "do_return",
+    [
+        {VALUE: ReadResult([0x0001]), DATA: ""},
+        {VALUE: ExceptionResponse(0x06), DATA: "Pymodbus:"},
+        {VALUE: IllegalFunctionRequest(0x06), DATA: "Pymodbus:"},
+        {VALUE: ModbusException("fail write_"), DATA: "Pymodbus:"},
+    ],
+)
+async def test_pb_service_write(
+    hass, do_write, do_return, caplog, mock_modbus_with_pymodbus
+):
     """Run test for service write_register."""
 
     func_name = {
-        CALL_TYPE_WRITE_COIL: mock_modbus.write_coil,
-        CALL_TYPE_WRITE_COILS: mock_modbus.write_coils,
-        CALL_TYPE_WRITE_REGISTER: mock_modbus.write_register,
-        CALL_TYPE_WRITE_REGISTERS: mock_modbus.write_registers,
+        CALL_TYPE_WRITE_COIL: mock_modbus_with_pymodbus.write_coil,
+        CALL_TYPE_WRITE_COILS: mock_modbus_with_pymodbus.write_coils,
+        CALL_TYPE_WRITE_REGISTER: mock_modbus_with_pymodbus.write_register,
+        CALL_TYPE_WRITE_REGISTERS: mock_modbus_with_pymodbus.write_registers,
     }
 
     data = {
@@ -250,28 +414,42 @@ async def test_pb_service_write(hass, do_write, caplog, mock_modbus):
         ATTR_ADDRESS: 16,
         do_write[DATA]: do_write[VALUE],
     }
+    mock_modbus_with_pymodbus.reset_mock()
+    caplog.clear()
+    caplog.set_level(logging.DEBUG)
+    func_name[do_write[FUNC]].return_value = do_return[VALUE]
     await hass.services.async_call(DOMAIN, do_write[SERVICE], data, blocking=True)
     assert func_name[do_write[FUNC]].called
     assert func_name[do_write[FUNC]].call_args[0] == (
         data[ATTR_ADDRESS],
         data[do_write[DATA]],
     )
-    mock_modbus.reset_mock()
-
-    for return_value in [
-        ExceptionResponse(0x06),
-        IllegalFunctionRequest(0x06),
-        ModbusException("fail write_"),
-    ]:
-        caplog.set_level(logging.DEBUG)
-        func_name[do_write[FUNC]].return_value = return_value
-        await hass.services.async_call(DOMAIN, do_write[SERVICE], data, blocking=True)
-        assert func_name[do_write[FUNC]].called
+    if do_return[DATA]:
         assert caplog.messages[-1].startswith("Pymodbus:")
-        mock_modbus.reset_mock()
 
 
-async def _read_helper(hass, do_group, do_type, do_return, do_exception, mock_pymodbus):
+@pytest.fixture
+async def mock_modbus_read_pymodbus(
+    hass,
+    do_group,
+    do_type,
+    do_scan_interval,
+    do_return,
+    do_exception,
+    caplog,
+    mock_pymodbus,
+):
+    """Load integration modbus using mocked pymodbus."""
+    caplog.clear()
+    caplog.set_level(logging.ERROR)
+    mock_pymodbus.read_coils.side_effect = do_exception
+    mock_pymodbus.read_discrete_inputs.side_effect = do_exception
+    mock_pymodbus.read_input_registers.side_effect = do_exception
+    mock_pymodbus.read_holding_registers.side_effect = do_exception
+    mock_pymodbus.read_coils.return_value = do_return
+    mock_pymodbus.read_discrete_inputs.return_value = do_return
+    mock_pymodbus.read_input_registers.return_value = do_return
+    mock_pymodbus.read_holding_registers.return_value = do_return
     config = {
         DOMAIN: [
             {
@@ -284,91 +462,63 @@ async def _read_helper(hass, do_group, do_type, do_return, do_exception, mock_py
                         CONF_INPUT_TYPE: do_type,
                         CONF_NAME: TEST_SENSOR_NAME,
                         CONF_ADDRESS: 51,
-                        CONF_SCAN_INTERVAL: 1,
+                        CONF_SCAN_INTERVAL: do_scan_interval,
                     }
                 ],
             }
-        ]
+        ],
     }
-    mock_pymodbus.read_coils.side_effect = do_exception
-    mock_pymodbus.read_discrete_inputs.side_effect = do_exception
-    mock_pymodbus.read_input_registers.side_effect = do_exception
-    mock_pymodbus.read_holding_registers.side_effect = do_exception
-    mock_pymodbus.read_coils.return_value = do_return
-    mock_pymodbus.read_discrete_inputs.return_value = do_return
-    mock_pymodbus.read_input_registers.return_value = do_return
-    mock_pymodbus.read_holding_registers.return_value = do_return
     now = dt_util.utcnow()
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         assert await async_setup_component(hass, DOMAIN, config) is True
         await hass.async_block_till_done()
+    assert DOMAIN in hass.config.components
+    assert caplog.text == ""
     now = now + timedelta(seconds=DEFAULT_SCAN_INTERVAL + 60)
     with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
         async_fire_time_changed(hass, now)
         await hass.async_block_till_done()
+    yield mock_pymodbus
 
 
 @pytest.mark.parametrize(
-    "do_return,do_exception,do_expect",
+    "do_domain, do_group,do_type,do_scan_interval",
     [
-        [ReadResult([7]), None, "7"],
-        [IllegalFunctionRequest(0x99), None, STATE_UNAVAILABLE],
-        [ExceptionResponse(0x99), None, STATE_UNAVAILABLE],
-        [ReadResult([7]), ModbusException("fail read_"), STATE_UNAVAILABLE],
+        [SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_HOLDING, 1],
+        [SENSOR_DOMAIN, CONF_SENSORS, CALL_TYPE_REGISTER_INPUT, 1],
+        [BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS, CALL_TYPE_DISCRETE, 1],
+        [BINARY_SENSOR_DOMAIN, CONF_BINARY_SENSORS, CALL_TYPE_COIL, 1],
     ],
 )
 @pytest.mark.parametrize(
-    "do_type",
-    [CALL_TYPE_REGISTER_HOLDING, CALL_TYPE_REGISTER_INPUT],
+    "do_return,do_exception,do_expect_state,do_expect_value",
+    [
+        [ReadResult([1]), None, STATE_ON, "1"],
+        [IllegalFunctionRequest(0x99), None, STATE_UNAVAILABLE, STATE_UNAVAILABLE],
+        [ExceptionResponse(0x99), None, STATE_UNAVAILABLE, STATE_UNAVAILABLE],
+        [
+            ReadResult([1]),
+            ModbusException("fail read_"),
+            STATE_UNAVAILABLE,
+            STATE_UNAVAILABLE,
+        ],
+    ],
 )
-async def test_pb_read_value(
-    hass, caplog, do_type, do_return, do_exception, do_expect, mock_pymodbus
+async def test_pb_read(
+    hass, do_domain, do_expect_state, do_expect_value, caplog, mock_modbus_read_pymodbus
 ):
     """Run test for different read."""
 
-    # the purpose of this test is to test the special
-    # return values from pymodbus:
-    #     ExceptionResponse, IllegalResponse
-    # and exceptions.
-    # We "hijiack" binary_sensor and sensor in order
-    # to make a proper blackbox test.
-    await _read_helper(
-        hass, CONF_SENSORS, do_type, do_return, do_exception, mock_pymodbus
-    )
-
     # Check state
-    entity_id = f"{SENSOR_DOMAIN}.{TEST_SENSOR_NAME}"
+    entity_id = f"{do_domain}.{TEST_SENSOR_NAME}"
+    state = hass.states.get(entity_id).state
     assert hass.states.get(entity_id).state
 
-
-@pytest.mark.parametrize(
-    "do_return,do_exception,do_expect",
-    [
-        [ReadResult([0x01]), None, STATE_ON],
-        [IllegalFunctionRequest(0x99), None, STATE_UNAVAILABLE],
-        [ExceptionResponse(0x99), None, STATE_UNAVAILABLE],
-        [ReadResult([7]), ModbusException("fail read_"), STATE_UNAVAILABLE],
-    ],
-)
-@pytest.mark.parametrize("do_type", [CALL_TYPE_DISCRETE, CALL_TYPE_COIL])
-async def test_pb_read_state(
-    hass, caplog, do_type, do_return, do_exception, do_expect, mock_pymodbus
-):
-    """Run test for different read."""
-
-    # the purpose of this test is to test the special
-    # return values from pymodbus:
-    #     ExceptionResponse, IllegalResponse
-    # and exceptions.
-    # We "hijiack" binary_sensor and sensor in order
-    # to make a proper blackbox test.
-    await _read_helper(
-        hass, CONF_BINARY_SENSORS, do_type, do_return, do_exception, mock_pymodbus
-    )
-
-    # Check state
-    entity_id = f"{BINARY_SENSOR_DOMAIN}.{TEST_SENSOR_NAME}"
-    state = hass.states.get(entity_id).state
+    # this if is needed to avoid explode the
+    if do_domain == SENSOR_DOMAIN:
+        do_expect = do_expect_value
+    else:
+        do_expect = do_expect_state
     assert state == do_expect
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Without the "old style" configuration, the tests can be heavily simplified.

This PR simplifies test_init.py, but using fixtures and also testing pymodbus API and class ModbusHub 100%.

With pymodbus API tested, the platform tests can concentrate on testing the platform functionality with a much
simpler mock interface (class ModbusHub instead of pymodbus) with simple return values and no pymodbus exceptions (in line or real exceptions).

test_init.py have quite a lot of changes, therefore it is submitted as a PR, next PR should contain multiple platforms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
