### PR TITLE
Allow ignoring template returns in template fan

### DIFF
--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -59,6 +59,7 @@ CONF_SET_SPEED_ACTION = "set_speed"
 CONF_SET_OSCILLATING_ACTION = "set_oscillating"
 CONF_SET_DIRECTION_ACTION = "set_direction"
 CONF_SET_PRESET_MODE_ACTION = "set_preset_mode"
+IGNORED_TEMPLATE_RESULT = "_IGNORED"
 
 _VALID_STATES = [STATE_ON, STATE_OFF]
 _VALID_OSC = [True, False]
@@ -547,6 +548,8 @@ class TemplateFan(TemplateEntity, FanEntity):
         try:
             percentage = int(float(percentage))
         except ValueError:
+            if percentage == IGNORED_TEMPLATE_RESULT:
+                return
             _LOGGER.error("Received invalid percentage: %s", percentage)
             self._speed = None
             self._percentage = 0
@@ -577,6 +580,8 @@ class TemplateFan(TemplateEntity, FanEntity):
             self._speed = None
             self._percentage = None
             self._preset_mode = None
+        elif preset_mode == IGNORED_TEMPLATE_RESULT:
+            return
         else:
             _LOGGER.error(
                 "Received invalid preset_mode: %s. Expected: %s",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This allows a fan template to do nothing if a percentage_template or preset_mode_template return a special value. This is required if the percentage and the preset mode are both determined based on the same entity/attribute. For example, the LZW36 fan device can run in "breeze" mode. This is done by setting the percentage to 1. Creating a fan template to enable this is currently impossible. With this change, it could look something like this: 
```yaml
my_fan_template:
  friendly_name: "My Fan"
  value_template: "{{ states('fan.actual_fan_device') }}"
  percentage_template: >
    {% if is_state_attr('fan.actual_fan_device', 'percentage', 1) %}
      _IGNORED
    {% else %}
      {{ state_attr('fan.actual_fan_device', 'percentage') }}
    {% endif %}
  preset_mode_template: >
    {% if is_state_attr('fan.actual_fan_device', 'percentage', 1) %}
      breezy
    {% else %}
      _IGNORED
    {% endif %}
  turn_on:
    service: fan.turn_on
    entity_id: fan.actual_fan_device
  turn_off:
    service: fan.turn_off
    entity_id: fan.actual_fan_device
  set_percentage:
    service: fan.set_percentage
    entity_id: fan.actual_fan_device
    data:
      percentage: "{{percentage}}"
  set_preset_mode:
    service: fan.set_percentage
    entity_id: fan.actual_fan_device
    data:
      percentage: 1
  preset_modes:
    - 'breezy'
  speed_count: 3
```

I don't know if this is something HA wants to support, but I'd love a way to solve this problem. I think this would work. Thanks!

I've made a request on the HA forums, but didn't get any responses: https://community.home-assistant.io/t/make-preset-mode-template-and-percentage-template-based-off-the-same-value/313189


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
