### PR TITLE
Fix time condition microsecond offset when using input helpers

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -752,7 +752,6 @@ def time(
             before_entity.attributes.get("hour", 23),
             before_entity.attributes.get("minute", 59),
             before_entity.attributes.get("second", 59),
-            999999,
         )
 
     if after < before:

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -791,6 +791,30 @@ async def test_time_using_input_datetime(hass):
             hass, after="input_datetime.pm", before="input_datetime.am"
         )
 
+    # Trigger on PM time
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=18, minute=0, second=0),
+    ):
+        assert condition.time(
+            hass, after="input_datetime.pm", before="input_datetime.am"
+        )
+        assert not condition.time(
+            hass, after="input_datetime.am", before="input_datetime.pm"
+        )
+
+    # Trigger on AM time
+    with patch(
+        "homeassistant.helpers.condition.dt_util.now",
+        return_value=dt_util.now().replace(hour=6, minute=0, second=0),
+    ):
+        assert not condition.time(
+            hass, after="input_datetime.pm", before="input_datetime.am"
+        )
+        assert condition.time(
+            hass, after="input_datetime.am", before="input_datetime.pm"
+        )
+
     with pytest.raises(ConditionError):
         condition.time(hass, after="input_datetime.not_existing")
 

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -802,6 +802,8 @@ async def test_time_using_input_datetime(hass):
         assert not condition.time(
             hass, after="input_datetime.am", before="input_datetime.pm"
         )
+        assert condition.time(hass, after="input_datetime.pm")
+        assert not condition.time(hass, before="input_datetime.pm")
 
     # Trigger on AM time
     with patch(
@@ -814,6 +816,8 @@ async def test_time_using_input_datetime(hass):
         assert condition.time(
             hass, after="input_datetime.am", before="input_datetime.pm"
         )
+        assert condition.time(hass, after="input_datetime.am")
+        assert not condition.time(hass, before="input_datetime.am")
 
     with pytest.raises(ConditionError):
         condition.time(hass, after="input_datetime.not_existing")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When using input helpers in a time condition, somehow I managed to magically add 999999 microseconds to the before time. This makes it behave a bit unexpected.

These below is the tested and working behavior now:

```
now: 18:00
before: 06:00
after: 18:00
Result -> True
```

```
now: 18:00
before: 18:00
after: 06:00
Result -> False (previously, before this PR: True)
```

```
now: 06:00
before: 06:00
after: 18:00
Result -> False (previously, before this PR: True)
```

```
now: 06:00
before: 18:00
after: 06:00
Result -> True
```


```
now: 18:00
before: 18:00
Result -> False (previous, before this PR: True)
```

```
now: 18:00
after: 18:00
Result -> True
```

```
now: 06:00
before: 06:00
Result -> False (previous, before this PR: True)
```

```
now: 06:00
after: 06:00
Result -> True
```

Created a test case to reproduce and guard for it.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50246
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
