### PR TITLE
Add zwave_js WS API cmds to get node state and version info

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1171,6 +1171,8 @@ class DumpView(HomeAssistantView):
 
     async def get(self, request: web.Request, config_entry_id: str) -> web.Response:
         """Dump the state of Z-Wave."""
+        if not request["hass_user"].is_admin:
+            raise Unauthorized()
         hass = request.app["hass"]
 
         if config_entry_id not in hass.data[DOMAIN]:
@@ -1199,6 +1201,8 @@ class NodeDumpView(HomeAssistantView):
         self, request: web.Request, config_entry_id: str, node_id: str
     ) -> web.Response:
         """Dump the state of a Z-Wave node."""
+        if not request["hass_user"].is_admin:
+            raise Unauthorized()
         hass = request.app["hass"]
 
         if config_entry_id not in hass.data[DOMAIN]:
@@ -1209,11 +1213,12 @@ class NodeDumpView(HomeAssistantView):
         if not node:
             raise web_exceptions.HTTPNotFound
 
+        filename = f"zwave_js_node_{node.node_id}_state.json"
         return web.Response(
             body=json.dumps(node.data, indent=2) + "\n",
             headers={
                 hdrs.CONTENT_TYPE: "application/json",
-                hdrs.CONTENT_DISPOSITION: f'attachment; filename="zwave_js_node_{node.node_id}_state.json"',
+                hdrs.CONTENT_DISPOSITION: f'attachment; filename="{filename}"',
             },
         )
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1176,7 +1176,7 @@ class DumpView(HomeAssistantView):
         if config_entry_id not in hass.data[DOMAIN]:
             raise web_exceptions.HTTPBadRequest
 
-        entry: ConfigEntry = hass.config_entries.async_get_entry(config_entry_id)
+        entry = hass.config_entries.async_get_entry(config_entry_id)
 
         msgs = await dump.dump_msgs(entry.data[CONF_URL], async_get_clientsession(hass))
 
@@ -1204,8 +1204,8 @@ class NodeDumpView(HomeAssistantView):
         if config_entry_id not in hass.data[DOMAIN]:
             raise web_exceptions.HTTPBadRequest
 
-        client: Client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
-        node: Node = client.driver.controller.nodes.get(int(node_id))
+        client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
+        node = client.driver.controller.nodes.get(int(node_id))
         if not node:
             raise web_exceptions.HTTPNotFound
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1222,7 +1222,10 @@ class NodeDumpView(HomeAssistantView):
 
         filename = f"zwave_js_node_{node.node_id}_state.json"
         return web.Response(
-            body=json.dumps([version_info, node.data], indent=2) + "\n",
+            body=json.dumps(
+                {"version_info": version_info, "node_state": node.data}, indent=2
+            )
+            + "\n",
             headers={
                 hdrs.CONTENT_TYPE: "application/json",
                 hdrs.CONTENT_DISPOSITION: f'attachment; filename="{filename}"',

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1208,14 +1208,21 @@ class NodeDumpView(HomeAssistantView):
         if config_entry_id not in hass.data[DOMAIN]:
             raise web_exceptions.HTTPBadRequest
 
-        client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
+        client: Client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
         node = client.driver.controller.nodes.get(int(node_id))
         if not node:
             raise web_exceptions.HTTPNotFound
 
+        version_info = {
+            "driverVersion": client.version.driver_version,
+            "serverVersion": client.version.server_version,
+            "minSchemaVersion": client.version.min_schema_version,
+            "maxSchemaVersion": client.version.max_schema_version,
+        }
+
         filename = f"zwave_js_node_{node.node_id}_state.json"
         return web.Response(
-            body=json.dumps(node.data, indent=2) + "\n",
+            body=json.dumps([version_info, node.data], indent=2) + "\n",
             headers={
                 hdrs.CONTENT_TYPE: "application/json",
                 hdrs.CONTENT_DISPOSITION: f'attachment; filename="{filename}"',

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1329,7 +1329,7 @@ class FirmwareUploadView(HomeAssistantView):
             raise web_exceptions.HTTPBadRequest
 
         entry = hass.config_entries.async_get_entry(config_entry_id)
-        client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
+        client: Client = hass.data[DOMAIN][config_entry_id][DATA_CLIENT]
         node = client.driver.controller.nodes.get(int(node_id))
         if not node:
             raise web_exceptions.HTTPNotFound

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1232,10 +1232,10 @@ async def websocket_version_info(
 ) -> None:
     """Get version info from the Z-Wave JS server."""
     version_info = {
-        "driverVersion": client.version.driver_version,
-        "serverVersion": client.version.server_version,
-        "minSchemaVersion": client.version.min_schema_version,
-        "maxSchemaVersion": client.version.max_schema_version,
+        "driver_version": client.version.driver_version,
+        "server_version": client.version.server_version,
+        "min_schema_version": client.version.min_schema_version,
+        "max_schema_version": client.version.max_schema_version,
     }
     connection.send_result(
         msg[ID],

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1304,14 +1304,20 @@ async def test_dump_view(integration, hass_client):
     assert json.loads(await resp.text()) == [{"hello": "world"}, {"second": "msg"}]
 
 
-async def test_dump_node_view(multisensor_6, integration, hass_client):
+async def test_dump_node_view(multisensor_6, integration, hass_client, version_state):
     """Test the HTTP dump node view."""
     client = await hass_client()
     resp = await client.get(
         f"/api/zwave_js/dump/{integration.entry_id}/{multisensor_6.node_id}"
     )
     assert resp.status == 200
-    assert json.loads(await resp.text()) == multisensor_6.data
+    version_info = {
+        "driverVersion": version_state["driverVersion"],
+        "serverVersion": version_state["serverVersion"],
+        "minSchemaVersion": 0,
+        "maxSchemaVersion": 0,
+    }
+    assert json.loads(await resp.text()) == [version_info, multisensor_6.data]
 
 
 async def test_firmware_upload_view(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1304,6 +1304,16 @@ async def test_dump_view(integration, hass_client):
     assert json.loads(await resp.text()) == [{"hello": "world"}, {"second": "msg"}]
 
 
+async def test_dump_node_view(multisensor_6, integration, hass_client):
+    """Test the HTTP dump node view."""
+    client = await hass_client()
+    resp = await client.get(
+        f"/api/zwave_js/dump/{integration.entry_id}/{multisensor_6.node_id}"
+    )
+    assert resp.status == 200
+    assert json.loads(await resp.text()) == multisensor_6.data
+
+
 async def test_firmware_upload_view(
     hass, multisensor_6, integration, hass_client, firmware_file
 ):
@@ -1352,6 +1362,7 @@ async def test_firmware_upload_view_invalid_payload(
     "method, url",
     [
         ("get", "/api/zwave_js/dump/INVALID"),
+        ("get", "/api/zwave_js/dump/INVALID/1"),
         ("post", "/api/zwave_js/firmware/upload/INVALID/1"),
     ],
 )
@@ -1363,7 +1374,11 @@ async def test_view_invalid_entry_id(integration, hass_client, method, url):
 
 
 @pytest.mark.parametrize(
-    "method, url", [("post", "/api/zwave_js/firmware/upload/{}/111")]
+    "method, url",
+    [
+        ("get", "/api/zwave_js/dump/{}/111"),
+        ("post", "/api/zwave_js/firmware/upload/{}/111"),
+    ],
 )
 async def test_view_invalid_node_id(integration, hass_client, method, url):
     """Test an invalid config entry id parameter."""

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1358,10 +1358,10 @@ async def test_version_info(hass, integration, hass_ws_client, version_state):
     ws_client = await hass_ws_client(hass)
 
     version_info = {
-        "driverVersion": version_state["driverVersion"],
-        "serverVersion": version_state["serverVersion"],
-        "minSchemaVersion": 0,
-        "maxSchemaVersion": 0,
+        "driver_version": version_state["driverVersion"],
+        "server_version": version_state["serverVersion"],
+        "min_schema_version": 0,
+        "max_schema_version": 0,
     }
 
     await ws_client.send_json(

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1361,6 +1361,43 @@ async def test_firmware_upload_view_invalid_payload(
 @pytest.mark.parametrize(
     "method, url",
     [
+        ("get", "/api/zwave_js/dump/{}"),
+    ],
+)
+async def test_view_non_admin_user(
+    integration, hass_client, hass_admin_user, method, url
+):
+    """Test config entry level views for non-admin users."""
+    client = await hass_client()
+    # Verify we require admin user
+    hass_admin_user.groups = []
+    resp = await client.request(method, url.format(integration.entry_id))
+    assert resp.status == 401
+
+
+@pytest.mark.parametrize(
+    "method, url",
+    [
+        ("get", "/api/zwave_js/dump/{}/{}"),
+        ("post", "/api/zwave_js/firmware/upload/{}/{}"),
+    ],
+)
+async def test_node_view_non_admin_user(
+    multisensor_6, integration, hass_client, hass_admin_user, method, url
+):
+    """Test node level views for non-admin users."""
+    client = await hass_client()
+    # Verify we require admin user
+    hass_admin_user.groups = []
+    resp = await client.request(
+        method, url.format(integration.entry_id, multisensor_6.node_id)
+    )
+    assert resp.status == 401
+
+
+@pytest.mark.parametrize(
+    "method, url",
+    [
         ("get", "/api/zwave_js/dump/INVALID"),
         ("get", "/api/zwave_js/dump/INVALID/1"),
         ("post", "/api/zwave_js/firmware/upload/INVALID/1"),

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1317,7 +1317,10 @@ async def test_dump_node_view(multisensor_6, integration, hass_client, version_s
         "minSchemaVersion": 0,
         "maxSchemaVersion": 0,
     }
-    assert json.loads(await resp.text()) == [version_info, multisensor_6.data]
+    assert json.loads(await resp.text()) == {
+        "version_info": version_info,
+        "node_state": multisensor_6.data,
+    }
 
 
 async def test_firmware_upload_view(


### PR DESCRIPTION
## Proposed change
We have the link on the configuration page to retrieve a dump of an entire network, but often when users report device specific issues, they only want to share the state of the node in question. This isn't a ton of work for the user to generate from the network dump, but sometimes the JSON is improperly formatted and it wouldn't hurt to have a link on the zwave_js device page to download the state of just that node.

To implement this, we've created two new WS API commands to get a state dump of the node and version info from the server. These can be stitched together into a JSON string in the frontend to deliver to the user's browser - see the following two areas of code to see how this is done for automation traces:
- https://github.com/home-assistant/frontend/blob/dev/src/panels/config/automation/trace/ha-automation-trace.ts#L90-L100
- https://github.com/home-assistant/frontend/blob/f71157c24dc5cadc7e524232213a04abcb9a4100/src/panels/config/automation/trace/ha-automation-trace.ts#L393-L409

Proposed JSON:
```json
{
    "versionInfo": {...},
    "nodeState": {...}
}
```

CC @cgarwood 


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
