### PR TITLE
Add cover platform to bosch_shc integration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -123,6 +123,7 @@ omit =
     homeassistant/components/bosch_shc/__init__.py
     homeassistant/components/bosch_shc/binary_sensor.py
     homeassistant/components/bosch_shc/const.py
+    homeassistant/components/bosch_shc/cover.py
     homeassistant/components/bosch_shc/entity.py
     homeassistant/components/bosch_shc/sensor.py
     homeassistant/components/braviatv/__init__.py

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -19,7 +19,7 @@ from .const import (
     DOMAIN,
 )
 
-PLATFORMS = ["binary_sensor", "sensor"]
+PLATFORMS = ["binary_sensor", "cover", "sensor"]
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -1,0 +1,97 @@
+"""Platform for cover integration."""
+from boschshcpy import SHCSession, SHCShutterControl
+
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    DEVICE_CLASS_SHUTTER,
+    SUPPORT_CLOSE,
+    SUPPORT_OPEN,
+    SUPPORT_SET_POSITION,
+    SUPPORT_STOP,
+    CoverEntity,
+)
+
+from .const import DATA_SESSION, DOMAIN
+from .entity import SHCEntity
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the SHC cover platform."""
+
+    entities = []
+    session: SHCSession = hass.data[DOMAIN][config_entry.entry_id][DATA_SESSION]
+
+    for cover in session.device_helper.shutter_controls:
+        entities.append(
+            ShutterControlCover(
+                device=cover,
+                parent_id=session.information.unique_id,
+                entry_id=config_entry.entry_id,
+            )
+        )
+
+    if entities:
+        async_add_entities(entities)
+
+
+class ShutterControlCover(SHCEntity, CoverEntity):
+    """Representation of a SHC shutter control device."""
+
+    @property
+    def supported_features(self):
+        """Flag supported features."""
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
+
+    @property
+    def device_class(self):
+        """Return the class of this device, from component DEVICE_CLASSES."""
+        return DEVICE_CLASS_SHUTTER
+
+    @property
+    def current_cover_position(self):
+        """Return the current cover position."""
+        return self._device.level * 100.0
+
+    def stop_cover(self, **kwargs):
+        """Stop the cover."""
+        self._device.stop()
+
+    @property
+    def is_closed(self):
+        """Return if the cover is closed or not."""
+        if self.current_cover_position is None:
+            return None
+        if self.current_cover_position == 0.0:
+            return True
+        return False
+
+    @property
+    def is_opening(self):
+        """Return if the cover is opening or not."""
+        return (
+            self._device.operation_state
+            == SHCShutterControl.ShutterControlService.State.OPENING
+        )
+
+    @property
+    def is_closing(self):
+        """Return if the cover is closing or not."""
+        return (
+            self._device.operation_state
+            == SHCShutterControl.ShutterControlService.State.CLOSING
+        )
+
+    def open_cover(self, **kwargs):
+        """Open the cover."""
+        self._device.level = 1.0
+
+    def close_cover(self, **kwargs):
+        """Close cover."""
+        self._device.level = 0.0
+
+    def set_cover_position(self, **kwargs):
+        """Move the cover to a specific position."""
+        if ATTR_POSITION in kwargs:
+            position = float(kwargs[ATTR_POSITION])
+            position = min(100, max(0, position))
+            self._device.level = position / 100.0

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -61,9 +61,7 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         """Return if the cover is closed or not."""
         if self.current_cover_position is None:
             return None
-        if self.current_cover_position == 0.0:
-            return True
-        return False
+        return self.current_cover_position == 0.0
 
     @property
     def is_opening(self):

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -36,16 +36,11 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class ShutterControlCover(SHCEntity, CoverEntity):
     """Representation of a SHC shutter control device."""
-
-    @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
-
-    @property
-    def device_class(self):
-        """Return the class of this device, from component DEVICE_CLASSES."""
-        return DEVICE_CLASS_SHUTTER
+    
+    _attr_device_class = DEVICE_CLASS_SHUTTER
+    _attr_supported_features = (
+        SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION
+    )
 
     @property
     def current_cover_position(self):

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -36,7 +36,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 
 class ShutterControlCover(SHCEntity, CoverEntity):
     """Representation of a SHC shutter control device."""
-    
+
     _attr_device_class = DEVICE_CLASS_SHUTTER
     _attr_supported_features = (
         SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP | SUPPORT_SET_POSITION

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -54,8 +54,6 @@ class ShutterControlCover(SHCEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        if self.current_cover_position is None:
-            return None
         return self.current_cover_position == 0.0
 
     @property

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -54,7 +54,7 @@ class ShutterControlCover(SHCEntity, CoverEntity):
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        return self.current_cover_position == 0.0
+        return self.current_cover_position == 0
 
     @property
     def is_opening(self):

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -45,7 +45,7 @@ class ShutterControlCover(SHCEntity, CoverEntity):
     @property
     def current_cover_position(self):
         """Return the current cover position."""
-        return self._device.level * 100.0
+        return round(self._device.level * 100.0)
 
     def stop_cover(self, **kwargs):
         """Stop the cover."""
@@ -84,7 +84,5 @@ class ShutterControlCover(SHCEntity, CoverEntity):
 
     def set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""
-        if ATTR_POSITION in kwargs:
-            position = float(kwargs[ATTR_POSITION])
-            position = min(100, max(0, position))
-            self._device.level = position / 100.0
+        position = kwargs[ATTR_POSITION]
+        self._device.level = position / 100.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Added functionality for shutter controls via cover platform. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18102

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
