### PR TITLE
Add swap to climate and change data_count -> count in modbus

### DIFF
--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -58,6 +58,7 @@ from .const import (
     CONF_BYTESIZE,
     CONF_CLIMATES,
     CONF_CLOSE_COMM_ON_ERROR,
+    CONF_DATA_COUNT,
     CONF_DATA_TYPE,
     CONF_FANS,
     CONF_INPUT_TYPE,
@@ -186,31 +187,34 @@ BASE_SWITCH_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
 )
 
 
-CLIMATE_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
-    {
-        vol.Optional(CONF_INPUT_TYPE, default=CALL_TYPE_REGISTER_HOLDING): vol.In(
-            [
-                CALL_TYPE_REGISTER_HOLDING,
-                CALL_TYPE_REGISTER_INPUT,
-            ]
-        ),
-        vol.Required(CONF_TARGET_TEMP): cv.positive_int,
-        vol.Optional(CONF_COUNT, default=2): cv.positive_int,
-        vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT): vol.In(
-            [DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT, DATA_TYPE_CUSTOM]
-        ),
-        vol.Optional(CONF_PRECISION, default=1): cv.positive_int,
-        vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
-        vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
-        vol.Optional(CONF_MAX_TEMP, default=35): cv.positive_int,
-        vol.Optional(CONF_MIN_TEMP, default=5): cv.positive_int,
-        vol.Optional(CONF_STEP, default=0.5): vol.Coerce(float),
-        vol.Optional(CONF_STRUCTURE, default=DEFAULT_STRUCTURE_PREFIX): cv.string,
-        vol.Optional(CONF_TEMPERATURE_UNIT, default=DEFAULT_TEMP_UNIT): cv.string,
-        vol.Optional(CONF_SWAP, default=CONF_SWAP_NONE): vol.In(
-            [CONF_SWAP_NONE, CONF_SWAP_BYTE, CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]
-        ),
-    }
+CLIMATE_SCHEMA = vol.All(
+    cv.deprecated(CONF_DATA_COUNT, replacement_key=CONF_COUNT),
+    BASE_COMPONENT_SCHEMA.extend(
+        {
+            vol.Optional(CONF_INPUT_TYPE, default=CALL_TYPE_REGISTER_HOLDING): vol.In(
+                [
+                    CALL_TYPE_REGISTER_HOLDING,
+                    CALL_TYPE_REGISTER_INPUT,
+                ]
+            ),
+            vol.Required(CONF_TARGET_TEMP): cv.positive_int,
+            vol.Optional(CONF_COUNT, default=2): cv.positive_int,
+            vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT): vol.In(
+                [DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT, DATA_TYPE_CUSTOM]
+            ),
+            vol.Optional(CONF_PRECISION, default=1): cv.positive_int,
+            vol.Optional(CONF_SCALE, default=1): vol.Coerce(float),
+            vol.Optional(CONF_OFFSET, default=0): vol.Coerce(float),
+            vol.Optional(CONF_MAX_TEMP, default=35): cv.positive_int,
+            vol.Optional(CONF_MIN_TEMP, default=5): cv.positive_int,
+            vol.Optional(CONF_STEP, default=0.5): vol.Coerce(float),
+            vol.Optional(CONF_STRUCTURE, default=DEFAULT_STRUCTURE_PREFIX): cv.string,
+            vol.Optional(CONF_TEMPERATURE_UNIT, default=DEFAULT_TEMP_UNIT): cv.string,
+            vol.Optional(CONF_SWAP, default=CONF_SWAP_NONE): vol.In(
+                [CONF_SWAP_NONE, CONF_SWAP_BYTE, CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]
+            ),
+        }
+    ),
 )
 
 COVERS_SCHEMA = BASE_COMPONENT_SCHEMA.extend(

--- a/homeassistant/components/modbus/__init__.py
+++ b/homeassistant/components/modbus/__init__.py
@@ -58,7 +58,6 @@ from .const import (
     CONF_BYTESIZE,
     CONF_CLIMATES,
     CONF_CLOSE_COMM_ON_ERROR,
-    CONF_DATA_COUNT,
     CONF_DATA_TYPE,
     CONF_FANS,
     CONF_INPUT_TYPE,
@@ -196,7 +195,7 @@ CLIMATE_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
             ]
         ),
         vol.Required(CONF_TARGET_TEMP): cv.positive_int,
-        vol.Optional(CONF_DATA_COUNT, default=2): cv.positive_int,
+        vol.Optional(CONF_COUNT, default=2): cv.positive_int,
         vol.Optional(CONF_DATA_TYPE, default=DATA_TYPE_FLOAT): vol.In(
             [DATA_TYPE_INT, DATA_TYPE_UINT, DATA_TYPE_FLOAT, DATA_TYPE_CUSTOM]
         ),
@@ -208,6 +207,9 @@ CLIMATE_SCHEMA = BASE_COMPONENT_SCHEMA.extend(
         vol.Optional(CONF_STEP, default=0.5): vol.Coerce(float),
         vol.Optional(CONF_STRUCTURE, default=DEFAULT_STRUCTURE_PREFIX): cv.string,
         vol.Optional(CONF_TEMPERATURE_UNIT, default=DEFAULT_TEMP_UNIT): cv.string,
+        vol.Optional(CONF_SWAP, default=CONF_SWAP_NONE): vol.In(
+            [CONF_SWAP_NONE, CONF_SWAP_BYTE, CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]
+        ),
     }
 )
 

--- a/homeassistant/components/modbus/climate.py
+++ b/homeassistant/components/modbus/climate.py
@@ -11,6 +11,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_TARGET_TEMPERATURE,
 )
 from homeassistant.const import (
+    CONF_COUNT,
     CONF_NAME,
     CONF_OFFSET,
     CONF_STRUCTURE,
@@ -28,13 +29,16 @@ from .const import (
     CALL_TYPE_REGISTER_HOLDING,
     CALL_TYPE_WRITE_REGISTERS,
     CONF_CLIMATES,
-    CONF_DATA_COUNT,
     CONF_DATA_TYPE,
     CONF_MAX_TEMP,
     CONF_MIN_TEMP,
     CONF_PRECISION,
     CONF_SCALE,
     CONF_STEP,
+    CONF_SWAP,
+    CONF_SWAP_BYTE,
+    CONF_SWAP_WORD,
+    CONF_SWAP_WORD_BYTE,
     CONF_TARGET_TEMP,
     DATA_TYPE_CUSTOM,
     DEFAULT_STRUCT_FORMAT,
@@ -59,7 +63,7 @@ async def async_setup_platform(
     entities = []
     for entity in discovery_info[CONF_CLIMATES]:
         hub: ModbusHub = hass.data[MODBUS_DOMAIN][discovery_info[CONF_NAME]]
-        count = entity[CONF_DATA_COUNT]
+        count = entity[CONF_COUNT]
         data_type = entity[CONF_DATA_TYPE]
         name = entity[CONF_NAME]
         structure = entity[CONF_STRUCTURE]
@@ -110,7 +114,7 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         self._current_temperature = None
         self._data_type = config[CONF_DATA_TYPE]
         self._structure = config[CONF_STRUCTURE]
-        self._count = config[CONF_DATA_COUNT]
+        self._count = config[CONF_COUNT]
         self._precision = config[CONF_PRECISION]
         self._scale = config[CONF_SCALE]
         self._offset = config[CONF_OFFSET]
@@ -118,6 +122,7 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         self._max_temp = config[CONF_MAX_TEMP]
         self._min_temp = config[CONF_MIN_TEMP]
         self._temp_step = config[CONF_STEP]
+        self._swap = config[CONF_SWAP]
 
     async def async_added_to_hass(self):
         """Handle entity which will be added."""
@@ -194,6 +199,21 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
         self._available = result is not None
         await self.async_update()
 
+    def _swap_registers(self, registers):
+        """Do swap as needed."""
+        if self._swap in [CONF_SWAP_BYTE, CONF_SWAP_WORD_BYTE]:
+            # convert [12][34] --> [21][43]
+            for i, register in enumerate(registers):
+                registers[i] = int.from_bytes(
+                    register.to_bytes(2, byteorder="little"),
+                    byteorder="big",
+                    signed=False,
+                )
+        if self._swap in [CONF_SWAP_WORD, CONF_SWAP_WORD_BYTE]:
+            # convert [12][34] ==> [34][12]
+            registers.reverse()
+        return registers
+
     async def async_update(self, now=None):
         """Update Target & Current Temperature."""
         # remark "now" is a dummy parameter to avoid problems with
@@ -216,9 +236,8 @@ class ModbusThermostat(BasePlatform, RestoreEntity, ClimateEntity):
             self._available = False
             return -1
 
-        byte_string = b"".join(
-            [x.to_bytes(2, byteorder="big") for x in result.registers]
-        )
+        registers = self._swap_registers(result.registers)
+        byte_string = b"".join([x.to_bytes(2, byteorder="big") for x in registers])
         val = struct.unpack(self._structure, byte_string)
         if len(val) != 1 or not isinstance(val[0], (float, int)):
             _LOGGER.error(

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -3,14 +3,11 @@ import pytest
 
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.climate.const import HVAC_MODE_AUTO
-from homeassistant.components.modbus.const import (
-    CONF_CLIMATES,
-    CONF_DATA_COUNT,
-    CONF_TARGET_TEMP,
-)
+from homeassistant.components.modbus.const import CONF_CLIMATES, CONF_TARGET_TEMP
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_ADDRESS,
+    CONF_COUNT,
     CONF_NAME,
     CONF_SCAN_INTERVAL,
     CONF_SLAVE,
@@ -28,7 +25,7 @@ from tests.common import mock_restore_cache
         {},
         {
             CONF_SCAN_INTERVAL: 20,
-            CONF_DATA_COUNT: 2,
+            CONF_COUNT: 2,
         },
     ],
 )
@@ -73,7 +70,7 @@ async def test_temperature_climate(hass, regs, expected):
             CONF_SLAVE: 1,
             CONF_TARGET_TEMP: 117,
             CONF_ADDRESS: 117,
-            CONF_DATA_COUNT: 2,
+            CONF_COUNT: 2,
         },
         climate_name,
         CLIMATE_DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
‘data_count’ is no longer supported, please use ‘count’

No longer supported:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    climates:
      - name: "Watlow F4T"
        address: 27586
        input_type: holding
        data_count: 1
        data_type: custom
        max_temp: 35
        min_temp: 15
        offset: 0
        precision: 1
        scale: 0.1
        max_temp: 30
        structure: ">f"
        target_temp_register: 2782
        temp_step: 1
        temperature_unit: C
```

Please change to:
```yaml
modbus:
  - name: hub1
    type: tcp
    host: IP_ADDRESS
    port: 502
    climates:
      - name: "Watlow F4T"
        address: 27586
        input_type: holding
        count: 1
        data_type: custom
        max_temp: 35
        min_temp: 15
        offset: 0
        precision: 1
        scale: 0.1
        max_temp: 30
        structure: ">f"
        target_temp_register: 2782
        temp_step: 1
        temperature_unit: C
```
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow climate to have the same options as sensor, and prepare to share code.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
https://github.com/home-assistant/home-assistant.io/pull/18136

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
