### PR TITLE
Force SimpliSafe to reauthenticate with a password

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -170,7 +170,7 @@ async def async_setup_entry(hass, config_entry):  # noqa: C901
     try:
         api = await async_get_api()
     except InvalidCredentialsError:
-        raise ConfigEntryAuthFailed
+        raise ConfigEntryAuthFailed  # pylint: disable=raise-missing-from
     except SimplipyError as err:
         LOGGER.error("Config entry failed: %s", err)
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -154,6 +154,7 @@ async def async_setup_entry(hass, config_entry):  # noqa: C901
         hass.config_entries.async_update_entry(config_entry, **entry_updates)
 
     _verify_domain_control = verify_domain_control(hass, DOMAIN)
+
     client_id = await async_get_client_id(hass)
     websession = aiohttp_client.async_get_clientsession(hass)
 

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -169,8 +169,8 @@ async def async_setup_entry(hass, config_entry):  # noqa: C901
 
     try:
         api = await async_get_api()
-    except InvalidCredentialsError:
-        raise ConfigEntryAuthFailed  # pylint: disable=raise-missing-from
+    except InvalidCredentialsError as err:
+        raise ConfigEntryAuthFailed from err
     except SimplipyError as err:
         LOGGER.error("Config entry failed: %s", err)
         raise ConfigEntryNotReady from err

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -302,10 +302,10 @@ async def async_reload_entry(hass, config_entry):
 class SimpliSafe:
     """Define a SimpliSafe data object."""
 
-    def __init__(self, hass, config_entry, api, get_api_coro):
+    def __init__(self, hass, config_entry, api, async_get_api):
         """Initialize."""
         self._api = api
-        self._get_api_coro = get_api_coro
+        self._async_get_api = async_get_api
         self._hass = hass
         self._system_notifications = {}
         self.config_entry = config_entry
@@ -383,7 +383,7 @@ class SimpliSafe:
         for result in results:
             if isinstance(result, InvalidCredentialsError):
                 try:
-                    self._api = await self._get_api_coro()
+                    self._api = await self._async_get_api()
                     return
                 except SimplipyError as err:
                     raise ConfigEntryAuthFailed(

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -6,7 +6,7 @@ from simplipy import API
 from simplipy.errors import EndpointUnavailable, InvalidCredentialsError, SimplipyError
 import voluptuous as vol
 
-from homeassistant.const import ATTR_CODE, CONF_CODE, CONF_TOKEN, CONF_USERNAME
+from homeassistant.const import ATTR_CODE, CONF_CODE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import CoreState, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import (
@@ -107,14 +107,6 @@ SERVICE_SET_SYSTEM_PROPERTIES_SCHEMA = SERVICE_BASE_SCHEMA.extend(
 CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
 
-@callback
-def _async_save_refresh_token(hass, config_entry, token):
-    """Save a refresh token to the config entry."""
-    hass.config_entries.async_update_entry(
-        config_entry, data={**config_entry.data, CONF_TOKEN: token}
-    )
-
-
 async def async_get_client_id(hass):
     """Get a client ID (based on the HASS unique ID) for the SimpliSafe API.
 
@@ -136,15 +128,14 @@ async def async_register_base_station(hass, system, config_entry_id):
     )
 
 
-async def async_setup(hass, config):
-    """Set up the SimpliSafe component."""
-    hass.data[DOMAIN] = {DATA_CLIENT: {}, DATA_LISTENER: {}}
-    return True
-
-
 async def async_setup_entry(hass, config_entry):  # noqa: C901
     """Set up SimpliSafe as config entry."""
-    hass.data[DOMAIN][DATA_LISTENER][config_entry.entry_id] = []
+    hass.data.setdefault(DOMAIN, {DATA_CLIENT: {}, DATA_LISTENER: {}})
+    hass.data[DOMAIN][DATA_CLIENT].setdefault(config_entry.entry_id, [])
+    hass.data[DOMAIN][DATA_LISTENER].setdefault(config_entry.entry_id, [])
+
+    if CONF_PASSWORD not in config_entry.data:
+        raise ConfigEntryAuthFailed("Config schema change requires re-authentication")
 
     entry_updates = {}
     if not config_entry.unique_id:
@@ -163,24 +154,27 @@ async def async_setup_entry(hass, config_entry):  # noqa: C901
         hass.config_entries.async_update_entry(config_entry, **entry_updates)
 
     _verify_domain_control = verify_domain_control(hass, DOMAIN)
-
     client_id = await async_get_client_id(hass)
     websession = aiohttp_client.async_get_clientsession(hass)
 
-    try:
-        api = await API.login_via_token(
-            config_entry.data[CONF_TOKEN], client_id=client_id, session=websession
+    async def async_get_api():
+        """Define a helper to get an authenticated SimpliSafe API object."""
+        return await API.login_via_credentials(
+            config_entry.data[CONF_USERNAME],
+            config_entry.data[CONF_PASSWORD],
+            client_id=client_id,
+            session=websession,
         )
+
+    try:
+        api = await async_get_api()
     except InvalidCredentialsError:
-        LOGGER.error("Invalid credentials provided")
-        return False
+        raise ConfigEntryAuthFailed
     except SimplipyError as err:
         LOGGER.error("Config entry failed: %s", err)
         raise ConfigEntryNotReady from err
 
-    _async_save_refresh_token(hass, config_entry, api.refresh_token)
-
-    simplisafe = SimpliSafe(hass, api, config_entry)
+    simplisafe = SimpliSafe(hass, config_entry, api, async_get_api)
 
     try:
         await simplisafe.async_init()
@@ -307,10 +301,10 @@ async def async_reload_entry(hass, config_entry):
 class SimpliSafe:
     """Define a SimpliSafe data object."""
 
-    def __init__(self, hass, api, config_entry):
+    def __init__(self, hass, config_entry, api, get_api_coro):
         """Initialize."""
         self._api = api
-        self._emergency_refresh_token_used = False
+        self._get_api_coro = get_api_coro
         self._hass = hass
         self._system_notifications = {}
         self.config_entry = config_entry
@@ -387,23 +381,13 @@ class SimpliSafe:
 
         for result in results:
             if isinstance(result, InvalidCredentialsError):
-                if self._emergency_refresh_token_used:
-                    raise ConfigEntryAuthFailed(
-                        "Update failed with stored refresh token"
-                    )
-
-                LOGGER.warning("SimpliSafe cloud error; trying stored refresh token")
-                self._emergency_refresh_token_used = True
-
                 try:
-                    await self._api.refresh_access_token(
-                        self.config_entry.data[CONF_TOKEN]
-                    )
+                    self._api = await self._get_api_coro()
                     return
                 except SimplipyError as err:
-                    raise UpdateFailed(  # pylint: disable=raise-missing-from
-                        f"Error while using stored refresh token: {err}"
-                    )
+                    raise ConfigEntryAuthFailed(
+                        "Unable to re-authenticate with SimpliSafe"
+                    ) from err
 
             if isinstance(result, EndpointUnavailable):
                 # In case the user attempts an action not allowed in their current plan,
@@ -413,16 +397,6 @@ class SimpliSafe:
 
             if isinstance(result, SimplipyError):
                 raise UpdateFailed(f"SimpliSafe error while updating: {result}")
-
-        if self._api.refresh_token != self.config_entry.data[CONF_TOKEN]:
-            _async_save_refresh_token(
-                self._hass, self.config_entry, self._api.refresh_token
-            )
-
-        # If we've reached this point using an emergency refresh token, we're in the
-        # clear and we can discard it:
-        if self._emergency_refresh_token_used:
-            self._emergency_refresh_token_used = False
 
 
 class SimpliSafeEntity(CoordinatorEntity):

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -131,8 +131,8 @@ async def async_register_base_station(hass, system, config_entry_id):
 async def async_setup_entry(hass, config_entry):  # noqa: C901
     """Set up SimpliSafe as config entry."""
     hass.data.setdefault(DOMAIN, {DATA_CLIENT: {}, DATA_LISTENER: {}})
-    hass.data[DOMAIN][DATA_CLIENT].setdefault(config_entry.entry_id, [])
-    hass.data[DOMAIN][DATA_LISTENER].setdefault(config_entry.entry_id, [])
+    hass.data[DOMAIN][DATA_CLIENT][config_entry.entry_id] = []
+    hass.data[DOMAIN][DATA_LISTENER][config_entry.entry_id] = []
 
     if CONF_PASSWORD not in config_entry.data:
         raise ConfigEntryAuthFailed("Config schema change requires re-authentication")

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -390,7 +390,7 @@ class SimpliSafe:
                         "Unable to re-authenticate with SimpliSafe"
                     ) from err
                 except SimplipyError as err:
-                    raise UpdateFailed(f"SimpliSafe error while updating: {err}")
+                    raise UpdateFailed(f"SimpliSafe error while updating: {err}") from err
 
             if isinstance(result, EndpointUnavailable):
                 # In case the user attempts an action not allowed in their current plan,

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -390,7 +390,9 @@ class SimpliSafe:
                         "Unable to re-authenticate with SimpliSafe"
                     ) from err
                 except SimplipyError as err:
-                    raise UpdateFailed(f"SimpliSafe error while updating: {err}") from err
+                    raise UpdateFailed(
+                        f"SimpliSafe error while updating: {err}"
+                    ) from err
 
             if isinstance(result, EndpointUnavailable):
                 # In case the user attempts an action not allowed in their current plan,

--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -385,10 +385,12 @@ class SimpliSafe:
                 try:
                     self._api = await self._async_get_api()
                     return
-                except SimplipyError as err:
+                except InvalidCredentialsError as err:
                     raise ConfigEntryAuthFailed(
                         "Unable to re-authenticate with SimpliSafe"
                     ) from err
+                except SimplipyError as err:
+                    raise UpdateFailed(f"SimpliSafe error while updating: {err}")
 
             if isinstance(result, EndpointUnavailable):
                 # In case the user attempts an action not allowed in their current plan,

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -89,7 +89,6 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         existing_entry = await self.async_set_unique_id(self._username)
         if existing_entry:
             self.hass.config_entries.async_update_entry(existing_entry, data=user_input)
-            # Reload the config entry (otherwise devices will remain unavailable):
             self.hass.async_create_task(
                 self.hass.config_entries.async_reload(existing_entry.entry_id)
             )

--- a/homeassistant/components/simplisafe/config_flow.py
+++ b/homeassistant/components/simplisafe/config_flow.py
@@ -8,7 +8,7 @@ from simplipy.errors import (
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 from homeassistant.helpers import aiohttp_client
 
@@ -59,7 +59,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         errors = {}
 
         try:
-            simplisafe = await self._async_get_simplisafe_api()
+            await self._async_get_simplisafe_api()
         except PendingAuthorizationError:
             LOGGER.info("Awaiting confirmation of MFA email click")
             return await self.async_step_mfa()
@@ -79,7 +79,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_finish(
             {
                 CONF_USERNAME: self._username,
-                CONF_TOKEN: simplisafe.refresh_token,
+                CONF_PASSWORD: self._password,
                 CONF_CODE: self._code,
             }
         )
@@ -89,6 +89,10 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         existing_entry = await self.async_set_unique_id(self._username)
         if existing_entry:
             self.hass.config_entries.async_update_entry(existing_entry, data=user_input)
+            # Reload the config entry (otherwise devices will remain unavailable):
+            self.hass.async_create_task(
+                self.hass.config_entries.async_reload(existing_entry.entry_id)
+            )
             return self.async_abort(reason="reauth_successful")
         return self.async_create_entry(title=self._username, data=user_input)
 
@@ -98,7 +102,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_show_form(step_id="mfa")
 
         try:
-            simplisafe = await self._async_get_simplisafe_api()
+            await self._async_get_simplisafe_api()
         except PendingAuthorizationError:
             LOGGER.error("Still awaiting confirmation of MFA email click")
             return self.async_show_form(
@@ -108,7 +112,7 @@ class SimpliSafeFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         return await self.async_step_finish(
             {
                 CONF_USERNAME: self._username,
-                CONF_TOKEN: simplisafe.refresh_token,
+                CONF_PASSWORD: self._password,
                 CONF_CODE: self._code,
             }
         )

--- a/homeassistant/components/simplisafe/const.py
+++ b/homeassistant/components/simplisafe/const.py
@@ -9,7 +9,6 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "simplisafe"
 
 DATA_CLIENT = "client"
-DATA_EVENT = "event"
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 

--- a/homeassistant/components/simplisafe/const.py
+++ b/homeassistant/components/simplisafe/const.py
@@ -9,6 +9,7 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "simplisafe"
 
 DATA_CLIENT = "client"
+DATA_EVENT = "event"
 
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=30)
 

--- a/homeassistant/components/simplisafe/strings.json
+++ b/homeassistant/components/simplisafe/strings.json
@@ -7,7 +7,7 @@
       },
       "reauth_confirm": {
         "title": "[%key:common::config_flow::title::reauth%]",
-        "description": "Your access token has expired or been revoked. Enter your password to re-link your account.",
+        "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         }

--- a/homeassistant/components/simplisafe/translations/en.json
+++ b/homeassistant/components/simplisafe/translations/en.json
@@ -19,7 +19,7 @@
                 "data": {
                     "password": "Password"
                 },
-                "description": "Your access token has expired or been revoked. Enter your password to re-link your account.",
+                "description": "Your access has expired or been revoked. Enter your password to re-link your account.",
                 "title": "Reauthenticate Integration"
             },
             "user": {

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -128,6 +128,8 @@ async def test_step_reauth(hass):
         "homeassistant.components.simplisafe.async_setup_entry", return_value=True
     ), patch(
         "simplipy.API.login_via_credentials", new=AsyncMock(return_value=mock_api())
+    ), patch(
+        "homeassistant.config_entries.ConfigEntries.async_reload"
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"], user_input={CONF_PASSWORD: "password"}

--- a/tests/components/simplisafe/test_config_flow.py
+++ b/tests/components/simplisafe/test_config_flow.py
@@ -10,7 +10,7 @@ from simplipy.errors import (
 from homeassistant import data_entry_flow
 from homeassistant.components.simplisafe import DOMAIN
 from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
-from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_TOKEN, CONF_USERNAME
+from homeassistant.const import CONF_CODE, CONF_PASSWORD, CONF_USERNAME
 
 from tests.common import MockConfigEntry
 
@@ -33,7 +33,11 @@ async def test_duplicate_error(hass):
     MockConfigEntry(
         domain=DOMAIN,
         unique_id="user@email.com",
-        data={CONF_USERNAME: "user@email.com", CONF_TOKEN: "12345", CONF_CODE: "1234"},
+        data={
+            CONF_USERNAME: "user@email.com",
+            CONF_PASSWORD: "password",
+            CONF_CODE: "1234",
+        },
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -102,7 +106,11 @@ async def test_step_reauth(hass):
     MockConfigEntry(
         domain=DOMAIN,
         unique_id="user@email.com",
-        data={CONF_USERNAME: "user@email.com", CONF_TOKEN: "12345", CONF_CODE: "1234"},
+        data={
+            CONF_USERNAME: "user@email.com",
+            CONF_PASSWORD: "password",
+            CONF_CODE: "1234",
+        },
     ).add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
@@ -151,7 +159,7 @@ async def test_step_user(hass):
         assert result["title"] == "user@email.com"
         assert result["data"] == {
             CONF_USERNAME: "user@email.com",
-            CONF_TOKEN: "12345abc",
+            CONF_PASSWORD: "password",
             CONF_CODE: "1234",
         }
 
@@ -197,7 +205,7 @@ async def test_step_user_mfa(hass):
         assert result["title"] == "user@email.com"
         assert result["data"] == {
             CONF_USERNAME: "user@email.com",
-            CONF_TOKEN: "12345abc",
+            CONF_PASSWORD: "password",
             CONF_CODE: "1234",
         }
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Due to the unofficial SimpliSafe cloud API's flakiness, some (but not all) users are experiencing frequent refresh token failure for no reason, leading them to need reauth their SimpliSafe integration multiple times a day. Unfortunately, because this doesn't occur with every user, it indicates the API's refresh tokens can't be trusted.

To mitigate this, this PR alters the integration to store the user's SimpliSafe password and, when their access token expires, use that password to reauth. This isn't a breaking change: upon load, the user will be prompted to reauth their integration automatically.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
