### PR TITLE
Update fortios device tracker to support FortiOS 7.0

### DIFF
--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -46,14 +46,14 @@ def get_scanner(hass, config):
         _LOGGER.error("Failed to login to FortiOS API: %s", ex)
         return None
 
-    """Get FortiGate major SW version """
+    """Get FortiGate major SW version."""
     status_json = fgt.monitor("system/status", "")
     fos_major_version = int(status_json["version"][1])
 
     if fos_major_version < 6 or fos_major_version > 7:
         _LOGGER.error(
-            "unsupported FortiOS version, fos_major_version =  %s",
-            str(fos_major_version)
+            "Unsupported FortiOS version, fos_major_version =  %s",
+            str(fos_major_version),
         )
         return None
 
@@ -64,7 +64,7 @@ def get_scanner(hass, config):
         api_url = "user/device/query"
     else:
         _LOGGER.error(
-            "unsupported FortiOS version, fos_major_version =  %s",
+            "Unsupported FortiOS version, fos_major_version =  %s",
             str(fos_major_version)
         )
         return None
@@ -101,7 +101,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                         self._clients.append(client["mac"].upper())
             else:
                 _LOGGER.error(
-                    "unsupported FortiOS version, fos_major_version =  %s",
+                    "Unsupported FortiOS version, fos_major_version =  %s",
                     str(self._fos_major_version)
                 )
 
@@ -132,7 +132,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                         name = client["hostname"]
                     else:
                         _LOGGER.error(
-                            "unsupported FortiOS version, fos_major_version =  %s",
+                            "Unsupported FortiOS version, fos_major_version =  %s",
                             str(self._fos_major_version)
                         )
                         return None

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -28,6 +28,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
+
 def get_scanner(hass, config):
     """Validate the configuration and return a FortiOSDeviceScanner."""
     host = config[DOMAIN][CONF_HOST]
@@ -50,8 +51,8 @@ def get_scanner(hass, config):
     fos_major_version = int(status_json["version"][1])
 
     if fos_major_version < 6 or fos_major_version > 7:
-       _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(fos_major_version))
-       return None
+        _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(fos_major_version))
+        return None
 
     api_url = ""
     if fos_major_version == 6:

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -85,9 +85,9 @@ class FortiOSDeviceScanner(DeviceScanner):
 
         if clients_json:
             if self._fos_major_version == 6:
-            for client in clients_json["results"]:
-                if client["last_seen"] < 180:
-                    self._clients.append(client["mac"].upper())
+                for client in clients_json["results"]:
+                    if client["last_seen"] < 180:
+                        self._clients.append(client["mac"].upper())
             elif self._fos_major_version == 7:
                for client in clients_json["results"]:
                    if client["is_online"] == True:
@@ -117,7 +117,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                 try:
                     name = ""
                     if self._fos_major_version == 6:
-                    name = client["host"]["name"]
+                        name = client["host"]["name"]
                     elif self._fos_major_version ==7:
                         name = client["hostname"]
                     else:

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -46,7 +46,6 @@ def get_scanner(hass, config):
         _LOGGER.error("Failed to login to FortiOS API: %s", ex)
         return None
 
-    """Get FortiGate major SW version."""
     status_json = fgt.monitor("system/status", "")
     fos_major_version = int(status_json["version"][1])
 

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -28,7 +28,6 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     }
 )
 
-
 def get_scanner(hass, config):
     """Validate the configuration and return a FortiOSDeviceScanner."""
     host = config[DOMAIN][CONF_HOST]
@@ -46,29 +45,55 @@ def get_scanner(hass, config):
         _LOGGER.error("Failed to login to FortiOS API: %s", ex)
         return None
 
-    return FortiOSDeviceScanner(fgt)
+    """Get FortiGate major SW version """
+    status_json = fgt.monitor("system/status", "")
+    fos_major_version = int(status_json["version"][1])
+
+    if fos_major_version < 6 or fos_major_version > 7:
+       _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(fos_major_version))
+       return None
+
+    api_url = ""
+    if fos_major_version == 6:
+        api_url = "user/device/select"
+    elif fos_major_version == 7:
+        api_url = "user/device/query"
+    else:
+        _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(fos_major_version))
+        return None
+
+    return FortiOSDeviceScanner(fgt, fos_major_version, api_url)
 
 
 class FortiOSDeviceScanner(DeviceScanner):
     """This class queries a FortiOS unit for connected devices."""
 
-    def __init__(self, fgt) -> None:
+    def __init__(self, fgt, fos_major_version, api_url) -> None:
         """Initialize the scanner."""
         self._clients = {}
         self._clients_json = {}
         self._fgt = fgt
+        self._fos_major_version = fos_major_version
+        self._api_url = api_url
 
     def update(self):
         """Update clients from the device."""
-        clients_json = self._fgt.monitor("user/device/select", "")
+        clients_json = self._fgt.monitor(self._api_url, "")
         self._clients_json = clients_json
 
         self._clients = []
 
         if clients_json:
+            if self._fos_major_version == 6:
             for client in clients_json["results"]:
                 if client["last_seen"] < 180:
                     self._clients.append(client["mac"].upper())
+            elif self._fos_major_version == 7:
+               for client in clients_json["results"]:
+                   if client["is_online"] == True:
+                       self._clients.append(client["mac"].upper())
+            else:
+               _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -90,7 +115,14 @@ class FortiOSDeviceScanner(DeviceScanner):
         for client in data["results"]:
             if client["mac"] == device:
                 try:
+                    name = ""
+                    if self._fos_major_version == 6:
                     name = client["host"]["name"]
+                    elif self._fos_major_version ==7:
+                        name = client["hostname"]
+                    else:
+                        _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))
+                        return None
                     _LOGGER.debug("Getting device name=%s", name)
                     return name
                 except KeyError as kex:

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -53,7 +53,7 @@ def get_scanner(hass, config):
     if fos_major_version < 6 or fos_major_version > 7:
         _LOGGER.error(
             "unsupported FortiOS version, fos_major_version =  %s",
-            str(fos_major_version),
+            str(fos_major_version)
         )
         return None
 
@@ -65,7 +65,7 @@ def get_scanner(hass, config):
     else:
         _LOGGER.error(
             "unsupported FortiOS version, fos_major_version =  %s",
-            str(fos_major_version),
+            str(fos_major_version)
         )
         return None
 

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -90,11 +90,11 @@ class FortiOSDeviceScanner(DeviceScanner):
                     if client["last_seen"] < 180:
                         self._clients.append(client["mac"].upper())
             elif self._fos_major_version == 7:
-               for client in clients_json["results"]:
-                   if client["is_online"] == True:
-                       self._clients.append(client["mac"].upper())
+                for client in clients_json["results"]:
+                    if client["is_online"]:
+                        self._clients.append(client["mac"].upper())
             else:
-               _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))
+                _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -119,7 +119,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                     name = ""
                     if self._fos_major_version == 6:
                         name = client["host"]["name"]
-                    elif self._fos_major_version ==7:
+                    elif self._fos_major_version == 7:
                         name = client["hostname"]
                     else:
                         _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -64,8 +64,8 @@ def get_scanner(hass, config):
         api_url = "user/device/query"
     else:
         _LOGGER.error(
-            "Unsupported FortiOS version, fos_major_version =  %s",
-            str(fos_major_version)
+            "FortiOS version %s is not supported",
+            str(fos_major_version),
         )
         return None
 
@@ -101,7 +101,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                         self._clients.append(client["mac"].upper())
             else:
                 _LOGGER.error(
-                    "Unsupported FortiOS version, fos_major_version =  %s",
+                    "FortiOS version %s is not supported",
                     str(self._fos_major_version),
                 )
 
@@ -132,7 +132,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                         name = client["hostname"]
                     else:
                         _LOGGER.error(
-                            "Unsupported FortiOS version, fos_major_version =  %s",
+                            "FortiOS version %s is not supported",
                             str(self._fos_major_version),
                         )
                         return None

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -102,7 +102,7 @@ class FortiOSDeviceScanner(DeviceScanner):
             else:
                 _LOGGER.error(
                     "Unsupported FortiOS version, fos_major_version =  %s",
-                    str(self._fos_major_version)
+                    str(self._fos_major_version),
                 )
 
     def scan_devices(self):
@@ -133,7 +133,7 @@ class FortiOSDeviceScanner(DeviceScanner):
                     else:
                         _LOGGER.error(
                             "Unsupported FortiOS version, fos_major_version =  %s",
-                            str(self._fos_major_version)
+                            str(self._fos_major_version),
                         )
                         return None
                     _LOGGER.debug("Getting device name=%s", name)

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -98,11 +98,6 @@ class FortiOSDeviceScanner(DeviceScanner):
                 for client in clients_json["results"]:
                     if client["is_online"]:
                         self._clients.append(client["mac"].upper())
-            else:
-                _LOGGER.error(
-                    "FortiOS version %s is not supported",
-                    str(self._fos_major_version),
-                )
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -124,12 +124,6 @@ class FortiOSDeviceScanner(DeviceScanner):
                         name = client["host"]["name"]
                     elif self._fos_major_version == 7:
                         name = client["hostname"]
-                    else:
-                        _LOGGER.error(
-                            "FortiOS version %s is not supported",
-                            str(self._fos_major_version),
-                        )
-                        return None
                     _LOGGER.debug("Getting device name=%s", name)
                     return name
                 except KeyError as kex:

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -56,17 +56,9 @@ def get_scanner(hass, config):
         )
         return None
 
-    api_url = ""
+    api_url = "user/device/query"
     if fos_major_version == 6:
         api_url = "user/device/select"
-    elif fos_major_version == 7:
-        api_url = "user/device/query"
-    else:
-        _LOGGER.error(
-            "FortiOS version %s is not supported",
-            str(fos_major_version),
-        )
-        return None
 
     return FortiOSDeviceScanner(fgt, fos_major_version, api_url)
 

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -52,7 +52,7 @@ def get_scanner(hass, config):
     if fos_major_version < 6 or fos_major_version > 7:
         _LOGGER.error(
             "Unsupported FortiOS version, fos_major_version =  %s",
-            str(fos_major_version),
+            fos_major_version,
         )
         return None
 

--- a/homeassistant/components/fortios/device_tracker.py
+++ b/homeassistant/components/fortios/device_tracker.py
@@ -51,7 +51,10 @@ def get_scanner(hass, config):
     fos_major_version = int(status_json["version"][1])
 
     if fos_major_version < 6 or fos_major_version > 7:
-        _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(fos_major_version))
+        _LOGGER.error(
+            "unsupported FortiOS version, fos_major_version =  %s",
+            str(fos_major_version),
+        )
         return None
 
     api_url = ""
@@ -60,7 +63,10 @@ def get_scanner(hass, config):
     elif fos_major_version == 7:
         api_url = "user/device/query"
     else:
-        _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(fos_major_version))
+        _LOGGER.error(
+            "unsupported FortiOS version, fos_major_version =  %s",
+            str(fos_major_version),
+        )
         return None
 
     return FortiOSDeviceScanner(fgt, fos_major_version, api_url)
@@ -94,7 +100,10 @@ class FortiOSDeviceScanner(DeviceScanner):
                     if client["is_online"]:
                         self._clients.append(client["mac"].upper())
             else:
-                _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))
+                _LOGGER.error(
+                    "unsupported FortiOS version, fos_major_version =  %s",
+                    str(self._fos_major_version)
+                )
 
     def scan_devices(self):
         """Scan for new devices and return a list with found device IDs."""
@@ -122,7 +131,10 @@ class FortiOSDeviceScanner(DeviceScanner):
                     elif self._fos_major_version == 7:
                         name = client["hostname"]
                     else:
-                        _LOGGER.error("unsupported FortiOS version, fos_major_version =  %s", str(self._fos_major_version))
+                        _LOGGER.error(
+                            "unsupported FortiOS version, fos_major_version =  %s",
+                            str(self._fos_major_version)
+                        )
                         return None
                     _LOGGER.debug("Getting device name=%s", name)
                     return name

--- a/homeassistant/components/fortios/manifest.json
+++ b/homeassistant/components/fortios/manifest.json
@@ -2,7 +2,7 @@
   "domain": "fortios",
   "name": "FortiOS",
   "documentation": "https://www.home-assistant.io/integrations/fortios/",
-  "requirements": ["fortiosapi==0.10.8"],
+  "requirements": ["fortiosapi==1.0.5"],
   "codeowners": ["@kimfrellsen"],
   "iot_class": "local_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -618,7 +618,7 @@ fnvhash==0.1.0
 foobot_async==1.0.0
 
 # homeassistant.components.fortios
-fortiosapi==0.10.8
+fortiosapi==1.0.5
 
 # homeassistant.components.freebox
 freebox-api==0.0.10


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
Updated fortios device tracker to support FortiOS 7.0.
With the release of FortiOS 7.0, Fortinet has deprecated an API that this integration used.
With this updated the device tracker support both FortiOS 6.x and 7.0.
Over time FortiOS 6.x is expected to be removed.
-->

Upstream changes: https://github.com/fortinet-solutions-cse/fortiosapi/compare/v0.10.8...v1.0.5

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
