### PR TITLE
Add color_mode white

### DIFF
--- a/homeassistant/components/light/__init__.py
+++ b/homeassistant/components/light/__init__.py
@@ -61,6 +61,7 @@ COLOR_MODE_XY = "xy"
 COLOR_MODE_RGB = "rgb"
 COLOR_MODE_RGBW = "rgbw"
 COLOR_MODE_RGBWW = "rgbww"
+COLOR_MODE_WHITE = "white"  # Must *NOT* be the only supported mode
 
 VALID_COLOR_MODES = {
     COLOR_MODE_ONOFF,
@@ -71,6 +72,7 @@ VALID_COLOR_MODES = {
     COLOR_MODE_RGB,
     COLOR_MODE_RGBW,
     COLOR_MODE_RGBWW,
+    COLOR_MODE_WHITE,
 }
 COLOR_MODES_BRIGHTNESS = VALID_COLOR_MODES - {COLOR_MODE_ONOFF}
 COLOR_MODES_COLOR = {
@@ -90,6 +92,7 @@ def valid_supported_color_modes(color_modes: Iterable[str]) -> set[str]:
         or COLOR_MODE_UNKNOWN in color_modes
         or (COLOR_MODE_BRIGHTNESS in color_modes and len(color_modes) > 1)
         or (COLOR_MODE_ONOFF in color_modes and len(color_modes) > 1)
+        or (COLOR_MODE_WHITE in color_modes and len(color_modes) == 1)
     ):
         raise vol.Error(f"Invalid supported_color_modes {sorted(color_modes)}")
     return color_modes
@@ -151,6 +154,7 @@ ATTR_MIN_MIREDS = "min_mireds"
 ATTR_MAX_MIREDS = "max_mireds"
 ATTR_COLOR_NAME = "color_name"
 ATTR_WHITE_VALUE = "white_value"
+ATTR_WHITE = "white"
 
 # Brightness of the light, 0..255 or percentage
 ATTR_BRIGHTNESS = "brightness"
@@ -195,6 +199,19 @@ LIGHT_TURN_ON_SCHEMA = {
     vol.Exclusive(ATTR_BRIGHTNESS_STEP, ATTR_BRIGHTNESS): VALID_BRIGHTNESS_STEP,
     vol.Exclusive(ATTR_BRIGHTNESS_STEP_PCT, ATTR_BRIGHTNESS): VALID_BRIGHTNESS_STEP_PCT,
     vol.Exclusive(ATTR_COLOR_NAME, COLOR_GROUP): cv.string,
+    vol.Exclusive(ATTR_COLOR_TEMP, COLOR_GROUP): vol.All(
+        vol.Coerce(int), vol.Range(min=1)
+    ),
+    vol.Exclusive(ATTR_KELVIN, COLOR_GROUP): cv.positive_int,
+    vol.Exclusive(ATTR_HS_COLOR, COLOR_GROUP): vol.All(
+        vol.ExactSequence(
+            (
+                vol.All(vol.Coerce(float), vol.Range(min=0, max=360)),
+                vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
+            )
+        ),
+        vol.Coerce(tuple),
+    ),
     vol.Exclusive(ATTR_RGB_COLOR, COLOR_GROUP): vol.All(
         vol.ExactSequence((cv.byte,) * 3), vol.Coerce(tuple)
     ),
@@ -207,19 +224,7 @@ LIGHT_TURN_ON_SCHEMA = {
     vol.Exclusive(ATTR_XY_COLOR, COLOR_GROUP): vol.All(
         vol.ExactSequence((cv.small_float, cv.small_float)), vol.Coerce(tuple)
     ),
-    vol.Exclusive(ATTR_HS_COLOR, COLOR_GROUP): vol.All(
-        vol.ExactSequence(
-            (
-                vol.All(vol.Coerce(float), vol.Range(min=0, max=360)),
-                vol.All(vol.Coerce(float), vol.Range(min=0, max=100)),
-            )
-        ),
-        vol.Coerce(tuple),
-    ),
-    vol.Exclusive(ATTR_COLOR_TEMP, COLOR_GROUP): vol.All(
-        vol.Coerce(int), vol.Range(min=1)
-    ),
-    vol.Exclusive(ATTR_KELVIN, COLOR_GROUP): cv.positive_int,
+    vol.Exclusive(ATTR_WHITE, COLOR_GROUP): True,
     ATTR_WHITE_VALUE: vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
     ATTR_FLASH: VALID_FLASH,
     ATTR_EFFECT: cv.string,

--- a/homeassistant/components/light/reproduce_state.py
+++ b/homeassistant/components/light/reproduce_state.py
@@ -72,15 +72,14 @@ COLOR_GROUP = [
 ]
 
 COLOR_MODE_TO_ATTRIBUTE = {
-    COLOR_MODE_COLOR_TEMP: ATTR_COLOR_TEMP,
-    COLOR_MODE_HS: ATTR_HS_COLOR,
-    COLOR_MODE_RGB: ATTR_RGB_COLOR,
-    COLOR_MODE_RGBW: ATTR_RGBW_COLOR,
-    COLOR_MODE_RGBWW: ATTR_RGBWW_COLOR,
-    COLOR_MODE_XY: ATTR_XY_COLOR,
+    COLOR_MODE_COLOR_TEMP: (ATTR_COLOR_TEMP, ATTR_COLOR_TEMP),
+    COLOR_MODE_HS: (ATTR_HS_COLOR, ATTR_HS_COLOR),
+    COLOR_MODE_RGB: (ATTR_RGB_COLOR, ATTR_RGB_COLOR),
+    COLOR_MODE_RGBW: (ATTR_RGBW_COLOR, ATTR_RGBW_COLOR),
+    COLOR_MODE_RGBWW: (ATTR_RGBWW_COLOR, ATTR_RGBWW_COLOR),
+    COLOR_MODE_WHITE: (ATTR_WHITE, ATTR_BRIGHTNESS),
+    COLOR_MODE_XY: (ATTR_XY_COLOR, ATTR_XY_COLOR),
 }
-
-COLOR_MODE_TO_PARAMETER = {COLOR_MODE_WHITE: (ATTR_WHITE, True)}
 
 DEPRECATED_GROUP = [
     ATTR_BRIGHTNESS_PCT,
@@ -163,19 +162,17 @@ async def _async_reproduce_state(
             # Remove deprecated white value if we got a valid color mode
             service_data.pop(ATTR_WHITE_VALUE, None)
             color_mode = state.attributes[ATTR_COLOR_MODE]
-            if color_attr := COLOR_MODE_TO_ATTRIBUTE.get(color_mode):
-                if color_attr not in state.attributes:
+            if parameter_state := COLOR_MODE_TO_ATTRIBUTE.get(color_mode):
+                parameter, state_attr = parameter_state
+                if state_attr not in state.attributes:
                     _LOGGER.warning(
                         "Color mode %s specified but attribute %s missing for: %s",
                         color_mode,
-                        color_attr,
+                        state_attr,
                         state.entity_id,
                     )
                     return
-                service_data[color_attr] = state.attributes[color_attr]
-            if color_key_value := COLOR_MODE_TO_PARAMETER.get(color_mode):
-                color_parameter, color_value = color_key_value
-                service_data[color_parameter] = color_value
+                service_data[parameter] = state.attributes[state_attr]
         else:
             # Fall back to Choosing the first color that is specified
             for color_attr in COLOR_GROUP:

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1608,9 +1608,7 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
         "light",
         "turn_on",
         {
-            "entity_id": [
-                entity0.entity_id,
-            ],
+            "entity_id": [entity0.entity_id],
             "brightness_pct": 100,
             "hs_color": (240, 100),
         },
@@ -1623,12 +1621,7 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
     await hass.services.async_call(
         "light",
         "turn_on",
-        {
-            "entity_id": [
-                entity0.entity_id,
-            ],
-            "white": 50,
-        },
+        {"entity_id": [entity0.entity_id], "white": 50},
         blocking=True,
     )
     _, data = entity0.last_call("turn_on")
@@ -1638,12 +1631,7 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
     await hass.services.async_call(
         "light",
         "turn_on",
-        {
-            "entity_id": [
-                entity0.entity_id,
-            ],
-            "white": 0,
-        },
+        {"entity_id": [entity0.entity_id], "white": 0},
         blocking=True,
     )
     _, data = entity0.last_call("turn_off")
@@ -1653,13 +1641,7 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
     await hass.services.async_call(
         "light",
         "turn_on",
-        {
-            "entity_id": [
-                entity0.entity_id,
-            ],
-            "brightness_pct": 100,
-            "white": 50,
-        },
+        {"entity_id": [entity0.entity_id], "brightness_pct": 100, "white": 50},
         blocking=True,
     )
     _, data = entity0.last_call("turn_on")
@@ -1669,13 +1651,7 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
     await hass.services.async_call(
         "light",
         "turn_on",
-        {
-            "entity_id": [
-                entity0.entity_id,
-            ],
-            "brightness": 100,
-            "white": 0,
-        },
+        {"entity_id": [entity0.entity_id], "brightness": 100, "white": 0},
         blocking=True,
     )
     _, data = entity0.last_call("turn_on")
@@ -1685,13 +1661,7 @@ async def test_light_service_call_white_mode(hass, enable_custom_integrations):
     await hass.services.async_call(
         "light",
         "turn_on",
-        {
-            "entity_id": [
-                entity0.entity_id,
-            ],
-            "brightness_pct": 0,
-            "white": 50,
-        },
+        {"entity_id": [entity0.entity_id], "brightness_pct": 0, "white": 50},
         blocking=True,
     )
     _, data = entity0.last_call("turn_off")

--- a/tests/components/light/test_init.py
+++ b/tests/components/light/test_init.py
@@ -1586,6 +1586,118 @@ async def test_light_service_call_color_conversion(hass, enable_custom_integrati
     assert data == {"brightness": 128, "rgbww_color": (0, 75, 140, 255, 255)}
 
 
+async def test_light_service_call_white_mode(hass, enable_custom_integrations):
+    """Test color_mode white in service calls."""
+    platform = getattr(hass.components, "test.light")
+    platform.init(empty=True)
+
+    platform.ENTITIES.append(platform.MockLight("Test_white", STATE_ON))
+    entity0 = platform.ENTITIES[0]
+    entity0.supported_color_modes = {light.COLOR_MODE_HS, light.COLOR_MODE_WHITE}
+
+    assert await async_setup_component(hass, "light", {"light": {"platform": "test"}})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity0.entity_id)
+    assert state.attributes["supported_color_modes"] == [
+        light.COLOR_MODE_HS,
+        light.COLOR_MODE_WHITE,
+    ]
+
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+            ],
+            "brightness_pct": 100,
+            "hs_color": (240, 100),
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"brightness": 255, "hs_color": (240.0, 100.0)}
+
+    entity0.calls = []
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+            ],
+            "white": 50,
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"white": 50}
+
+    entity0.calls = []
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+            ],
+            "white": 0,
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_off")
+    assert data == {}
+
+    entity0.calls = []
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+            ],
+            "brightness_pct": 100,
+            "white": 50,
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"white": 255}
+
+    entity0.calls = []
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+            ],
+            "brightness": 100,
+            "white": 0,
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_on")
+    assert data == {"white": 100}
+
+    entity0.calls = []
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {
+            "entity_id": [
+                entity0.entity_id,
+            ],
+            "brightness_pct": 0,
+            "white": 50,
+        },
+        blocking=True,
+    )
+    _, data = entity0.last_call("turn_off")
+    assert data == {}
+
+
 async def test_light_state_color_conversion(hass, enable_custom_integrations):
     """Test color conversion in state updates."""
     platform = getattr(hass.components, "test.light")

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -189,6 +189,7 @@ async def test_filter_color_modes(hass, caplog, color_mode):
         **VALID_RGBW_COLOR,
         **VALID_RGBWW_COLOR,
         **VALID_XY_COLOR,
+        **VALID_BRIGHTNESS,
     }
 
     turn_on_calls = async_mock_service(hass, "light", "turn_on")
@@ -198,16 +199,23 @@ async def test_filter_color_modes(hass, caplog, color_mode):
     )
 
     expected_map = {
-        light.COLOR_MODE_COLOR_TEMP: VALID_COLOR_TEMP,
-        light.COLOR_MODE_BRIGHTNESS: {},
-        light.COLOR_MODE_HS: VALID_HS_COLOR,
-        light.COLOR_MODE_ONOFF: {},
-        light.COLOR_MODE_RGB: VALID_RGB_COLOR,
-        light.COLOR_MODE_RGBW: VALID_RGBW_COLOR,
-        light.COLOR_MODE_RGBWW: VALID_RGBWW_COLOR,
-        light.COLOR_MODE_UNKNOWN: {**VALID_HS_COLOR, **VALID_WHITE_VALUE},
-        light.COLOR_MODE_WHITE: {light.ATTR_WHITE: True},
-        light.COLOR_MODE_XY: VALID_XY_COLOR,
+        light.COLOR_MODE_COLOR_TEMP: {**VALID_BRIGHTNESS, **VALID_COLOR_TEMP},
+        light.COLOR_MODE_BRIGHTNESS: VALID_BRIGHTNESS,
+        light.COLOR_MODE_HS: {**VALID_BRIGHTNESS, **VALID_HS_COLOR},
+        light.COLOR_MODE_ONOFF: {**VALID_BRIGHTNESS},
+        light.COLOR_MODE_RGB: {**VALID_BRIGHTNESS, **VALID_RGB_COLOR},
+        light.COLOR_MODE_RGBW: {**VALID_BRIGHTNESS, **VALID_RGBW_COLOR},
+        light.COLOR_MODE_RGBWW: {**VALID_BRIGHTNESS, **VALID_RGBWW_COLOR},
+        light.COLOR_MODE_UNKNOWN: {
+            **VALID_BRIGHTNESS,
+            **VALID_HS_COLOR,
+            **VALID_WHITE_VALUE,
+        },
+        light.COLOR_MODE_WHITE: {
+            **VALID_BRIGHTNESS,
+            light.ATTR_WHITE: VALID_BRIGHTNESS[light.ATTR_BRIGHTNESS],
+        },
+        light.COLOR_MODE_XY: {**VALID_BRIGHTNESS, **VALID_XY_COLOR},
     }
     expected = expected_map[color_mode]
 

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -223,6 +223,13 @@ async def test_filter_color_modes(hass, caplog, color_mode):
     assert turn_on_calls[0].domain == "light"
     assert dict(turn_on_calls[0].data) == {"entity_id": "light.entity", **expected}
 
+    # This should do nothing, the light is already in the desired state
+    hass.states.async_set("light.entity", "on", {"color_mode": color_mode, **expected})
+    await hass.helpers.state.async_reproduce_state(
+        [State("light.entity", "on", {**expected, "color_mode": color_mode})]
+    )
+    assert len(turn_on_calls) == 1
+
 
 async def test_deprecation_warning(hass, caplog):
     """Test deprecation warning."""

--- a/tests/components/light/test_reproduce_state.py
+++ b/tests/components/light/test_reproduce_state.py
@@ -172,6 +172,7 @@ async def test_reproducing_states(hass, caplog):
         light.COLOR_MODE_RGBW,
         light.COLOR_MODE_RGBWW,
         light.COLOR_MODE_UNKNOWN,
+        light.COLOR_MODE_WHITE,
         light.COLOR_MODE_XY,
     ),
 )
@@ -205,6 +206,7 @@ async def test_filter_color_modes(hass, caplog, color_mode):
         light.COLOR_MODE_RGBW: VALID_RGBW_COLOR,
         light.COLOR_MODE_RGBWW: VALID_RGBWW_COLOR,
         light.COLOR_MODE_UNKNOWN: {**VALID_HS_COLOR, **VALID_WHITE_VALUE},
+        light.COLOR_MODE_WHITE: {light.ATTR_WHITE: True},
         light.COLOR_MODE_XY: VALID_XY_COLOR,
     }
     expected = expected_map[color_mode]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `color_mode` `white`

This is useful for RGBW type lights which don't support independent control of all channels; the light can be set to *either* white *or* a color, similar to a zigbee hs + color_temp light which can be set to *either* a color *or* white with adjustable color temperature but not both.
RGBW lights which allow independent control of all 4 channels should be using `color_mode` `rgbw` instead.

This adds a new parameter `white` (0..255) to the `light.turn_on` service. There's no new `white` state attribute.
Passing a valid `white` will set the light's brightness to the value aof `white` and set the light's color_mode to `white`

While similar to the deprecated `white_value`, this is not exactly the same:
- `white_value` was poorly documented, and integrations hence treated it differently
- `white_value` was present as a state attribute

To set the light in color_mode white:

Service call: `{"service": "light.turn_on", "data": {"white":50}}`
Light state after the call: {"color_mode": "white", "brightness": 50}

It's allowed to pass both `brightness` and `white` in the service call, in that case the `brightness` has priority and the passed brightness will be forwarded as "white" to the light.

Example:
Service call: `{"service": "light.turn_on", "data": {"white":50, "brightness": 100}}`
Filtered service call to the light: `{"service": "light.turn_on", "data": {"white":100}}`

If `white` is 0 the call will be converted to a turn off call:
Service call: `{"service": "light.turn_on", "data": {"white":0}}`
Filtered service call to the light: `{"service": "light.turn_off"}`

But `brightness` still has priority:
If `white` is 0 the call will be converted to a turn off call:
Service call: `{"service": "light.turn_on", "data": {"white":0, "brightness": 100}}`
Filtered service call to the light: `{"service": "light.turn_on", "data": {"white":100}}`


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
