### PR TITLE
Remove reverse_order (replaced by generic swap)

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -242,12 +242,14 @@ LIGHT_SCHEMA = BASE_SWITCH_SCHEMA.extend({})
 
 FAN_SCHEMA = BASE_SWITCH_SCHEMA.extend({})
 
-SENSOR_SCHEMA = BASE_STRUCT_SCHEMA.extend(
-    {
-        vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
-        vol.deprecated(CONF_REVERSE_ORDER): cv.boolean,
-        vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
-    }
+SENSOR_SCHEMA = vol.All(
+    cv.deprecated(CONF_REVERSE_ORDER),
+    BASE_STRUCT_SCHEMA.extend(
+        {
+            vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
+            vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+        }
+    ),
 )
 
 BINARY_SENSOR_SCHEMA = BASE_COMPONENT_SCHEMA.extend(

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -68,6 +68,7 @@ from .const import (
     CONF_PRECISION,
     CONF_RETRIES,
     CONF_RETRY_ON_EMPTY,
+    CONF_REVERSE_ORDER,
     CONF_SCALE,
     CONF_STATE_CLOSED,
     CONF_STATE_CLOSING,
@@ -244,6 +245,7 @@ FAN_SCHEMA = BASE_SWITCH_SCHEMA.extend({})
 SENSOR_SCHEMA = BASE_STRUCT_SCHEMA.extend(
     {
         vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
+        vol.deprecated(CONF_REVERSE_ORDER): cv.boolean,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     }
 )

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -248,6 +248,7 @@ SENSOR_SCHEMA = vol.All(
         {
             vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
             vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+            vol.Optional(CONF_REVERSE_ORDER): cv.boolean,
         }
     ),
 )

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -68,7 +68,6 @@ from .const import (
     CONF_PRECISION,
     CONF_RETRIES,
     CONF_RETRY_ON_EMPTY,
-    CONF_REVERSE_ORDER,
     CONF_SCALE,
     CONF_STATE_CLOSED,
     CONF_STATE_CLOSING,
@@ -245,7 +244,6 @@ FAN_SCHEMA = BASE_SWITCH_SCHEMA.extend({})
 SENSOR_SCHEMA = BASE_STRUCT_SCHEMA.extend(
     {
         vol.Optional(CONF_DEVICE_CLASS): SENSOR_DEVICE_CLASSES_SCHEMA,
-        vol.Optional(CONF_REVERSE_ORDER): cv.boolean,
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
     }
 )

--- a/homeassistant/components/modbus/validators.py
+++ b/homeassistant/components/modbus/validators.py
@@ -17,11 +17,9 @@ from homeassistant.const import (
 
 from .const import (
     CONF_DATA_TYPE,
-    CONF_REVERSE_ORDER,
     CONF_SWAP,
     CONF_SWAP_BYTE,
     CONF_SWAP_NONE,
-    CONF_SWAP_WORD,
     DATA_TYPE_CUSTOM,
     DATA_TYPE_STRING,
     DEFAULT_SCAN_INTERVAL,
@@ -70,13 +68,6 @@ def sensor_schema_validator(config):
         )
 
     swap_type = config.get(CONF_SWAP)
-
-    if CONF_REVERSE_ORDER in config:
-        if config[CONF_REVERSE_ORDER]:
-            swap_type = CONF_SWAP_WORD
-        else:
-            swap_type = CONF_SWAP_NONE
-        del config[CONF_REVERSE_ORDER]
 
     if config.get(CONF_SWAP) != CONF_SWAP_NONE:
         if swap_type == CONF_SWAP_BYTE:

--- a/tests/components/modbus/test_init.py
+++ b/tests/components/modbus/test_init.py
@@ -41,7 +41,6 @@ from homeassistant.components.modbus.const import (
     CONF_DATA_TYPE,
     CONF_INPUT_TYPE,
     CONF_PARITY,
-    CONF_REVERSE_ORDER,
     CONF_STOPBITS,
     CONF_SWAP,
     CONF_SWAP_BYTE,
@@ -136,13 +135,6 @@ async def test_number_validator():
             CONF_NAME: TEST_SENSOR_NAME,
             CONF_COUNT: 2,
             CONF_DATA_TYPE: DATA_TYPE_INT,
-            CONF_REVERSE_ORDER: True,
-        },
-        {
-            CONF_NAME: TEST_SENSOR_NAME,
-            CONF_COUNT: 2,
-            CONF_DATA_TYPE: DATA_TYPE_INT,
-            CONF_REVERSE_ORDER: False,
         },
         {
             CONF_NAME: TEST_SENSOR_NAME,

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -10,7 +10,6 @@ from homeassistant.components.modbus.const import (
     CONF_INPUT_TYPE,
     CONF_PRECISION,
     CONF_REGISTERS,
-    CONF_REVERSE_ORDER,
     CONF_SCALE,
     CONF_SWAP,
     CONF_SWAP_BYTE,
@@ -55,7 +54,6 @@ from tests.common import mock_restore_cache
             CONF_DATA_TYPE: "int",
             CONF_PRECISION: 0,
             CONF_SCALE: 1,
-            CONF_REVERSE_ORDER: False,
             CONF_OFFSET: 0,
             CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
             CONF_DEVICE_CLASS: "battery",
@@ -67,7 +65,6 @@ from tests.common import mock_restore_cache
             CONF_DATA_TYPE: "int",
             CONF_PRECISION: 0,
             CONF_SCALE: 1,
-            CONF_REVERSE_ORDER: False,
             CONF_OFFSET: 0,
             CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
             CONF_DEVICE_CLASS: "battery",
@@ -330,15 +327,6 @@ async def test_config_wrong_struct_sensor(
             },
             [0x89AB, 0xCDEF],
             str(0x89ABCDEF),
-        ),
-        (
-            {
-                CONF_COUNT: 2,
-                CONF_DATA_TYPE: DATA_TYPE_UINT,
-                CONF_REVERSE_ORDER: True,
-            },
-            [0x89AB, 0xCDEF],
-            str(0xCDEF89AB),
         ),
         (
             {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Modbus sensor ‘reverse_order’ is no longer supported, please use ‘swap’ instead.

Old configuration:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    sensors:
      - name: Sensor1
        address: 100
        reverse_order: true
```

New configuration:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    sensors:
      - name: Sensor1
        address: 100
        swap: word
```



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In 2021.6 reverse_order was removed from the documentation, now it is being removed from the code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:
Already in ‘current’

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
