### PR TITLE
Resolve addon repository slug for device registry

### DIFF
--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -71,7 +71,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 DATA_CORE_INFO = "hassio_core_info"
 DATA_HOST_INFO = "hassio_host_info"
-DATA_ADDONS = "hassio_addons"
+DATA_STORE = "hassio_store"
 DATA_INFO = "hassio_info"
 DATA_OS_INFO = "hassio_os_info"
 DATA_SUPERVISOR_INFO = "hassio_supervisor_info"
@@ -294,12 +294,12 @@ def get_host_info(hass):
 
 @callback
 @bind_hass
-def get_addons(hass):
-    """Return addons information.
+def get_store(hass):
+    """Return store information.
 
     Async friendly.
     """
-    return hass.data.get(DATA_ADDONS)
+    return hass.data.get(DATA_STORE)
 
 
 @callback
@@ -467,7 +467,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         try:
             hass.data[DATA_INFO] = await hassio.get_info()
             hass.data[DATA_HOST_INFO] = await hassio.get_host_info()
-            hass.data[DATA_ADDONS] = await hassio.get_addons()
+            hass.data[DATA_STORE] = await hassio.get_store()
             hass.data[DATA_CORE_INFO] = await hassio.get_core_info()
             hass.data[DATA_SUPERVISOR_INFO] = await hassio.get_supervisor_info()
             hass.data[DATA_OS_INFO] = await hassio.get_os_info()
@@ -640,18 +640,18 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
         """Update data via library."""
         new_data = {}
         supervisor_info = get_supervisor_info(self.hass)
-        addons_info = get_addons(self.hass)
+        store_data = get_store(self.hass)
 
         repositories = {
             repo[ATTR_SLUG]: repo[ATTR_NAME]
-            for repo in addons_info.get("repositories", [])
+            for repo in store_data.get("repositories", [])
         }
 
         new_data["addons"] = {
             addon[ATTR_SLUG]: {
                 **addon,
                 ATTR_REPOSITORY: repositories.get(
-                    addon.get(ATTR_REPOSITORY, ""), addon.get(ATTR_REPOSITORY)
+                    addon.get(ATTR_REPOSITORY), addon.get(ATTR_REPOSITORY, "")
                 ),
             }
             for addon in supervisor_info.get("addons", [])

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -71,6 +71,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 DATA_CORE_INFO = "hassio_core_info"
 DATA_HOST_INFO = "hassio_host_info"
+DATA_ADDONS = "hassio_addons"
 DATA_INFO = "hassio_info"
 DATA_OS_INFO = "hassio_os_info"
 DATA_SUPERVISOR_INFO = "hassio_supervisor_info"
@@ -293,6 +294,16 @@ def get_host_info(hass):
 
 @callback
 @bind_hass
+def get_addons(hass):
+    """Return addon information.
+
+    Async friendly.
+    """
+    return hass.data.get(DATA_ADDONS)
+
+
+@callback
+@bind_hass
 def get_supervisor_info(hass):
     """Return Supervisor information.
 
@@ -456,6 +467,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:  # noqa:
         try:
             hass.data[DATA_INFO] = await hassio.get_info()
             hass.data[DATA_HOST_INFO] = await hassio.get_host_info()
+            hass.data[DATA_ADDONS] = await hassio.get_addons()
             hass.data[DATA_CORE_INFO] = await hassio.get_core_info()
             hass.data[DATA_SUPERVISOR_INFO] = await hassio.get_supervisor_info()
             hass.data[DATA_OS_INFO] = await hassio.get_os_info()
@@ -627,10 +639,22 @@ class HassioDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Any]:
         """Update data via library."""
         new_data = {}
-        addon_data = get_supervisor_info(self.hass)
+        supervisor_info = get_supervisor_info(self.hass)
+        addons_info = get_addons(self.hass)
+
+        repositories = {
+            repo[ATTR_SLUG]: repo[ATTR_NAME]
+            for repo in addons_info.get("repositories", [])
+        }
 
         new_data["addons"] = {
-            addon[ATTR_SLUG]: addon for addon in addon_data.get("addons", [])
+            addon[ATTR_SLUG]: {
+                **addon,
+                ATTR_REPOSITORY: repositories.get(
+                    addon.get(ATTR_REPOSITORY, ""), addon.get(ATTR_REPOSITORY)
+                ),
+            }
+            for addon in supervisor_info.get("addons", [])
         }
         if self.is_hass_os:
             new_data["os"] = get_os_info(self.hass)

--- a/homeassistant/components/hassio/__init__.py
+++ b/homeassistant/components/hassio/__init__.py
@@ -295,7 +295,7 @@ def get_host_info(hass):
 @callback
 @bind_hass
 def get_addons(hass):
-    """Return addon information.
+    """Return addons information.
 
     Async friendly.
     """

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -119,6 +119,14 @@ class HassIO:
         return self.send_command(f"/addons/{addon}/info", method="get")
 
     @api_data
+    def get_addons(self):
+        """Return data for all Add-ons.
+
+        This method return a coroutine.
+        """
+        return self.send_command("/addons", method="get")
+
+    @api_data
     def get_ingress_panels(self):
         """Return data for Add-on ingress panels.
 

--- a/homeassistant/components/hassio/handler.py
+++ b/homeassistant/components/hassio/handler.py
@@ -119,12 +119,12 @@ class HassIO:
         return self.send_command(f"/addons/{addon}/info", method="get")
 
     @api_data
-    def get_addons(self):
-        """Return data for all Add-ons.
+    def get_store(self):
+        """Return data from the store.
 
         This method return a coroutine.
         """
-        return self.send_command("/addons", method="get")
+        return self.send_command("/store", method="get")
 
     @api_data
     def get_ingress_panels(self):

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -33,7 +33,7 @@ def mock_all(aioclient_mock, request):
         },
     )
     aioclient_mock.get(
-        "http://127.0.0.1/addons",
+        "http://127.0.0.1/store",
         json={
             "result": "ok",
             "data": {"addons": [], "repositories": []},

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -33,6 +33,13 @@ def mock_all(aioclient_mock, request):
         },
     )
     aioclient_mock.get(
+        "http://127.0.0.1/addons",
+        json={
+            "result": "ok",
+            "data": {"addons": [], "repositories": []},
+        },
+    )
+    aioclient_mock.get(
         "http://127.0.0.1/host/info",
         json={
             "result": "ok",
@@ -67,6 +74,7 @@ def mock_all(aioclient_mock, request):
                     "update_available": False,
                     "version": "1.0.0",
                     "version_latest": "1.0.0",
+                    "repository": "core",
                     "url": "https://github.com/home-assistant/addons/test",
                 },
                 {
@@ -76,6 +84,7 @@ def mock_all(aioclient_mock, request):
                     "update_available": False,
                     "version": "1.0.0",
                     "version_latest": "1.0.0",
+                    "repository": "core",
                     "url": "https://github.com",
                 },
             ],
@@ -92,7 +101,7 @@ async def test_setup_api_ping(hass, aioclient_mock):
         result = await async_setup_component(hass, "hassio", {})
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert hass.components.hassio.get_core_info()["version_latest"] == "1.0.0"
     assert hass.components.hassio.is_hassio()
 
@@ -131,7 +140,7 @@ async def test_setup_api_push_api_data(hass, aioclient_mock):
         )
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -147,7 +156,7 @@ async def test_setup_api_push_api_data_server_host(hass, aioclient_mock):
         )
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 9999
     assert not aioclient_mock.mock_calls[1][2]["watchdog"]
@@ -159,7 +168,7 @@ async def test_setup_api_push_api_data_default(hass, aioclient_mock, hass_storag
         result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     refresh_token = aioclient_mock.mock_calls[1][2]["refresh_token"]
@@ -206,7 +215,7 @@ async def test_setup_api_existing_hassio_user(hass, aioclient_mock, hass_storage
         result = await async_setup_component(hass, "hassio", {"http": {}, "hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert not aioclient_mock.mock_calls[1][2]["ssl"]
     assert aioclient_mock.mock_calls[1][2]["port"] == 8123
     assert aioclient_mock.mock_calls[1][2]["refresh_token"] == token.token
@@ -220,7 +229,7 @@ async def test_setup_core_push_timezone(hass, aioclient_mock):
         result = await async_setup_component(hass, "hassio", {"hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert aioclient_mock.mock_calls[2][2]["timezone"] == "testzone"
 
     with patch("homeassistant.util.dt.set_default_time_zone"):
@@ -237,7 +246,7 @@ async def test_setup_hassio_no_additional_data(hass, aioclient_mock):
         result = await async_setup_component(hass, "hassio", {"hassio": {}})
         assert result
 
-    assert aioclient_mock.call_count == 9
+    assert aioclient_mock.call_count == 10
     assert aioclient_mock.mock_calls[-1][3]["X-Hassio-Key"] == "123456"
 
 

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -74,6 +74,9 @@ async def mock_supervisor_fixture(hass, aioclient_mock):
         "homeassistant.components.hassio.HassIO.get_host_info",
         return_value={},
     ), patch(
+        "homeassistant.components.hassio.HassIO.get_addons",
+        return_value={},
+    ), patch(
         "homeassistant.components.hassio.HassIO.get_supervisor_info",
         return_value={"diagnostics": True},
     ), patch(

--- a/tests/components/onboarding/test_views.py
+++ b/tests/components/onboarding/test_views.py
@@ -74,7 +74,7 @@ async def mock_supervisor_fixture(hass, aioclient_mock):
         "homeassistant.components.hassio.HassIO.get_host_info",
         return_value={},
     ), patch(
-        "homeassistant.components.hassio.HassIO.get_addons",
+        "homeassistant.components.hassio.HassIO.get_store",
         return_value={},
     ), patch(
         "homeassistant.components.hassio.HassIO.get_supervisor_info",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Resolve the addon repository slug to the repository name for the manufacturer in the device registry.
![image](https://user-images.githubusercontent.com/15093472/120174818-d17a2480-c205-11eb-8a36-55629ffc6865.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51273
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
