### PR TITLE
Bump aiopvpc to apply quickfix for new electricity price tariff

### DIFF
--- a/homeassistant/components/pvpc_hourly_pricing/manifest.json
+++ b/homeassistant/components/pvpc_hourly_pricing/manifest.json
@@ -3,7 +3,7 @@
   "name": "Spain electricity hourly pricing (PVPC)",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/pvpc_hourly_pricing",
-  "requirements": ["aiopvpc==2.1.1"],
+  "requirements": ["aiopvpc==2.1.2"],
   "codeowners": ["@azogue"],
   "quality_scale": "platinum",
   "iot_class": "cloud_polling"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -218,7 +218,7 @@ aiopulse==0.4.2
 aiopvapi==1.6.14
 
 # homeassistant.components.pvpc_hourly_pricing
-aiopvpc==2.1.1
+aiopvpc==2.1.2
 
 # homeassistant.components.webostv
 aiopylgtv==0.4.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -140,7 +140,7 @@ aiopulse==0.4.2
 aiopvapi==1.6.14
 
 # homeassistant.components.pvpc_hourly_pricing
-aiopvpc==2.1.1
+aiopvpc==2.1.2
 
 # homeassistant.components.webostv
 aiopylgtv==0.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since 2021-06-01, the three PVPC price tariffs in Spain become one and only: '2.0 TD',
and the JSON schema from the official API (data source of this integration)
is slightly different. So **the integration is broken right now** 🧨

This patch allows a no-pain jump between the old tariffs and the new one, making the integration work again :)

#### Details:

Release notes: https://github.com/azogue/aiopvpc/releases/tag/v2.1.2
Changelog: https://github.com/azogue/aiopvpc/blob/master/CHANGELOG.md
Diff/compare against current version: https://github.com/azogue/aiopvpc/compare/v2.1.1...v2.1.2

#### Context:

Regulated electricity prices have changed in Spain with date 2021-06-01. Before that we had 3 price tariffs that now become just one (really 2, as now prices are different for the Ceuta and Melilla cities):
- Old tariffs and prices: https://www.esios.ree.es/es/pvpc?date=31-05-2021
- New prices: https://www.esios.ree.es/es/pvpc?date=01-06-2021

**This change was expected**, but we had to wait for the publication of the first prices to _see_ how the new data schema looked (because it wasn't published anywhere 🤷🙈). In fact, we were lucky that the API endpoint didn't change 😅

Would be great to include this PR as soon as possible 🥺

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: **Integration not working since 2021-06-01**
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
