### PR TITLE
Refactor Sonos alarms

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -134,7 +134,7 @@ async def async_setup_entry(  # noqa: C901
             data.discovered[soco.uid] = speaker
             if soco.household_id not in data.alarms:
                 data.alarms[soco.household_id] = SonosAlarms(hass, soco.household_id)
-                data.alarms[soco.household_id].get_new_alarms(soco)
+                data.alarms[soco.household_id].setup(soco)
             if soco.household_id not in data.favorites:
                 data.favorites[soco.household_id] = SonosFavorites(
                     hass, soco.household_id

--- a/homeassistant/components/sonos/alarms.py
+++ b/homeassistant/components/sonos/alarms.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Coroutine, Iterator
 import logging
 from typing import Callable
 
@@ -12,6 +12,7 @@ from pysonos.events_base import Event as SonosEvent
 from pysonos.exceptions import SoCoException
 
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
 from .const import DATA_SONOS, SONOS_ALARM_UPDATE, SONOS_CREATE_ALARM
@@ -29,6 +30,12 @@ class SonosAlarms:
         self._alarms: dict[str, Alarm] = {}
         self._next_update: Callable | None = None
         self._processed_events = deque(maxlen=5)
+        self.async_poll: Coroutine | None = None
+
+    def setup(self, soco: SoCo) -> None:
+        """Set up the SonosAlarm instance."""
+        self.get_new_alarms(soco)
+        self.hass.add_job(self._async_create_debouncer)
 
     def __iter__(self) -> Iterator:
         """Return an iterator for the known alarms."""
@@ -38,6 +45,29 @@ class SonosAlarms:
     def get(self, alarm_id: str) -> Alarm | None:
         """Get an Alarm instance."""
         return self._alarms.get(alarm_id)
+
+    async def _async_create_debouncer(self) -> None:
+        """Create the polling debouncer in async context."""
+        self.async_poll = Debouncer(
+            self.hass,
+            _LOGGER,
+            cooldown=3,
+            immediate=False,
+            function=self._async_poll,
+        ).async_call
+
+    async def _async_poll(self) -> None:
+        """Poll any known speaker to update alarms."""
+        discovered = self.hass.data[DATA_SONOS].discovered
+
+        for uid, speaker in discovered.items():
+            _LOGGER.debug("Updating alarms using %s", speaker.soco)
+            success = await self._async_refresh(speaker.soco)
+
+            if success:
+                # Prefer this SoCo instance next update
+                discovered.move_to_end(uid, last=False)
+                break
 
     @callback
     def async_refresh(self, event: SonosEvent, soco: SoCo) -> None:
@@ -49,13 +79,21 @@ class SonosAlarms:
         self._processed_events.append(update_id)
         self.hass.async_create_task(self._async_refresh(soco))
 
-    async def _async_refresh(self, soco: SoCo) -> None:
-        """Create and update alarms."""
-        new_alarms = await self.hass.async_add_executor_job(self.get_new_alarms, soco)
+    async def _async_refresh(self, soco: SoCo) -> bool:
+        """Create and update alarms, return success."""
+        try:
+            new_alarms = await self.hass.async_add_executor_job(
+                self.get_new_alarms, soco
+            )
+        except (OSError, SoCoException) as exc:
+            _LOGGER.error("Could not refresh alarms using %s: %s", soco, exc)
+            return False
+
         for alarm in new_alarms:
             speaker = self.hass.data[DATA_SONOS].discovered[alarm.zone.uid]
             async_dispatcher_send(self.hass, SONOS_CREATE_ALARM, speaker, [alarm])
         async_dispatcher_send(self.hass, f"{SONOS_ALARM_UPDATE}-{self.household_id}")
+        return True
 
     def get_new_alarms(self, soco: SoCo) -> set[Alarm]:
         """Populate cache of known alarms.
@@ -63,10 +101,7 @@ class SonosAlarms:
         Prune deleted alarms and return new alarms.
         """
         new_alarms = set()
-        try:
-            soco_alarms = get_alarms(soco)
-        except (OSError, SoCoException) as exc:
-            _LOGGER.error("Could not refresh alarms from %s: %s", soco, exc)
+        soco_alarms = get_alarms(soco)
 
         for alarm in soco_alarms:
             if alarm.alarm_id not in self._alarms:

--- a/homeassistant/components/sonos/alarms.py
+++ b/homeassistant/components/sonos/alarms.py
@@ -1,0 +1,80 @@
+"""Class representing Sonos alarms."""
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Iterator
+import logging
+from typing import Callable
+
+from pysonos import SoCo
+from pysonos.alarms import Alarm, get_alarms
+from pysonos.events_base import Event as SonosEvent
+from pysonos.exceptions import SoCoException
+
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+
+from .const import DATA_SONOS, SONOS_ALARM_UPDATE, SONOS_CREATE_ALARM
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SonosAlarms:
+    """Storage class for Sonos alarms."""
+
+    def __init__(self, hass: HomeAssistant, household_id: str) -> None:
+        """Initialize the data."""
+        self.hass = hass
+        self.household_id = household_id
+        self._alarms: dict[str, Alarm] = {}
+        self._next_update: Callable | None = None
+        self._processed_events = deque(maxlen=5)
+
+    def __iter__(self) -> Iterator:
+        """Return an iterator for the known alarms."""
+        alarms = list(self._alarms.values())
+        return iter(alarms)
+
+    def get(self, alarm_id: str) -> Alarm | None:
+        """Get an Alarm instance."""
+        return self._alarms.get(alarm_id)
+
+    @callback
+    def async_refresh(self, event: SonosEvent, soco: SoCo) -> None:
+        """Create a task to update alarms from an event callback."""
+        if not (update_id := event.variables.get("alarm_list_version")):
+            return
+        if update_id in self._processed_events:
+            return
+        self._processed_events.append(update_id)
+        self.hass.async_create_task(self._async_refresh(soco))
+
+    async def _async_refresh(self, soco: SoCo) -> None:
+        """Create and update alarms."""
+        new_alarms = await self.hass.async_add_executor_job(self.get_new_alarms, soco)
+        for alarm in new_alarms:
+            speaker = self.hass.data[DATA_SONOS].discovered[alarm.zone.uid]
+            async_dispatcher_send(self.hass, SONOS_CREATE_ALARM, speaker, [alarm])
+        async_dispatcher_send(self.hass, f"{SONOS_ALARM_UPDATE}-{self.household_id}")
+
+    def get_new_alarms(self, soco: SoCo) -> set[Alarm]:
+        """Populate cache of known alarms.
+
+        Prune deleted alarms and return new alarms.
+        """
+        new_alarms = set()
+        try:
+            soco_alarms = get_alarms(soco)
+        except (OSError, SoCoException) as exc:
+            _LOGGER.error("Could not refresh alarms from %s: %s", soco, exc)
+
+        for alarm in soco_alarms:
+            if alarm.alarm_id not in self._alarms:
+                new_alarms.add(alarm)
+                self._alarms[alarm.alarm_id] = alarm
+
+        for alarm_id, alarm in list(self._alarms.items()):
+            if alarm not in soco_alarms:
+                self._alarms.pop(alarm_id)
+
+        return new_alarms

--- a/homeassistant/components/sonos/alarms.py
+++ b/homeassistant/components/sonos/alarms.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Coroutine, Iterator
 import logging
-from typing import Callable
 
 from pysonos import SoCo
 from pysonos.alarms import Alarm, get_alarms
@@ -28,7 +27,6 @@ class SonosAlarms:
         self.hass = hass
         self.household_id = household_id
         self._alarms: dict[str, Alarm] = {}
-        self._next_update: Callable | None = None
         self._processed_events = deque(maxlen=5)
         self.async_poll: Coroutine | None = None
 

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -245,6 +245,9 @@ class SonosSpeaker:
     #
     async def async_handle_new_entity(self, entity_type: str) -> None:
         """Listen to new entities to trigger first subscription."""
+        if self._platforms_ready == PLATFORMS:
+            return
+
         self._platforms_ready.add(entity_type)
         if self._platforms_ready == PLATFORMS:
             self._resubscription_lock = asyncio.Lock()

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -558,7 +558,7 @@ class SonosSpeaker:
             coordinator_uid = self.soco.uid
             slave_uids = []
 
-            with contextlib.suppress(SoCoException):
+            with contextlib.suppress(OSError, SoCoException):
                 if self.soco.group and self.soco.group.coordinator:
                     coordinator_uid = self.soco.group.coordinator.uid
                     slave_uids = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Refactor Sonos alarms to store and update at a central household (system) level, similar to favorites.

Fixes an issue where new alarms are only created if the event is processed on the speaker that receives the event.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
