### PR TITLE
Add sensor platform to SIA integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -944,6 +944,7 @@ omit =
     homeassistant/components/sia/binary_sensor.py
     homeassistant/components/sia/const.py
     homeassistant/components/sia/hub.py
+    homeassistant/components/sia/sensor.py
     homeassistant/components/sia/utils.py
     homeassistant/components/sia/sia_entity_base.py
     homeassistant/components/sinch/*

--- a/homeassistant/components/sia/const.py
+++ b/homeassistant/components/sia/const.py
@@ -4,7 +4,9 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 
-PLATFORMS = [ALARM_CONTROL_PANEL_DOMAIN, BINARY_SENSOR_DOMAIN]
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+
+PLATFORMS = [ALARM_CONTROL_PANEL_DOMAIN, BINARY_SENSOR_DOMAIN, SENSOR_DOMAIN]
 
 DOMAIN = "sia"
 
@@ -24,8 +26,10 @@ CONF_PING_INTERVAL = "ping_interval"
 CONF_ZONES = "zones"
 
 SIA_NAME_FORMAT = "{} - {} - zone {} - {}"
+SIA_NAME_FORMAT_SENSOR = "{} - {} - Last Ping"
 SIA_UNIQUE_ID_FORMAT_ALARM = "{}_{}_{}"
 SIA_UNIQUE_ID_FORMAT_BINARY = "{}_{}_{}_{}"
 SIA_HUB_ZONE = 0
+SIA_UNIQUE_ID_FORMAT_SENSOR = "{}_{}_last_ping"
 
 SIA_EVENT = "sia_event_{}_{}"

--- a/homeassistant/components/sia/const.py
+++ b/homeassistant/components/sia/const.py
@@ -3,7 +3,6 @@ from homeassistant.components.alarm_control_panel import (
     DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
 )
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
-
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 
 PLATFORMS = [ALARM_CONTROL_PANEL_DOMAIN, BINARY_SENSOR_DOMAIN, SENSOR_DOMAIN]

--- a/homeassistant/components/sia/sensor.py
+++ b/homeassistant/components/sia/sensor.py
@@ -81,7 +81,7 @@ class SIASensor(RestoreEntity):
         last_state = await self.async_get_last_state()
         if last_state is not None and last_state.state is not None:
             self._state = dt.fromisoformat(last_state.state)
-        self._update_icon()
+        self.async_update_icon()
 
         self.async_on_remove(
             async_dispatcher_connect(
@@ -91,7 +91,9 @@ class SIASensor(RestoreEntity):
             )
         )
         self.async_on_remove(
-            async_track_time_interval(self.hass, self._update_icon, self._ping_interval)
+            async_track_time_interval(
+                self.hass, self.async_update_icon, self._ping_interval
+            )
         )
 
     @callback
@@ -100,10 +102,10 @@ class SIASensor(RestoreEntity):
         self._attr_extra_state_attributes.update(get_attr_from_sia_event(sia_event))
         if sia_event.code == "RP":
             self._state = utcnow()
-        self._update_icon()
+        self.async_update_icon()
 
     @callback
-    def _update_icon(self, *_) -> None:
+    def async_update_icon(self, *_) -> None:
         """Update the icon."""
         if self._state < utcnow() - self._ping_interval:
             self._attr_icon = LATE_ICON

--- a/homeassistant/components/sia/sensor.py
+++ b/homeassistant/components/sia/sensor.py
@@ -1,0 +1,130 @@
+"""Module for SIA Sensors."""
+from __future__ import annotations
+
+from datetime import datetime as dt, timedelta
+import logging
+from typing import Any
+
+from pysiaalarm import SIAEvent
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PORT, DEVICE_CLASS_TIMESTAMP
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.typing import StateType
+from homeassistant.util.dt import utcnow
+
+from .const import (
+    CONF_ACCOUNT,
+    CONF_ACCOUNTS,
+    CONF_PING_INTERVAL,
+    DOMAIN,
+    SIA_EVENT,
+    SIA_NAME_FORMAT_SENSOR,
+    SIA_UNIQUE_ID_FORMAT_SENSOR,
+)
+from .utils import get_attr_from_sia_event
+
+_LOGGER = logging.getLogger(__name__)
+
+REGULAR_ICON = "mdi:clock-check"
+LATE_ICON = "mdi:clock-alert"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up sia_sensor from a config entry."""
+    async_add_entities(
+        SIASensor(entry, account_data) for account_data in entry.data[CONF_ACCOUNTS]
+    )
+
+
+class SIASensor(RestoreEntity):
+    """Class for SIA Sensors."""
+
+    def __init__(
+        self,
+        entry: ConfigEntry,
+        account_data: dict[str, Any],
+    ):
+        """Create SIASensor object."""
+        self._entry: ConfigEntry = entry
+        self._account_data: dict[str, Any] = account_data
+
+        self._port: int = self._entry.data[CONF_PORT]
+        self._account: str = self._account_data[CONF_ACCOUNT]
+        self._ping_interval: timedelta = timedelta(
+            minutes=self._account_data[CONF_PING_INTERVAL]
+        )
+
+        self._state: StateType = utcnow()
+        self._attr: dict[str, Any] = {}
+        self._cancel_icon_cb: CALLBACK_TYPE | None = None
+
+        self._attr_icon = REGULAR_ICON
+        self._attr_unit_of_measurement = "ISO8601"
+        self._attr_device_class = DEVICE_CLASS_TIMESTAMP
+        self._attr_should_poll = False
+        self._attr_name = SIA_NAME_FORMAT_SENSOR.format(self._port, self._account)
+        self._attr_unique_id = SIA_UNIQUE_ID_FORMAT_SENSOR.format(
+            self._entry.entry_id, self._account
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Once the sensor is added, see if it was there before and pull in that state."""
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None and last_state.state is not None:
+            self._state = dt.fromisoformat(last_state.state)
+        self._update_icon()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass,
+                SIA_EVENT.format(self._port, self._account),
+                self.async_handle_event,
+            )
+        )
+        self.async_on_remove(
+            async_track_time_interval(self.hass, self._update_icon, self._ping_interval)
+        )
+
+    async def async_handle_event(self, sia_event: SIAEvent):
+        """Listen to events for this port and account and update the state and attributes."""
+        self._attr.update(get_attr_from_sia_event(sia_event))
+        if sia_event.code == "RP":
+            self._state = utcnow()
+        self._update_icon()
+
+    @callback
+    def _update_icon(self, *_) -> None:
+        """Update the icon."""
+        if self._state < utcnow() - self._ping_interval:
+            self._attr_icon = LATE_ICON
+        else:
+            self._attr_icon = REGULAR_ICON
+        self.async_write_ha_state()
+
+    @property
+    def state(self) -> str:
+        """Return state."""
+        return self._state.isoformat()
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return device attributes."""
+        return self._attr
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info."""
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "via_device": (DOMAIN, f"{self._port}_{self._account}"),
+        }

--- a/homeassistant/components/sia/sensor.py
+++ b/homeassistant/components/sia/sensor.py
@@ -94,7 +94,8 @@ class SIASensor(RestoreEntity):
             async_track_time_interval(self.hass, self._update_icon, self._ping_interval)
         )
 
-    async def async_handle_event(self, sia_event: SIAEvent):
+    @callback
+    def async_handle_event(self, sia_event: SIAEvent):
         """Listen to events for this port and account and update the state and attributes."""
         self._attr_extra_state_attributes.update(get_attr_from_sia_event(sia_event))
         if sia_event.code == "RP":


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a sensor platform with a single sensor per SIA account that shows the last ping that came in (timestamp class), with a changing icon if the last ping is older than the ping_interval for that account.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
