### PR TITLE
Add support for state_class to AccuWeather integration

### DIFF
--- a/homeassistant/components/accuweather/const.py
+++ b/homeassistant/components/accuweather/const.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from typing import Final
 
+from homeassistant.components.sensor import ATTR_STATE_CLASS, STATE_CLASS_MEASUREMENT
 from homeassistant.components.weather import (
     ATTR_CONDITION_CLEAR_NIGHT,
     ATTR_CONDITION_CLOUDY,
@@ -80,6 +81,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "CloudCoverNight": {
         ATTR_DEVICE_CLASS: None,
@@ -88,6 +90,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "Grass": {
         ATTR_DEVICE_CLASS: None,
@@ -96,6 +99,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "HoursOfSun": {
         ATTR_DEVICE_CLASS: None,
@@ -104,6 +108,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TIME_HOURS,
         ATTR_UNIT_IMPERIAL: TIME_HOURS,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "Mold": {
         ATTR_DEVICE_CLASS: None,
@@ -112,6 +117,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "Ozone": {
         ATTR_DEVICE_CLASS: None,
@@ -120,6 +126,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: None,
         ATTR_UNIT_IMPERIAL: None,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "Ragweed": {
         ATTR_DEVICE_CLASS: None,
@@ -128,6 +135,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureMax": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -136,6 +144,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureMin": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -144,6 +153,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureShadeMax": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -152,6 +162,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureShadeMin": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -160,6 +171,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "ThunderstormProbabilityDay": {
         ATTR_DEVICE_CLASS: None,
@@ -168,6 +180,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "ThunderstormProbabilityNight": {
         ATTR_DEVICE_CLASS: None,
@@ -176,6 +189,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "Tree": {
         ATTR_DEVICE_CLASS: None,
@@ -184,6 +198,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "UVIndex": {
         ATTR_DEVICE_CLASS: None,
@@ -192,6 +207,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: UV_INDEX,
         ATTR_UNIT_IMPERIAL: UV_INDEX,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "WindGustDay": {
         ATTR_DEVICE_CLASS: None,
@@ -200,6 +216,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "WindGustNight": {
         ATTR_DEVICE_CLASS: None,
@@ -208,6 +225,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: None,
     },
     "WindDay": {
         ATTR_DEVICE_CLASS: None,
@@ -216,6 +234,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "WindNight": {
         ATTR_DEVICE_CLASS: None,
@@ -224,6 +243,7 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
 }
 
@@ -235,6 +255,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "Ceiling": {
         ATTR_DEVICE_CLASS: None,
@@ -243,6 +264,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: LENGTH_METERS,
         ATTR_UNIT_IMPERIAL: LENGTH_FEET,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "CloudCover": {
         ATTR_DEVICE_CLASS: None,
@@ -251,6 +273,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "DewPoint": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -259,6 +282,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "RealFeelTemperature": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -267,6 +291,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "RealFeelTemperatureShade": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -275,6 +300,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "Precipitation": {
         ATTR_DEVICE_CLASS: None,
@@ -283,6 +309,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: LENGTH_MILLIMETERS,
         ATTR_UNIT_IMPERIAL: LENGTH_INCHES,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "PressureTendency": {
         ATTR_DEVICE_CLASS: "accuweather__pressure_tendency",
@@ -291,6 +318,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: None,
         ATTR_UNIT_IMPERIAL: None,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: None,
     },
     "UVIndex": {
         ATTR_DEVICE_CLASS: None,
@@ -299,6 +327,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: UV_INDEX,
         ATTR_UNIT_IMPERIAL: UV_INDEX,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "WetBulbTemperature": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -307,6 +336,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "WindChillTemperature": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -315,6 +345,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "Wind": {
         ATTR_DEVICE_CLASS: None,
@@ -323,6 +354,7 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: True,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
     "WindGust": {
         ATTR_DEVICE_CLASS: None,
@@ -331,5 +363,6 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: False,
+        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
     },
 }

--- a/homeassistant/components/accuweather/const.py
+++ b/homeassistant/components/accuweather/const.py
@@ -81,7 +81,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "CloudCoverNight": {
         ATTR_DEVICE_CLASS: None,
@@ -90,7 +89,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "Grass": {
         ATTR_DEVICE_CLASS: None,
@@ -99,7 +97,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "HoursOfSun": {
         ATTR_DEVICE_CLASS: None,
@@ -108,7 +105,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TIME_HOURS,
         ATTR_UNIT_IMPERIAL: TIME_HOURS,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "Mold": {
         ATTR_DEVICE_CLASS: None,
@@ -117,7 +113,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "Ozone": {
         ATTR_DEVICE_CLASS: None,
@@ -126,7 +121,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: None,
         ATTR_UNIT_IMPERIAL: None,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "Ragweed": {
         ATTR_DEVICE_CLASS: None,
@@ -135,7 +129,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureMax": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -144,7 +137,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureMin": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -153,7 +145,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureShadeMax": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -162,7 +153,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "RealFeelTemperatureShadeMin": {
         ATTR_DEVICE_CLASS: DEVICE_CLASS_TEMPERATURE,
@@ -171,7 +161,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: TEMP_CELSIUS,
         ATTR_UNIT_IMPERIAL: TEMP_FAHRENHEIT,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "ThunderstormProbabilityDay": {
         ATTR_DEVICE_CLASS: None,
@@ -180,7 +169,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "ThunderstormProbabilityNight": {
         ATTR_DEVICE_CLASS: None,
@@ -189,7 +177,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: PERCENTAGE,
         ATTR_UNIT_IMPERIAL: PERCENTAGE,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "Tree": {
         ATTR_DEVICE_CLASS: None,
@@ -198,7 +185,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_UNIT_IMPERIAL: CONCENTRATION_PARTS_PER_CUBIC_METER,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "UVIndex": {
         ATTR_DEVICE_CLASS: None,
@@ -207,7 +193,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: UV_INDEX,
         ATTR_UNIT_IMPERIAL: UV_INDEX,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "WindGustDay": {
         ATTR_DEVICE_CLASS: None,
@@ -216,7 +201,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "WindGustNight": {
         ATTR_DEVICE_CLASS: None,
@@ -225,7 +209,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: False,
-        ATTR_STATE_CLASS: None,
     },
     "WindDay": {
         ATTR_DEVICE_CLASS: None,
@@ -234,7 +217,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "WindNight": {
         ATTR_DEVICE_CLASS: None,
@@ -243,7 +225,6 @@ FORECAST_SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: SPEED_KILOMETERS_PER_HOUR,
         ATTR_UNIT_IMPERIAL: SPEED_MILES_PER_HOUR,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
 }
 
@@ -318,7 +299,6 @@ SENSOR_TYPES: Final[dict[str, SensorDescription]] = {
         ATTR_UNIT_METRIC: None,
         ATTR_UNIT_IMPERIAL: None,
         ATTR_ENABLED: True,
-        ATTR_STATE_CLASS: None,
     },
     "UVIndex": {
         ATTR_DEVICE_CLASS: None,

--- a/homeassistant/components/accuweather/model.py
+++ b/homeassistant/components/accuweather/model.py
@@ -13,3 +13,4 @@ class SensorDescription(TypedDict):
     unit_metric: str | None
     unit_imperial: str | None
     enabled: bool
+    state_class: str | None

--- a/homeassistant/components/accuweather/model.py
+++ b/homeassistant/components/accuweather/model.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from typing import TypedDict
 
 
-class SensorDescription(TypedDict):
+class SensorDescription(TypedDict, total=False):
     """Sensor description class."""
 
     device_class: str | None

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any, cast
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import ATTR_STATE_CLASS, SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
@@ -97,6 +97,7 @@ class AccuWeatherSensor(CoordinatorEntity, SensorEntity):
         self._device_class = None
         self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self.forecast_day = forecast_day
+        self._attr_state_class = self._description[ATTR_STATE_CLASS]
 
     @property
     def name(self) -> str:

--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -97,7 +97,7 @@ class AccuWeatherSensor(CoordinatorEntity, SensorEntity):
         self._device_class = None
         self._attrs = {ATTR_ATTRIBUTION: ATTRIBUTION}
         self.forecast_day = forecast_day
-        self._attr_state_class = self._description[ATTR_STATE_CLASS]
+        self._attr_state_class = self._description.get(ATTR_STATE_CLASS)
 
     @property
     def name(self) -> str:

--- a/tests/components/accuweather/test_sensor.py
+++ b/tests/components/accuweather/test_sensor.py
@@ -4,7 +4,11 @@ import json
 from unittest.mock import PropertyMock, patch
 
 from homeassistant.components.accuweather.const import ATTRIBUTION, DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    DOMAIN as SENSOR_DOMAIN,
+    STATE_CLASS_MEASUREMENT,
+)
 from homeassistant.const import (
     ATTR_ATTRIBUTION,
     ATTR_DEVICE_CLASS,
@@ -43,6 +47,7 @@ async def test_sensor_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-fog"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_METERS
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_cloud_ceiling")
     assert entry
@@ -55,6 +60,7 @@ async def test_sensor_without_forecast(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == LENGTH_MILLIMETERS
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-rainy"
     assert state.attributes.get("type") is None
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_precipitation")
     assert entry
@@ -66,6 +72,7 @@ async def test_sensor_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_ICON) == "mdi:gauge"
     assert state.attributes.get(ATTR_DEVICE_CLASS) == "accuweather__pressure_tendency"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_pressure_tendency")
     assert entry
@@ -77,6 +84,7 @@ async def test_sensor_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_realfeel_temperature")
     assert entry
@@ -88,6 +96,7 @@ async def test_sensor_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UV_INDEX
     assert state.attributes.get("level") == "High"
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_uv_index")
     assert entry
@@ -105,6 +114,7 @@ async def test_sensor_with_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-partly-cloudy"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TIME_HOURS
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_hours_of_sun_0d")
     assert entry
@@ -116,6 +126,7 @@ async def test_sensor_with_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_realfeel_temperature_max_0d")
     assert entry
@@ -126,6 +137,7 @@ async def test_sensor_with_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_realfeel_temperature_min_0d")
     assert entry
@@ -137,6 +149,7 @@ async def test_sensor_with_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-lightning"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_thunderstorm_probability_day_0d")
     assert entry
@@ -148,6 +161,7 @@ async def test_sensor_with_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-lightning"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_thunderstorm_probability_night_0d")
     assert entry
@@ -160,6 +174,7 @@ async def test_sensor_with_forecast(hass):
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-sunny"
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UV_INDEX
     assert state.attributes.get("level") == "Moderate"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_uv_index_0d")
     assert entry
@@ -346,6 +361,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_apparent_temperature")
     assert entry
@@ -357,6 +373,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-cloudy"
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_cloud_cover")
     assert entry
@@ -368,6 +385,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_dew_point")
     assert entry
@@ -379,6 +397,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_realfeel_temperature_shade")
     assert entry
@@ -390,6 +409,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_wet_bulb_temperature")
     assert entry
@@ -401,6 +421,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_wind_chill_temperature")
     assert entry
@@ -412,6 +433,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == SPEED_KILOMETERS_PER_HOUR
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-windy"
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_wind_gust")
     assert entry
@@ -423,6 +445,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == SPEED_KILOMETERS_PER_HOUR
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-windy"
+    assert state.attributes.get(ATTR_STATE_CLASS) == STATE_CLASS_MEASUREMENT
 
     entry = registry.async_get("sensor.home_wind")
     assert entry
@@ -434,6 +457,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-cloudy"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_cloud_cover_day_0d")
     assert entry
@@ -445,6 +469,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == PERCENTAGE
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-cloudy"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_cloud_cover_night_0d")
     assert entry
@@ -459,6 +484,7 @@ async def test_sensor_enabled_without_forecast(hass):
     )
     assert state.attributes.get("level") == "Low"
     assert state.attributes.get(ATTR_ICON) == "mdi:grass"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_grass_pollen_0d")
     assert entry
@@ -485,6 +511,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get("level") == "Good"
     assert state.attributes.get(ATTR_ICON) == "mdi:vector-triangle"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_ozone_0d")
     assert entry
@@ -511,6 +538,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_ATTRIBUTION) == ATTRIBUTION
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == TEMP_CELSIUS
     assert state.attributes.get(ATTR_DEVICE_CLASS) == DEVICE_CLASS_TEMPERATURE
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_realfeel_temperature_shade_max_0d")
     assert entry
@@ -537,6 +565,7 @@ async def test_sensor_enabled_without_forecast(hass):
     )
     assert state.attributes.get("level") == "Low"
     assert state.attributes.get(ATTR_ICON) == "mdi:tree-outline"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_tree_pollen_0d")
     assert entry
@@ -561,6 +590,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == SPEED_KILOMETERS_PER_HOUR
     assert state.attributes.get("direction") == "WNW"
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-windy"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_wind_night_0d")
     assert entry
@@ -573,6 +603,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == SPEED_KILOMETERS_PER_HOUR
     assert state.attributes.get("direction") == "S"
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-windy"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_wind_gust_day_0d")
     assert entry
@@ -585,6 +616,7 @@ async def test_sensor_enabled_without_forecast(hass):
     assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == SPEED_KILOMETERS_PER_HOUR
     assert state.attributes.get("direction") == "WSW"
     assert state.attributes.get(ATTR_ICON) == "mdi:weather-windy"
+    assert state.attributes.get(ATTR_STATE_CLASS) is None
 
     entry = registry.async_get("sensor.home_wind_gust_night_0d")
     assert entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds support for `state_class` to AccuWeather sensor entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
