### PR TITLE
Add extra_state_attributes to KNX weather

### DIFF
--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -1,6 +1,8 @@
 """Support for KNX/IP weather station."""
 from __future__ import annotations
 
+from typing import Any
+
 from xknx import XKNX
 from xknx.devices import Weather as XknxWeather
 
@@ -13,6 +15,15 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from .const import DOMAIN
 from .knx_entity import KnxEntity
 from .schema import WeatherSchema
+
+ATTR_BRIGHTNESS_NORTH = "brightness_north"
+ATTR_BRIGHTNESS_EAST = "brightness_east"
+ATTR_BRIGHTNESS_SOUTH = "brightness_south"
+ATTR_BRIGHTNESS_WEST = "brightness_west"
+ATTR_RAIN_ALARM = "rain_alarm"
+ATTR_WIND_ALARM = "wind_alarm"
+ATTR_FROST_ALARM = "frost_alarm"
+ATTR_DAY_NIGHT = "night"
 
 
 async def async_setup_platform(
@@ -124,3 +135,26 @@ class KNXWeather(KnxEntity, WeatherEntity):
             if self._device.wind_speed is not None
             else None
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return device specific state attributes."""
+        attr: dict[str, Any] = {}
+        # pylint: disable=protected-access
+        if self._device._brightness_north.initialized:
+            attr[ATTR_BRIGHTNESS_NORTH] = self._device.brightness_north
+        if self._device._brightness_west.initialized:
+            attr[ATTR_BRIGHTNESS_WEST] = self._device.brightness_west
+        if self._device._brightness_south.initialized:
+            attr[ATTR_BRIGHTNESS_SOUTH] = self._device.brightness_south
+        if self._device._brightness_east.initialized:
+            attr[ATTR_BRIGHTNESS_EAST] = self._device.brightness_east
+        if self._device.rain_alarm is not None:
+            attr[ATTR_RAIN_ALARM] = self._device.rain_alarm
+        if self._device.wind_alarm is not None:
+            attr[ATTR_WIND_ALARM] = self._device.wind_alarm
+        if self._device.frost_alarm is not None:
+            attr[ATTR_FROST_ALARM] = self._device.frost_alarm
+        if self._device.day_night is not None:
+            attr[ATTR_DAY_NIGHT] = self._device.day_night
+        return attr if attr else None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The KNX weather entity has some features (alarms, brightness, night) that aren't supported by the HA weather entity base. These are very common for KNX weather sensors and are used for calculating the condition property. This PR adds them to extra_state_attributes.
In [2021.6 we removed the `create_sensors` option for weather entities](https://github.com/home-assistant/core/pull/49640) - recommending "Please use template sensors instead". This would need these attributes to exist 😬🙃

It would be nice if this could be added to a 2021.6 minor release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51465
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [x] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
