### PR TITLE
FX Luminaire Luxor low voltage integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -280,6 +280,7 @@ homeassistant/components/luftdaten/* @fabaff
 homeassistant/components/lupusec/* @majuss
 homeassistant/components/lutron/* @JonGilmore
 homeassistant/components/lutron_caseta/* @swails @bdraco
+homeassistant/components/luxor/* @pbozeman
 homeassistant/components/lyric/* @timmo001
 homeassistant/components/mastodon/* @fabaff
 homeassistant/components/matrix/* @tinloaf

--- a/homeassistant/components/luxor/__init__.py
+++ b/homeassistant/components/luxor/__init__.py
@@ -1,0 +1,34 @@
+"""The FX Luminaire Luxor low voltage controller integration."""
+from __future__ import annotations
+
+import luxor
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import aiohttp_client
+
+from .const import DOMAIN
+
+PLATFORMS = ["light"]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up FX Luminaire Luxor low voltage controller from a config entry."""
+    hass.data.setdefault(DOMAIN, {})
+    host = entry.data[CONF_HOST]
+    hass.data[DOMAIN][entry.entry_id] = luxor.Client(
+        host, aiohttp_client.async_get_clientsession(hass)
+    )
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+
+    return unload_ok

--- a/homeassistant/components/luxor/config_flow.py
+++ b/homeassistant/components/luxor/config_flow.py
@@ -1,0 +1,126 @@
+"""Config flow for FX Luminaire Luxor low voltage controller integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aiohttp import client_exceptions as aio_exceptions
+import luxor
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import aiohttp_client
+
+from .const import CONF_INCLUDE_LUXOR_THEMES, DEFAULT_INCLUDE_LUXOR_THEMES, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema({CONF_HOST: str})
+
+
+async def validate_luxor(host: str, hass: HomeAssistant):
+    """Validate the host is a Luxor controller.
+
+    Also serves as a mock point for unit testing of forms.
+    """
+    client = luxor.Client(host, aiohttp_client.async_get_clientsession(hass))
+
+    try:
+        await client.get_groups()
+    except aio_exceptions.ClientConnectorError as err:
+        _LOGGER.warn(err)
+        return False
+    except aio_exceptions.ClientError as err:
+        # in this case we connected with some http server,
+        # but to something other than a luxor device
+        _LOGGER.warn(f"host: {host} is likely not a Luxor controller. error: {err}")
+        return False
+
+    return True
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    host = data[CONF_HOST]
+    if not await validate_luxor(host, hass):
+        raise CannotConnect
+
+    return {"title": "Luxor Controller"}
+
+
+class LuxorConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for FX Luminaire Luxor low voltage controller."""
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        """Get the options flow for this handler."""
+        return LuxorOptionsFlowHandler(config_entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors = {}
+
+        try:
+            info = await validate_input(self.hass, user_input)
+        except CannotConnect:
+            errors["base"] = "cannot_connect"
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+
+class LuxorOptionsFlowHandler(config_entries.OptionsFlow):
+    """Handle Luxor options."""
+
+    def __init__(self, config_entry):
+        """Initialize Luxor options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage Luxor options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_INCLUDE_LUXOR_THEMES,
+                        default=self.config_entry.options.get(
+                            CONF_INCLUDE_LUXOR_THEMES, DEFAULT_INCLUDE_LUXOR_THEMES
+                        ),
+                    ): bool,
+                }
+            ),
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""

--- a/homeassistant/components/luxor/const.py
+++ b/homeassistant/components/luxor/const.py
@@ -1,0 +1,6 @@
+"""Constants for the FX Luminaire Luxor low voltage controller integration."""
+
+DOMAIN = "luxor"
+
+CONF_INCLUDE_LUXOR_THEMES = "include_luxor_themes"
+DEFAULT_INCLUDE_LUXOR_THEMES = False

--- a/homeassistant/components/luxor/light.py
+++ b/homeassistant/components/luxor/light.py
@@ -1,0 +1,199 @@
+"""Light support for FX Luminaire Luxor low voltage controller integration."""
+
+from datetime import timedelta
+import logging
+
+from aiohttp import client_exceptions as aio_exceptions
+import async_timeout
+from luxor import LuxorError
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    SUPPORT_BRIGHTNESS,
+    LightEntity,
+)
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+
+from .const import (
+    CONF_INCLUDE_LUXOR_THEMES,
+    DEFAULT_INCLUDE_LUXOR_THEMES,
+    DOMAIN as LUXOR_DOMAIN,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Luxor light platform.
+
+    Adds groups and themes from the Luxor controller as light entities.
+    """
+    client = hass.data[LUXOR_DOMAIN][config_entry.entry_id]
+
+    async def async_update_group_data():
+        """Fetch group data from Luxor controller."""
+        groups = await async_safe_fetch(client.get_groups)
+        return {group["Grp"]: group for group in groups}
+
+    light_coordinator = DataUpdateCoordinator(
+        hass,
+        _LOGGER,
+        name="luxor",
+        update_method=async_update_group_data,
+        update_interval=timedelta(seconds=1),
+    )
+
+    # Fetch initial data so we have data when entities subscribe
+    #
+    # If the refresh fails, async_config_entry_first_refresh will
+    # raise ConfigEntryNotReady and setup will try again later
+    await light_coordinator.async_config_entry_first_refresh()
+
+    entities = [
+        LuxorGroupLightEntity(light_coordinator, client, group_id)
+        for group_id in light_coordinator.data.keys()
+    ]
+    async_add_entities(entities)
+
+    #
+    # Add Luxor themes as lights, if configured to do so.
+    # Users might want avoid adding them if they do things like 'turn on all lights'
+    # that will result in enabling all the themes in parellel, which is not ideal.
+    #
+    async def async_update_theme_data():
+        """Fetch theme data from Luxor controller."""
+        themes = await async_safe_fetch(client.get_themes)
+        return {theme["ThemeIndex"]: theme for theme in themes}
+
+    include_luxor_themes = config_entry.options.get(
+        CONF_INCLUDE_LUXOR_THEMES, DEFAULT_INCLUDE_LUXOR_THEMES
+    )
+
+    if include_luxor_themes:
+        theme_coordinator = DataUpdateCoordinator(
+            hass,
+            _LOGGER,
+            name="luxor",
+            update_method=async_update_theme_data,
+            update_interval=timedelta(seconds=1),
+        )
+
+        await theme_coordinator.async_config_entry_first_refresh()
+
+        entities = [
+            LuxorThemeLightEntity(theme_coordinator, client, theme_id)
+            for theme_id in theme_coordinator.data.keys()
+        ]
+        async_add_entities(entities)
+
+    return True
+
+
+async def async_safe_fetch(method):
+    """Safely fetch data."""
+    try:
+        # Note: asyncio.TimeoutError and aiohttp.ClientError are already
+        # handled by the data update coordinator
+        async with async_timeout.timeout(10):
+            return await method()
+    except aio_exceptions.ClientConnectorError as err:
+        raise UpdateFailed(f"Connection error: {err}")
+    except LuxorError as err:
+        raise UpdateFailed(f"Error communicating with API: {err}")
+
+
+def luxor_brightness_to_hass(value):
+    """Convert luxor brightness 1..100 to hass format 0..255."""
+    return int((value * 255) // 100)
+
+
+def hass_to_luxor_brightness(value):
+    """Convert hass brightness 0..255 to luxor 1..100 scale."""
+    return int(round((value * 100) / 255))
+
+
+class LuxorGroupLightEntity(CoordinatorEntity, LightEntity):
+    """Representation of a Luxor light group as a homeassisant light entity."""
+
+    def __init__(self, coordinator, client, group_id):
+        """Initialize the light."""
+        super().__init__(coordinator)
+        self.client = client
+        self.group_id = group_id
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_BRIGHTNESS
+
+    @property
+    def brightness(self):
+        """Return the brightness of this light between 0..255."""
+        return luxor_brightness_to_hass(self._data["Inten"])
+
+    @property
+    def is_on(self):
+        """Return true if the light is on."""
+        return self._data["Inten"] > 0
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the light on."""
+        if ATTR_BRIGHTNESS in kwargs:
+            intensity = hass_to_luxor_brightness(kwargs[ATTR_BRIGHTNESS])
+        else:
+            intensity = 100
+
+        await self.client.illuminate_group(self.group_id, intensity=intensity)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the light off."""
+        await self.client.illuminate_group(self.group_id, intensity=0)
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def name(self):
+        """Return the name of the Luxor group."""
+        return self._data["Name"]
+
+    @property
+    def _data(self):
+        return self.coordinator.data[self.group_id]
+
+
+class LuxorThemeLightEntity(CoordinatorEntity, LightEntity):
+    """Representation of a Luxor theme as a homeassisant light entity."""
+
+    def __init__(self, coordinator, client, theme_id):
+        """Initialize the light."""
+        super().__init__(coordinator)
+        self.client = client
+        self.theme_id = theme_id
+
+    @property
+    def is_on(self):
+        """Return true if the light is on."""
+        return self._data["OnOff"] > 0
+
+    async def async_turn_on(self, **kwargs):
+        """Turn the light on."""
+        await self.client.illuminate_theme(self.theme_id, on_off=1)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs):
+        """Turn the light off."""
+        await self.client.illuminate_theme(self.theme_id, on_off=0)
+        await self.coordinator.async_request_refresh()
+
+    @property
+    def name(self):
+        """Return the name of the Luxor theme."""
+        return "(Theme) " + self._data["Name"]
+
+    @property
+    def _data(self):
+        return self.coordinator.data[self.theme_id]

--- a/homeassistant/components/luxor/manifest.json
+++ b/homeassistant/components/luxor/manifest.json
@@ -1,0 +1,17 @@
+{
+  "domain": "luxor",
+  "name": "FX Luminaire Luxor low voltage controller",
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/luxor",
+  "requirements": [
+    "luxor==0.0.1"
+  ],
+  "ssdp": [],
+  "zeroconf": [],
+  "homekit": {},
+  "dependencies": [],
+  "codeowners": [
+    "@pbozeman"
+  ],
+  "iot_class": "local_polling"
+}

--- a/homeassistant/components/luxor/strings.json
+++ b/homeassistant/components/luxor/strings.json
@@ -1,0 +1,19 @@
+{
+  "title": "FX Luminaire Luxor low voltage controller",
+  "config": {
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/luxor/translations/en.json
+++ b/homeassistant/components/luxor/translations/en.json
@@ -1,0 +1,29 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "data": {
+                    "host": "Host"
+                },
+                "title": "Luxor Controller Host or IP"
+            }
+        }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "include_luxor_themes": "Include Luxor themes"
+                }
+            }
+        }
+    },
+    "title": "FX Luminaire Luxor"
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -147,6 +147,7 @@ FLOWS = [
     "logi_circle",
     "luftdaten",
     "lutron_caseta",
+    "luxor",
     "lyric",
     "mailgun",
     "mazda",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -927,6 +927,9 @@ luftdaten==0.6.5
 # homeassistant.components.lupusec
 lupupy==0.0.18
 
+# homeassistant.components.luxor
+luxor==0.0.1
+
 # homeassistant.components.lw12wifi
 lw12==0.9.2
 

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -520,6 +520,9 @@ logi_circle==0.2.2
 # homeassistant.components.luftdaten
 luftdaten==0.6.5
 
+# homeassistant.components.luxor
+luxor==0.0.1
+
 # homeassistant.components.nmap_tracker
 mac-vendor-lookup==0.1.11
 

--- a/tests/components/luxor/__init__.py
+++ b/tests/components/luxor/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FX Luminaire Luxor low voltage controller integration."""

--- a/tests/components/luxor/test_config_flow.py
+++ b/tests/components/luxor/test_config_flow.py
@@ -1,0 +1,105 @@
+"""Test the FX Luminaire Luxor low voltage controller config flow."""
+from unittest.mock import patch
+
+from homeassistant import config_entries, setup
+from homeassistant.components.luxor import const
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import RESULT_TYPE_CREATE_ENTRY, RESULT_TYPE_FORM
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test we get the form."""
+    await setup.async_setup_component(hass, "persistent_notification", {})
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == RESULT_TYPE_FORM
+    assert result["errors"] is None
+
+    with patch(
+        "homeassistant.components.luxor.config_flow.validate_luxor",
+        return_value=True,
+    ), patch(
+        "homeassistant.components.luxor.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] == RESULT_TYPE_CREATE_ENTRY
+    assert result2["title"] == "Luxor Controller"
+    assert result2["data"] == {
+        "host": "1.1.1.1",
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_form_cannot_connect(hass: HomeAssistant) -> None:
+    """Test we handle cannot connect error."""
+    result = await hass.config_entries.flow.async_init(
+        const.DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    with patch(
+        "homeassistant.components.luxor.config_flow.validate_luxor",
+        return_value=False,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": "1.1.1.1",
+            },
+        )
+
+    assert result2["type"] == RESULT_TYPE_FORM
+    assert result2["errors"] == {"base": "cannot_connect"}
+
+
+async def test_options_flow(hass):
+    """Test options config flow."""
+    entry = MockConfigEntry(
+        domain="luxor",
+        data={"host": "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "init"
+    schema = result["data_schema"].schema
+    assert (
+        _get_schema_default(schema, const.CONF_INCLUDE_LUXOR_THEMES)
+        == const.DEFAULT_INCLUDE_LUXOR_THEMES
+    )
+    assert (
+        _get_schema_default(schema, const.CONF_INCLUDE_LUXOR_THEMES)
+        == const.DEFAULT_INCLUDE_LUXOR_THEMES
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            const.CONF_INCLUDE_LUXOR_THEMES: True,
+        },
+    )
+
+    assert result["type"] == "create_entry"
+    assert result["data"] == {
+        const.CONF_INCLUDE_LUXOR_THEMES: True,
+    }
+
+
+def _get_schema_default(schema, key_name):
+    """Iterate schema to find a key."""
+    for schema_key in schema:
+        if schema_key == key_name:
+            return schema_key.default()
+    raise KeyError(f"{key_name} not found in schema")


### PR DESCRIPTION
Support for the FX Luminaire low voltage controller.  See
https://www.fxl.com

The controller groups individual lights into Groups.  Entire Groups
are turned on and off together.  This integration exposes each Group
on the controller as a LightEntity.  Brightness for the group is
supported.

The controller can have several Themes, consisting of Groups, where each
group can have an associated brightness.  Themes can be turned on and
off.  This integration will optionally expose each Theme as a
LightEntity, in addition to the Groups.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
Support for the FX Luminaire low voltage controller.  See
https://www.fxl.com

The controller groups individual lights into Groups.  Entire Groups
are turned on and off together.  This integration exposes each Group
on the controller as a LightEntity.  Brightness for the group is
supported.

The controller can have several Themes, consisting of Groups, where each
group can have an associated brightness.  Themes can be turned on and
off.  This integration will optionally expose each Theme as a
LightEntity, in addition to the Groups.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [X] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
