### PR TITLE
Fix Tibber Pulse device name and sensor update

### DIFF
--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -186,6 +186,7 @@ class TibberSensor(SensorEntity):
         """Initialize the sensor."""
         self._tibber_home = tibber_home
         self._home_name = tibber_home.info["viewer"]["home"]["appNickname"]
+        self._device_name = None
         if self._home_name is None:
             self._home_name = tibber_home.info["viewer"]["home"]["address"].get(
                 "address1", ""
@@ -202,7 +203,7 @@ class TibberSensor(SensorEntity):
         """Return the device_info of the device."""
         device_info = {
             "identifiers": {(TIBBER_DOMAIN, self.device_id)},
-            "name": self.name,
+            "name": self._device_name,
             "manufacturer": MANUFACTURER,
         }
         if self._model is not None:
@@ -236,6 +237,8 @@ class TibberSensorElPrice(TibberSensor):
         self._attr_name = f"Electricity price {self._home_name}"
         self._attr_unique_id = f"{self._tibber_home.home_id}"
         self._model = "Price Sensor"
+
+        self._device_name = self._attr_name
 
     async def async_update(self):
         """Get the latest data and updates the states."""
@@ -295,6 +298,7 @@ class TibberSensorRT(TibberSensor):
         super().__init__(tibber_home)
         self._sensor_name = sensor_name
         self._model = "Tibber Pulse"
+        self._device_name = f"{self._model} {self._home_name}"
 
         self._attr_device_class = device_class
         self._attr_name = f"{self._sensor_name} {self._home_name}"

--- a/homeassistant/components/tibber/sensor.py
+++ b/homeassistant/components/tibber/sensor.py
@@ -330,7 +330,7 @@ class TibberSensorRT(TibberSensor):
         self.async_on_remove(
             async_dispatcher_connect(
                 self.hass,
-                SIGNAL_UPDATE_ENTITY.format(self._sensor_name),
+                SIGNAL_UPDATE_ENTITY.format(self.unique_id),
                 self._set_state,
             )
         )
@@ -370,7 +370,7 @@ class TibberRtDataHandler:
         self._async_add_entities = async_add_entities
         self._tibber_home = tibber_home
         self.hass = hass
-        self._entities = set()
+        self._entities = {}
 
     async def async_callback(self, payload):
         """Handle received data."""
@@ -393,7 +393,7 @@ class TibberRtDataHandler:
             if sensor_type in self._entities:
                 async_dispatcher_send(
                     self.hass,
-                    SIGNAL_UPDATE_ENTITY.format(RT_SENSOR_MAP[sensor_type][0]),
+                    SIGNAL_UPDATE_ENTITY.format(self._entities[sensor_type]),
                     state,
                     timestamp,
                 )
@@ -412,6 +412,6 @@ class TibberRtDataHandler:
                     state_class,
                 )
                 new_entities.append(entity)
-                self._entities.add(sensor_type)
+                self._entities[sensor_type] = entity.unique_id
         if new_entities:
             self._async_add_entities(new_entities)


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tibber, fix #51398  to handle multiple Tibber Pulse devices and correct device name

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51398
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
