### PR TITLE
Refactor zwave_js config flow

### DIFF
--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for Z-Wave JS integration."""
 from __future__ import annotations
 
+from abc import abstractmethod
 import asyncio
 import logging
 from typing import Any
@@ -14,7 +15,12 @@ from homeassistant import config_entries, exceptions
 from homeassistant.components.hassio import is_hassio
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
+from homeassistant.data_entry_flow import (
+    AbortFlow,
+    FlowHandler,
+    FlowManager,
+    FlowResult,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .addon import AddonError, AddonInfo, AddonManager, AddonState, get_addon_manager
@@ -39,6 +45,12 @@ SERVER_VERSION_TIMEOUT = 10
 
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
 STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_URL, default=DEFAULT_URL): str})
+
+
+def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:
+    """Return a schema for the manual step."""
+    default_url = user_input.get(CONF_URL, DEFAULT_URL)
+    return vol.Schema({vol.Required(CONF_URL, default=default_url): str})
 
 
 async def validate_input(hass: HomeAssistant, user_input: dict) -> VersionInfo:
@@ -70,135 +82,24 @@ async def async_get_version_info(hass: HomeAssistant, ws_address: str) -> Versio
     return version_info
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Z-Wave JS."""
-
-    VERSION = 1
+class BaseZwaveJSFlow(FlowHandler):
+    """Represent the base config flow for Z-Wave JS."""
 
     def __init__(self) -> None:
         """Set up flow instance."""
         self.network_key: str | None = None
         self.usb_path: str | None = None
-        self.use_addon = False
         self.ws_address: str | None = None
         # If we install the add-on we should uninstall it on entry remove.
         self.integration_created_addon = False
         self.install_task: asyncio.Task | None = None
         self.start_task: asyncio.Task | None = None
+        self.version_info: VersionInfo | None = None
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle the initial step."""
-        if is_hassio(self.hass):
-            return await self.async_step_on_supervisor()
-
-        return await self.async_step_manual()
-
-    async def async_step_manual(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle a manual configuration."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="manual", data_schema=STEP_USER_DATA_SCHEMA
-            )
-
-        errors = {}
-
-        try:
-            version_info = await validate_input(self.hass, user_input)
-        except InvalidInput as err:
-            errors["base"] = err.error
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-        else:
-            await self.async_set_unique_id(
-                version_info.home_id, raise_on_progress=False
-            )
-            # Make sure we disable any add-on handling
-            # if the controller is reconfigured in a manual step.
-            self._abort_if_unique_id_configured(
-                updates={
-                    **user_input,
-                    CONF_USE_ADDON: False,
-                    CONF_INTEGRATION_CREATED_ADDON: False,
-                }
-            )
-            self.ws_address = user_input[CONF_URL]
-            return self._async_create_entry_from_vars()
-
-        return self.async_show_form(
-            step_id="manual", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-        )
-
-    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
-        """Receive configuration from add-on discovery info.
-
-        This flow is triggered by the Z-Wave JS add-on.
-        """
-        self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
-        try:
-            version_info = await async_get_version_info(self.hass, self.ws_address)
-        except CannotConnect:
-            return self.async_abort(reason="cannot_connect")
-
-        await self.async_set_unique_id(version_info.home_id)
-        self._abort_if_unique_id_configured(updates={CONF_URL: self.ws_address})
-
-        return await self.async_step_hassio_confirm()
-
-    async def async_step_hassio_confirm(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Confirm the add-on discovery."""
-        if user_input is not None:
-            return await self.async_step_on_supervisor(
-                user_input={CONF_USE_ADDON: True}
-            )
-
-        return self.async_show_form(step_id="hassio_confirm")
-
-    @callback
-    def _async_create_entry_from_vars(self) -> FlowResult:
-        """Return a config entry for the flow."""
-        return self.async_create_entry(
-            title=TITLE,
-            data={
-                CONF_URL: self.ws_address,
-                CONF_USB_PATH: self.usb_path,
-                CONF_NETWORK_KEY: self.network_key,
-                CONF_USE_ADDON: self.use_addon,
-                CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
-            },
-        )
-
-    async def async_step_on_supervisor(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Handle logic when on Supervisor host."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
-            )
-        if not user_input[CONF_USE_ADDON]:
-            return await self.async_step_manual()
-
-        self.use_addon = True
-
-        addon_info = await self._async_get_addon_info()
-
-        if addon_info.state == AddonState.RUNNING:
-            addon_config = addon_info.options
-            self.usb_path = addon_config[CONF_ADDON_DEVICE]
-            self.network_key = addon_config.get(CONF_ADDON_NETWORK_KEY, "")
-            return await self.async_step_finish_addon_setup()
-
-        if addon_info.state == AddonState.NOT_RUNNING:
-            return await self.async_step_configure_addon()
-
-        return await self.async_step_install_addon()
+    @property
+    @abstractmethod
+    def flow_manager(args) -> FlowManager:
+        """Return the flow manager of the flow."""
 
     async def async_step_install_addon(
         self, user_input: dict[str, Any] | None = None
@@ -213,10 +114,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await self.install_task
         except AddonError as err:
+            self.install_task = None
             _LOGGER.error(err)
             return self.async_show_progress_done(next_step_id="install_failed")
 
         self.integration_created_addon = True
+        self.install_task = None
 
         return self.async_show_progress_done(next_step_id="configure_addon")
 
@@ -225,43 +128,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Add-on installation failed."""
         return self.async_abort(reason="addon_install_failed")
-
-    async def async_step_configure_addon(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
-        """Ask for config for Z-Wave JS add-on."""
-        addon_info = await self._async_get_addon_info()
-        addon_config = addon_info.options
-
-        errors: dict[str, str] = {}
-
-        if user_input is not None:
-            self.network_key = user_input[CONF_NETWORK_KEY]
-            self.usb_path = user_input[CONF_USB_PATH]
-
-            new_addon_config = {
-                CONF_ADDON_DEVICE: self.usb_path,
-                CONF_ADDON_NETWORK_KEY: self.network_key,
-            }
-
-            if new_addon_config != addon_config:
-                await self._async_set_addon_config(new_addon_config)
-
-            return await self.async_step_start_addon()
-
-        usb_path = addon_config.get(CONF_ADDON_DEVICE, self.usb_path or "")
-        network_key = addon_config.get(CONF_ADDON_NETWORK_KEY, self.network_key or "")
-
-        data_schema = vol.Schema(
-            {
-                vol.Required(CONF_USB_PATH, default=usb_path): str,
-                vol.Optional(CONF_NETWORK_KEY, default=network_key): str,
-            }
-        )
-
-        return self.async_show_form(
-            step_id="configure_addon", data_schema=data_schema, errors=errors
-        )
 
     async def async_step_start_addon(
         self, user_input: dict[str, Any] | None = None
@@ -275,10 +141,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         try:
             await self.start_task
-        except (CannotConnect, AddonError) as err:
+        except (CannotConnect, AddonError, AbortFlow) as err:
+            self.start_task = None
             _LOGGER.error(err)
             return self.async_show_progress_done(next_step_id="start_failed")
 
+        self.start_task = None
         return self.async_show_progress_done(next_step_id="finish_addon_setup")
 
     async def async_step_start_failed(
@@ -290,6 +158,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def _async_start_addon(self) -> None:
         """Start the Z-Wave JS add-on."""
         addon_manager: AddonManager = get_addon_manager(self.hass)
+        self.version_info = None
         try:
             await addon_manager.async_schedule_start_addon()
             # Sleep some seconds to let the add-on start properly before connecting.
@@ -301,7 +170,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         self.ws_address = (
                             f"ws://{discovery_info['host']}:{discovery_info['port']}"
                         )
-                    await async_get_version_info(self.hass, self.ws_address)
+                    self.version_info = await async_get_version_info(
+                        self.hass, self.ws_address
+                    )
                 except (AbortFlow, CannotConnect) as err:
                     _LOGGER.debug(
                         "Add-on not ready yet, waiting %s seconds: %s",
@@ -315,9 +186,16 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         finally:
             # Continue the flow after show progress when the task is done.
             self.hass.async_create_task(
-                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+                self.flow_manager.async_configure(flow_id=self.flow_id)
             )
 
+    @abstractmethod
+    async def async_step_configure_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask for config for Z-Wave JS add-on."""
+
+    @abstractmethod
     async def async_step_finish_addon_setup(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -326,27 +204,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         Get add-on discovery info and server version info.
         Set unique id and abort if already configured.
         """
-        if not self.ws_address:
-            discovery_info = await self._async_get_addon_discovery_info()
-            self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
-
-        if not self.unique_id:
-            try:
-                version_info = await async_get_version_info(self.hass, self.ws_address)
-            except CannotConnect as err:
-                raise AbortFlow("cannot_connect") from err
-            await self.async_set_unique_id(
-                version_info.home_id, raise_on_progress=False
-            )
-
-        self._abort_if_unique_id_configured(
-            updates={
-                CONF_URL: self.ws_address,
-                CONF_USB_PATH: self.usb_path,
-                CONF_NETWORK_KEY: self.network_key,
-            }
-        )
-        return self._async_create_entry_from_vars()
 
     async def _async_get_addon_info(self) -> AddonInfo:
         """Return and cache Z-Wave JS add-on info."""
@@ -376,7 +233,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         finally:
             # Continue the flow after show progress when the task is done.
             self.hass.async_create_task(
-                self.hass.config_entries.flow.async_configure(flow_id=self.flow_id)
+                self.flow_manager.async_configure(flow_id=self.flow_id)
             )
 
     async def _async_get_addon_discovery_info(self) -> dict:
@@ -389,6 +246,204 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             raise AbortFlow("addon_get_discovery_info_failed") from err
 
         return discovery_info_config
+
+
+class ConfigFlow(BaseZwaveJSFlow, config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Z-Wave JS."""
+
+    VERSION = 1
+
+    def __init__(self) -> None:
+        """Set up flow instance."""
+        super().__init__()
+        self.use_addon = False
+
+    @property
+    def flow_manager(self) -> config_entries.ConfigEntriesFlowManager:
+        """Return the correct flow manager."""
+        return self.hass.config_entries.flow
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial step."""
+        if is_hassio(self.hass):
+            return await self.async_step_on_supervisor()
+
+        return await self.async_step_manual()
+
+    async def async_step_manual(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle a manual configuration."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="manual", data_schema=get_manual_schema({})
+            )
+
+        errors = {}
+
+        try:
+            version_info = await validate_input(self.hass, user_input)
+        except InvalidInput as err:
+            errors["base"] = err.error
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            await self.async_set_unique_id(
+                version_info.home_id, raise_on_progress=False
+            )
+            # Make sure we disable any add-on handling
+            # if the controller is reconfigured in a manual step.
+            self._abort_if_unique_id_configured(
+                updates={
+                    **user_input,
+                    CONF_USE_ADDON: False,
+                    CONF_INTEGRATION_CREATED_ADDON: False,
+                }
+            )
+            self.ws_address = user_input[CONF_URL]
+            return self._async_create_entry_from_vars()
+
+        return self.async_show_form(
+            step_id="manual", data_schema=get_manual_schema(user_input), errors=errors
+        )
+
+    async def async_step_hassio(self, discovery_info: dict[str, Any]) -> FlowResult:
+        """Receive configuration from add-on discovery info.
+
+        This flow is triggered by the Z-Wave JS add-on.
+        """
+        self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
+        try:
+            version_info = await async_get_version_info(self.hass, self.ws_address)
+        except CannotConnect:
+            return self.async_abort(reason="cannot_connect")
+
+        await self.async_set_unique_id(version_info.home_id)
+        self._abort_if_unique_id_configured(updates={CONF_URL: self.ws_address})
+
+        return await self.async_step_hassio_confirm()
+
+    async def async_step_hassio_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Confirm the add-on discovery."""
+        if user_input is not None:
+            return await self.async_step_on_supervisor(
+                user_input={CONF_USE_ADDON: True}
+            )
+
+        return self.async_show_form(step_id="hassio_confirm")
+
+    async def async_step_on_supervisor(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle logic when on Supervisor host."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="on_supervisor", data_schema=ON_SUPERVISOR_SCHEMA
+            )
+        if not user_input[CONF_USE_ADDON]:
+            return await self.async_step_manual()
+
+        self.use_addon = True
+
+        addon_info = await self._async_get_addon_info()
+
+        if addon_info.state == AddonState.RUNNING:
+            addon_config = addon_info.options
+            self.usb_path = addon_config[CONF_ADDON_DEVICE]
+            self.network_key = addon_config.get(CONF_ADDON_NETWORK_KEY, "")
+            return await self.async_step_finish_addon_setup()
+
+        if addon_info.state == AddonState.NOT_RUNNING:
+            return await self.async_step_configure_addon()
+
+        return await self.async_step_install_addon()
+
+    async def async_step_configure_addon(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Ask for config for Z-Wave JS add-on."""
+        addon_info = await self._async_get_addon_info()
+        addon_config = addon_info.options
+
+        if user_input is not None:
+            self.network_key = user_input[CONF_NETWORK_KEY]
+            self.usb_path = user_input[CONF_USB_PATH]
+
+            new_addon_config = {
+                **addon_config,
+                CONF_ADDON_DEVICE: self.usb_path,
+                CONF_ADDON_NETWORK_KEY: self.network_key,
+            }
+
+            if new_addon_config != addon_config:
+                await self._async_set_addon_config(new_addon_config)
+
+            return await self.async_step_start_addon()
+
+        usb_path = addon_config.get(CONF_ADDON_DEVICE, self.usb_path or "")
+        network_key = addon_config.get(CONF_ADDON_NETWORK_KEY, self.network_key or "")
+
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_USB_PATH, default=usb_path): str,
+                vol.Optional(CONF_NETWORK_KEY, default=network_key): str,
+            }
+        )
+
+        return self.async_show_form(step_id="configure_addon", data_schema=data_schema)
+
+    async def async_step_finish_addon_setup(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Prepare info needed to complete the config entry.
+
+        Get add-on discovery info and server version info.
+        Set unique id and abort if already configured.
+        """
+        if not self.ws_address:
+            discovery_info = await self._async_get_addon_discovery_info()
+            self.ws_address = f"ws://{discovery_info['host']}:{discovery_info['port']}"
+
+        if not self.unique_id:
+            if not self.version_info:
+                try:
+                    self.version_info = await async_get_version_info(
+                        self.hass, self.ws_address
+                    )
+                except CannotConnect as err:
+                    raise AbortFlow("cannot_connect") from err
+
+            await self.async_set_unique_id(
+                self.version_info.home_id, raise_on_progress=False
+            )
+
+        self._abort_if_unique_id_configured(
+            updates={
+                CONF_URL: self.ws_address,
+                CONF_USB_PATH: self.usb_path,
+                CONF_NETWORK_KEY: self.network_key,
+            }
+        )
+        return self._async_create_entry_from_vars()
+
+    @callback
+    def _async_create_entry_from_vars(self) -> FlowResult:
+        """Return a config entry for the flow."""
+        return self.async_create_entry(
+            title=TITLE,
+            data={
+                CONF_URL: self.ws_address,
+                CONF_USB_PATH: self.usb_path,
+                CONF_NETWORK_KEY: self.network_key,
+                CONF_USE_ADDON: self.use_addon,
+                CONF_INTEGRATION_CREATED_ADDON: self.integration_created_addon,
+            },
+        )
 
 
 class CannotConnect(exceptions.HomeAssistantError):

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -44,7 +44,6 @@ ADDON_SETUP_TIMEOUT_ROUNDS = 4
 SERVER_VERSION_TIMEOUT = 10
 
 ON_SUPERVISOR_SCHEMA = vol.Schema({vol.Optional(CONF_USE_ADDON, default=True): bool})
-STEP_USER_DATA_SCHEMA = vol.Schema({vol.Required(CONF_URL, default=DEFAULT_URL): str})
 
 
 def get_manual_schema(user_input: dict[str, Any]) -> vol.Schema:

--- a/homeassistant/components/zwave_js/config_flow.py
+++ b/homeassistant/components/zwave_js/config_flow.py
@@ -98,7 +98,7 @@ class BaseZwaveJSFlow(FlowHandler):
 
     @property
     @abstractmethod
-    def flow_manager(args) -> FlowManager:
+    def flow_manager(self) -> FlowManager:
         """Return the flow manager of the flow."""
 
     async def async_step_install_addon(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Refactor the zwave_js config flow in preparation for adding an options flow.
- The options flow will re-use parts of the existing config flow, so the refactor moves the common parts to a base class with some abstract methods that should be implemented by the config and options flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
