### PR TITLE
Separate xiaomi_miio water box and mop attributes

### DIFF
--- a/homeassistant/components/xiaomi_miio/vacuum.py
+++ b/homeassistant/components/xiaomi_miio/vacuum.py
@@ -80,6 +80,7 @@ ATTR_ZONE_ARRAY = "zone"
 ATTR_ZONE_REPEATER = "repeats"
 ATTR_TIMERS = "timers"
 ATTR_MOP_ATTACHED = "mop_attached"
+ATTR_WATER_BOX_ATTACHED = "water_box_attached"
 
 SUPPORT_XIAOMI = (
     SUPPORT_STATE
@@ -309,6 +310,10 @@ class MiroboVacuum(XiaomiMiioEntity, StateVacuumEntity):
         """Return the specific state attributes of this vacuum cleaner."""
         attrs = {}
         if self.vacuum_state is not None:
+            is_mop_attached = self.vacuum_state.is_water_box_carriage_attached
+            if is_mop_attached is None:
+                is_mop_attached = self.vacuum_state.is_water_box_attached
+
             attrs.update(
                 {
                     ATTR_DO_NOT_DISTURB: STATE_ON
@@ -340,7 +345,8 @@ class MiroboVacuum(XiaomiMiioEntity, StateVacuumEntity):
                         self.consumable_state.sensor_dirty_left.total_seconds() / 3600
                     ),
                     ATTR_STATUS: str(self.vacuum_state.state),
-                    ATTR_MOP_ATTACHED: self.vacuum_state.is_water_box_attached,
+                    ATTR_MOP_ATTACHED: is_mop_attached,
+                    ATTR_WATER_BOX_ATTACHED: self.vacuum_state.is_water_box_attached,
                 }
             )
 


### PR DESCRIPTION
Signed-off-by: Kevin Hellemun <17928966+OGKevin@users.noreply.github.com>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change is backward compatible, for older models it just adds a new attribute that has the same value as the current attribute. For models where the water box and mop are separate, the split makes the most sense. 

This requires a new release of https://github.com/rytilahti/python-miio which contains:
https://github.com/rytilahti/python-miio/blob/6453bfee512150e3f062670e890533fcd67067ea/miio/vacuumcontainers.py#L194

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51361
- This PR is related to issue: #51361
- Link to documentation pull request: https://www.home-assistant.io/integrations/xiaomi_miio

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
