### PR TITLE
Ensure ssdp can callback messages that do not have an ST

### DIFF
--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -153,7 +153,7 @@ class Scanner:
     ) -> None:
         """Initialize class."""
         self.hass = hass
-        self.seen: set[tuple[str, None | str]] = set()
+        self.seen: set[tuple[str, str | None]] = set()
         self.cache: dict[tuple[str, str], Mapping[str, str]] = {}
         self._integration_matchers = integration_matchers
         self._cancel_scan: Callable[[], None] | None = None

--- a/homeassistant/components/ssdp/__init__.py
+++ b/homeassistant/components/ssdp/__init__.py
@@ -153,7 +153,7 @@ class Scanner:
     ) -> None:
         """Initialize class."""
         self.hass = hass
-        self.seen: set[tuple[str, str]] = set()
+        self.seen: set[tuple[str, None | str]] = set()
         self.cache: dict[tuple[str, str], Mapping[str, str]] = {}
         self._integration_matchers = integration_matchers
         self._cancel_scan: Callable[[], None] | None = None
@@ -268,20 +268,28 @@ class Scanner:
                     domains.add(domain)
         return domains
 
+    def _async_seen(self, header_st: str | None, header_location: str | None) -> bool:
+        """Check if we have seen a specific st and optional location."""
+        if header_st is None:
+            return True
+        return (header_st, header_location) in self.seen
+
+    def _async_see(self, header_st: str | None, header_location: str | None) -> None:
+        """Mark a specific st and optional location as seen."""
+        if header_st is not None:
+            self.seen.add((header_st, header_location))
+
     async def _async_process_entry(self, headers: Mapping[str, str]) -> None:
         """Process SSDP entries."""
         _LOGGER.debug("_async_process_entry: %s", headers)
-        if "st" not in headers or "location" not in headers:
-            return
-        h_st = headers["st"]
-        h_location = headers["location"]
-        key = (h_st, h_location)
+        h_st = headers.get("st")
+        h_location = headers.get("location")
 
-        if udn := _udn_from_usn(headers.get("usn")):
+        if h_st and (udn := _udn_from_usn(headers.get("usn"))):
             self.cache[(udn, h_st)] = headers
 
         callbacks = self._async_get_matching_callbacks(headers)
-        if key in self.seen and not callbacks:
+        if self._async_seen(h_st, h_location) and not callbacks:
             return
 
         assert self.description_manager is not None
@@ -290,9 +298,10 @@ class Scanner:
         discovery_info = discovery_info_from_headers_and_request(info_with_req)
 
         _async_process_callbacks(callbacks, discovery_info)
-        if key in self.seen:
+
+        if self._async_seen(h_st, h_location):
             return
-        self.seen.add(key)
+        self._async_see(h_st, h_location)
 
         for domain in self._async_matching_domains(info_with_req):
             _LOGGER.debug("Discovered %s at %s", domain, h_location)

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -478,6 +478,94 @@ async def test_scan_with_registered_callback(hass, aioclient_mock, caplog):
     assert "Failed to callback info" in caplog.text
 
 
+async def test_unsolicited_ssdp_registered_callback(hass, aioclient_mock, caplog):
+    """Test matching based on callback can handle unsolicited ssdp traffic without st."""
+    aioclient_mock.get(
+        "http://10.6.9.12:1400/xml/device_description.xml",
+        text="""
+<root>
+  <device>
+    <deviceType>Paulus</deviceType>
+  </device>
+</root>
+    """,
+    )
+    mock_ssdp_response = {
+        "location": "http://10.6.9.12:1400/xml/device_description.xml",
+        "nt": "uuid:RINCON_1111BB963FD801400",
+        "nts": "ssdp:alive",
+        "server": "Linux UPnP/1.0 Sonos/63.2-88230 (ZPS12)",
+        "usn": "uuid:RINCON_1111BB963FD801400",
+        "x-rincon-household": "Sonos_dfjfkdghjhkjfhkdjfhkd",
+        "x-rincon-bootseq": "250",
+        "bootid.upnp.org": "250",
+        "x-rincon-wifimode": "0",
+        "x-rincon-variant": "1",
+        "household.smartspeaker.audio": "Sonos_v3294823948542543534",
+    }
+    intergration_callbacks = []
+
+    @callback
+    def _async_intergration_callbacks(info):
+        intergration_callbacks.append(info)
+
+    def _generate_fake_ssdp_listener(*args, **kwargs):
+        listener = SSDPListener(*args, **kwargs)
+
+        async def _async_callback(*_):
+            await listener.async_callback(mock_ssdp_response)
+
+        @callback
+        def _callback(*_):
+            hass.async_create_task(listener.async_callback(mock_ssdp_response))
+
+        listener.async_start = _async_callback
+        listener.async_search = _callback
+        return listener
+
+    with patch(
+        "homeassistant.components.ssdp.SSDPListener",
+        new=_generate_fake_ssdp_listener,
+    ):
+        hass.state = CoreState.stopped
+        assert await async_setup_component(hass, ssdp.DOMAIN, {ssdp.DOMAIN: {}})
+        await hass.async_block_till_done()
+        ssdp.async_register_callback(
+            hass,
+            _async_intergration_callbacks,
+            {"nts": "ssdp:alive", "x-rincon-bootseq": MATCH_ALL},
+        )
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=200))
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        hass.state = CoreState.running
+        await hass.async_block_till_done()
+        async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=200))
+        await hass.async_block_till_done()
+        assert hass.state == CoreState.running
+
+    assert (
+        len(intergration_callbacks) == 2
+    )  # unsolicited callbacks without st are not cached
+    assert intergration_callbacks[0] == {
+        "UDN": "uuid:RINCON_1111BB963FD801400",
+        "bootid.upnp.org": "250",
+        "deviceType": "Paulus",
+        "household.smartspeaker.audio": "Sonos_v3294823948542543534",
+        "nt": "uuid:RINCON_1111BB963FD801400",
+        "nts": "ssdp:alive",
+        "ssdp_location": "http://10.6.9.12:1400/xml/device_description.xml",
+        "ssdp_server": "Linux UPnP/1.0 Sonos/63.2-88230 (ZPS12)",
+        "ssdp_usn": "uuid:RINCON_1111BB963FD801400",
+        "x-rincon-bootseq": "250",
+        "x-rincon-household": "Sonos_dfjfkdghjhkjfhkdjfhkd",
+        "x-rincon-variant": "1",
+        "x-rincon-wifimode": "0",
+    }
+    assert "Failed to callback info" not in caplog.text
+
+
 async def test_scan_second_hit(hass, aioclient_mock, caplog):
     """Test matching on second scan."""
     aioclient_mock.get(


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Sonos sends unsolicited messages when the device reboots. We want
to capture these to ensure we can recover the subscriptions as soon
as the device reboots

Supports https://github.com/home-assistant/core/pull/51377


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
