### PR TITLE
Clean up unused Sonos subscriptions

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -129,8 +129,9 @@ async def async_setup_entry(  # noqa: C901
         pysonos.config.EVENT_ADVERTISE_IP = advertise_addr
 
     async def _async_stop_event_listener(event: Event) -> None:
-        for speaker in data.discovered.values():
-            await speaker.async_unsubscribe()
+        await asyncio.gather(
+            *[speaker.async_unsubscribe() for speaker in data.discovered.values()]
+        )
         if events_asyncio.event_listener:
             await events_asyncio.event_listener.async_stop()
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -129,6 +129,8 @@ async def async_setup_entry(  # noqa: C901
         pysonos.config.EVENT_ADVERTISE_IP = advertise_addr
 
     async def _async_stop_event_listener(event: Event) -> None:
+        for speaker in data.discovered.values():
+            await speaker.async_unsubscribe()
         if events_asyncio.event_listener:
             await events_asyncio.event_listener.async_stop()
 

--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -130,7 +130,8 @@ async def async_setup_entry(  # noqa: C901
 
     async def _async_stop_event_listener(event: Event) -> None:
         await asyncio.gather(
-            *[speaker.async_unsubscribe() for speaker in data.discovered.values()]
+            *[speaker.async_unsubscribe() for speaker in data.discovered.values()],
+            return_exceptions=True,
         )
         if events_asyncio.event_listener:
             await events_asyncio.event_listener.async_stop()

--- a/homeassistant/components/sonos/entity.py
+++ b/homeassistant/components/sonos/entity.py
@@ -64,13 +64,14 @@ class SonosEntity(Entity):
 
     async def async_poll(self, now: datetime.datetime) -> None:
         """Poll the entity if subscriptions fail."""
-        if self.speaker.is_first_poll:
+        if not self.speaker.subscriptions_failed:
             _LOGGER.warning(
                 "%s cannot reach [%s], falling back to polling, functionality may be limited",
                 self.speaker.zone_name,
                 self.speaker.subscription_address,
             )
-            self.speaker.is_first_poll = False
+            self.speaker.subscriptions_failed = True
+            await self.speaker.async_unsubscribe()
         try:
             await self.async_update()  # pylint: disable=no-member
         except (OSError, SoCoException) as ex:

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -333,13 +333,11 @@ class SonosSpeaker:
 
     async def async_unsubscribe(self) -> None:
         """Cancel all subscriptions."""
-        for subscription in self._subscriptions:
-            _LOGGER.debug(
-                "Unsubscribing %s [%s]",
-                self.zone_name,
-                subscription.service.service_type,
-            )
-            await subscription.unsubscribe()
+        _LOGGER.debug("Unsubscribing from events for %s", self.zone_name)
+        await asyncio.gather(
+            *[subscription.unsubscribe() for subscription in self._subscriptions],
+            return_exceptions=True,
+        )
         self._subscriptions = []
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
While testing intentional connectivity issues between Sonos speakers and HA, I ran into some issues which _may_ be explained by the inability to send subscription callback events from Sonos->HA. An HA instance which did not have any connectivity issues appeared to be affected by another where connectivity was blocked. It seemed like callback events may be processed serially by the speaker and failing callbacks can delay "good" callbacks.

This PR detects if those callbacks are failing and explicitly cancels those failing subscriptions. It also cleans up subscriptions on shutdown to ensure the speakers don't try to continue to sending events to a receiver that no longer exists.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #43190
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
