### PR TITLE
Convert ecobee pressure to local units

### DIFF
--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -116,7 +116,8 @@ class EcobeeWeather(WeatherEntity):
         try:
             pressure = self.get_forecast(0, "pressure")
             if not self.hass.config.units.is_metric:
-                return pressure_convert(pressure, PRESSURE_HPA, PRESSURE_INHG)
+                pressure = pressure_convert(pressure, PRESSURE_HPA, PRESSURE_INHG)
+                return round(pressure, 2)
             return round(pressure)
         except ValueError:
             return None

--- a/homeassistant/components/ecobee/weather.py
+++ b/homeassistant/components/ecobee/weather.py
@@ -12,8 +12,9 @@ from homeassistant.components.weather import (
     ATTR_FORECAST_WIND_SPEED,
     WeatherEntity,
 )
-from homeassistant.const import TEMP_FAHRENHEIT
+from homeassistant.const import PRESSURE_HPA, PRESSURE_INHG, TEMP_FAHRENHEIT
 from homeassistant.util import dt as dt_util
+from homeassistant.util.pressure import convert as pressure_convert
 
 from .const import (
     _LOGGER,
@@ -113,7 +114,10 @@ class EcobeeWeather(WeatherEntity):
     def pressure(self):
         """Return the pressure."""
         try:
-            return int(self.get_forecast(0, "pressure"))
+            pressure = self.get_forecast(0, "pressure")
+            if not self.hass.config.units.is_metric:
+                return pressure_convert(pressure, PRESSURE_HPA, PRESSURE_INHG)
+            return round(pressure)
         except ValueError:
             return None
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Convert the pressure in the Ecobee weather integration to metric/imperial depending on what Home Assistant is configured to use. This is the same behavior as the OpenWeatherMap ([code](https://github.com/home-assistant/core/blob/c057c9d9aba7140914ce30bcd54075d6b27fb58d/homeassistant/components/openweathermap/weather.py#L95-L103)) and Climacell ([code](https://github.com/home-assistant/core/blob/c057c9d9aba7140914ce30bcd54075d6b27fb58d/homeassistant/components/climacell/weather.py#L238-L245)) weather integrations.

The pressure units from Ecobee API are undocumented, but they look like hPa or millibars (both are equal so I just chose hPa in the code). See #24524 as well.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #29947 

:warning: There many many more `weather` integrations that do not convert their pressure units to the correct format. There is probably a better solution than making each integration convert to the correct pressure unit: Something like #48641 seems like it could help.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
