### PR TITLE
Allow number/sensor entities in numeric state conditions/triggers

### DIFF
--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -926,7 +926,7 @@ SERVICE_SCHEMA = vol.All(
 )
 
 NUMERIC_STATE_THRESHOLD_SCHEMA = vol.Any(
-    vol.Coerce(float), vol.All(str, entity_domain("input_number"))
+    vol.Coerce(float), vol.All(str, entity_domain(["input_number", "number", "sensor"]))
 )
 
 CONDITION_BASE_SCHEMA = {vol.Optional(CONF_ALIAS): string}

--- a/tests/components/homeassistant/triggers/test_numeric_state.py
+++ b/tests/components/homeassistant/triggers/test_numeric_state.py
@@ -47,9 +47,13 @@ async def setup_comp(hass):
             }
         },
     )
+    hass.states.async_set("number.value_10", 10)
+    hass.states.async_set("sensor.value_10", 10)
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_not_fires_on_entity_removal(hass, calls, below):
     """Test the firing with removed entity."""
     hass.states.async_set("test.entity", 11)
@@ -75,7 +79,9 @@ async def test_if_not_fires_on_entity_removal(hass, calls, below):
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_fires_on_entity_change_below(hass, calls, below):
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -120,7 +126,9 @@ async def test_if_fires_on_entity_change_below(hass, calls, below):
     assert calls[0].data["id"] == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_fires_on_entity_change_over_to_below(hass, calls, below):
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -147,7 +155,9 @@ async def test_if_fires_on_entity_change_over_to_below(hass, calls, below):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_fires_on_entities_change_over_to_below(hass, calls, below):
     """Test the firing with changed entities."""
     hass.states.async_set("test.entity_1", 11)
@@ -178,7 +188,9 @@ async def test_if_fires_on_entities_change_over_to_below(hass, calls, below):
     assert len(calls) == 2
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_not_fires_on_entity_change_below_to_below(hass, calls, below):
     """Test the firing with changed entity."""
     context = Context()
@@ -217,7 +229,9 @@ async def test_if_not_fires_on_entity_change_below_to_below(hass, calls, below):
     assert len(calls) == 1
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_not_below_fires_on_entity_change_to_equal(hass, calls, below):
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 11)
@@ -244,7 +258,9 @@ async def test_if_not_below_fires_on_entity_change_to_equal(hass, calls, below):
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("below", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "below", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_not_fires_on_initial_entity_below(hass, calls, below):
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 9)
@@ -271,7 +287,9 @@ async def test_if_not_fires_on_initial_entity_below(hass, calls, below):
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("above", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "above", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_not_fires_on_initial_entity_above(hass, calls, above):
     """Test the firing when starting with a match."""
     hass.states.async_set("test.entity", 11)
@@ -298,7 +316,9 @@ async def test_if_not_fires_on_initial_entity_above(hass, calls, above):
     assert len(calls) == 0
 
 
-@pytest.mark.parametrize("above", (10, "input_number.value_10"))
+@pytest.mark.parametrize(
+    "above", (10, "input_number.value_10", "number.value_10", "sensor.value_10")
+)
 async def test_if_fires_on_entity_change_above(hass, calls, above):
     """Test the firing with changed entity."""
     hass.states.async_set("test.entity", 9)
@@ -1632,8 +1652,8 @@ def test_below_above():
         )
 
 
-def test_schema_input_number():
-    """Test input_number only is accepted for above/below."""
+def test_schema_unacceptable_entities():
+    """Test input_number, number & sensor only is accepted for above/below."""
     with pytest.raises(vol.Invalid):
         numeric_state_trigger.TRIGGER_SCHEMA(
             {

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1265,12 +1265,12 @@ async def test_numeric_state_attribute(hass):
 
 async def test_numeric_state_using_input_number(hass):
     """Test numeric_state conditions using input_number entities."""
+    hass.states.async_set("number.low", 10)
     await async_setup_component(
         hass,
         "input_number",
         {
             "input_number": {
-                "low": {"min": 0, "max": 255, "initial": 10},
                 "high": {"min": 0, "max": 255, "initial": 100},
             }
         },
@@ -1285,7 +1285,7 @@ async def test_numeric_state_using_input_number(hass):
                     "condition": "numeric_state",
                     "entity_id": "sensor.temperature",
                     "below": "input_number.high",
-                    "above": "input_number.low",
+                    "above": "number.low",
                 },
             ],
         },
@@ -1317,10 +1317,10 @@ async def test_numeric_state_using_input_number(hass):
     )
     assert test(hass)
 
-    hass.states.async_set("input_number.low", "unknown")
+    hass.states.async_set("number.low", "unknown")
     assert not test(hass)
 
-    hass.states.async_set("input_number.low", "unavailable")
+    hass.states.async_set("number.low", "unavailable")
     assert not test(hass)
 
     with pytest.raises(ConditionError):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Back in 2020, we added support for referencing `input_number.*` entities in the numeric state triggers and conditions, making those more dynamic.

This PR extends this to the `number` and `sensor` domains.

```yaml
condition:
  - condition: numeric_state
    entity_id: sensor.outside_temperature
    above: sensor.inside_temperature
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51423
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18084

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
