### PR TITLE
Fix last activity consideration for AVM Fritz!Tools device tracker

### DIFF
--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -217,11 +217,12 @@ class FritzDevice:
         """Update device info."""
         utc_point_in_time = dt_util.utcnow()
 
-        consider_home_evaluated = dev_home
         if self._last_activity:
             consider_home_evaluated = (
                 utc_point_in_time - self._last_activity
             ).total_seconds() < consider_home
+        else:
+            consider_home_evaluated = dev_home
 
         if not self._name:
             self._name = dev_info.name or self._mac.replace(":", "_")

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -217,15 +217,16 @@ class FritzDevice:
         """Update device info."""
         utc_point_in_time = dt_util.utcnow()
 
+        consider_home_evaluated = (
+            (utc_point_in_time - self._last_activity).total_seconds() < consider_home
+            if self._last_activity
+            else dev_home
+        )
+
         if not self._name:
             self._name = dev_info.name or self._mac.replace(":", "_")
 
-        if not dev_home and self._last_activity:
-            self._connected = (
-                utc_point_in_time - self._last_activity
-            ).total_seconds() < consider_home
-        else:
-            self._connected = dev_home
+        self._connected = dev_home or consider_home_evaluated
 
         if dev_home:
             self._last_activity = utc_point_in_time

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -230,10 +230,7 @@ class FritzDevice:
         if dev_home:
             self._last_activity = utc_point_in_time
 
-        if self._connected:
-            self._ip_address = dev_info.ip_address
-        else:
-            self._ip_address = None
+        self._ip_address = dev_info.ip_address if self._connected else None
 
     @property
     def is_connected(self):

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -217,11 +217,11 @@ class FritzDevice:
         """Update device info."""
         utc_point_in_time = dt_util.utcnow()
 
-        consider_home_evaluated = (
-            (utc_point_in_time - self._last_activity).total_seconds() < consider_home
-            if self._last_activity
-            else dev_home
-        )
+        consider_home_evaluated = dev_home
+        if self._last_activity:
+            consider_home_evaluated = (
+                utc_point_in_time - self._last_activity
+            ).total_seconds() < consider_home
 
         if not self._name:
             self._name = dev_info.name or self._mac.replace(":", "_")

--- a/homeassistant/components/fritz/common.py
+++ b/homeassistant/components/fritz/common.py
@@ -227,9 +227,11 @@ class FritzDevice:
         else:
             self._connected = dev_home
 
+        if dev_home:
+            self._last_activity = utc_point_in_time
+
         if self._connected:
             self._ip_address = dev_info.ip_address
-            self._last_activity = utc_point_in_time
         else:
             self._ip_address = None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes how `last_activity` is set.
The connected state based on "considered home" time frame is calculated based on `last_activity`, which is always set to now as long as state is connected, so it would never become not connected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51346 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
