### PR TITLE
Refactor stream to create partial segments

### DIFF
--- a/homeassistant/components/stream/const.py
+++ b/homeassistant/components/stream/const.py
@@ -18,8 +18,9 @@ FORMAT_CONTENT_TYPE = {HLS_PROVIDER: "application/vnd.apple.mpegurl"}
 OUTPUT_IDLE_TIMEOUT = 300  # Idle timeout due to inactivity
 
 NUM_PLAYLIST_SEGMENTS = 3  # Number of segments to use in HLS playlist
-MAX_SEGMENTS = 4  # Max number of segments to keep around
+MAX_SEGMENTS = 5  # Max number of segments to keep around
 TARGET_SEGMENT_DURATION = 2.0  # Each segment is about this many seconds
+TARGET_PART_DURATION = 1.0
 SEGMENT_DURATION_ADJUSTER = 0.1  # Used to avoid missing keyframe boundaries
 # Each segment is at least this many seconds
 MIN_SEGMENT_DURATION = TARGET_SEGMENT_DURATION - SEGMENT_DURATION_ADJUSTER

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -20,18 +20,33 @@ PROVIDERS = Registry()
 
 
 @attr.s(slots=True)
+class Part:
+    """Represent a segment part."""
+
+    duration: float = attr.ib()
+    independent: bool = attr.ib()
+    data: bytes = attr.ib()
+
+
+@attr.s(slots=True)
 class Segment:
     """Represent a segment."""
 
-    sequence: int = attr.ib()
-    # the init of the mp4
-    init: bytes = attr.ib()
-    # the video data (moof + mddat)s of the mp4
-    moof_data: bytes = attr.ib()
-    duration: float = attr.ib()
+    sequence: int = attr.ib(default=0)
+    # the init of the mp4 the segment is based on
+    init: bytes = attr.ib(default=None)
+    duration: float = attr.ib(default=0)
     # For detecting discontinuities across stream restarts
     stream_id: int = attr.ib(default=0)
+    parts: list[Part] = attr.ib(factory=list)
+    # This value is the current length of the segment
+    last_write_pos: int = attr.ib(default=0)
     start_time: datetime.datetime = attr.ib(factory=datetime.datetime.utcnow)
+
+    @property
+    def complete(self) -> bool:
+        """Return whether the Segment is complete."""
+        return self.duration > 0
 
 
 class IdleTimer:

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -39,8 +39,6 @@ class Segment:
     # For detecting discontinuities across stream restarts
     stream_id: int = attr.ib(default=0)
     parts: list[Part] = attr.ib(factory=list)
-    # This value is the current length of the segment
-    last_write_pos: int = attr.ib(default=0)
     start_time: datetime.datetime = attr.ib(factory=datetime.datetime.utcnow)
 
     @property

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -46,6 +46,10 @@ class Segment:
         """Return whether the Segment is complete."""
         return self.duration > 0
 
+    def get_bytes_without_init(self) -> bytes:
+        """Return reconstructed data for entire segment as bytes."""
+        return b"".join([part.data for part in self.parts])
+
 
 class IdleTimer:
     """Invoke a callback after an inactivity timeout.

--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -24,7 +24,7 @@ class Part:
     """Represent a segment part."""
 
     duration: float = attr.ib()
-    independent: bool = attr.ib()
+    has_keyframe: bool = attr.ib()
     data: bytes = attr.ib()
 
 

--- a/homeassistant/components/stream/fmp4utils.py
+++ b/homeassistant/components/stream/fmp4utils.py
@@ -25,16 +25,6 @@ def find_box(
         index += int.from_bytes(box_header[0:4], byteorder="big")
 
 
-def get_init_and_moof_data(segment: memoryview) -> tuple[bytes, bytes]:
-    """Get the init and moof data from a segment."""
-    moof_location = next(find_box(segment, b"moof"), 0)
-    mfra_location = next(find_box(segment, b"mfra"), len(segment))
-    return (
-        segment[:moof_location].tobytes(),
-        segment[moof_location:mfra_location].tobytes(),
-    )
-
-
 def get_codec_string(mp4_bytes: bytes) -> str:
     """Get RFC 6381 codec string."""
     codecs = []

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -38,7 +38,12 @@ class HlsMasterPlaylistView(StreamView):
         # Calculate file size / duration and use a small multiplier to account for variation
         # hls spec already allows for 25% variation
         segment = track.get_segment(track.sequences[-2])
-        bandwidth = round(segment.last_write_pos * 8 / segment.duration * 1.2)
+        bandwidth = round(
+            (len(segment.init) + sum(len(part.data) for part in segment.parts))
+            * 8
+            / segment.duration
+            * 1.2
+        )
         codecs = get_codec_string(segment.init)
         lines = [
             "#EXTM3U",

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -172,7 +172,7 @@ class HlsSegmentView(StreamView):
             return web.HTTPNotFound()
         headers = {"Content-Type": "video/iso.segment"}
         return web.Response(
-            body=b"".join([part.data for part in segment.parts]),
+            body=segment.get_bytes_without_init(),
             headers=headers,
         )
 

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -116,7 +116,7 @@ class HlsPlaylistView(StreamView):
                 )
             playlist.extend(
                 [
-                    f"#EXTINF:{float(segment.duration):.04f},",
+                    f"#EXTINF:{segment.duration:.3f},",
                     f"./segment/{segment.sequence}.m4s",
                 ]
             )

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -57,7 +57,7 @@ def recorder_save_worker(file_out: str, segments: deque[Segment]):
 
         # Open segment
         source = av.open(
-            BytesIO(segment.init + segment.moof_data),
+            BytesIO(segment.init + b"".join([part.data for part in segment.parts])),
             "r",
             format=SEGMENT_CONTAINER_FORMAT,
         )

--- a/homeassistant/components/stream/recorder.py
+++ b/homeassistant/components/stream/recorder.py
@@ -57,7 +57,7 @@ def recorder_save_worker(file_out: str, segments: deque[Segment]):
 
         # Open segment
         source = av.open(
-            BytesIO(segment.init + b"".join([part.data for part in segment.parts])),
+            BytesIO(segment.init + segment.get_bytes_without_init()),
             "r",
             format=SEGMENT_CONTAINER_FORMAT,
         )

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterator, Mapping, ValuesView
+from collections.abc import Iterator, Mapping
 from fractions import Fraction
 from io import BytesIO
 import logging
@@ -38,8 +38,6 @@ class SegmentBuffer:
         self._outputs_callback: Callable[
             [], Mapping[str, StreamOutput]
         ] = outputs_callback
-        # Each element is a StreamOutput
-        self._outputs: ValuesView[StreamOutput] | list[StreamOutput] = []
         # sequence gets incremented before the first segment so the first segment
         # has a sequence number of 0.
         self._sequence = -1
@@ -154,8 +152,7 @@ class SegmentBuffer:
             self._segment.init = self._memory_file.getbuffer()[:byte_position].tobytes()
             # Fetch the latest StreamOutputs, which may have changed since the
             # worker started.
-            self._outputs = self._outputs_callback().values()
-            for stream_output in self._outputs:
+            for stream_output in self._outputs_callback().values():
                 stream_output.put(self._segment)
         else:  # These are the ends of the part segments
             self._segment.parts.append(

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -70,6 +70,9 @@ class SegmentBuffer:
                 "avoid_negative_ts": "disabled",
                 "fragment_index": str(sequence + 1),
                 "video_track_timescale": str(int(1 / input_vstream.time_base)),
+                # Create a fragments every TARGET_PART_DURATION. The data from each fragment is stored in
+                # a "Part" that can be combined with the data from all the other "Part"s, plus an init
+                # section, to reconstitute the data in a "Segment".
                 "frag_duration": str(int(TARGET_PART_DURATION * 1e6)),
             },
         )

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 from collections import deque
+from collections.abc import Iterator, Mapping, ValuesView
+from fractions import Fraction
 from io import BytesIO
 import logging
-from typing import cast
+from threading import Event
+from typing import Callable, cast
 
 import av
 
@@ -17,9 +20,9 @@ from .const import (
     PACKETS_TO_WAIT_FOR_AUDIO,
     SEGMENT_CONTAINER_FORMAT,
     SOURCE_TIMEOUT,
+    TARGET_PART_DURATION,
 )
-from .core import Segment, StreamOutput
-from .fmp4utils import get_init_and_moof_data
+from .core import Part, Segment, StreamOutput
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -27,15 +30,20 @@ _LOGGER = logging.getLogger(__name__)
 class SegmentBuffer:
     """Buffer for writing a sequence of packets to the output as a segment."""
 
-    def __init__(self, outputs_callback) -> None:
+    def __init__(
+        self, outputs_callback: Callable[[], Mapping[str, StreamOutput]]
+    ) -> None:
         """Initialize SegmentBuffer."""
-        self._stream_id = 0
-        self._outputs_callback = outputs_callback
-        self._outputs: list[StreamOutput] = []
+        self._stream_id: int = 0
+        self._outputs_callback: Callable[
+            [], Mapping[str, StreamOutput]
+        ] = outputs_callback
+        # Each element is a StreamOutput
+        self._outputs: ValuesView[StreamOutput] | list[StreamOutput] = []
         # sequence gets incremented before the first segment so the first segment
         # has a sequence number of 0.
         self._sequence = -1
-        self._segment_start_pts = None
+        self._segment_start_pts: int = cast(int, None)
         self._memory_file: BytesIO = cast(BytesIO, None)
         self._av_output: av.container.OutputContainer = None
         self._input_video_stream: av.video.VideoStream = None
@@ -43,6 +51,10 @@ class SegmentBuffer:
         self._output_video_stream: av.video.VideoStream = None
         self._output_audio_stream = None  # av.audio.AudioStream | None
         self._segment: Segment = cast(Segment, None)
+        self._part_start_dts: int = cast(int, None)
+        self._last_packet_dts: int = cast(int, None)
+        self._part_is_independent = False
+        self._last_packet_independent = False
 
     @staticmethod
     def make_new_av(
@@ -56,10 +68,11 @@ class SegmentBuffer:
             container_options={
                 # Removed skip_sidx - see https://github.com/home-assistant/core/pull/39970
                 # "cmaf" flag replaces several of the movflags used, but too recent to use for now
-                "movflags": "frag_custom+empty_moov+default_base_moof+frag_discont+negative_cts_offsets+skip_trailer",
+                "movflags": "empty_moov+default_base_moof+frag_discont+negative_cts_offsets+skip_trailer",
                 "avoid_negative_ts": "disabled",
                 "fragment_index": str(sequence + 1),
                 "video_track_timescale": str(int(1 / input_vstream.time_base)),
+                "frag_duration": str(int(TARGET_PART_DURATION * 1e6)),
             },
         )
 
@@ -73,15 +86,14 @@ class SegmentBuffer:
         self._input_video_stream = video_stream
         self._input_audio_stream = audio_stream
 
-    def reset(self, video_pts):
+    def reset(self, video_pts: int) -> None:
         """Initialize a new stream segment."""
         # Keep track of the number of segments we've processed
         self._sequence += 1
-        self._segment_start_pts = video_pts
-
-        # Fetch the latest StreamOutputs, which may have changed since the
-        # worker started.
-        self._outputs = self._outputs_callback().values()
+        self._segment_start_pts = (
+            self._part_start_dts
+        ) = self._last_packet_dts = video_pts
+        self._segment = Segment(sequence=self._sequence, stream_id=self._stream_id)
         self._memory_file = BytesIO()
         self._av_output = self.make_new_av(
             memory_file=self._memory_file,
@@ -98,18 +110,31 @@ class SegmentBuffer:
                 template=self._input_audio_stream
             )
 
-    def mux_packet(self, packet):
+    def mux_packet(self, packet: av.Packet) -> None:
         """Mux a packet to the appropriate output stream."""
 
         # Check for end of segment
-        if packet.stream == self._input_video_stream and packet.is_keyframe:
-            duration = (packet.pts - self._segment_start_pts) * packet.time_base
-            if duration >= MIN_SEGMENT_DURATION:
-                # Save segment to outputs
-                self.flush(duration)
+        if packet.stream == self._input_video_stream:
+
+            self.check_flush_part(packet)
+
+            if (
+                packet.is_keyframe
+                and (
+                    segment_duration := (packet.pts - self._segment_start_pts)
+                    * packet.time_base
+                )
+                >= MIN_SEGMENT_DURATION
+            ):
+                # Flush segment (also flushes the stub part segment)
+                self.flush(segment_duration, packet)
 
                 # Reinitialize
                 self.reset(packet.pts)
+
+            self._last_packet_dts = packet.dts
+            self._part_is_independent |= self._last_packet_independent
+            self._last_packet_independent = packet.is_keyframe
 
         # Mux the packet
         if packet.stream == self._input_video_stream:
@@ -119,33 +144,71 @@ class SegmentBuffer:
             packet.stream = self._output_audio_stream
             self._av_output.mux(packet)
 
-    def flush(self, duration):
+    def check_flush_part(self, packet: av.Packet) -> None:
+        """Check for and mark a part segment boundary and record its duration."""
+        byte_position = self._memory_file.tell()
+        if self._segment.last_write_pos == byte_position:
+            return
+        if self._segment.last_write_pos == 0:  # The beginning of the first moof
+            self._segment.last_write_pos = byte_position
+            self._segment.init = self._memory_file.getbuffer()[:byte_position].tobytes()
+            # Fetch the latest StreamOutputs, which may have changed since the
+            # worker started.
+            self._outputs = self._outputs_callback().values()
+            for stream_output in self._outputs:
+                stream_output.put(self._segment)
+        else:  # These are the ends of the part segments
+            self._segment.parts.append(
+                Part(
+                    # The end of a part segment will actually have occurred before the last video packet
+                    duration=float(
+                        (self._last_packet_dts - self._part_start_dts)
+                        * packet.time_base
+                    ),
+                    independent=self._part_is_independent,
+                    data=self._memory_file.getbuffer()[
+                        self._segment.last_write_pos : byte_position
+                    ].tobytes(),
+                )
+            )
+            self._segment.last_write_pos = byte_position
+            self._part_start_dts = self._last_packet_dts
+            self._part_is_independent = False
+
+    def flush(self, duration: Fraction, packet: av.Packet) -> None:
         """Create a segment from the buffered packets and write to output."""
         self._av_output.close()
-        segment = Segment(
-            self._sequence,
-            *get_init_and_moof_data(self._memory_file.getbuffer()),
-            duration,
-            self._stream_id,
+        self._segment.duration = float(duration)
+        # Also flush the part segment (need to close the output above before this)
+        end_loc = self._memory_file.tell()
+        self._segment.parts.append(
+            Part(
+                duration=float((packet.pts - self._part_start_dts) * packet.time_base),
+                independent=self._part_is_independent | self._last_packet_independent,
+                data=self._memory_file.getbuffer()[
+                    self._segment.last_write_pos :
+                ].tobytes(),
+            )
         )
-        self._memory_file.close()
-        for stream_output in self._outputs:
-            stream_output.put(segment)
+        self._segment.last_write_pos = end_loc
+        self._memory_file.close()  # We don't need the BytesIO object anymore
 
-    def discontinuity(self):
+    def discontinuity(self) -> None:
         """Mark the stream as having been restarted."""
         # Preserving sequence and stream_id here keep the HLS playlist logic
         # simple to check for discontinuity at output time, and to determine
         # the discontinuity sequence number.
         self._stream_id += 1
 
-    def close(self):
+    def close(self) -> None:
         """Close stream buffer."""
         self._av_output.close()
         self._memory_file.close()
 
 
-def stream_worker(source, options, segment_buffer, quit_event):  # noqa: C901
+def stream_worker(  # noqa: C901
+    source: str, options: dict, segment_buffer: SegmentBuffer, quit_event: Event
+) -> None:
     """Handle consuming streams."""
 
     try:
@@ -172,21 +235,21 @@ def stream_worker(source, options, segment_buffer, quit_event):  # noqa: C901
         audio_stream = None
 
     # Iterator for demuxing
-    container_packets = None
+    container_packets: Iterator[av.Packet]
     # The decoder timestamps of the latest packet in each stream we processed
     last_dts = {video_stream: float("-inf"), audio_stream: float("-inf")}
     # Keep track of consecutive packets without a dts to detect end of stream.
     missing_dts = 0
     # The video pts at the beginning of the segment
-    segment_start_pts = None
+    segment_start_pts: int | None = None
     # Because of problems 1 and 2 below, we need to store the first few packets and replay them
-    initial_packets = deque()
+    initial_packets: deque[av.Packet] = deque()
 
     # Have to work around two problems with RTSP feeds in ffmpeg
     # 1 - first frame has bad pts/dts https://trac.ffmpeg.org/ticket/5018
     # 2 - seeking can be problematic https://trac.ffmpeg.org/ticket/7815
 
-    def peek_first_pts():
+    def peek_first_pts() -> bool:
         """Initialize by peeking into the first few packets of the stream.
 
         Deal with problem #1 above (bad first packet pts/dts) by recalculating using pts/dts from second packet.
@@ -268,6 +331,7 @@ def stream_worker(source, options, segment_buffer, quit_event):  # noqa: C901
         return
 
     segment_buffer.set_streams(video_stream, audio_stream)
+    assert isinstance(segment_start_pts, int)
     segment_buffer.reset(segment_start_pts)
 
     while not quit_event.is_set():

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -263,7 +263,7 @@ def stream_worker(  # noqa: C901
         """Initialize by peeking into the first few packets of the stream.
 
         Deal with problem #1 above (bad first packet pts/dts) by recalculating using pts/dts from second packet.
-        Also load the first video keyframe pts into segment_start_pts and check if the audio stream really exists.
+        Also load the first video keyframe dts into segment_start_dts and check if the audio stream really exists.
         """
         nonlocal segment_start_dts, audio_stream, container_packets
         missing_dts = 0

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -165,7 +165,7 @@ class SegmentBuffer:
                     duration=float(
                         (packet.dts - self._part_start_dts) * packet.time_base
                     ),
-                    independent=self._part_has_keyframe,
+                    has_keyframe=self._part_has_keyframe,
                     data=self._memory_file.getbuffer()[
                         self._segment_last_write_pos : byte_position
                     ].tobytes(),
@@ -184,7 +184,7 @@ class SegmentBuffer:
         self._segment.parts.append(
             Part(
                 duration=float((packet.dts - self._part_start_dts) * packet.time_base),
-                independent=self._part_has_keyframe,
+                has_keyframe=self._part_has_keyframe,
                 data=self._memory_file.getbuffer()[
                     self._segment_last_write_pos :
                 ].tobytes(),

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -9,6 +9,8 @@ nothing for the test to verify. The solution is the WorkerSync class that
 allows the tests to pause the worker thread before finalizing the stream
 so that it can inspect the output.
 """
+from __future__ import annotations
+
 import asyncio
 from collections import deque
 import logging

--- a/tests/components/stream/conftest.py
+++ b/tests/components/stream/conftest.py
@@ -9,13 +9,19 @@ nothing for the test to verify. The solution is the WorkerSync class that
 allows the tests to pause the worker thread before finalizing the stream
 so that it can inspect the output.
 """
+import asyncio
+from collections import deque
 import logging
 import threading
 from unittest.mock import patch
 
+import async_timeout
 import pytest
 
 from homeassistant.components.stream import Stream
+from homeassistant.components.stream.core import Segment
+
+TEST_TIMEOUT = 7.0  # Lower than 9s home assistant timeout
 
 
 class WorkerSync:
@@ -55,6 +61,60 @@ def stream_worker_sync(hass):
     with patch(
         "homeassistant.components.stream.Stream._worker_finished",
         side_effect=sync.blocking_finish,
+        autospec=True,
+    ):
+        yield sync
+
+
+class SaveRecordWorkerSync:
+    """
+    Test fixture to manage RecordOutput thread for recorder_save_worker.
+
+    This is used to assert that the worker is started and stopped cleanly
+    to avoid thread leaks in tests.
+    """
+
+    def __init__(self):
+        """Initialize SaveRecordWorkerSync."""
+        self._save_event = None
+        self._segments = None
+        self._save_thread = None
+        self.reset()
+
+    def recorder_save_worker(self, file_out: str, segments: deque[Segment]):
+        """Mock method for patch."""
+        logging.debug("recorder_save_worker thread started")
+        assert self._save_thread is None
+        self._segments = segments
+        self._save_thread = threading.current_thread()
+        self._save_event.set()
+
+    async def get_segments(self):
+        """Return the recorded video segments."""
+        with async_timeout.timeout(TEST_TIMEOUT):
+            await self._save_event.wait()
+        return self._segments
+
+    async def join(self):
+        """Verify save worker was invoked and block on shutdown."""
+        with async_timeout.timeout(TEST_TIMEOUT):
+            await self._save_event.wait()
+        self._save_thread.join(timeout=TEST_TIMEOUT)
+        assert not self._save_thread.is_alive()
+
+    def reset(self):
+        """Reset callback state for reuse in tests."""
+        self._save_thread = None
+        self._save_event = asyncio.Event()
+
+
+@pytest.fixture()
+def record_worker_sync(hass):
+    """Patch recorder_save_worker for clean thread shutdown for test."""
+    sync = SaveRecordWorkerSync()
+    with patch(
+        "homeassistant.components.stream.recorder.recorder_save_worker",
+        side_effect=sync.recorder_save_worker,
         autospec=True,
     ):
         yield sync

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -322,7 +322,6 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
     # Fetch the actual segments with a fake byte payload
     for segment in hls.get_segments():
         segment.init = INIT_BYTES
-        segment.last_write_pos = len(segment.init) + len(FAKE_PAYLOAD)
         segment.parts = [
             Part(
                 duration=SEGMENT_DURATION,

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -325,7 +325,7 @@ async def test_hls_max_segments(hass, hls_stream, stream_worker_sync):
         segment.parts = [
             Part(
                 duration=SEGMENT_DURATION,
-                independent=True,
+                has_keyframe=True,
                 data=FAKE_PAYLOAD,
             )
         ]

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -70,7 +70,7 @@ def make_segment(segment, discontinuity=False):
                 + "Z",
             ]
         )
-    response.extend(["#EXTINF:10.0000,", f"./segment/{segment}.m4s"])
+    response.extend([f"#EXTINF:{SEGMENT_DURATION:.3f},", f"./segment/{segment}.m4s"])
     return "\n".join(response)
 
 

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -278,9 +278,7 @@ async def test_record_stream_audio(
             stream_worker_sync.resume()
 
         result = av.open(
-            BytesIO(
-                last_segment.init + b"".join(part.data for part in last_segment.parts)
-            ),
+            BytesIO(last_segment.init + last_segment.get_bytes_without_init()),
             "r",
             format="mp4",
         )

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -1,6 +1,4 @@
 """The tests for hls streams."""
-from __future__ import annotations
-
 from datetime import timedelta
 from io import BytesIO
 import os

--- a/tests/components/stream/test_recorder.py
+++ b/tests/components/stream/test_recorder.py
@@ -125,7 +125,7 @@ def add_parts_to_segment(segment, source):
     segment.parts = [
         Part(
             duration=None,
-            independent=None,
+            has_keyframe=None,
             http_range_start=None,
             data=source.getbuffer()[moof_locs[i] : moof_locs[i + 1]],
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#49608 implements LL-HLS in stream, but that PR is too large, making it hard to review. This an intermediate PR which refactors the component to fragment segments into partial segments and stores them as `Part`s.
The meat of the change in this PR is in the worker. The output segment is now opened with the `frag_duration` option so that ffmpeg will fragment the mp4 output automatically. The worker monitors new fragment availability by monitoring the file pointer of the BytesIO object, adding a `Part` as each fragment becomes available. As `Segment`s hold the `Part`s, they are now added while they are empty, and they are filled with `Part`s as the `Part`s become available. As a result, the queue length is extended by 1, making space for the last `Segment` which is usually a work in progress.
The video moof/mdat data is now stored across different parts in `Part.data` instead of in `Segment.moof_data`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
