### PR TITLE
Fix HLS idle timer in stream

### DIFF
--- a/homeassistant/components/stream/core.py
+++ b/homeassistant/components/stream/core.py
@@ -84,7 +84,7 @@ class StreamOutput:
     ) -> None:
         """Initialize a stream output."""
         self._hass = hass
-        self._idle_timer = idle_timer
+        self.idle_timer = idle_timer
         self._event = asyncio.Event()
         self._segments: deque[Segment] = deque(maxlen=deque_maxlen)
 
@@ -96,7 +96,7 @@ class StreamOutput:
     @property
     def idle(self) -> bool:
         """Return True if the output is idle."""
-        return self._idle_timer.idle
+        return self.idle_timer.idle
 
     @property
     def last_sequence(self) -> int:
@@ -139,7 +139,6 @@ class StreamOutput:
 
     async def recv(self) -> bool:
         """Wait for and retrieve the latest segment."""
-        self._idle_timer.awake()
         await self._event.wait()
         return self.last_segment is not None
 
@@ -151,7 +150,7 @@ class StreamOutput:
     def _async_put(self, segment: Segment) -> None:
         """Store output from event loop."""
         # Start idle timeout when we start receiving data
-        self._idle_timer.start()
+        self.idle_timer.start()
         self._segments.append(segment)
         self._event.set()
         self._event.clear()
@@ -159,7 +158,7 @@ class StreamOutput:
     def cleanup(self):
         """Handle cleanup."""
         self._event.set()
-        self._idle_timer.clear()
+        self.idle_timer.clear()
         self._segments = deque(maxlen=self._segments.maxlen)
 
 

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -165,6 +165,7 @@ class HlsSegmentView(StreamView):
     async def handle(self, request, stream, sequence):
         """Return fmp4 segment."""
         track = stream.add_provider(HLS_PROVIDER)
+        track.idle_timer.awake()
         if not (segment := track.get_segment(int(sequence))):
             return web.HTTPNotFound()
         headers = {"Content-Type": "video/iso.segment"}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#51191 moved the location the IdleTimer in stream was called, and this had the unintended consequence of not keeping the HLS stream alive and preventing the token from changing. This PR calls the IdleTimer.awake() function explicitly when the HLS handler serves segment data.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
