### PR TITLE
Add system option to disable polling

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -287,7 +287,7 @@ async def system_options_update(hass, connection, msg):
 
     result = {
         "system_options": entry.system_options.as_dict(),
-        "restart_required": False,
+        "require_restart": False,
     }
 
     if (
@@ -295,7 +295,7 @@ async def system_options_update(hass, connection, msg):
         and entry.state is config_entries.ConfigEntryState.LOADED
     ):
         if not await hass.config_entries.async_reload(entry.entry_id):
-            result["restart_required"] = (
+            result["require_restart"] = (
                 entry.state is config_entries.ConfigEntryState.FAILED_UNLOAD
             )
 

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -31,7 +31,6 @@ async def async_setup(hass):
     hass.components.websocket_api.async_register_command(config_entry_disable)
     hass.components.websocket_api.async_register_command(config_entry_update)
     hass.components.websocket_api.async_register_command(config_entries_progress)
-    hass.components.websocket_api.async_register_command(system_options_list)
     hass.components.websocket_api.async_register_command(system_options_update)
     hass.components.websocket_api.async_register_command(ignore_config_flow)
 
@@ -231,20 +230,6 @@ def config_entries_progress(hass, connection, msg):
     )
 
 
-@websocket_api.require_admin
-@websocket_api.async_response
-@websocket_api.websocket_command(
-    {"type": "config_entries/system_options/list", "entry_id": str}
-)
-async def system_options_list(hass, connection, msg):
-    """List all system options for a config entry."""
-    entry_id = msg["entry_id"]
-    entry = hass.config_entries.async_get_entry(entry_id)
-
-    if entry:
-        connection.send_result(msg["id"], entry.system_options.as_dict())
-
-
 def send_entry_not_found(connection, msg_id):
     """Send Config entry not found error."""
     connection.send_error(
@@ -406,6 +391,7 @@ def entry_json(entry: config_entries.ConfigEntry) -> dict:
         "state": entry.state.value,
         "supports_options": supports_options,
         "supports_unload": entry.supports_unload,
+        "system_options": entry.system_options.as_dict(),
         "disabled_by": entry.disabled_by,
         "reason": entry.reason,
     }

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -994,12 +994,10 @@ class ConfigEntries:
             changed = True
             entry.options = MappingProxyType(options)
 
-        if (
-            system_options is not UNDEFINED
-            and entry.system_options.as_dict() != system_options
-        ):
-            changed = True
+        if system_options is not UNDEFINED:
+            old_system_options = entry.system_options.as_dict()
             entry.system_options.update(**system_options)
+            changed = entry.system_options.as_dict() != old_system_options
 
         if not changed:
             return False
@@ -1408,14 +1406,27 @@ class SystemOptions:
     """Config entry system options."""
 
     disable_new_entities: bool = attr.ib(default=False)
+    disable_polling: bool = attr.ib(default=False)
 
-    def update(self, *, disable_new_entities: bool) -> None:
+    def update(
+        self,
+        *,
+        disable_new_entities: bool | UndefinedType = UNDEFINED,
+        disable_polling: bool | UndefinedType = UNDEFINED,
+    ) -> None:
         """Update properties."""
-        self.disable_new_entities = disable_new_entities
+        if disable_new_entities is not UNDEFINED:
+            self.disable_new_entities = disable_new_entities
+
+        if disable_polling is not UNDEFINED:
+            self.disable_polling = disable_polling
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this config entries system options."""
-        return {"disable_new_entities": self.disable_new_entities}
+        return {
+            "disable_new_entities": self.disable_new_entities,
+            "disable_polling": self.disable_polling,
+        }
 
 
 class EntityRegistryDisabledHandler:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -395,8 +395,10 @@ class EntityPlatform:
             )
             raise
 
-        if self._async_unsub_polling is not None or not any(
-            entity.should_poll for entity in self.entities.values()
+        if (
+            (self.config_entry and self.config_entry.system_options.disable_polling)
+            or self._async_unsub_polling is not None
+            or not any(entity.should_poll for entity in self.entities.values())
         ):
             return
 

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -214,6 +214,7 @@ class EntityPlatform:
         @callback
         def async_create_setup_task() -> Coroutine:
             """Get task to set up platform."""
+            config_entries.current_entry.set(config_entry)
             return platform.async_setup_entry(  # type: ignore[no-any-return,union-attr]
                 self.hass, config_entry, self._async_schedule_add_entities
             )

--- a/homeassistant/helpers/update_coordinator.py
+++ b/homeassistant/helpers/update_coordinator.py
@@ -49,6 +49,7 @@ class DataUpdateCoordinator(Generic[T]):
         self.name = name
         self.update_method = update_method
         self.update_interval = update_interval
+        self.config_entry = config_entries.current_entry.get()
 
         # It's None before the first successful update.
         # Components should call async_config_entry_first_refresh
@@ -108,6 +109,9 @@ class DataUpdateCoordinator(Generic[T]):
     def _schedule_refresh(self) -> None:
         """Schedule a refresh."""
         if self.update_interval is None:
+            return
+
+        if self.config_entry and self.config_entry.system_options.disable_polling:
             return
 
         if self._unsub_refresh:
@@ -229,9 +233,8 @@ class DataUpdateCoordinator(Generic[T]):
             if raise_on_auth_failed:
                 raise
 
-            config_entry = config_entries.current_entry.get()
-            if config_entry:
-                config_entry.async_start_reauth(self.hass)
+            if self.config_entry:
+                self.config_entry.async_start_reauth(self.hass)
         except NotImplementedError as err:
             self.last_exception = err
             raise err

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -87,6 +87,10 @@ async def test_get_entries(hass, client):
                 "state": core_ce.ConfigEntryState.NOT_LOADED.value,
                 "supports_options": True,
                 "supports_unload": True,
+                "system_options": {
+                    "disable_new_entities": False,
+                    "disable_polling": False,
+                },
                 "disabled_by": None,
                 "reason": None,
             },
@@ -97,6 +101,10 @@ async def test_get_entries(hass, client):
                 "state": core_ce.ConfigEntryState.SETUP_ERROR.value,
                 "supports_options": False,
                 "supports_unload": False,
+                "system_options": {
+                    "disable_new_entities": False,
+                    "disable_polling": False,
+                },
                 "disabled_by": None,
                 "reason": "Unsupported API",
             },
@@ -107,6 +115,10 @@ async def test_get_entries(hass, client):
                 "state": core_ce.ConfigEntryState.NOT_LOADED.value,
                 "supports_options": False,
                 "supports_unload": False,
+                "system_options": {
+                    "disable_new_entities": False,
+                    "disable_polling": False,
+                },
                 "disabled_by": core_ce.DISABLED_USER,
                 "reason": None,
             },
@@ -328,6 +340,10 @@ async def test_create_account(hass, client, enable_custom_integrations):
             "state": core_ce.ConfigEntryState.LOADED.value,
             "supports_options": False,
             "supports_unload": False,
+            "system_options": {
+                "disable_new_entities": False,
+                "disable_polling": False,
+            },
             "title": "Test Entry",
             "reason": None,
         },
@@ -399,6 +415,10 @@ async def test_two_step_flow(hass, client, enable_custom_integrations):
                 "state": core_ce.ConfigEntryState.LOADED.value,
                 "supports_options": False,
                 "supports_unload": False,
+                "system_options": {
+                    "disable_new_entities": False,
+                    "disable_polling": False,
+                },
                 "title": "user-title",
                 "reason": None,
             },
@@ -676,30 +696,6 @@ async def test_two_step_options_flow(hass, client):
             "description": None,
             "description_placeholders": None,
         }
-
-
-async def test_list_system_options(hass, hass_ws_client):
-    """Test that we can list an entries system options."""
-    assert await async_setup_component(hass, "config", {})
-    ws_client = await hass_ws_client(hass)
-
-    entry = MockConfigEntry(domain="demo")
-    entry.add_to_hass(hass)
-
-    await ws_client.send_json(
-        {
-            "id": 5,
-            "type": "config_entries/system_options/list",
-            "entry_id": entry.entry_id,
-        }
-    )
-    response = await ws_client.receive_json()
-
-    assert response["success"]
-    assert response["result"] == {
-        "disable_new_entities": False,
-        "disable_polling": False,
-    }
 
 
 async def test_update_system_options(hass, hass_ws_client):

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -725,7 +725,7 @@ async def test_update_system_options(hass, hass_ws_client):
 
     assert response["success"]
     assert response["result"] == {
-        "restart_required": False,
+        "require_restart": False,
         "system_options": {"disable_new_entities": True, "disable_polling": False},
     }
     assert entry.system_options.disable_new_entities is True
@@ -744,7 +744,7 @@ async def test_update_system_options(hass, hass_ws_client):
 
     assert response["success"]
     assert response["result"] == {
-        "restart_required": True,
+        "require_restart": True,
         "system_options": {"disable_new_entities": False, "disable_polling": True},
     }
     assert entry.system_options.disable_new_entities is False

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -57,6 +57,19 @@ async def test_polling_only_updates_entities_it_should_poll(hass):
     assert poll_ent.async_update.called
 
 
+async def test_polling_disabled_by_config_entry(hass):
+    """Test the polling of only updated entities."""
+    entity_platform = MockEntityPlatform(hass)
+    entity_platform.config_entry = MockConfigEntry(
+        system_options={"disable_polling": True}
+    )
+
+    poll_ent = MockEntity(should_poll=True)
+
+    await entity_platform.async_add_entities([poll_ent])
+    assert entity_platform._async_unsub_polling is None
+
+
 async def test_polling_updates_entities_with_exception(hass):
     """Test the updated entities that not break with an exception."""
     component = EntityComponent(_LOGGER, DOMAIN, hass, timedelta(seconds=20))

--- a/tests/helpers/test_update_coordinator.py
+++ b/tests/helpers/test_update_coordinator.py
@@ -9,13 +9,14 @@ import aiohttp
 import pytest
 import requests
 
+from homeassistant import config_entries
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import update_coordinator
 from homeassistant.util.dt import utcnow
 
-from tests.common import async_fire_time_changed
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -371,3 +372,12 @@ async def test_async_config_entry_first_refresh_success(crd, caplog):
     await crd.async_config_entry_first_refresh()
 
     assert crd.last_update_success is True
+
+
+async def test_not_schedule_refresh_if_system_option_disable_polling(hass):
+    """Test we do not schedule a refresh if disable polling in config entry."""
+    entry = MockConfigEntry(system_options={"disable_polling": True})
+    config_entries.current_entry.set(entry)
+    crd = get_crd(hass, DEFAULT_UPDATE_INTERVAL)
+    crd.async_add_listener(lambda: None)
+    assert crd._unsub_refresh is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a system option to disable polling. 

Changes `config_entries/system_options/update` WS response to:

```ts
{
  requires_restart: boolean,
  system_options: {
    disable_polling: boolean,
    disable_new_entities: boolean
  }
}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
