### PR TITLE
Add Datacoordinator for garmin connect

### DIFF
--- a/homeassistant/components/garmin_connect/__init__.py
+++ b/homeassistant/components/garmin_connect/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_API, DATA_COORDINATOR, DEFAULT_UPDATE_INTERVAL, DOMAIN
+from .const import DATA_COORDINATOR, DEFAULT_UPDATE_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -62,7 +62,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
-        DATA_API: api,
         DATA_COORDINATOR: coordinator,
     }
 

--- a/homeassistant/components/garmin_connect/__init__.py
+++ b/homeassistant/components/garmin_connect/__init__.py
@@ -89,8 +89,8 @@ async def async_update_garmin_data(api):
         GarminConnectAuthenticationError,
         GarminConnectTooManyRequestsError,
         GarminConnectConnectionError,
-    ):
-        raise UpdateFailed
+    ) as error:
+        raise UpdateFailed(error) from error
 
     return {
         **summary,

--- a/homeassistant/components/garmin_connect/alarm_util.py
+++ b/homeassistant/components/garmin_connect/alarm_util.py
@@ -25,7 +25,6 @@ def calculate_next_active_alarms(alarms):
     Alarms are sorted by time
     """
     active_alarms = []
-    _LOGGER.debug(alarms)
 
     for alarm_setting in alarms:
         if alarm_setting["alarmMode"] != "ON":

--- a/homeassistant/components/garmin_connect/const.py
+++ b/homeassistant/components/garmin_connect/const.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
 
 DOMAIN = "garmin_connect"
 ATTRIBUTION = "connect.garmin.com"
-DATA_API = "api"
 DATA_COORDINATOR = "coordinator"
 DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
 

--- a/homeassistant/components/garmin_connect/const.py
+++ b/homeassistant/components/garmin_connect/const.py
@@ -144,7 +144,7 @@ GARMIN_ENTITY_LIST = {
     ],
     "averageStressLevel": ["Avg Stress Level", "lvl", "mdi:flash-alert", None, True],
     "maxStressLevel": ["Max Stress Level", "lvl", "mdi:flash-alert", None, True],
-    "stressQualifier": ["Stress Qualifier", "", "mdi:flash-alert", None, False],
+    "stressQualifier": ["Stress Qualifier", None, "mdi:flash-alert", None, False],
     "stressDuration": ["Stress Duration", TIME_MINUTES, "mdi:flash-alert", None, False],
     "restStressDuration": [
         "Rest Stress Duration",

--- a/homeassistant/components/garmin_connect/const.py
+++ b/homeassistant/components/garmin_connect/const.py
@@ -7,11 +7,14 @@ from homeassistant.const import (
     MASS_KILOGRAMS,
     PERCENTAGE,
     TIME_MINUTES,
+    TIME_YEARS,
 )
 
 DOMAIN = "garmin_connect"
 ATTRIBUTION = "connect.garmin.com"
-DEFAULT_UPDATE_INTERVAL = timedelta(minutes=10)
+DATA_API = "api"
+DATA_COORDINATOR = "coordinator"
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=5)
 
 GARMIN_ENTITY_LIST = {
     "totalSteps": ["Total Steps", "steps", "mdi:walk", None, True],
@@ -127,7 +130,7 @@ GARMIN_ENTITY_LIST = {
     "maxAvgHeartRate": ["Max Avg Heart Rate", "bpm", "mdi:heart-pulse", None, False],
     "abnormalHeartRateAlertsCount": [
         "Abnormal HR Counts",
-        "",
+        None,
         "mdi:heart-pulse",
         None,
         False,
@@ -343,13 +346,13 @@ GARMIN_ENTITY_LIST = {
         False,
     ],
     "weight": ["Weight", MASS_KILOGRAMS, "mdi:weight-kilogram", None, False],
-    "bmi": ["BMI", "", "mdi:food", None, False],
+    "bmi": ["BMI", "", "mdi:food", "bmi", False],
     "bodyFat": ["Body Fat", PERCENTAGE, "mdi:food", None, False],
     "bodyWater": ["Body Water", PERCENTAGE, "mdi:water-percent", None, False],
     "bodyMass": ["Body Mass", MASS_KILOGRAMS, "mdi:food", None, False],
     "muscleMass": ["Muscle Mass", MASS_KILOGRAMS, "mdi:dumbbell", None, False],
-    "physiqueRating": ["Physique Rating", "", "mdi:numeric", None, False],
-    "visceralFat": ["Visceral Fat", "", "mdi:food", None, False],
-    "metabolicAge": ["Metabolic Age", "", "mdi:calendar-heart", None, False],
+    "physiqueRating": ["Physique Rating", None, "mdi:numeric", None, False],
+    "visceralFat": ["Visceral Fat", PERCENTAGE, "mdi:food", None, False],
+    "metabolicAge": ["Metabolic Age", TIME_YEARS, "mdi:calendar-heart", None, False],
     "nextAlarm": ["Next Alarm Time", None, "mdi:alarm", DEVICE_CLASS_TIMESTAMP, True],
 }

--- a/homeassistant/components/garmin_connect/const.py
+++ b/homeassistant/components/garmin_connect/const.py
@@ -346,7 +346,7 @@ GARMIN_ENTITY_LIST = {
         False,
     ],
     "weight": ["Weight", MASS_KILOGRAMS, "mdi:weight-kilogram", None, False],
-    "bmi": ["BMI", "", "mdi:food", "bmi", False],
+    "bmi": ["BMI", "bmi", "mdi:food", None, False],
     "bodyFat": ["Body Fat", PERCENTAGE, "mdi:food", None, False],
     "bodyWater": ["Body Water", PERCENTAGE, "mdi:water-percent", None, False],
     "bodyMass": ["Body Mass", MASS_KILOGRAMS, "mdi:food", None, False],

--- a/homeassistant/components/garmin_connect/const.py
+++ b/homeassistant/components/garmin_connect/const.py
@@ -142,8 +142,8 @@ GARMIN_ENTITY_LIST = {
         None,
         False,
     ],
-    "averageStressLevel": ["Avg Stress Level", "", "mdi:flash-alert", None, True],
-    "maxStressLevel": ["Max Stress Level", "", "mdi:flash-alert", None, True],
+    "averageStressLevel": ["Avg Stress Level", "lvl", "mdi:flash-alert", None, True],
+    "maxStressLevel": ["Max Stress Level", "lvl", "mdi:flash-alert", None, True],
     "stressQualifier": ["Stress Qualifier", "", "mdi:flash-alert", None, False],
     "stressDuration": ["Stress Duration", TIME_MINUTES, "mdi:flash-alert", None, False],
     "restStressDuration": [

--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -61,7 +61,7 @@ async def async_setup_entry(
             )
         )
 
-    async_add_entities(entities, True)
+    async_add_entities(entities)
 
 
 class GarminConnectSensor(CoordinatorEntity, SensorEntity):

--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ATTRIBUTION, CONF_ID
+from homeassistant.const import ATTR_ATTRIBUTION, CONF_ID, DEVICE_CLASS_TIMESTAMP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -88,7 +88,6 @@ class GarminConnectSensor(CoordinatorEntity, SensorEntity):
         self._icon = icon
         self._device_class = device_class
         self._enabled_default = enabled_default
-        self._state = None
 
     @property
     def name(self):
@@ -116,7 +115,11 @@ class GarminConnectSensor(CoordinatorEntity, SensorEntity):
                 self.coordinator.data[self._type]
             )
             if active_alarms:
-                self._state = active_alarms[0]
+                value = active_alarms[0]
+
+        if self._device_class == DEVICE_CLASS_TIMESTAMP:
+            return value
+
         return round(value, 2)
 
     @property

--- a/homeassistant/components/garmin_connect/sensor.py
+++ b/homeassistant/components/garmin_connect/sensor.py
@@ -3,20 +3,23 @@ from __future__ import annotations
 
 import logging
 
-from garminconnect_aio import (
-    GarminConnectAuthenticationError,
-    GarminConnectConnectionError,
-    GarminConnectTooManyRequestsError,
-)
-
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_ATTRIBUTION, CONF_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .alarm_util import calculate_next_active_alarms
-from .const import ATTRIBUTION, DOMAIN, GARMIN_ENTITY_LIST
+from .const import (
+    ATTRIBUTION,
+    DATA_COORDINATOR,
+    DOMAIN as GARMIN_DOMAIN,
+    GARMIN_ENTITY_LIST,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,19 +28,10 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, async_add_entities
 ) -> None:
     """Set up Garmin Connect sensor based on a config entry."""
-    garmin_data = hass.data[DOMAIN][entry.entry_id]
+    coordinator: DataUpdateCoordinator = hass.data[GARMIN_DOMAIN][entry.entry_id][
+        DATA_COORDINATOR
+    ]
     unique_id = entry.data[CONF_ID]
-
-    try:
-        await garmin_data.async_update()
-    except (
-        GarminConnectConnectionError,
-        GarminConnectAuthenticationError,
-        GarminConnectTooManyRequestsError,
-    ) as err:
-        _LOGGER.error("Error occurred during Garmin Connect Client update: %s", err)
-    except Exception:  # pylint: disable=broad-except
-        _LOGGER.exception("Unknown error occurred during Garmin Connect Client update")
 
     entities = []
     for (
@@ -56,7 +50,7 @@ async def async_setup_entry(
         )
         entities.append(
             GarminConnectSensor(
-                garmin_data,
+                coordinator,
                 unique_id,
                 sensor_type,
                 name,
@@ -70,12 +64,12 @@ async def async_setup_entry(
     async_add_entities(entities, True)
 
 
-class GarminConnectSensor(SensorEntity):
+class GarminConnectSensor(CoordinatorEntity, SensorEntity):
     """Representation of a Garmin Connect Sensor."""
 
     def __init__(
         self,
-        data,
+        coordinator,
         unique_id,
         sensor_type,
         name,
@@ -84,8 +78,9 @@ class GarminConnectSensor(SensorEntity):
         device_class,
         enabled_default: bool = True,
     ):
-        """Initialize."""
-        self._data = data
+        """Initialize a Garmin Connect sensor."""
+        super().__init__(coordinator)
+
         self._unique_id = unique_id
         self._type = sensor_type
         self._name = name
@@ -109,7 +104,22 @@ class GarminConnectSensor(SensorEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return self._state
+        if self.coordinator.data:
+            if self.coordinator.data[self._type]:
+                value = self.coordinator.data[self._type]
+                if "Duration" in self._type or "Seconds" in self._type:
+                    value = value // 60
+                elif "Mass" in self._type or self._type == "weight":
+                    value = value / 1000
+                elif self._type == "nextAlarm":
+                    active_alarms = calculate_next_active_alarms(
+                        self.coordinator.data[self._type]
+                    )
+                    if active_alarms:
+                        self._state = active_alarms[0]
+                return round(value, 2)
+
+        return None
 
     @property
     def unique_id(self) -> str:
@@ -124,24 +134,26 @@ class GarminConnectSensor(SensorEntity):
     @property
     def extra_state_attributes(self):
         """Return attributes for sensor."""
-        if not self._data.data:
+        if not self.coordinator.data:
             return {}
+
         attributes = {
-            "source": self._data.data["source"],
-            "last_synced": self._data.data["lastSyncTimestampGMT"],
+            "source": self.coordinator.data["source"],
+            "last_synced": self.coordinator.data["lastSyncTimestampGMT"],
             ATTR_ATTRIBUTION: ATTRIBUTION,
         }
         if self._type == "nextAlarm":
             attributes["next_alarms"] = calculate_next_active_alarms(
-                self._data.data[self._type]
+                self.coordinator.data[self._type]
             )
+
         return attributes
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device information."""
         return {
-            "identifiers": {(DOMAIN, self._unique_id)},
+            "identifiers": {(GARMIN_DOMAIN, self._unique_id)},
             "name": "Garmin Connect",
             "manufacturer": "Garmin Connect",
         }
@@ -160,40 +172,3 @@ class GarminConnectSensor(SensorEntity):
     def device_class(self):
         """Return the device class of the sensor."""
         return self._device_class
-
-    async def async_update(self):
-        """Update the data from Garmin Connect."""
-        if not self.enabled:
-            return
-
-        await self._data.async_update()
-        data = self._data.data
-        if not data:
-            _LOGGER.error("Didn't receive data from Garmin Connect")
-            return
-        if data.get(self._type) is None:
-            _LOGGER.debug("Entity type %s not set in fetched data", self._type)
-            self._available = False
-            return
-        self._available = True
-
-        if "Duration" in self._type or "Seconds" in self._type:
-            self._state = data[self._type] // 60
-        elif "Mass" in self._type or self._type == "weight":
-            self._state = round((data[self._type] / 1000), 2)
-        elif (
-            self._type == "bodyFat" or self._type == "bodyWater" or self._type == "bmi"
-        ):
-            self._state = round(data[self._type], 2)
-        elif self._type == "nextAlarm":
-            active_alarms = calculate_next_active_alarms(data[self._type])
-            if active_alarms:
-                self._state = active_alarms[0]
-            else:
-                self._available = False
-        else:
-            self._state = data[self._type]
-
-        _LOGGER.debug(
-            "Entity %s set to state %s %s", self._type, self._state, self._unit
-        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Changed the units of measurements to the following sensors:
Max Stress Level -> 'lvl'
BMI -> 'bmi'
Visceral Fat -> %
Metabolic Age -> y
Abnormal HR Counts -> None
Stress Qualifier -> None
Physique Rating -> None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Replaced legacy update code with DataCoordinator.
- Updated polling frequency to 5 mins.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
