### PR TITLE
Update Somfy to reduce calls to /site entrypoint

### DIFF
--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -20,7 +20,7 @@ from .coordinator import SomfyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=60)
+SCAN_INTERVAL = timedelta(minutes=1)
 SCAN_INTERVAL_ALL_ASSUMED_STATE = timedelta(minutes=60)
 
 SOMFY_AUTH_CALLBACK_PATH = "/auth/somfy/callback"

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -5,7 +5,6 @@ import logging
 from pymfy.api.devices.category import Category
 import voluptuous as vol
 
-from homeassistant.components.somfy.coordinator import SomfyDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_OPTIMISTIC
 from homeassistant.core import HomeAssistant
@@ -16,7 +15,8 @@ from homeassistant.helpers import (
 )
 
 from . import api, config_flow
-from .const import API, COORDINATOR, DOMAIN
+from .const import COORDINATOR, DOMAIN
+from .coordinator import SomfyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -122,5 +122,4 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    hass.data[DOMAIN].pop(API, None)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -1,5 +1,4 @@
 """Support for Somfy hubs."""
-from abc import abstractmethod
 from datetime import timedelta
 import logging
 
@@ -8,24 +7,20 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CLIENT_ID, CONF_CLIENT_SECRET, CONF_OPTIMISTIC
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     config_entry_oauth2_flow,
     config_validation as cv,
     device_registry as dr,
 )
-from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from . import api, config_flow
 from .const import API, COORDINATOR, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=1)
+SCAN_INTERVAL = timedelta(seconds=60)
 SCAN_INTERVAL_ALL_ASSUMED_STATE = timedelta(minutes=60)
 
 SOMFY_AUTH_CALLBACK_PATH = "/auth/somfy/callback"
@@ -142,68 +137,3 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
     hass.data[DOMAIN].pop(API, None)
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-
-class SomfyEntity(CoordinatorEntity, Entity):
-    """Representation of a generic Somfy device."""
-
-    def __init__(self, coordinator, device_id, somfy_api):
-        """Initialize the Somfy device."""
-        super().__init__(coordinator)
-        self._id = device_id
-        self.api = somfy_api
-
-    @property
-    def device(self):
-        """Return data for the device id."""
-        return self.coordinator.data[self._id]
-
-    @property
-    def unique_id(self) -> str:
-        """Return the unique id base on the id returned by Somfy."""
-        return self._id
-
-    @property
-    def name(self) -> str:
-        """Return the name of the device."""
-        return self.device.name
-
-    @property
-    def device_info(self):
-        """Return device specific attributes.
-
-        Implemented by platform classes.
-        """
-        return {
-            "identifiers": {(DOMAIN, self.unique_id)},
-            "name": self.name,
-            "model": self.device.type,
-            "via_device": (DOMAIN, self.device.parent_id),
-            # For the moment, Somfy only returns their own device.
-            "manufacturer": "Somfy",
-        }
-
-    def has_capability(self, capability: str) -> bool:
-        """Test if device has a capability."""
-        capabilities = self.device.capabilities
-        return bool([c for c in capabilities if c.name == capability])
-
-    def has_state(self, state: str) -> bool:
-        """Test if device has a state."""
-        states = self.device.states
-        return bool([c for c in states if c.name == state])
-
-    @property
-    def assumed_state(self) -> bool:
-        """Return if the device has an assumed state."""
-        return not bool(self.device.states)
-
-    @callback
-    def _handle_coordinator_update(self):
-        """Process an update from the coordinator."""
-        self._create_device()
-        super()._handle_coordinator_update()
-
-    @abstractmethod
-    def _create_device(self):
-        """Update the device with the latest data."""

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -20,7 +20,7 @@ from .coordinator import SomfyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(minutes=1)
+SCAN_INTERVAL = timedelta(seconds=70)
 SCAN_INTERVAL_ALL_ASSUMED_STATE = timedelta(minutes=60)
 
 SOMFY_AUTH_CALLBACK_PATH = "/auth/somfy/callback"
@@ -79,7 +79,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
 
     data = hass.data[DOMAIN]
-
     coordinator = SomfyDataUpdateCoordinator(
         hass,
         _LOGGER,

--- a/homeassistant/components/somfy/__init__.py
+++ b/homeassistant/components/somfy/__init__.py
@@ -20,7 +20,7 @@ from .coordinator import SomfyDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-SCAN_INTERVAL = timedelta(seconds=70)
+SCAN_INTERVAL = timedelta(minutes=1)
 SCAN_INTERVAL_ALL_ASSUMED_STATE = timedelta(minutes=60)
 
 SOMFY_AUTH_CALLBACK_PATH = "/auth/somfy/callback"

--- a/homeassistant/components/somfy/climate.py
+++ b/homeassistant/components/somfy/climate.py
@@ -23,7 +23,7 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
-from .const import API, COORDINATOR, DOMAIN
+from .const import COORDINATOR, DOMAIN
 from .entity import SomfyEntity
 
 SUPPORTED_CATEGORIES = {Category.HVAC.value}
@@ -49,10 +49,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Somfy climate platform."""
     domain_data = hass.data[DOMAIN]
     coordinator = domain_data[COORDINATOR]
-    api = domain_data[API]
 
     climates = [
-        SomfyClimate(coordinator, device_id, api)
+        SomfyClimate(coordinator, device_id)
         for device_id, device in coordinator.data.items()
         if SUPPORTED_CATEGORIES & set(device.categories)
     ]
@@ -63,15 +62,15 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class SomfyClimate(SomfyEntity, ClimateEntity):
     """Representation of a Somfy thermostat device."""
 
-    def __init__(self, coordinator, device_id, api):
+    def __init__(self, coordinator, device_id):
         """Initialize the Somfy device."""
-        super().__init__(coordinator, device_id, api)
+        super().__init__(coordinator, device_id)
         self._climate = None
         self._create_device()
 
     def _create_device(self):
         """Update the device with the latest data."""
-        self._climate = Thermostat(self.device, self.api)
+        self._climate = Thermostat(self.device, self.coordinator.client)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/somfy/climate.py
+++ b/homeassistant/components/somfy/climate.py
@@ -23,8 +23,8 @@ from homeassistant.components.climate.const import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
 
-from . import SomfyEntity
 from .const import API, COORDINATOR, DOMAIN
+from .entity import SomfyEntity
 
 SUPPORTED_CATEGORIES = {Category.HVAC.value}
 

--- a/homeassistant/components/somfy/const.py
+++ b/homeassistant/components/somfy/const.py
@@ -2,4 +2,3 @@
 
 DOMAIN = "somfy"
 COORDINATOR = "coordinator"
-API = "api"

--- a/homeassistant/components/somfy/coordinator.py
+++ b/homeassistant/components/somfy/coordinator.py
@@ -6,9 +6,10 @@ from typing import Dict, Optional
 
 from pymfy.api.model import Device
 from pymfy.api.somfy_api import SomfyApi
+from requests.exceptions import HTTPError
 
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 
 class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
@@ -33,10 +34,27 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
 
         self.data = {}
         self.client = client
+        self.site_ids = []
+        self.last_site_index = -1
 
     async def _async_update_data(self) -> Dict[str, Device]:
         """Fetch Somfy data."""
-        devices = await self.hass.async_add_executor_job(self.client.get_devices)
+        if not self.site_ids:
+            try:
+                sites = await self.hass.async_add_executor_job(self.client.get_sites)
+            except HTTPError:
+                sites = []
+            self.side_ids = [site.id for site in sites]
+            if not self.site_ids:
+                raise UpdateFailed("Somfy did not returned any site id.")
+
+        try:
+            devices = await self.hass.async_add_executor_job(
+                self.client.get_devices, self._site_id
+            )
+        except HTTPError:
+            devices = []
+
         previous_devices = self.data
         # Sometimes Somfy returns an empty list.
         if not devices and previous_devices:
@@ -45,3 +63,12 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
             )
             return previous_devices
         return {dev.id: dev for dev in devices}
+
+    @property
+    def _site_id(self):
+        """Return the next site id to retrieve.
+
+        This tweak is required as Somfy does not allow to call the /site entrypoint more than once per minute.
+        """
+        self.last_site_index = (self.last_site_index + 1) % len(self.site_ids)
+        return self.site_ids[self.last_site_index]

--- a/homeassistant/components/somfy/coordinator.py
+++ b/homeassistant/components/somfy/coordinator.py
@@ -1,8 +1,8 @@
 """Helpers to help coordinate updated."""
+from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Dict, Optional
 
 from pymfy.api.model import Device
 from pymfy.api.somfy_api import SomfyApi
@@ -22,8 +22,8 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
         *,
         name: str,
         client: SomfyApi,
-        update_interval: Optional[timedelta] = None,
-    ):
+        update_interval: timedelta | None = None,
+    ) -> None:
         """Initialize global data updater."""
         super().__init__(
             hass,
@@ -37,14 +37,14 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
         self.site_ids = []
         self.last_site_index = -1
 
-    async def _async_update_data(self) -> Dict[str, Device]:
+    async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Somfy data."""
         if not self.site_ids:
             try:
                 sites = await self.hass.async_add_executor_job(self.client.get_sites)
             except HTTPError:
                 sites = []
-            self.side_ids = [site.id for site in sites]
+            self.site_ids = [site.id for site in sites]
             if not self.site_ids:
                 raise UpdateFailed("Somfy did not returned any site id.")
 
@@ -62,6 +62,7 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
                 "No devices returned. Assuming the previous ones are still valid"
             )
             return previous_devices
+
         return {dev.id: dev for dev in devices}
 
     @property

--- a/homeassistant/components/somfy/coordinator.py
+++ b/homeassistant/components/somfy/coordinator.py
@@ -1,0 +1,47 @@
+"""Helpers to help coordinate updated."""
+
+from datetime import timedelta
+import logging
+from typing import Dict, Optional
+
+from pymfy.api.model import Device
+from pymfy.api.somfy_api import SomfyApi
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+
+
+class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Somfy data."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: logging.Logger,
+        *,
+        name: str,
+        client: SomfyApi,
+        update_interval: Optional[timedelta] = None,
+    ):
+        """Initialize global data updater."""
+        super().__init__(
+            hass,
+            logger,
+            name=name,
+            update_interval=update_interval,
+        )
+
+        self.data = {}
+        self.client = client
+
+    async def _async_update_data(self) -> Dict[str, Device]:
+        """Fetch Somfy data."""
+        devices = await self.hass.async_add_executor_job(self.client.get_devices)
+        previous_devices = self.data
+        # Sometimes Somfy returns an empty list.
+        if not devices and previous_devices:
+            self.logger.debug(
+                "No devices returned. Assuming the previous ones are still valid"
+            )
+            return previous_devices
+        return {dev.id: dev for dev in devices}

--- a/homeassistant/components/somfy/coordinator.py
+++ b/homeassistant/components/somfy/coordinator.py
@@ -43,7 +43,7 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if not self.site_device:
             sites = await self.hass.async_add_executor_job(self.client.get_sites)
-            if not sites:
+            if len(sites) == 0:
                 return {}
             self.site_device = {site.id: [] for site in sites}
 

--- a/homeassistant/components/somfy/coordinator.py
+++ b/homeassistant/components/somfy/coordinator.py
@@ -39,7 +39,7 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch Somfy data.
 
-        Somfy only allow one call per minute to /site.
+        Somfy only allow one call per minute to /site. There is one exception: 2 calls are allowed after site retrieval.
         """
         if not self.site_device:
             sites = await self.hass.async_add_executor_job(self.client.get_sites)

--- a/homeassistant/components/somfy/coordinator.py
+++ b/homeassistant/components/somfy/coordinator.py
@@ -43,7 +43,7 @@ class SomfyDataUpdateCoordinator(DataUpdateCoordinator):
         """
         if not self.site_device:
             sites = await self.hass.async_add_executor_job(self.client.get_sites)
-            if len(sites) == 0:
+            if not sites:
                 return {}
             self.site_device = {site.id: [] for site in sites}
 

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -21,7 +21,7 @@ from homeassistant.components.cover import (
 from homeassistant.const import CONF_OPTIMISTIC, STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from .const import API, COORDINATOR, DOMAIN
+from .const import COORDINATOR, DOMAIN
 from .entity import SomfyEntity
 
 BLIND_DEVICE_CATEGORIES = {Category.INTERIOR_BLIND.value, Category.EXTERIOR_BLIND.value}
@@ -37,10 +37,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Somfy cover platform."""
     domain_data = hass.data[DOMAIN]
     coordinator = domain_data[COORDINATOR]
-    api = domain_data[API]
 
     covers = [
-        SomfyCover(coordinator, device_id, api, domain_data[CONF_OPTIMISTIC])
+        SomfyCover(coordinator, device_id, domain_data[CONF_OPTIMISTIC])
         for device_id, device in coordinator.data.items()
         if SUPPORTED_CATEGORIES & set(device.categories)
     ]
@@ -51,9 +50,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
     """Representation of a Somfy cover device."""
 
-    def __init__(self, coordinator, device_id, api, optimistic):
+    def __init__(self, coordinator, device_id, optimistic):
         """Initialize the Somfy device."""
-        super().__init__(coordinator, device_id, api)
+        super().__init__(coordinator, device_id)
         self.categories = set(self.device.categories)
         self.optimistic = optimistic
         self._closed = None
@@ -64,7 +63,7 @@ class SomfyCover(SomfyEntity, RestoreEntity, CoverEntity):
 
     def _create_device(self) -> Blind:
         """Update the device with the latest data."""
-        self._cover = Blind(self.device, self.api)
+        self._cover = Blind(self.device, self.coordinator.client)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/somfy/cover.py
+++ b/homeassistant/components/somfy/cover.py
@@ -21,8 +21,8 @@ from homeassistant.components.cover import (
 from homeassistant.const import CONF_OPTIMISTIC, STATE_CLOSED, STATE_OPEN
 from homeassistant.helpers.restore_state import RestoreEntity
 
-from . import SomfyEntity
 from .const import API, COORDINATOR, DOMAIN
+from .entity import SomfyEntity
 
 BLIND_DEVICE_CATEGORIES = {Category.INTERIOR_BLIND.value, Category.EXTERIOR_BLIND.value}
 SHUTTER_DEVICE_CATEGORIES = {Category.EXTERIOR_BLIND.value}

--- a/homeassistant/components/somfy/entity.py
+++ b/homeassistant/components/somfy/entity.py
@@ -12,11 +12,10 @@ from .const import DOMAIN
 class SomfyEntity(CoordinatorEntity, Entity):
     """Representation of a generic Somfy device."""
 
-    def __init__(self, coordinator, device_id, somfy_api):
+    def __init__(self, coordinator, device_id):
         """Initialize the Somfy device."""
         super().__init__(coordinator)
         self._id = device_id
-        self.api = somfy_api
 
     @property
     def device(self):

--- a/homeassistant/components/somfy/entity.py
+++ b/homeassistant/components/somfy/entity.py
@@ -1,0 +1,74 @@
+"""Entity representing a Somfy device."""
+
+from abc import abstractmethod
+
+from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+
+class SomfyEntity(CoordinatorEntity, Entity):
+    """Representation of a generic Somfy device."""
+
+    def __init__(self, coordinator, device_id, somfy_api):
+        """Initialize the Somfy device."""
+        super().__init__(coordinator)
+        self._id = device_id
+        self.api = somfy_api
+
+    @property
+    def device(self):
+        """Return data for the device id."""
+        return self.coordinator.data[self._id]
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique id base on the id returned by Somfy."""
+        return self._id
+
+    @property
+    def name(self) -> str:
+        """Return the name of the device."""
+        return self.device.name
+
+    @property
+    def device_info(self):
+        """Return device specific attributes.
+
+        Implemented by platform classes.
+        """
+        return {
+            "identifiers": {(DOMAIN, self.unique_id)},
+            "name": self.name,
+            "model": self.device.type,
+            "via_device": (DOMAIN, self.device.parent_id),
+            # For the moment, Somfy only returns their own device.
+            "manufacturer": "Somfy",
+        }
+
+    def has_capability(self, capability: str) -> bool:
+        """Test if device has a capability."""
+        capabilities = self.device.capabilities
+        return bool([c for c in capabilities if c.name == capability])
+
+    def has_state(self, state: str) -> bool:
+        """Test if device has a state."""
+        states = self.device.states
+        return bool([c for c in states if c.name == state])
+
+    @property
+    def assumed_state(self) -> bool:
+        """Return if the device has an assumed state."""
+        return not bool(self.device.states)
+
+    @callback
+    def _handle_coordinator_update(self):
+        """Process an update from the coordinator."""
+        self._create_device()
+        super()._handle_coordinator_update()
+
+    @abstractmethod
+    def _create_device(self):
+        """Update the device with the latest data."""

--- a/homeassistant/components/somfy/manifest.json
+++ b/homeassistant/components/somfy/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://www.home-assistant.io/integrations/somfy",
   "dependencies": ["http"],
   "codeowners": ["@tetienne"],
-  "requirements": ["pymfy==0.9.3"],
+  "requirements": ["pymfy==0.11.0"],
   "zeroconf": [
     {
       "type": "_kizbox._tcp.local.",

--- a/homeassistant/components/somfy/sensor.py
+++ b/homeassistant/components/somfy/sensor.py
@@ -6,7 +6,7 @@ from pymfy.api.devices.thermostat import Thermostat
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
 
-from .const import API, COORDINATOR, DOMAIN
+from .const import COORDINATOR, DOMAIN
 from .entity import SomfyEntity
 
 SUPPORTED_CATEGORIES = {Category.HVAC.value}
@@ -16,10 +16,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Somfy sensor platform."""
     domain_data = hass.data[DOMAIN]
     coordinator = domain_data[COORDINATOR]
-    api = domain_data[API]
 
     sensors = [
-        SomfyThermostatBatterySensor(coordinator, device_id, api)
+        SomfyThermostatBatterySensor(coordinator, device_id)
         for device_id, device in coordinator.data.items()
         if SUPPORTED_CATEGORIES & set(device.categories)
     ]
@@ -33,15 +32,15 @@ class SomfyThermostatBatterySensor(SomfyEntity, SensorEntity):
     _attr_device_class = DEVICE_CLASS_BATTERY
     _attr_unit_of_measurement = PERCENTAGE
 
-    def __init__(self, coordinator, device_id, api):
+    def __init__(self, coordinator, device_id):
         """Initialize the Somfy device."""
-        super().__init__(coordinator, device_id, api)
+        super().__init__(coordinator, device_id)
         self._climate = None
         self._create_device()
 
     def _create_device(self):
         """Update the device with the latest data."""
-        self._climate = Thermostat(self.device, self.api)
+        self._climate = Thermostat(self.device, self.coordinator.client)
 
     @property
     def state(self) -> int:

--- a/homeassistant/components/somfy/sensor.py
+++ b/homeassistant/components/somfy/sensor.py
@@ -6,8 +6,8 @@ from pymfy.api.devices.thermostat import Thermostat
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import DEVICE_CLASS_BATTERY, PERCENTAGE
 
-from . import SomfyEntity
 from .const import API, COORDINATOR, DOMAIN
+from .entity import SomfyEntity
 
 SUPPORTED_CATEGORIES = {Category.HVAC.value}
 

--- a/homeassistant/components/somfy/switch.py
+++ b/homeassistant/components/somfy/switch.py
@@ -4,7 +4,7 @@ from pymfy.api.devices.category import Category
 
 from homeassistant.components.switch import SwitchEntity
 
-from .const import API, COORDINATOR, DOMAIN
+from .const import COORDINATOR, DOMAIN
 from .entity import SomfyEntity
 
 
@@ -12,10 +12,9 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the Somfy switch platform."""
     domain_data = hass.data[DOMAIN]
     coordinator = domain_data[COORDINATOR]
-    api = domain_data[API]
 
     switches = [
-        SomfyCameraShutter(coordinator, device_id, api)
+        SomfyCameraShutter(coordinator, device_id)
         for device_id, device in coordinator.data.items()
         if Category.CAMERA.value in device.categories
     ]
@@ -26,14 +25,14 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class SomfyCameraShutter(SomfyEntity, SwitchEntity):
     """Representation of a Somfy Camera Shutter device."""
 
-    def __init__(self, coordinator, device_id, api):
+    def __init__(self, coordinator, device_id):
         """Initialize the Somfy device."""
-        super().__init__(coordinator, device_id, api)
+        super().__init__(coordinator, device_id)
         self._create_device()
 
     def _create_device(self):
         """Update the device with the latest data."""
-        self.shutter = CameraProtect(self.device, self.api)
+        self.shutter = CameraProtect(self.device, self.coordinator.client)
 
     def turn_on(self, **kwargs) -> None:
         """Turn the entity on."""

--- a/homeassistant/components/somfy/switch.py
+++ b/homeassistant/components/somfy/switch.py
@@ -4,8 +4,8 @@ from pymfy.api.devices.category import Category
 
 from homeassistant.components.switch import SwitchEntity
 
-from . import SomfyEntity
 from .const import API, COORDINATOR, DOMAIN
+from .entity import SomfyEntity
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1562,7 +1562,7 @@ pymelcloud==2.5.3
 pymeteoclimatic==0.0.6
 
 # homeassistant.components.somfy
-pymfy==0.9.3
+pymfy==0.11.0
 
 # homeassistant.components.xiaomi_tv
 pymitv==1.4.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -873,7 +873,7 @@ pymelcloud==2.5.3
 pymeteoclimatic==0.0.6
 
 # homeassistant.components.somfy
-pymfy==0.9.3
+pymfy==0.11.0
 
 # homeassistant.components.mochad
 pymochad==0.2.0

--- a/tests/components/somfy/test_config_flow.py
+++ b/tests/components/somfy/test_config_flow.py
@@ -82,7 +82,9 @@ async def test_full_flow(
         },
     )
 
-    with patch("homeassistant.components.somfy.api.ConfigEntrySomfyApi"):
+    with patch(
+        "homeassistant.components.somfy.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["data"]["auth_implementation"] == DOMAIN
@@ -95,12 +97,7 @@ async def test_full_flow(
         "expires_in": 60,
     }
 
-    assert DOMAIN in hass.config.components
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert entry.state is config_entries.ConfigEntryState.LOADED
-
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    assert entry.state is config_entries.ConfigEntryState.NOT_LOADED
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_abort_if_authorization_timeout(hass, current_request_with_host):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Somfy recently changed the rules about polling their server to get the latest status. The purpose of this PR is to apply these rules.

```
We are contacting you today to inform you about the new rules we are now applying to the API:

    First of all, no limitation will be applied on the POST /device/{deviceId}/exec endpoint as we want to provide you a total freedom on controlling your devices.
    On the other hand, polling frequency on the GET /site and child endpoints will now have to be under 1 call per minute.
```

Release notes:
- https://github.com/tetienne/somfy-open-api/releases/tag/v0.9.4
- https://github.com/tetienne/somfy-open-api/releases/tag/v0.10.1
- https://github.com/tetienne/somfy-open-api/releases/tag/v0.11.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50815
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
