### PR TITLE
Fix exception after removing Shelly config entry and stopping HA

### DIFF
--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -288,8 +288,10 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
 
     def shutdown(self):
         """Shutdown the wrapper."""
-        self.device.shutdown()
-        self._async_remove_device_updates_handler()
+        if self.device:
+            self.device.shutdown()
+            self._async_remove_device_updates_handler()
+        self.device = None
 
     @callback
     def _handle_ha_stop(self, _):

--- a/homeassistant/components/shelly/__init__.py
+++ b/homeassistant/components/shelly/__init__.py
@@ -291,7 +291,7 @@ class ShellyDeviceWrapper(update_coordinator.DataUpdateCoordinator):
         if self.device:
             self.device.shutdown()
             self._async_remove_device_updates_handler()
-        self.device = None
+            self.device = None
 
     @callback
     def _handle_ha_stop(self, _):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently after remove Shelly config entry and stop HA we get an exception because we call `device.shutdown()` twice:
```
2021-06-01 08:55:41 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback EventBus.async_listen_once.<locals>._onetime_listener(<Event homeassistant_stop[L]>) at /home/maciek/develop/home-assistant-core/homeassistant/core.py:819
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/home/maciek/develop/home-assistant-core/homeassistant/core.py", line 833, in _onetime_listener
    self._hass.async_run_job(listener, event)
  File "/home/maciek/develop/home-assistant-core/homeassistant/core.py", line 451, in async_run_job
    return self.async_run_hass_job(HassJob(target), *args)
  File "/home/maciek/develop/home-assistant-core/homeassistant/core.py", line 432, in async_run_hass_job
    hassjob.target(*args)
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/__init__.py", line 302, in _handle_ha_stop
    self.shutdown()
  File "/home/maciek/develop/home-assistant-core/homeassistant/components/shelly/__init__.py", line 293, in shutdown
    self.device.shutdown()
  File "/home/maciek/develop/home-assistant-core/venv/lib/python3.9/site-packages/aioshelly/__init__.py", line 244, in shutdown
    self._unsub_listening()
  File "/home/maciek/develop/home-assistant-core/venv/lib/python3.9/site-packages/aioshelly/coap.py", line 126, in <lambda>
    return lambda: self.subscriptions.pop(ip)
KeyError: '192.168.2.176'
```
This PR fix this problem.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #49731
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
