### PR TITLE
Add Ecobee humidifier device_info and unique_id

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -220,6 +220,7 @@ omit =
     homeassistant/components/ecobee/__init__.py
     homeassistant/components/ecobee/binary_sensor.py
     homeassistant/components/ecobee/climate.py
+    homeassistant/components/ecobee/humidifier.py
     homeassistant/components/ecobee/notify.py
     homeassistant/components/ecobee/sensor.py
     homeassistant/components/ecobee/weather.py

--- a/homeassistant/components/ecobee/humidifier.py
+++ b/homeassistant/components/ecobee/humidifier.py
@@ -10,7 +10,7 @@ from homeassistant.components.humidifier.const import (
     SUPPORT_MODES,
 )
 
-from .const import DOMAIN
+from .const import DOMAIN, ECOBEE_MODEL_TO_NAME, MANUFACTURER
 
 SCAN_INTERVAL = timedelta(minutes=3)
 
@@ -42,6 +42,31 @@ class EcobeeHumidifier(HumidifierEntity):
         self._last_humidifier_on_mode = MODE_MANUAL
 
         self.update_without_throttle = False
+
+    @property
+    def name(self):
+        """Return the name of the humidifier."""
+        return self._name
+
+    @property
+    def unique_id(self):
+        """Return unique_id for humidifier."""
+        return f"{self.thermostat['identifier']}"
+
+    @property
+    def device_info(self):
+        """Return device information for the ecobee humidifier."""
+        try:
+            model = f"{ECOBEE_MODEL_TO_NAME[self.thermostat['modelNumber']]} Thermostat"
+        except KeyError:
+            return None
+
+        return {
+            "identifiers": {(DOMAIN, self.thermostat["identifier"])},
+            "name": self.name,
+            "manufacturer": MANUFACTURER,
+            "model": model,
+        }
 
     async def async_update(self):
         """Get the latest state from the thermostat."""
@@ -83,11 +108,6 @@ class EcobeeHumidifier(HumidifierEntity):
     def mode(self):
         """Return the current mode, e.g., off, auto, manual."""
         return self.thermostat["settings"]["humidifierMode"]
-
-    @property
-    def name(self):
-        """Return the name of the ecobee thermostat."""
-        return self._name
 
     @property
     def supported_features(self):

--- a/homeassistant/components/ecobee/humidifier.py
+++ b/homeassistant/components/ecobee/humidifier.py
@@ -58,7 +58,8 @@ class EcobeeHumidifier(HumidifierEntity):
         """Return device information for the ecobee humidifier."""
         try:
             model = f"{ECOBEE_MODEL_TO_NAME[self.thermostat['modelNumber']]} Thermostat"
-        except KeyError:
+        except KeyError:  # pragma: no cover
+            """Ecobee model is not in our list"""
             return None
 
         return {

--- a/homeassistant/components/ecobee/humidifier.py
+++ b/homeassistant/components/ecobee/humidifier.py
@@ -58,7 +58,7 @@ class EcobeeHumidifier(HumidifierEntity):
         """Return device information for the ecobee humidifier."""
         try:
             model = f"{ECOBEE_MODEL_TO_NAME[self.thermostat['modelNumber']]} Thermostat"
-        except KeyError:  # pragma: no cover
+        except KeyError:
             # Ecobee model is not in our list
             return None
 

--- a/homeassistant/components/ecobee/humidifier.py
+++ b/homeassistant/components/ecobee/humidifier.py
@@ -59,7 +59,7 @@ class EcobeeHumidifier(HumidifierEntity):
         try:
             model = f"{ECOBEE_MODEL_TO_NAME[self.thermostat['modelNumber']]} Thermostat"
         except KeyError:  # pragma: no cover
-            """Ecobee model is not in our list"""
+            # Ecobee model is not in our list
             return None
 
         return {

--- a/tests/components/ecobee/test_humidifier.py
+++ b/tests/components/ecobee/test_humidifier.py
@@ -27,6 +27,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
+    STATE_ON,
 )
 
 from .common import setup_platform
@@ -39,7 +40,7 @@ async def test_attributes(hass):
     await setup_platform(hass, HUMIDIFIER_DOMAIN)
 
     state = hass.states.get(DEVICE_ID)
-    assert state.state == STATE_OFF
+    assert state.state == STATE_ON
     assert state.attributes.get(ATTR_MIN_HUMIDITY) == DEFAULT_MIN_HUMIDITY
     assert state.attributes.get(ATTR_MAX_HUMIDITY) == DEFAULT_MAX_HUMIDITY
     assert state.attributes.get(ATTR_HUMIDITY) == 40

--- a/tests/fixtures/ecobee/ecobee-data.json
+++ b/tests/fixtures/ecobee/ecobee-data.json
@@ -1,6 +1,7 @@
 {
     "thermostatList": [
-        {"identifier": 8675309,
+        {
+            "identifier": 8675309,
             "name": "ecobee",
             "modelNumber": "athenaSmart",
             "program": {
@@ -27,7 +28,7 @@
                 "heatCoolMinDelta": 50,
                 "holdAction": "nextTransition",
                 "hasHumidifier": true,
-                "humidifierMode": "off",
+                "humidifierMode": "manual",
                 "humidity": "30"
             },
             "equipmentStatus": "fan",

--- a/tests/fixtures/ecobee/ecobee-data.json
+++ b/tests/fixtures/ecobee/ecobee-data.json
@@ -1,6 +1,8 @@
 {
     "thermostatList": [
-        {"name": "ecobee",
+        {"identifier": 8675309,
+            "name": "ecobee",
+            "modelNumber": "athenaSmart",
             "program": {
                 "climates": [
                     {"name": "Climate1", "climateRef": "c1"},
@@ -9,6 +11,7 @@
                 "currentClimateRef": "c1"
             },
             "runtime": {
+                "connected": false,
                 "actualTemperature": 300,
                 "actualHumidity": 15,
                 "desiredHeat": 400,
@@ -37,7 +40,28 @@
                     "endDate": "2022-01-01 10:00:00",
                     "startDate": "2022-02-02 11:00:00"
                 }
-            ]}
+            ],
+            "remoteSensors": [
+                {
+                    "id": "rs:100",
+                    "name": "Remote Sensor 1",
+                    "type": "ecobee3_remote_sensor",
+                    "code": "WKRP",
+                    "inUse": false,
+                    "capability": [
+                        {
+                            "id": "1",
+                            "type": "temperature",
+                            "value": "782"
+                        }, {
+                            "id": "2",
+                            "type": "occupancy",
+                            "value": "false"
+                        }
+                    ]
+                }
+            ]
+        }
     ]
-
 }
+


### PR DESCRIPTION
The humidifier support in the Ecobee integration did not return device_info, causing the humidifier to not be associated
with the ecobee integration or the parent thermostat.
Added unique_id property

This change also fills out the ecobee-data.json fixture data a bit to address failures in the test setup and increase coverage in the tests.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change

This change adds the device_info and unique_id properties to the ecobee humidifier support code. Without the device_info property the ecobee humidifier is not being linked in as an entity of the ecobee thermostat, and is not associated with the ecobee integration.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50046

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
