### PR TITLE
Update requirement of homematicip_cloud component to v1.0.1

### DIFF
--- a/homeassistant/components/homematicip_cloud/manifest.json
+++ b/homeassistant/components/homematicip_cloud/manifest.json
@@ -3,7 +3,7 @@
   "name": "HomematicIP Cloud",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/homematicip_cloud",
-  "requirements": ["homematicip==0.13.1"],
+  "requirements": ["homematicip==1.0.1"],
   "codeowners": [],
   "quality_scale": "platinum",
   "iot_class": "cloud_push"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -786,7 +786,7 @@ homeassistant-pyozw==0.1.10
 homeconnect==0.6.3
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.13.1
+homematicip==1.0.1
 
 # homeassistant.components.home_plus_control
 homepluscontrol==0.0.5

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -450,7 +450,7 @@ homeassistant-pyozw==0.1.10
 homeconnect==0.6.3
 
 # homeassistant.components.homematicip_cloud
-homematicip==0.13.1
+homematicip==1.0.1
 
 # homeassistant.components.home_plus_control
 homepluscontrol==0.0.5

--- a/tests/fixtures/homematicip_cloud.json
+++ b/tests/fixtures/homematicip_cloud.json
@@ -7037,7 +7037,7 @@
             "dutyCycle": false,
             "homeId": "00000000-0000-0000-0000-000000000001",
             "id": "00000000-0000-0000-0000-000000000016",
-            "ignorableDevices": [],
+            "ignorableDeviceChannels": [],
             "label": "INTERNAL",
             "lastStatusUpdate": 1524515489257,
             "lowBat": false,
@@ -7373,7 +7373,7 @@
             "dutyCycle": false,
             "homeId": "00000000-0000-0000-0000-000000000001",
             "id": "00000000-0000-0000-0000-000000000005",
-            "ignorableDevices": [],
+            "ignorableDeviceChannels": [],
             "label": "EXTERNAL",
             "lastStatusUpdate": 1524516526498,
             "lowBat": false,
@@ -8363,7 +8363,10 @@
                 "activationInProgress": false,
                 "active": true,
                 "alarmActive": false,
-                "alarmEventDeviceId": "3014F7110000000000000007",
+                "alarmEventDeviceChannel": {
+                    "channelIndex": 1,
+                    "deviceId": "3014F7110000000000000007"
+                },
                 "alarmEventTimestamp": 1524504122047,
                 "alarmSecurityJournalEntryType": "SENSOR_EVENT",
                 "functionalGroups": [


### PR DESCRIPTION
## Proposed change

Update homematicip rest library
Update to homematicip rest api v1.0.1 to fix issues with unknown ACCESS_CONTROL and SECURITY_AND_ALARM

https://github.com/coreGreenberet/homematicip-rest-api/compare/0.13.1...1.0.1

## Type of change
Update requirement of homematicip_cloud component

- [X] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50586
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist


- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:


- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum


To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone


[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io

Link to changes from previous dependency version to new one: https://github.com/coreGreenberet/homematicip-rest-api/compare/0.13.1...1.0.1
