### PR TITLE
Add color mode support to WLED

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -237,9 +237,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
     @property
     def rgbw_color(self) -> tuple[int, int, int, int] | None:
         """Return the color value."""
-        if not self._rgbw or not self._wv:
-            return None
-
         return cast(
             Tuple[int, int, int, int],
             self.coordinator.data.state.segments[self._segment].color_primary,

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -221,7 +221,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         }
 
     @property
-    @property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the color value."""
         return self.coordinator.data.state.segments[self._segment].color_primary[:3]

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -230,8 +230,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the color value."""
-        if self._rgbw and self._wv:
-            return None
         return self.coordinator.data.state.segments[self._segment].color_primary[:3]
 
     @property

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -2,23 +2,21 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Any
+from typing import Any, Tuple, cast
 
 import voluptuous as vol
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
     ATTR_EFFECT,
-    ATTR_HS_COLOR,
+    ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
     ATTR_TRANSITION,
-    ATTR_WHITE_VALUE,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_COLOR_TEMP,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_RGB,
+    COLOR_MODE_RGBW,
     SUPPORT_EFFECT,
     SUPPORT_TRANSITION,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -28,7 +26,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import (
     async_get_registry as async_get_entity_registry,
 )
-import homeassistant.util.color as color_util
 
 from . import WLEDDataUpdateCoordinator, WLEDEntity, wled_exception_handler
 from .const import (
@@ -96,14 +93,16 @@ async def async_setup_entry(
 class WLEDMasterLight(WLEDEntity, LightEntity):
     """Defines a WLED master light."""
 
-    _attr_supported_features = SUPPORT_BRIGHTNESS | SUPPORT_TRANSITION
+    _attr_color_mode = COLOR_MODE_BRIGHTNESS
     _attr_icon = "mdi:led-strip-variant"
+    _attr_supported_features = SUPPORT_TRANSITION
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator) -> None:
         """Initialize WLED master light."""
         super().__init__(coordinator=coordinator)
         self._attr_name = f"{coordinator.data.info.name} Master"
         self._attr_unique_id = coordinator.data.info.mac_address
+        self._attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
 
     @property
     def brightness(self) -> int | None:
@@ -165,12 +164,14 @@ class WLEDMasterLight(WLEDEntity, LightEntity):
 class WLEDSegmentLight(WLEDEntity, LightEntity):
     """Defines a WLED light based on a segment."""
 
+    _attr_supported_features = SUPPORT_EFFECT | SUPPORT_TRANSITION
     _attr_icon = "mdi:led-strip-variant"
 
     def __init__(self, coordinator: WLEDDataUpdateCoordinator, segment: int) -> None:
         """Initialize WLED segment light."""
         super().__init__(coordinator=coordinator)
         self._rgbw = coordinator.data.info.leds.rgbw
+        self._wv = coordinator.data.info.leds.wv
         self._segment = segment
 
         # If this is the one and only segment, use a simpler name
@@ -181,6 +182,10 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         self._attr_unique_id = (
             f"{self.coordinator.data.info.mac_address}_{self._segment}"
         )
+
+        self._attr_supported_color_modes = {COLOR_MODE_RGB}
+        if self._rgbw and self._wv:
+            self._attr_supported_color_modes = {COLOR_MODE_RGBW}
 
     @property
     def available(self) -> bool:
@@ -214,10 +219,29 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         }
 
     @property
-    def hs_color(self) -> tuple[float, float]:
-        """Return the hue and saturation color value [float, float]."""
-        color = self.coordinator.data.state.segments[self._segment].color_primary
-        return color_util.color_RGB_to_hs(*color[:3])
+    def color_mode(self) -> str:
+        """Return the color mode of a light."""
+        if self._rgbw and self._wv:
+            return COLOR_MODE_RGBW
+        return COLOR_MODE_RGB
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        """Return the color value."""
+        if self._rgbw and self._wv:
+            return None
+        return self.coordinator.data.state.segments[self._segment].color_primary[:3]
+
+    @property
+    def rgbw_color(self) -> tuple[int, int, int, int] | None:
+        """Return the color value."""
+        if not self._rgbw or not self._wv:
+            return None
+
+        return cast(
+            Tuple[int, int, int, int],
+            self.coordinator.data.state.segments[self._segment].color_primary,
+        )
 
     @property
     def effect(self) -> str | None:
@@ -237,28 +261,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
             )
 
         return state.segments[self._segment].brightness
-
-    @property
-    def white_value(self) -> int | None:
-        """Return the white value of this light between 0..255."""
-        color = self.coordinator.data.state.segments[self._segment].color_primary
-        return color[-1] if self._rgbw else None
-
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        flags = (
-            SUPPORT_BRIGHTNESS
-            | SUPPORT_COLOR
-            | SUPPORT_COLOR_TEMP
-            | SUPPORT_EFFECT
-            | SUPPORT_TRANSITION
-        )
-
-        if self._rgbw:
-            flags |= SUPPORT_WHITE_VALUE
-
-        return flags
 
     @property
     def effect_list(self) -> list[str]:
@@ -301,17 +303,11 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
             ATTR_SEGMENT_ID: self._segment,
         }
 
-        if ATTR_COLOR_TEMP in kwargs:
-            mireds = color_util.color_temperature_kelvin_to_mired(
-                kwargs[ATTR_COLOR_TEMP]
-            )
-            data[ATTR_COLOR_PRIMARY] = tuple(
-                map(int, color_util.color_temperature_to_rgb(mireds))
-            )
+        if ATTR_RGB_COLOR in kwargs:
+            data[ATTR_COLOR_PRIMARY] = kwargs[ATTR_RGB_COLOR]
 
-        if ATTR_HS_COLOR in kwargs:
-            hue, sat = kwargs[ATTR_HS_COLOR]
-            data[ATTR_COLOR_PRIMARY] = color_util.color_hsv_to_RGB(hue, sat, 100)
+        if ATTR_RGBW_COLOR in kwargs:
+            data[ATTR_COLOR_PRIMARY] = kwargs[ATTR_RGBW_COLOR]
 
         if ATTR_TRANSITION in kwargs:
             # WLED uses 100ms per unit, so 10 = 1 second.
@@ -322,27 +318,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
 
         if ATTR_EFFECT in kwargs:
             data[ATTR_EFFECT] = kwargs[ATTR_EFFECT]
-
-        # Support for RGBW strips, adds white value
-        if self._rgbw and any(
-            x in (ATTR_COLOR_TEMP, ATTR_HS_COLOR, ATTR_WHITE_VALUE) for x in kwargs
-        ):
-            # WLED cannot just accept a white value, it needs the color.
-            # We use the last know color in case just the white value changes.
-            if all(x not in (ATTR_COLOR_TEMP, ATTR_HS_COLOR) for x in kwargs):
-                hue, sat = self.hs_color
-                data[ATTR_COLOR_PRIMARY] = color_util.color_hsv_to_RGB(hue, sat, 100)
-
-            # On a RGBW strip, when the color is pure white, disable the RGB LEDs in
-            # WLED by setting RGB to 0,0,0
-            if data[ATTR_COLOR_PRIMARY] == (255, 255, 255):
-                data[ATTR_COLOR_PRIMARY] = (0, 0, 0)
-
-            # Add requested or last known white value
-            if ATTR_WHITE_VALUE in kwargs:
-                data[ATTR_COLOR_PRIMARY] += (kwargs[ATTR_WHITE_VALUE],)
-            else:
-                data[ATTR_COLOR_PRIMARY] += (self.white_value,)
 
         # When only 1 segment is present, switch along the master, and use
         # the master for power/brightness control.

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -221,11 +221,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         }
 
     @property
-    def color_mode(self) -> str:
-        """Return the color mode of a light."""
-        if self._rgbw and self._wv:
-            return COLOR_MODE_RGBW
-        return COLOR_MODE_RGB
 
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -183,8 +183,10 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
             f"{self.coordinator.data.info.mac_address}_{self._segment}"
         )
 
+        self._attr_color_mode = COLOR_MODE_RGB
         self._attr_supported_color_modes = {COLOR_MODE_RGB}
         if self._rgbw and self._wv:
+            self._attr_color_mode = COLOR_MODE_RGBW
             self._attr_supported_color_modes = {COLOR_MODE_RGBW}
 
     @property

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -221,7 +221,6 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         }
 
     @property
-
     @property
     def rgb_color(self) -> tuple[int, int, int] | None:
         """Return the color value."""

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -6,12 +6,11 @@ from wled import Device as WLEDDevice, WLEDConnectionError
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_TEMP,
     ATTR_EFFECT,
     ATTR_HS_COLOR,
     ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
     ATTR_TRANSITION,
-    ATTR_WHITE_VALUE,
     DOMAIN as LIGHT_DOMAIN,
 )
 from homeassistant.components.wled import SCAN_INTERVAL
@@ -142,20 +141,6 @@ async def test_segment_change_state(
             on=True,
             segment_id=0,
             transition=50,
-        )
-
-    with patch("wled.WLED.segment") as light_mock:
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_COLOR_TEMP: 400},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        light_mock.assert_called_once_with(
-            color_primary=(255, 159, 70),
-            on=True,
-            segment_id=0,
         )
 
 
@@ -394,36 +379,7 @@ async def test_rgbw_light(
 
     state = hass.states.get("light.wled_rgbw_light")
     assert state.state == STATE_ON
-    assert state.attributes.get(ATTR_HS_COLOR) == (0.0, 100.0)
-    assert state.attributes.get(ATTR_WHITE_VALUE) == 139
-
-    with patch("wled.WLED.segment") as light_mock:
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "light.wled_rgbw_light", ATTR_COLOR_TEMP: 400},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        light_mock.assert_called_once_with(
-            on=True,
-            segment_id=0,
-            color_primary=(255, 159, 70, 139),
-        )
-
-    with patch("wled.WLED.segment") as light_mock:
-        await hass.services.async_call(
-            LIGHT_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "light.wled_rgbw_light", ATTR_WHITE_VALUE: 100},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        light_mock.assert_called_once_with(
-            color_primary=(255, 0, 0, 100),
-            on=True,
-            segment_id=0,
-        )
+    assert state.attributes.get(ATTR_RGBW_COLOR) == (255, 0, 0, 139)
 
     with patch("wled.WLED.segment") as light_mock:
         await hass.services.async_call(
@@ -431,14 +387,13 @@ async def test_rgbw_light(
             SERVICE_TURN_ON,
             {
                 ATTR_ENTITY_ID: "light.wled_rgbw_light",
-                ATTR_RGB_COLOR: (255, 255, 255),
-                ATTR_WHITE_VALUE: 100,
+                ATTR_RGBW_COLOR: (255, 255, 255, 255),
             },
             blocking=True,
         )
         await hass.async_block_till_done()
         light_mock.assert_called_once_with(
-            color_primary=(0, 0, 0, 100),
+            color_primary=(255, 255, 255, 255),
             on=True,
             segment_id=0,
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

With the latest updates to the upstream library, we now know if the WLED is actually in RGBW or RGB mode. And thanks to the new color modes in HA, we don't have to juggle with colors anymore.

This PR implements the new color modes for WLED, removing all workarounds and junk 😃 

Verified with aircoookie, that we should handle RGBW + White Value enabled as RGBW, if WV is not enabled, we should use RGB even if the strip is RGBW.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
