### PR TITLE
Check initial connect() worked in modbus

### DIFF
--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -196,8 +196,8 @@ class ModbusHub:
             },
         }
 
-    def _log_error(self, exception_error: ModbusException, error_state=True):
-        log_text = "Pymodbus: " + str(exception_error)
+    def _log_error(self, text: str, error_state=True):
+        log_text = "Pymodbus: " + text
         if self._in_error:
             _LOGGER.debug(log_text)
         else:
@@ -242,13 +242,12 @@ class ModbusHub:
                     reset_socket=self._config_reset_socket,
                 )
         except ModbusException as exception_error:
-            self._log_error(exception_error, error_state=False)
+            self._log_error(str(exception_error), error_state=False)
             return False
 
         async with self._lock:
             if not await self.hass.async_add_executor_job(self._pymodbus_connect):
-                exception = ModbusException("initial connect failed, no retry")
-                self._log_error(exception, error_state=False)
+                self._log_error("initial connect failed, no retry", error_state=False)
                 return False
 
         self._call_type[CALL_TYPE_COIL][ENTRY_FUNC] = self._client.read_coils
@@ -289,7 +288,7 @@ class ModbusHub:
             try:
                 self._client.close()
             except ModbusException as exception_error:
-                self._log_error(exception_error)
+                self._log_error(str(exception_error))
         self._client = None
 
     async def async_close(self):
@@ -306,7 +305,7 @@ class ModbusHub:
         try:
             return self._client.connect()
         except ModbusException as exception_error:
-            self._log_error(exception_error, error_state=False)
+            self._log_error(str(exception_error), error_state=False)
             return False
 
     def _pymodbus_call(self, unit, address, value, use_call):
@@ -315,10 +314,10 @@ class ModbusHub:
         try:
             result = self._call_type[use_call][ENTRY_FUNC](address, value, **kwargs)
         except ModbusException as exception_error:
-            self._log_error(exception_error)
+            self._log_error(str(exception_error))
             result = exception_error
         if not hasattr(result, self._call_type[use_call][ENTRY_ATTR]):
-            self._log_error(result)
+            self._log_error(str(result))
             return None
         self._in_error = False
         return result

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -247,8 +247,8 @@ class ModbusHub:
 
         async with self._lock:
             if not await self.hass.async_add_executor_job(self._pymodbus_connect):
-                text = ModbusException("initial connect failed, no retry")
-                self._log_error(text, error_state=False)
+                exception = ModbusException("initial connect failed, no retry")
+                self._log_error(exception, error_state=False)
                 return False
 
         self._call_type[CALL_TYPE_COIL][ENTRY_FUNC] = self._client.read_coils

--- a/homeassistant/components/modbus/modbus.py
+++ b/homeassistant/components/modbus/modbus.py
@@ -197,7 +197,7 @@ class ModbusHub:
         }
 
     def _log_error(self, text: str, error_state=True):
-        log_text = "Pymodbus: " + text
+        log_text = f"Pymodbus: {text}"
         if self._in_error:
             _LOGGER.debug(log_text)
         else:

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -511,15 +511,24 @@ async def test_pymodbus_constructor_fail(hass, caplog):
     ) as mock_pb:
         caplog.set_level(logging.ERROR)
         mock_pb.side_effect = ModbusException("test no class")
-        assert await async_setup_component(hass, DOMAIN, config) is True
+        assert await async_setup_component(hass, DOMAIN, config) is False
         await hass.async_block_till_done()
-        assert len(caplog.records) == 1
+        assert caplog.messages[0].startswith("Pymodbus: Modbus Error: test")
         assert caplog.records[0].levelname == "ERROR"
         assert mock_pb.called
 
 
-async def test_pymodbus_connect_fail(hass, caplog, mock_pymodbus):
-    """Run test for failing pymodbus constructor."""
+@pytest.mark.parametrize(
+    "do_connect,do_exception,do_text",
+    [
+        [False, None, "initial"],
+        [True, ModbusException("no connect"), "no connect"],
+    ],
+)
+async def test_pymodbus_connect_fail(
+    hass, do_connect, do_exception, do_text, caplog, mock_pymodbus
+):
+    """Run test for failing pymodbus connect."""
     config = {
         DOMAIN: [
             {
@@ -530,12 +539,69 @@ async def test_pymodbus_connect_fail(hass, caplog, mock_pymodbus):
         ]
     }
     caplog.set_level(logging.ERROR)
-    mock_pymodbus.connect.side_effect = ModbusException("test connect fail")
-    mock_pymodbus.close.side_effect = ModbusException("test connect fail")
+    mock_pymodbus.connect.return_value = do_connect
+    mock_pymodbus.connect.side_effect = do_exception
+    assert await async_setup_component(hass, DOMAIN, config) is False
+    await hass.async_block_till_done()
+    assert caplog.messages[0].startswith(f"Pymodbus: Modbus Error: {do_text}")
+    assert caplog.records[0].levelname == "ERROR"
+
+
+async def test_pymodbus_close_fail(hass, caplog, mock_pymodbus):
+    """Run test for failing pymodbus close."""
+    config = {
+        DOMAIN: [
+            {
+                CONF_TYPE: "tcp",
+                CONF_HOST: TEST_HOST,
+                CONF_PORT: 5501,
+            }
+        ]
+    }
+    caplog.set_level(logging.ERROR)
+    mock_pymodbus.connect.return_value = True
+    mock_pymodbus.close.side_effect = ModbusException("close fail")
     assert await async_setup_component(hass, DOMAIN, config) is True
     await hass.async_block_till_done()
-    assert len(caplog.records) == 1
-    assert caplog.records[0].levelname == "ERROR"
+    # Close() is called as part of teardown
+
+
+async def test_disconnect(hass, mock_pymodbus):
+    """Run test for startup delay."""
+
+    # the purpose of this test is to test a device disconnect
+    # We "hijiack" a binary_sensor to make a proper blackbox test.
+    entity_id = f"{BINARY_SENSOR_DOMAIN}.{TEST_SENSOR_NAME}"
+    config = {
+        DOMAIN: [
+            {
+                CONF_TYPE: "tcp",
+                CONF_HOST: TEST_HOST,
+                CONF_PORT: 5501,
+                CONF_NAME: TEST_MODBUS_NAME,
+                CONF_BINARY_SENSORS: [
+                    {
+                        CONF_INPUT_TYPE: CALL_TYPE_COIL,
+                        CONF_NAME: f"{TEST_SENSOR_NAME}",
+                        CONF_ADDRESS: 52,
+                    },
+                ],
+            }
+        ]
+    }
+    mock_pymodbus.read_coils.return_value = ReadResult([0x01])
+    mock_pymodbus.is_socket_open.return_value = False
+    now = dt_util.utcnow()
+    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
+        assert await async_setup_component(hass, DOMAIN, config) is True
+        await hass.async_block_till_done()
+
+    # pass first scan_interval
+    now = now + timedelta(seconds=20)
+    with mock.patch("homeassistant.helpers.event.dt_util.utcnow", return_value=now):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
 async def test_delay(hass, mock_pymodbus):

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -521,8 +521,8 @@ async def test_pymodbus_constructor_fail(hass, caplog):
 @pytest.mark.parametrize(
     "do_connect,do_exception,do_text",
     [
-        [False, None, "initial"],
-        [True, ModbusException("no connect"), "no connect"],
+        [False, None, "initial connect failed, no retry"],
+        [True, ModbusException("no connect"), "Modbus Error: no connect"],
     ],
 )
 async def test_pymodbus_connect_fail(
@@ -543,7 +543,7 @@ async def test_pymodbus_connect_fail(
     mock_pymodbus.connect.side_effect = do_exception
     assert await async_setup_component(hass, DOMAIN, config) is False
     await hass.async_block_till_done()
-    assert caplog.messages[0].startswith(f"Pymodbus: Modbus Error: {do_text}")
+    assert caplog.messages[0].startswith(f"Pymodbus: {do_text}")
     assert caplog.records[0].levelname == "ERROR"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If the initial connect() failed it would go undetected. Furthermore a disconnect later would also not be reported.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
Fixes #51364 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
