### PR TITLE
Add trigger condition

### DIFF
--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -945,7 +945,7 @@ async def async_trigger_from_config(
         return (
             variables is not None
             and "trigger" in variables
-            and variables["trigger"].get["id"] == trigger_id
+            and variables["trigger"].get("id") in trigger_id
         )
 
     return trigger_if

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     CONF_DEVICE_ID,
     CONF_DOMAIN,
     CONF_ENTITY_ID,
+    CONF_ID,
     CONF_STATE,
     CONF_VALUE_TEMPLATE,
     CONF_WEEKDAY,
@@ -928,6 +929,26 @@ async def async_device_from_config(
             platform.async_condition_from_config(config, config_validation),  # type: ignore
         )
     )
+
+
+async def async_trigger_from_config(
+    hass: HomeAssistant, config: ConfigType, config_validation: bool = True
+) -> ConditionCheckerType:
+    """Test a trigger condition."""
+    if config_validation:
+        config = cv.TRIGGER_CONDITION_SCHEMA(config)
+    trigger_id = config[CONF_ID]
+
+    @trace_condition_function
+    def trigger_if(hass: HomeAssistant, variables: TemplateVarsType = None) -> bool:
+        """Validate trigger based if-condition."""
+        return (
+            variables is not None
+            and "trigger" in variables
+            and variables["trigger"].get["id"] == trigger_id
+        )
+
+    return trigger_if
 
 
 async def async_validate_condition_config(

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -1030,7 +1030,8 @@ TIME_CONDITION_SCHEMA = vol.All(
 TRIGGER_CONDITION_SCHEMA = vol.Schema(
     {
         **CONDITION_BASE_SCHEMA,
-        vol.Required("trigger_id"): str,
+        vol.Required(CONF_CONDITION): "trigger",
+        vol.Required(CONF_ID): vol.All(ensure_list, [string]),
     }
 )
 
@@ -1098,16 +1099,17 @@ CONDITION_SCHEMA: vol.Schema = vol.Schema(
         key_value_schemas(
             CONF_CONDITION,
             {
+                "and": AND_CONDITION_SCHEMA,
+                "device": DEVICE_CONDITION_SCHEMA,
+                "not": NOT_CONDITION_SCHEMA,
                 "numeric_state": NUMERIC_STATE_CONDITION_SCHEMA,
+                "or": OR_CONDITION_SCHEMA,
                 "state": STATE_CONDITION_SCHEMA,
                 "sun": SUN_CONDITION_SCHEMA,
                 "template": TEMPLATE_CONDITION_SCHEMA,
                 "time": TIME_CONDITION_SCHEMA,
+                "trigger": TRIGGER_CONDITION_SCHEMA,
                 "zone": ZONE_CONDITION_SCHEMA,
-                "and": AND_CONDITION_SCHEMA,
-                "or": OR_CONDITION_SCHEMA,
-                "not": NOT_CONDITION_SCHEMA,
-                "device": DEVICE_CONDITION_SCHEMA,
             },
         ),
         dynamic_template,

--- a/homeassistant/helpers/config_validation.py
+++ b/homeassistant/helpers/config_validation.py
@@ -45,6 +45,7 @@ from homeassistant.const import (
     CONF_EVENT_DATA,
     CONF_EVENT_DATA_TEMPLATE,
     CONF_FOR,
+    CONF_ID,
     CONF_PLATFORM,
     CONF_REPEAT,
     CONF_SCAN_INTERVAL,
@@ -1026,6 +1027,13 @@ TIME_CONDITION_SCHEMA = vol.All(
     has_at_least_one_key("before", "after", "weekday"),
 )
 
+TRIGGER_CONDITION_SCHEMA = vol.Schema(
+    {
+        **CONDITION_BASE_SCHEMA,
+        vol.Required("trigger_id"): str,
+    }
+)
+
 ZONE_CONDITION_SCHEMA = vol.Schema(
     {
         **CONDITION_BASE_SCHEMA,
@@ -1106,7 +1114,9 @@ CONDITION_SCHEMA: vol.Schema = vol.Schema(
     )
 )
 
-TRIGGER_BASE_SCHEMA = vol.Schema({vol.Required(CONF_PLATFORM): str})
+TRIGGER_BASE_SCHEMA = vol.Schema(
+    {vol.Required(CONF_PLATFORM): str, vol.Optional(CONF_ID): str}
+)
 
 TRIGGER_SCHEMA = vol.All(
     ensure_list, [TRIGGER_BASE_SCHEMA.extend({}, extra=vol.ALLOW_EXTRA)]

--- a/homeassistant/helpers/trigger.py
+++ b/homeassistant/helpers/trigger.py
@@ -8,7 +8,7 @@ from typing import Any, Callable
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_PLATFORM
+from homeassistant.const import CONF_ID, CONF_PLATFORM
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType
@@ -74,7 +74,8 @@ async def async_initialize_triggers(
     triggers = []
     for idx, conf in enumerate(trigger_config):
         platform = await _async_get_trigger_platform(hass, conf)
-        info = {**info, "trigger_id": f"{idx}"}
+        trigger_id = conf.get(CONF_ID, f"{idx}")
+        info = {**info, "trigger_id": trigger_id}
         triggers.append(platform.async_attach_trigger(hass, conf, action, info))
 
     attach_results = await asyncio.gather(*triggers, return_exceptions=True)

--- a/tests/components/automation/test_init.py
+++ b/tests/components/automation/test_init.py
@@ -1405,3 +1405,97 @@ async def test_trigger_service(hass, calls):
     assert len(calls) == 1
     assert calls[0].data.get("trigger") == {"platform": None}
     assert calls[0].context.parent_id is context.id
+
+
+async def test_trigger_condition_implicit_id(hass, calls):
+    """Test triggers."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": [
+                    {"platform": "event", "event_type": "test_event1"},
+                    {"platform": "event", "event_type": "test_event2"},
+                    {"platform": "event", "event_type": "test_event3"},
+                ],
+                "action": {
+                    "choose": [
+                        {
+                            "conditions": {"condition": "trigger", "id": [0, "2"]},
+                            "sequence": {
+                                "service": "test.automation",
+                                "data": {"param": "one"},
+                            },
+                        },
+                        {
+                            "conditions": {"condition": "trigger", "id": "1"},
+                            "sequence": {
+                                "service": "test.automation",
+                                "data": {"param": "two"},
+                            },
+                        },
+                    ]
+                },
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[-1].data.get("param") == "one"
+
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[-1].data.get("param") == "two"
+
+    hass.bus.async_fire("test_event3")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[-1].data.get("param") == "one"
+
+
+async def test_trigger_condition_explicit_id(hass, calls):
+    """Test triggers."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: {
+                "trigger": [
+                    {"platform": "event", "event_type": "test_event1", "id": "one"},
+                    {"platform": "event", "event_type": "test_event2", "id": "two"},
+                ],
+                "action": {
+                    "choose": [
+                        {
+                            "conditions": {"condition": "trigger", "id": "one"},
+                            "sequence": {
+                                "service": "test.automation",
+                                "data": {"param": "one"},
+                            },
+                        },
+                        {
+                            "conditions": {"condition": "trigger", "id": "two"},
+                            "sequence": {
+                                "service": "test.automation",
+                                "data": {"param": "two"},
+                            },
+                        },
+                    ]
+                },
+            }
+        },
+    )
+
+    hass.bus.async_fire("test_event1")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[-1].data.get("param") == "one"
+
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[-1].data.get("param") == "two"

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -2829,3 +2829,17 @@ async def test_if_action_after_sunset_no_offset_kotzebue(hass, hass_ws_client, c
         "sun",
         {"result": True, "wanted_time_after": "2015-07-23T11:22:18.467277+00:00"},
     )
+
+
+async def test_trigger(hass):
+    """Test trigger condition."""
+    test = await condition.async_from_config(
+        hass,
+        {"alias": "Trigger Cond", "condition": "trigger", "id": "123456"},
+    )
+
+    assert not test(hass)
+    assert not test(hass, {})
+    assert not test(hass, {"other_var": "123456"})
+    assert not test(hass, {"trigger": {"trigger_id": "123456"}})
+    assert test(hass, {"trigger": {"id": "123456"}})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add a new `trigger` condition to test if an automation was started by a certain trigger, the trigger is identified by its index or by an optional id.
Make it possible to assign an `id` to automation triggers. If no `id` is specified, the id will be assigned the index of the trigger, converted to a string.

### Example
```yaml
trigger:
  - platform: event
    event_type: test_event_1
    id: event_1_trigger
  - platform: event
    event_type: test_event_2
    id: event_2_trigger
  - platform: event
    event_type: test_event_3
action:
  - choose:
      - conditions:
        - condition: trigger
          id:
            - event_1_trigger
            - event_2_trigger
        sequence:
         - service: blabla
      - conditions:
        - condition: trigger
          id: "2" # The number `2` is also allowed
        sequence:
         - service: blabla
```

This enables the automation editor to automatically assign an `id` to each added trigger, as well as allowing the user to add a condition "triggered by" and select one of the triggers defined in the automation.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:
  - https://github.com/home-assistant/home-assistant.io/pull/18159
  - https://github.com/home-assistant/home-assistant.io/pull/18160

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
