### PR TITLE
Fix Sonos battery sensors on S1 firmware

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -173,7 +173,7 @@ class SonosSpeaker:
         self.zone_name = speaker_info["zone_name"]
 
         # Battery
-        self.battery_info: dict[str, Any] | None = None
+        self.battery_info: dict[str, Any] = {}
         self._last_battery_event: datetime.datetime | None = None
         self._battery_poll_timer: Callable | None = None
 
@@ -208,21 +208,15 @@ class SonosSpeaker:
             self.hass, f"{SONOS_SEEN}-{self.soco.uid}", self.async_seen
         )
 
-        if (battery_info := fetch_battery_info_or_none(self.soco)) is None:
-            self._platforms_ready.update({BINARY_SENSOR_DOMAIN, SENSOR_DOMAIN})
-        else:
+        if battery_info := fetch_battery_info_or_none(self.soco):
             self.battery_info = battery_info
-            # Only create a polling task if successful, may fail on S1 firmware
-            if battery_info:
-                # Battery events can be infrequent, polling is still necessary
-                self._battery_poll_timer = self.hass.helpers.event.track_time_interval(
-                    self.async_poll_battery, BATTERY_SCAN_INTERVAL
-                )
-            else:
-                _LOGGER.warning(
-                    "S1 firmware detected, battery sensor may update infrequently"
-                )
+            # Battery events can be infrequent, polling is still necessary
+            self._battery_poll_timer = self.hass.helpers.event.track_time_interval(
+                self.async_poll_battery, BATTERY_SCAN_INTERVAL
+            )
             dispatcher_send(self.hass, SONOS_CREATE_BATTERY, self)
+        else:
+            self._platforms_ready.update({BINARY_SENSOR_DOMAIN, SENSOR_DOMAIN})
 
         if new_alarms := self.update_alarms_for_speaker():
             dispatcher_send(self.hass, SONOS_CREATE_ALARM, self, new_alarms)
@@ -386,7 +380,7 @@ class SonosSpeaker:
 
     async def async_update_device_properties(self, event: SonosEvent) -> None:
         """Update device properties from an event."""
-        if (more_info := event.variables.get("more_info")) is not None:
+        if more_info := event.variables.get("more_info"):
             battery_dict = dict(x.split(":") for x in more_info.split(","))
             await self.async_update_battery_info(battery_dict)
         self.async_write_entity_states()
@@ -515,12 +509,19 @@ class SonosSpeaker:
 
         if not self._battery_poll_timer:
             # Battery info received for an S1 speaker
+            new_battery = not self.battery_info
             self.battery_info.update(
                 {
                     "Level": int(battery_dict["BattPct"]),
                     "PowerSource": "EXTERNAL" if is_charging else "BATTERY",
                 }
             )
+            if new_battery:
+                _LOGGER.warning(
+                    "S1 firmware detected on %s, battery info may update infrequently",
+                    self.zone_name,
+                )
+                async_dispatcher_send(self.hass, SONOS_CREATE_BATTERY, self)
             return
 
         if is_charging == self.charging:

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -3,7 +3,7 @@ from pysonos.exceptions import NotSupportedException
 
 from homeassistant.components.sonos import DOMAIN
 from homeassistant.components.sonos.binary_sensor import ATTR_BATTERY_POWER_SOURCE
-from homeassistant.const import STATE_OFF, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.setup import async_setup_component
 
 
@@ -68,21 +68,18 @@ async def test_battery_on_S1(hass, config_entry, config, soco, battery_event):
 
     entity_registry = await hass.helpers.entity_registry.async_get_registry()
 
-    battery = entity_registry.entities["sensor.zone_a_battery"]
-    battery_state = hass.states.get(battery.entity_id)
-    assert battery_state.state == STATE_UNAVAILABLE
-
-    power = entity_registry.entities["binary_sensor.zone_a_power"]
-    power_state = hass.states.get(power.entity_id)
-    assert power_state.state == STATE_UNAVAILABLE
+    assert "sensor.zone_a_battery" not in entity_registry.entities
+    assert "binary_sensor.zone_a_power" not in entity_registry.entities
 
     # Update the speaker with a callback event
     sub_callback(battery_event)
     await hass.async_block_till_done()
 
+    battery = entity_registry.entities["sensor.zone_a_battery"]
     battery_state = hass.states.get(battery.entity_id)
     assert battery_state.state == "100"
 
+    power = entity_registry.entities["binary_sensor.zone_a_power"]
     power_state = hass.states.get(power.entity_id)
     assert power_state.state == STATE_OFF
     assert power_state.attributes.get(ATTR_BATTERY_POWER_SOURCE) == "BATTERY"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After a couple attempts, I finally understand how Sonos Move speakers on S1 firmware behave when working with the battery. This should finally resolve #50169.

I was able to reproduce the behavior in the issue above on my S2 speaker by emulating the provided responses.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #50169
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
