### PR TITLE
Add support for color_mode white to Tasmota light

### DIFF
--- a/homeassistant/components/tasmota/manifest.json
+++ b/homeassistant/components/tasmota/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tasmota",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tasmota",
-  "requirements": ["hatasmota==0.2.14"],
+  "requirements": ["hatasmota==0.2.15"],
   "dependencies": ["mqtt"],
   "mqtt": ["tasmota/discovery/#"],
   "codeowners": ["@emontnemery"],

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -738,7 +738,7 @@ hass-nabucasa==0.43.0
 hass_splunk==0.1.1
 
 # homeassistant.components.tasmota
-hatasmota==0.2.14
+hatasmota==0.2.15
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.2

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -411,7 +411,7 @@ hangups==0.4.14
 hass-nabucasa==0.43.0
 
 # homeassistant.components.tasmota
-hatasmota==0.2.14
+hatasmota==0.2.15
 
 # homeassistant.components.jewish_calendar
 hdate==0.10.2

--- a/tests/components/light/common.py
+++ b/tests/components/light/common.py
@@ -17,6 +17,7 @@ from homeassistant.components.light import (
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
     ATTR_TRANSITION,
+    ATTR_WHITE,
     ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
     DOMAIN,
@@ -50,6 +51,7 @@ def turn_on(
     flash=None,
     effect=None,
     color_name=None,
+    white=None,
 ):
     """Turn all or specified light on."""
     hass.add_job(
@@ -71,6 +73,7 @@ def turn_on(
         flash,
         effect,
         color_name,
+        white,
     )
 
 
@@ -92,6 +95,7 @@ async def async_turn_on(
     flash=None,
     effect=None,
     color_name=None,
+    white=None,
 ):
     """Turn all or specified light on."""
     data = {
@@ -113,6 +117,7 @@ async def async_turn_on(
             (ATTR_FLASH, flash),
             (ATTR_EFFECT, effect),
             (ATTR_COLOR_NAME, color_name),
+            (ATTR_WHITE, white),
         ]
         if value is not None
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Tasmota doesn't support independent control of all four channels of an RGBW light, so `rgbw_color` was a very poor fit for it and gave counter-intuitive results.
Tasmota lights supporting color and white will now be added as a light supporting color modes `hs` and `white`, not as a light supporting color_mode `rgbw`.

Scenes setting a Tasmota light can updated by using the scene UI editor.

Automations setting a Tasmota light need to be updated manually, to set a light to white mode do:
```yaml
  - service: light.turn_on
    target:
      entity_id: light.genbbc05
    data:
      white: 242
```

Note that Tasmota offers the [White Blend Mode](https://tasmota.github.io/docs/White-Blend-Mode/) feature, if this is enabled the light will be added as a color light to Home Assistant, and Tasmota will enable the white channel for colors with low saturation.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add support for color_mode `white` to Tasmota light

Bump hatasmota from 0.2.14 to 0.2.15

Changes:

 - 0.2.15 (https://github.com/emontnemery/hatasmota/releases/tag/0.2.15)
   - Revert "Improve support for RGBW lights" [#96](https://github.com/emontnemery/hatasmota/pull/#96) @emontnemery
   - Bump pylint from 2.8.2 to 2.8.3 [#94](https://github.com/emontnemery/hatasmota/pull/#94) @dependabot
   - Bump black from 21.5b1 to 21.5b2 [#95](https://github.com/emontnemery/hatasmota/pull/#95) @dependabot

Git compare: https://github.com/emontnemery/hatasmota/compare/0.2.14..0.2.15

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
