### PR TITLE
Improve error when HomeKit accessory underlying entity is missing

### DIFF
--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -54,7 +54,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import State
 from homeassistant.helpers import device_registry
-from homeassistant.helpers.entityfilter import generate_filter
+from homeassistant.helpers.entityfilter import (
+    CONF_EXCLUDE_DOMAINS,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_EXCLUDE_ENTITY_GLOBS,
+    CONF_INCLUDE_DOMAINS,
+    CONF_INCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITY_GLOBS,
+    convert_filter,
+)
 from homeassistant.setup import async_setup_component
 from homeassistant.util import json as json_util
 
@@ -63,6 +71,27 @@ from .util import PATH_HOMEKIT, async_init_entry, async_init_integration
 from tests.common import MockConfigEntry, mock_device_registry, mock_registry
 
 IP_ADDRESS = "127.0.0.1"
+
+
+def generate_filter(
+    include_domains,
+    include_entities,
+    exclude_domains,
+    exclude_entites,
+    include_globs=None,
+    exclude_globs=None,
+):
+    """Generate an entity filter using the standard method."""
+    return convert_filter(
+        {
+            CONF_INCLUDE_DOMAINS: include_domains,
+            CONF_INCLUDE_ENTITIES: include_entities,
+            CONF_EXCLUDE_DOMAINS: exclude_domains,
+            CONF_EXCLUDE_ENTITIES: exclude_entites,
+            CONF_INCLUDE_ENTITY_GLOBS: include_globs or [],
+            CONF_EXCLUDE_ENTITY_GLOBS: exclude_globs or [],
+        }
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -1171,6 +1200,31 @@ async def test_homekit_start_in_accessory_mode(
     )
     assert hk_driver_start.called
     assert homekit.status == STATUS_RUNNING
+
+
+async def test_homekit_start_in_accessory_mode_missing_entity(
+    hass, hk_driver, mock_zeroconf, device_reg, caplog
+):
+    """Test HomeKit start method in accessory mode."""
+    entry = await async_init_integration(hass)
+
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_ACCESSORY)
+
+    homekit.bridge = Mock()
+    homekit.bridge.accessories = []
+    homekit.driver = hk_driver
+    homekit.driver.accessory = Accessory(hk_driver, "any")
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit.add_bridge_accessory") as mock_add_acc, patch(
+        f"{PATH_HOMEKIT}.show_setup_message"
+    ), patch("pyhap.accessory_driver.AccessoryDriver.async_start"):
+        await homekit.async_start()
+
+    await hass.async_block_till_done()
+    mock_add_acc.assert_not_called()
+    assert homekit.status == STATUS_WAIT
+
+    assert "entity not available" in caplog.text
 
 
 async def test_wait_for_port_to_free(hass, hk_driver, mock_zeroconf, caplog):

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1205,7 +1205,7 @@ async def test_homekit_start_in_accessory_mode(
 async def test_homekit_start_in_accessory_mode_missing_entity(
     hass, hk_driver, mock_zeroconf, device_reg, caplog
 ):
-    """Test HomeKit start method in accessory mode."""
+    """Test HomeKit start method in accessory mode when entity is not available."""
     entry = await async_init_integration(hass)
 
     homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_ACCESSORY)


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve error when HomeKit accessory underlying entity is missing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51699
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
