### PR TITLE
Add mac address to samsungtv config entry data if missing

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -7,6 +7,7 @@ from homeassistant import config_entries
 from homeassistant.components.media_player.const import DOMAIN as MP_DOMAIN
 from homeassistant.const import (
     CONF_HOST,
+    CONF_MAC,
     CONF_METHOD,
     CONF_NAME,
     CONF_PORT,
@@ -17,7 +18,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 
 from .bridge import SamsungTVBridge
-from .const import CONF_ON_ACTION, DEFAULT_NAME, DOMAIN, LOGGER
+from .const import CONF_ON_ACTION, DEFAULT_NAME, DOMAIN, LOGGER, METHOD_WEBSOCKET
 
 
 def ensure_unique_hosts(value):
@@ -90,13 +91,7 @@ async def async_setup_entry(hass, entry):
     """Set up the Samsung TV platform."""
 
     # Initialize bridge
-    data = entry.data.copy()
-    bridge = _async_get_device_bridge(data)
-    if bridge.port is None and bridge.default_port is not None:
-        # For backward compat, set default port for websocket tv
-        data[CONF_PORT] = bridge.default_port
-        hass.config_entries.async_update_entry(entry, data=data)
-        bridge = _async_get_device_bridge(data)
+    bridge = await _async_create_bridge_with_updated_data(hass, entry)
 
     def stop_bridge(event):
         """Stop SamsungTV bridge connection."""
@@ -109,6 +104,28 @@ async def async_setup_entry(hass, entry):
     hass.data[DOMAIN][entry.entry_id] = bridge
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     return True
+
+
+async def _async_create_bridge_with_updated_data(hass, entry):
+    """Create a bridge object and update any missing data in the config entry."""
+    bridge = _async_get_device_bridge(entry.data)
+    updated_data = {}
+
+    if bridge.port is None and bridge.default_port is not None:
+        # For backward compat, set default port for websocket tv
+        updated_data[CONF_PORT] = bridge.default_port
+        bridge = _async_get_device_bridge({**entry.data, **updated_data})
+
+    if not entry.data.get(CONF_MAC) and bridge.method == METHOD_WEBSOCKET:
+        if mac := await hass.async_add_executor_job(bridge.mac_from_device):
+            updated_data[CONF_MAC] = mac
+
+    if updated_data:
+        data = entry.data.copy()
+        data.update(updated_data)
+        hass.config_entries.async_update_entry(entry, data=data)
+
+    return bridge
 
 
 async def async_unload_entry(hass, entry):

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -149,8 +149,7 @@ async def _async_create_bridge_with_updated_data(hass, entry):
             updated_data[CONF_MAC] = mac
 
     if updated_data:
-        data = entry.data.copy()
-        data.update(updated_data)
+        data = {**entry.data, **updated_data}
         hass.config_entries.async_update_entry(entry, data=data)
 
     return bridge

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     CONF_TIMEOUT,
     CONF_TOKEN,
 )
+from homeassistant.helpers.device_registry import format_mac
 
 from .const import (
     CONF_DESCRIPTION,
@@ -32,6 +33,15 @@ from .const import (
     VALUE_CONF_NAME,
     WEBSOCKET_PORTS,
 )
+
+
+def mac_from_device_info(info):
+    """Extract the mac address from the device info."""
+    if info is not None:
+        dev_info = info.get("device", {})
+        if dev_info.get("networkType") == "wireless" and dev_info.get("wifiMac"):
+            return format_mac(dev_info.get("wifiMac"))
+    return None
 
 
 class SamsungTVBridge(ABC):
@@ -65,6 +75,10 @@ class SamsungTVBridge(ABC):
     @abstractmethod
     def device_info(self):
         """Try to gather infos of this TV."""
+
+    @abstractmethod
+    def mac_from_device(self):
+        """Try to fetch the mac address of the TV."""
 
     def is_on(self):
         """Tells if the TV is on."""
@@ -148,6 +162,10 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
             CONF_TIMEOUT: 1,
         }
 
+    def mac_from_device(self):
+        """Try to fetch the mac address of the TV."""
+        return None
+
     def try_connect(self):
         """Try to connect to the Legacy TV."""
         config = {
@@ -213,6 +231,10 @@ class SamsungTVWSBridge(SamsungTVBridge):
         super().__init__(method, host, port)
         self.token = token
         self.default_port = 8001
+
+    def mac_from_device(self):
+        """Try to fetch the mac address of the TV."""
+        return mac_from_device_info(self.device_info())
 
     def try_connect(self):
         """Try to connect to the Websocket TV."""

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -53,7 +53,7 @@ async def async_get_device_info(hass, bridge, host):
 
 def _get_device_info(bridge, host):
     """Fetch the port, method, and device info."""
-    if bridge:
+    if bridge and bridge.port:
         return bridge.port, bridge.method, bridge.device_info()
 
     for port in WEBSOCKET_PORTS:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -58,6 +58,7 @@ def _get_device_info(bridge, host):
     for port in WEBSOCKET_PORTS:
         bridge = SamsungTVBridge.get_bridge(METHOD_WEBSOCKET, host, port)
         if info := bridge.device_info():
+            LOGGER.warning("got device info: %s", info)
             return port, METHOD_WEBSOCKET, info
 
     bridge = SamsungTVBridge.get_bridge(METHOD_LEGACY, host, LEGACY_PORT)

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -41,7 +41,7 @@ def mac_from_device_info(info):
     """Extract the mac address from the device info."""
     dev_info = info.get("device", {})
     if dev_info.get("networkType") == "wireless" and dev_info.get("wifiMac"):
-        return format_mac(dev_info.get("wifiMac"))
+        return format_mac(dev_info["wifiMac"])
     return None
 
 

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -58,7 +58,6 @@ def _get_device_info(bridge, host):
     for port in WEBSOCKET_PORTS:
         bridge = SamsungTVBridge.get_bridge(METHOD_WEBSOCKET, host, port)
         if info := bridge.device_info():
-            LOGGER.warning("got device info: %s", info)
             return port, METHOD_WEBSOCKET, info
 
     bridge = SamsungTVBridge.get_bridge(METHOD_LEGACY, host, LEGACY_PORT)

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -39,10 +39,9 @@ from .const import (
 
 def mac_from_device_info(info):
     """Extract the mac address from the device info."""
-    if info is not None:
-        dev_info = info.get("device", {})
-        if dev_info.get("networkType") == "wireless" and dev_info.get("wifiMac"):
-            return format_mac(dev_info.get("wifiMac"))
+    dev_info = info.get("device", {})
+    if dev_info.get("networkType") == "wireless" and dev_info.get("wifiMac"):
+        return format_mac(dev_info.get("wifiMac"))
     return None
 
 
@@ -257,7 +256,8 @@ class SamsungTVWSBridge(SamsungTVBridge):
 
     def mac_from_device(self):
         """Try to fetch the mac address of the TV."""
-        return mac_from_device_info(self.device_info())
+        info = self.device_info()
+        return mac_from_device_info(info) if info else None
 
     def try_connect(self):
         """Try to connect to the Websocket TV."""

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -24,7 +24,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.typing import DiscoveryInfoType
 
-from .bridge import SamsungTVBridge
+from .bridge import SamsungTVBridge, async_get_device_info, mac_from_device_info
 from .const import (
     ATTR_PROPERTIES,
     CONF_MANUFACTURER,
@@ -45,23 +45,6 @@ from .const import (
 
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_HOST): str, vol.Required(CONF_NAME): str})
 SUPPORTED_METHODS = [METHOD_LEGACY, METHOD_WEBSOCKET]
-
-
-def _get_device_info(host):
-    """Fetch device info by any websocket method."""
-    for port in WEBSOCKET_PORTS:
-        bridge = SamsungTVBridge.get_bridge(METHOD_WEBSOCKET, host, port)
-        if info := bridge.device_info():
-            return info
-    return None
-
-
-async def async_get_device_info(hass, bridge, host):
-    """Fetch device info from bridge or websocket."""
-    if bridge:
-        return await hass.async_add_executor_job(bridge.device_info)
-
-    return await hass.async_add_executor_job(_get_device_info, host)
 
 
 def _strip_uuid(udn):
@@ -134,7 +117,9 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def _async_get_and_check_device_info(self):
         """Try to get the device info."""
-        info = await async_get_device_info(self.hass, self._bridge, self._host)
+        _port, _method, info = await async_get_device_info(
+            self.hass, self._bridge, self._host
+        )
         if not info:
             raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
         dev_info = info.get("device", {})
@@ -146,8 +131,8 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._name = name.replace("[TV] ", "") if name else device_type
         self._title = f"{self._name} ({self._model})"
         self._udn = _strip_uuid(dev_info.get("udn", info["id"]))
-        if dev_info.get("networkType") == "wireless" and dev_info.get("wifiMac"):
-            self._mac = format_mac(dev_info.get("wifiMac"))
+        if mac := mac_from_device_info(info):
+            self._mac = mac
         self._device_info = info
 
     async def async_step_import(self, user_input=None):
@@ -156,11 +141,11 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         # since the TV may be off at startup
         await self._async_set_name_host_from_input(user_input)
         self._async_abort_entries_match({CONF_HOST: self._host})
-        if user_input.get(CONF_PORT) in WEBSOCKET_PORTS:
+        port = user_input.get(CONF_PORT)
+        if port in WEBSOCKET_PORTS:
             user_input[CONF_METHOD] = METHOD_WEBSOCKET
-        else:
+        elif port == LEGACY_PORT:
             user_input[CONF_METHOD] = METHOD_LEGACY
-            user_input[CONF_PORT] = LEGACY_PORT
         user_input[CONF_MANUFACTURER] = DEFAULT_MANUFACTURER
         return self.async_create_entry(
             title=self._title,

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -21,6 +21,7 @@ def remote_fixture():
         remote = Mock()
         remote.__enter__ = Mock()
         remote.__exit__ = Mock()
+        remote.port.return_value = 55000
         remote_class.return_value = remote
         yield remote
 
@@ -37,6 +38,7 @@ def remotews_fixture():
         remotews = Mock()
         remotews.__enter__ = Mock()
         remotews.__exit__ = Mock()
+        remotews.port.return_value = 8002
         remotews.rest_device_info.return_value = {
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
             "device": {

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -687,6 +687,7 @@ async def test_autodetect_websocket(hass: HomeAssistant, remote: Mock, remotews:
             "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
             "device": {
                 "modelName": "82GXARRS",
+                "networkType": "wireless",
                 "wifiMac": "aa:bb:cc:dd:ee:ff",
                 "udn": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
                 "mac": "aa:bb:cc:dd:ee:ff",
@@ -707,6 +708,11 @@ async def test_autodetect_websocket(hass: HomeAssistant, remote: Mock, remotews:
             call(**AUTODETECT_WEBSOCKET_SSL),
             call(**DEVICEINFO_WEBSOCKET_SSL),
         ]
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
 async def test_autodetect_auth_missing(hass: HomeAssistant, remote: Mock):

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -363,6 +363,29 @@ async def test_ssdp_legacy_not_supported(hass: HomeAssistant, remote: Mock):
         assert result["reason"] == RESULT_NOT_SUPPORTED
 
 
+async def test_ssdp_websocket_success_populates_mac_address(
+    hass: HomeAssistant, remotews: Mock
+):
+    """Test starting a flow from ssdp for a supported device populates the mac."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_SSDP}, data=MOCK_SSDP_DATA
+    )
+    assert result["type"] == "form"
+    assert result["step_id"] == "confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input="whatever"
+    )
+    assert result["type"] == "create_entry"
+    assert result["title"] == "Living Room (82GXARRS)"
+    assert result["data"][CONF_HOST] == "fake_host"
+    assert result["data"][CONF_NAME] == "Living Room"
+    assert result["data"][CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert result["data"][CONF_MANUFACTURER] == "Samsung fake_manufacturer"
+    assert result["data"][CONF_MODEL] == "82GXARRS"
+    assert result["result"].unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
+
+
 async def test_ssdp_websocket_not_supported(hass: HomeAssistant, remote: Mock):
     """Test starting a flow from discovery for not supported device."""
     with patch(

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -8,6 +8,7 @@ from homeassistant.components.samsungtv.const import (
     METHOD_WEBSOCKET,
 )
 from homeassistant.components.samsungtv.media_player import SUPPORT_SAMSUNGTV
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
@@ -30,6 +31,16 @@ MOCK_CONFIG = {
         }
     ]
 }
+MOCK_CONFIG_WITHOUT_PORT = {
+    SAMSUNGTV_DOMAIN: [
+        {
+            CONF_HOST: "fake_host",
+            CONF_NAME: "fake",
+            CONF_ON_ACTION: [{"delay": "00:00:01"}],
+        }
+    ]
+}
+
 REMOTE_CALL = {
     "name": "HomeAssistant",
     "description": "HomeAssistant",
@@ -65,6 +76,25 @@ async def test_setup(hass: HomeAssistant, remote: Mock):
             DOMAIN, SERVICE_VOLUME_UP, {ATTR_ENTITY_ID: ENTITY_ID}, True
         )
         assert remote.call_args == call(REMOTE_CALL)
+
+
+async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
+    """Test import from yaml when the device is offline."""
+    with patch(
+        "homeassistant.components.samsungtv.bridge.Remote", side_effect=OSError
+    ), patch(
+        "homeassistant.components.samsungtv.bridge.SamsungTVWS.open",
+        side_effect=OSError,
+    ), patch(
+        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
+        return_value="fake_host",
+    ):
+        await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
+        await hass.async_block_till_done()
+
+    config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    assert len(config_entries_domain) == 1
+    assert config_entries_domain[0].state == ConfigEntryState.SETUP_RETRY
 
 
 async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog):

--- a/tests/components/samsungtv/test_init.py
+++ b/tests/components/samsungtv/test_init.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_SUPPORTED_FEATURES,
     CONF_HOST,
+    CONF_MAC,
     CONF_METHOD,
     CONF_NAME,
     SERVICE_VOLUME_UP,
@@ -95,6 +96,22 @@ async def test_setup_from_yaml_without_port_device_offline(hass: HomeAssistant):
     config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
     assert len(config_entries_domain) == 1
     assert config_entries_domain[0].state == ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_from_yaml_without_port_device_online(
+    hass: HomeAssistant, remotews: Mock
+):
+    """Test import from yaml when the device is online."""
+    with patch(
+        "homeassistant.components.samsungtv.config_flow.socket.gethostbyname",
+        return_value="fake_host",
+    ):
+        await async_setup_component(hass, SAMSUNGTV_DOMAIN, MOCK_CONFIG)
+        await hass.async_block_till_done()
+
+    config_entries_domain = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+    assert len(config_entries_domain) == 1
+    assert config_entries_domain[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
 async def test_setup_duplicate_config(hass: HomeAssistant, remote: Mock, caplog):

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -159,13 +159,32 @@ async def test_setup_websocket(hass, remotews, mock_now):
         remote = Mock()
         remote.__enter__ = Mock(return_value=enter)
         remote.__exit__ = Mock()
+        remote.rest_device_info.return_value = {
+            "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+            "device": {
+                "modelName": "82GXARRS",
+                "wifiMac": "aa:bb:cc:dd:ee:ff",
+                "name": "[TV] Living Room",
+                "type": "Samsung SmartTV",
+                "networkType": "wireless",
+            },
+        }
         remote_class.return_value = remote
 
         await setup_samsungtv(hass, MOCK_CONFIGWS)
 
-        assert remote_class.call_count == 1
-        assert remote_class.call_args_list == [call(**MOCK_CALLS_WS)]
+        assert remote_class.call_count == 2
+        assert remote_class.call_args_list == [
+            call(**MOCK_CALLS_WS),
+            call(**MOCK_CALLS_WS),
+        ]
         assert hass.states.get(ENTITY_ID)
+
+        await hass.async_block_till_done()
+
+        config_entries = hass.config_entries.async_entries(SAMSUNGTV_DOMAIN)
+        assert len(config_entries) == 1
+        assert config_entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
 
 
 async def test_setup_websocket_2(hass, mock_now):
@@ -183,20 +202,37 @@ async def test_setup_websocket_2(hass, mock_now):
     assert len(config_entries) == 1
     assert entry is config_entries[0]
 
-    assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
-    await hass.async_block_till_done()
-
-    next_update = mock_now + timedelta(minutes=5)
-    with patch(
-        "homeassistant.components.samsungtv.bridge.SamsungTVWS"
-    ) as remote, patch("homeassistant.util.dt.utcnow", return_value=next_update):
-        async_fire_time_changed(hass, next_update)
+    with patch("homeassistant.components.samsungtv.bridge.SamsungTVWS") as remote_class:
+        enter = Mock()
+        type(enter).token = PropertyMock(return_value="987654321")
+        remote = Mock()
+        remote.__enter__ = Mock(return_value=enter)
+        remote.__exit__ = Mock()
+        remote.rest_device_info.return_value = {
+            "id": "uuid:be9554b9-c9fb-41f4-8920-22da015376a4",
+            "device": {
+                "modelName": "82GXARRS",
+                "wifiMac": "aa:bb:cc:dd:ee:ff",
+                "name": "[TV] Living Room",
+                "type": "Samsung SmartTV",
+                "networkType": "wireless",
+            },
+        }
+        remote_class.return_value = remote
+        assert await async_setup_component(hass, SAMSUNGTV_DOMAIN, {})
         await hass.async_block_till_done()
+
+        assert config_entries[0].data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+
+        next_update = mock_now + timedelta(minutes=5)
+        with patch("homeassistant.util.dt.utcnow", return_value=next_update):
+            async_fire_time_changed(hass, next_update)
+            await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state
-    assert remote.call_count == 1
-    assert remote.call_args_list == [call(**MOCK_CALLS_WS)]
+    assert remote_class.call_count == 3
+    assert remote_class.call_args_list[0] == call(**MOCK_CALLS_WS)
 
 
 async def test_update_on(hass, remote, mock_now):


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add mac address to samsungtv config entry data if missing to ensure the device can turn back on.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51553
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
