### PR TITLE
Detect Sonos reboots and recreate subscriptions

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -161,12 +161,12 @@ async def async_setup_entry(  # noqa: C901
     def _manual_hosts(now: datetime.datetime | None = None) -> None:
         """Players from network configuration."""
         for host in hosts:
-            ip = socket.gethostbyname(host)
+            ip_addr = socket.gethostbyname(host)
             known_uid = next(
                 (
                     uid
                     for uid, speaker in data.discovered.items()
-                    if speaker.soco.ip_address == ip
+                    if speaker.soco.ip_address == ip_addr
                 ),
                 None,
             )
@@ -174,7 +174,7 @@ async def async_setup_entry(  # noqa: C901
             if known_uid:
                 async_dispatcher_send(hass, f"{SONOS_SEEN}-{known_uid}")
             else:
-                soco = _create_soco(ip, "configured")
+                soco = _create_soco(ip_addr, "configured")
                 if soco and soco.is_visible:
                     _discovered_player(soco)
 

--- a/homeassistant/components/sonos/const.py
+++ b/homeassistant/components/sonos/const.py
@@ -143,6 +143,7 @@ SONOS_GROUP_UPDATE = "sonos_group_update"
 SONOS_HOUSEHOLD_UPDATED = "sonos_household_updated"
 SONOS_ALARM_UPDATE = "sonos_alarm_update"
 SONOS_STATE_UPDATED = "sonos_state_updated"
+SONOS_REBOOTED = "sonos_rebooted"
 SONOS_SEEN = "sonos_seen"
 
 SOURCE_LINEIN = "Line-in"

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -482,7 +482,11 @@ class SonosSpeaker:
 
     async def async_rebooted(self, soco: SoCo) -> None:
         """Handle a detected speaker reboot."""
-        _LOGGER.warning("%s rebooted, reconnecting with %s", self.zone_name, soco)
+        _LOGGER.warning(
+            "%s rebooted or lost network connectivity, reconnecting with %s",
+            self.zone_name,
+            soco,
+        )
         await self.async_unseen(will_reconnect=True)
         await self.async_seen(soco)
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -47,6 +47,7 @@ from .const import (
     SONOS_ENTITY_CREATED,
     SONOS_GROUP_UPDATE,
     SONOS_POLL_UPDATE,
+    SONOS_REBOOTED,
     SONOS_SEEN,
     SONOS_STATE_PLAYING,
     SONOS_STATE_TRANSITIONING,
@@ -164,6 +165,7 @@ class SonosSpeaker:
         # Dispatcher handles
         self._entity_creation_dispatcher: Callable | None = None
         self._group_dispatcher: Callable | None = None
+        self._reboot_dispatcher: Callable | None = None
         self._seen_dispatcher: Callable | None = None
 
         # Device information
@@ -206,6 +208,9 @@ class SonosSpeaker:
         )
         self._seen_dispatcher = dispatcher_connect(
             self.hass, f"{SONOS_SEEN}-{self.soco.uid}", self.async_seen
+        )
+        self._reboot_dispatcher = dispatcher_connect(
+            self.hass, f"{SONOS_REBOOTED}-{self.soco.uid}", self.async_rebooted
         )
 
         if (battery_info := fetch_battery_info_or_none(self.soco)) is None:
@@ -454,10 +459,10 @@ class SonosSpeaker:
 
         self.async_write_entity_states()
 
-    async def async_unseen(self, now: datetime.datetime | None = None) -> None:
+    async def async_unseen(
+        self, now: datetime.datetime | None = None, will_reconnect: bool = False
+    ) -> None:
         """Make this player unavailable when it was not seen recently."""
-        self.async_write_entity_states()
-
         if self._seen_timer:
             self._seen_timer()
             self._seen_timer = None
@@ -470,7 +475,15 @@ class SonosSpeaker:
             await subscription.unsubscribe()
 
         self._subscriptions = []
-        self.hass.data[DATA_SONOS].ssdp_known.remove(self.soco.uid)
+
+        if not will_reconnect:
+            self.hass.data[DATA_SONOS].ssdp_known.remove(self.soco.uid)
+            self.async_write_entity_states()
+
+    async def async_rebooted(self) -> None:
+        """Handle a detected speaker reboot."""
+        await self.async_unseen(will_reconnect=True)
+        await self.async_seen()
 
     #
     # Alarm management

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -480,10 +480,11 @@ class SonosSpeaker:
             self.hass.data[DATA_SONOS].ssdp_known.remove(self.soco.uid)
             self.async_write_entity_states()
 
-    async def async_rebooted(self) -> None:
+    async def async_rebooted(self, soco: SoCo) -> None:
         """Handle a detected speaker reboot."""
+        _LOGGER.warning("%s rebooted, reconnecting with %s", self.zone_name, soco)
         await self.async_unseen(will_reconnect=True)
-        await self.async_seen()
+        await self.async_seen(soco)
 
     #
     # Alarm management


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Building on top of #51033, we now have access to the SSDP response payloads and can detect when a Sonos speaker has been rebooted. When rebooting a speaker it silently drops all known callback subscriptions. This will let us detect this scenario and recreate them sooner.

A faster implementation of #50793 which still relies on a 20 minute timeout.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
