### PR TITLE
Always load middle to handle forwarded proxy data

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -232,7 +232,7 @@ class HomeAssistantHTTP:
         # forwarded middleware needs to go second.
         setup_security_filter(app)
 
-        async_setup_forwarded(app, trusted_proxies)
+        async_setup_forwarded(app, use_x_forwarded_for, trusted_proxies)
 
         setup_request_context(app, current_request)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -249,7 +249,6 @@ class HomeAssistantHTTP:
         self.ssl_key = ssl_key
         self.server_host = server_host
         self.server_port = server_port
-        self.use_x_forwarded_for = use_x_forwarded_for
         self.trusted_proxies = trusted_proxies
         self.is_ban_enabled = is_ban_enabled
         self.ssl_profile = ssl_profile

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -232,10 +232,7 @@ class HomeAssistantHTTP:
         # forwarded middleware needs to go second.
         setup_security_filter(app)
 
-        # Only register middleware if `use_x_forwarded_for` is enabled
-        # and trusted proxies are provided
-        if use_x_forwarded_for and trusted_proxies:
-            async_setup_forwarded(app, trusted_proxies)
+        async_setup_forwarded(app, trusted_proxies)
 
         setup_request_context(app, current_request)
 

--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -96,7 +96,7 @@ def async_setup_forwarded(
             _LOGGER.warning(
                 "Received X-Forwarded-For header from untrusted proxy %s, headers not processed; "
                 "This request will be blocked in Home Assistant 2021.7 unless you configure "
-                "your HTTP integration to allow this proxy to reverse your Home Assistant instance.",
+                "your HTTP integration to allow this proxy to reverse your Home Assistant instance",
                 connected_ip,
             )
             # Not trusted, Block this request in the future, continue as normal

--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -76,7 +76,13 @@ def async_setup_forwarded(
             return await handler(request)
 
         # Get connected IP
-        assert request.transport is not None
+        if (
+            request.transport is None
+            or request.transport.get_extra_info("peername") is None
+        ):
+            # Connected IP isn't retrieveable from the request transport, continue
+            return await handler(request)
+
         connected_ip = ip_address(request.transport.get_extra_info("peername")[0])
 
         # We have X-Forwarded-For, but config does not agree

--- a/tests/components/http/test_auth.py
+++ b/tests/components/http/test_auth.py
@@ -53,7 +53,7 @@ def app(hass):
     app = web.Application()
     app["hass"] = hass
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [])
+    async_setup_forwarded(app, True, [])
     return app
 
 

--- a/tests/components/http/test_forwarded.py
+++ b/tests/components/http/test_forwarded.py
@@ -28,7 +28,7 @@ async def test_x_forwarded_for_without_trusted_proxy(aiohttp_client, caplog):
     app = web.Application()
     app.router.add_get("/", handler)
 
-    async_setup_forwarded(app, [])
+    async_setup_forwarded(app, True, [])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get("/", headers={X_FORWARDED_FOR: "255.255.255.255"})
@@ -74,13 +74,40 @@ async def test_x_forwarded_for_with_trusted_proxy(
     app = web.Application()
     app.router.add_get("/", handler)
     async_setup_forwarded(
-        app, [ip_network(trusted_proxy) for trusted_proxy in trusted_proxies]
+        app, True, [ip_network(trusted_proxy) for trusted_proxy in trusted_proxies]
     )
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get("/", headers={X_FORWARDED_FOR: x_forwarded_for})
 
     assert resp.status == 200
+
+
+async def test_x_forwarded_for_disabled_with_proxy(aiohttp_client, caplog):
+    """Test that we warn when processing is disabled, but proxy has been detected."""
+
+    async def handler(request):
+        url = mock_api_client.make_url("/")
+        assert request.host == f"{url.host}:{url.port}"
+        assert request.scheme == "http"
+        assert not request.secure
+        assert request.remote == "127.0.0.1"
+
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+
+    async_setup_forwarded(app, False, [])
+
+    mock_api_client = await aiohttp_client(app)
+    resp = await mock_api_client.get("/", headers={X_FORWARDED_FOR: "255.255.255.255"})
+
+    assert resp.status == 200
+    assert (
+        "A request from a reverse proxy was received from 127.0.0.1, but your HTTP "
+        "integration is not set-up for reverse proxies" in caplog.text
+    )
 
 
 async def test_x_forwarded_for_with_untrusted_proxy(aiohttp_client):
@@ -97,7 +124,7 @@ async def test_x_forwarded_for_with_untrusted_proxy(aiohttp_client):
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("1.1.1.1")])
+    async_setup_forwarded(app, True, [ip_network("1.1.1.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get("/", headers={X_FORWARDED_FOR: "255.255.255.255"})
@@ -119,7 +146,7 @@ async def test_x_forwarded_for_with_spoofed_header(aiohttp_client):
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -148,7 +175,7 @@ async def test_x_forwarded_for_with_malformed_header(
     """Test that we get a HTTP 400 bad request with a malformed header."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
 
@@ -162,7 +189,7 @@ async def test_x_forwarded_for_with_multiple_headers(aiohttp_client, caplog):
     """Test that we get a HTTP 400 bad request with multiple headers."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
 
@@ -193,7 +220,7 @@ async def test_x_forwarded_proto_without_trusted_proxy(aiohttp_client):
     app = web.Application()
     app.router.add_get("/", handler)
 
-    async_setup_forwarded(app, [])
+    async_setup_forwarded(app, True, [])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -245,7 +272,7 @@ async def test_x_forwarded_proto_with_trusted_proxy(
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.0/24")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.0/24")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -273,7 +300,7 @@ async def test_x_forwarded_proto_with_trusted_proxy_multiple_for(aiohttp_client)
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.0/24")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.0/24")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -301,7 +328,7 @@ async def test_x_forwarded_proto_not_processed_without_for(aiohttp_client):
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get("/", headers={X_FORWARDED_PROTO: "https"})
@@ -313,7 +340,7 @@ async def test_x_forwarded_proto_with_multiple_headers(aiohttp_client, caplog):
     """Test that we get a HTTP 400 bad request with multiple headers."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -339,7 +366,7 @@ async def test_x_forwarded_proto_empty_element(
     """Test that we get a HTTP 400 bad request with empty proto."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -364,7 +391,7 @@ async def test_x_forwarded_proto_incorrect_number_of_elements(
     """Test that we get a HTTP 400 bad request with incorrect number of elements."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -397,7 +424,7 @@ async def test_x_forwarded_host_without_trusted_proxy(aiohttp_client):
     app = web.Application()
     app.router.add_get("/", handler)
 
-    async_setup_forwarded(app, [])
+    async_setup_forwarded(app, True, [])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -421,7 +448,7 @@ async def test_x_forwarded_host_with_trusted_proxy(aiohttp_client):
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -446,7 +473,7 @@ async def test_x_forwarded_host_not_processed_without_for(aiohttp_client):
 
     app = web.Application()
     app.router.add_get("/", handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get("/", headers={X_FORWARDED_HOST: "example.com"})
@@ -458,7 +485,7 @@ async def test_x_forwarded_host_with_multiple_headers(aiohttp_client, caplog):
     """Test that we get a HTTP 400 bad request with multiple headers."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(
@@ -478,7 +505,7 @@ async def test_x_forwarded_host_with_empty_header(aiohttp_client, caplog):
     """Test that we get a HTTP 400 bad request with empty host value."""
     app = web.Application()
     app.router.add_get("/", mock_handler)
-    async_setup_forwarded(app, [ip_network("127.0.0.1")])
+    async_setup_forwarded(app, True, [ip_network("127.0.0.1")])
 
     mock_api_client = await aiohttp_client(app)
     resp = await mock_api_client.get(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR is a more centralized and less forgiving implementation of #51319.

The implementation in #51319, only triggers when a reverse proxy is used, but 
Home Assistant isn't configured for it, when using trusted networks authentication.
In this PR, this put this on any request (not just authentication).

Reasoning: When receiving forwarded headers from a proxy, but HA isn't configured there
are 2 possible situations:

1. Unexpected content (thus an attack attempt)
2. Misconfiguration

We should prevent both cases this is done by:

- The forwarded middleware is now always loaded
- The `use_x_forwarded_for` is passed into the middleware, so it can warn when forwarded headers are received, but HA wasn't expecting that.
- Extending existing warning when receiving a request from an untrusted proxy.


Tested with:
- [x] Without reverse proxies and configuration
- [x] Correctly configured HTTP integration with reverse proxy (NGinx)
- [x] `use_x_forwarded_for` disabled with reverse proxy giving the right warning.
- [x] Untrusted proxies giving the right message.
- [x] With reverse proxy and configured HTTP for it, the Home Assistant cloud still functions normal, without warnings.
- [x] Ingress still works without warnings, from both local, via proxy and through the Home Assistant cloud (tested with Node-RED & VSCode).
- [x] Supervisor API proxy still works without warnings (tested with Node-RED).

As a follow-up; we can start blocking these requests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
