### PR TITLE
Process dependencies when enabling a config entry

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -8,7 +8,7 @@ from homeassistant.components import websocket_api
 from homeassistant.components.http import HomeAssistantView
 from homeassistant.const import HTTP_FORBIDDEN, HTTP_NOT_FOUND
 from homeassistant.core import callback
-from homeassistant.exceptions import Unauthorized
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers.data_entry_flow import (
     FlowManagerIndexView,
     FlowManagerResourceView,
@@ -328,6 +328,12 @@ async def config_entry_disable(hass, connection, msg):
         pass
     except config_entries.UnknownEntry:
         send_entry_not_found(connection, msg["id"])
+        return
+    except HomeAssistantError as err:
+        action = "disable" if disabled_by else "enable"
+        connection.send_error(
+            msg["id"], "disable_failed", f"Failed to {action} config entry: {str(err)}"
+        )
         return
 
     result = {"require_restart": not result}

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -943,6 +943,13 @@ class ConfigEntries:
         ent_reg = entity_registry.async_get(self.hass)
 
         if not entry.disabled_by:
+            # Make sure requirements and dependencies of component are resolved
+            try:
+                domain = entry.domain
+                integration = await loader.async_get_integration(self.hass, domain)
+                await async_process_deps_reqs(self.hass, self._hass_config, integration)
+            except loader.IntegrationNotFound:
+                _LOGGER.error("Cannot find integration %s", domain)
             # The config entry will no longer be disabled, enable devices and entities
             device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
             entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -955,7 +955,7 @@ class ConfigEntries:
             except PrepareSetupError as err:
                 msg = f"Failed to load integration {entry.domain}: {str(err)}"
                 _LOGGER.error(msg)
-                raise HomeAssistantError(msg)
+                raise HomeAssistantError(msg) from err
             # The config entry will no longer be disabled, enable devices and entities
             device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
             entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)

--- a/homeassistant/config_entries.py
+++ b/homeassistant/config_entries.py
@@ -953,9 +953,9 @@ class ConfigEntries:
                     self.hass, entry.domain, self._hass_config
                 )
             except PrepareSetupError as err:
-                _LOGGER.error(
-                    "Failed to load integration %s: %s", entry.domain, str(err)
-                )
+                msg = f"Failed to load integration {entry.domain}: {str(err)}"
+                _LOGGER.error(msg)
+                raise HomeAssistantError(msg)
             # The config entry will no longer be disabled, enable devices and entities
             device_registry.async_config_entry_disabled_by_changed(dev_reg, entry)
             entity_registry.async_config_entry_disabled_by_changed(ent_reg, entry)

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -189,7 +189,7 @@ async def async_prepare_setup_component(
     # without requiring imports to be in functions.
     try:
         await async_process_deps_reqs(hass, config, integration)
-    except PrepareSetupError as err:
+    except HomeAssistantError as err:
         raise PrepareSetupError(str(err), integration.documentation)
 
     return integration

--- a/homeassistant/setup.py
+++ b/homeassistant/setup.py
@@ -175,8 +175,8 @@ async def async_prepare_setup_component(
     """Prepare to setup a component for Home Assistant."""
     try:
         integration = await loader.async_get_integration(hass, domain)
-    except loader.IntegrationNotFound:
-        raise PrepareSetupError("Integration not found.")
+    except loader.IntegrationNotFound as err:
+        raise PrepareSetupError("Integration not found.") from err
 
     if integration.disabled:
         raise PrepareSetupError(f"Integration is disabled - {integration.disabled}")
@@ -190,7 +190,7 @@ async def async_prepare_setup_component(
     try:
         await async_process_deps_reqs(hass, config, integration)
     except HomeAssistantError as err:
-        raise PrepareSetupError(str(err), integration.documentation)
+        raise PrepareSetupError(str(err), integration.documentation) from err
 
     return integration
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Process dependencies when enabling a disabled config entry

The following sequence would previously fail with `ModuleNotFoundError: No module named 'aioesphomeapi'`:
start HA, setup esphome, disable esphome, stop HA, pip3 uninstall aioesphomeapi, start HA, enable esphome

A more likely scenario would be an update of a dependency.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
