### PR TITLE
Cleanup of code reviews from initial modern forms

### DIFF
--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -42,11 +42,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    # if entry.unique_id is None:
-    #     hass.config_entries.async_update_entry(
-    #         entry, unique_id=coordinator.data.info.mac_address
-    #     )
-
     # Set up all platforms for this device/entry.
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 

--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -15,7 +15,6 @@ from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODEL, ATTR_NAME, ATTR_SW_VERSION, CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import (
@@ -38,10 +37,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Create Modern Forms instance for this entry
     coordinator = ModernFormsDataUpdateCoordinator(hass, host=entry.data[CONF_HOST])
-    await coordinator.async_refresh()
-
-    if not coordinator.last_update_success:
-        raise ConfigEntryNotReady
+    await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
@@ -52,10 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
 
     # Set up all platforms for this device/entry.
-    for platform in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
+    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
 
     return True
 
@@ -106,7 +99,7 @@ class ModernFormsDataUpdateCoordinator(DataUpdateCoordinator[ModernFormsDeviceSt
         host: str,
     ) -> None:
         """Initialize global Modern Forms data updater."""
-        self.modernforms = ModernFormsDevice(
+        self.modern_forms = ModernFormsDevice(
             host, session=async_get_clientsession(hass)
         )
 
@@ -125,7 +118,7 @@ class ModernFormsDataUpdateCoordinator(DataUpdateCoordinator[ModernFormsDeviceSt
     async def _async_update_data(self) -> ModernFormsDevice:
         """Fetch data from Modern Forms."""
         try:
-            return await self.modernforms.update(
+            return await self.modern_forms.update(
                 full_update=not self.last_update_success
             )
         except ModernFormsError as error:
@@ -152,7 +145,6 @@ class ModernFormsDeviceEntity(CoordinatorEntity[ModernFormsDataUpdateCoordinator
         self._entry_id = entry_id
         self._attr_icon = icon
         self._attr_name = name
-        self._unsub_dispatcher = None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -42,10 +42,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    if entry.unique_id is None:
-        hass.config_entries.async_update_entry(
-            entry, unique_id=coordinator.data.info.mac_address
-        )
+    # if entry.unique_id is None:
+    #     hass.config_entries.async_update_entry(
+    #         entry, unique_id=coordinator.data.info.mac_address
+    #     )
 
     # Set up all platforms for this device/entry.
     hass.config_entries.async_setup_platforms(entry, PLATFORMS)

--- a/homeassistant/components/modern_forms/config_flow.py
+++ b/homeassistant/components/modern_forms/config_flow.py
@@ -6,11 +6,7 @@ from typing import Any
 from aiomodernforms import ModernFormsConnectionError, ModernFormsDevice
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    CONN_CLASS_LOCAL_POLL,
-    SOURCE_ZEROCONF,
-    ConfigFlow,
-)
+from homeassistant.config_entries import SOURCE_ZEROCONF, ConfigFlow
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_NAME
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -23,7 +19,6 @@ class ModernFormsFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a ModernForms config flow."""
 
     VERSION = 1
-    CONNECTION_CLASS = CONN_CLASS_LOCAL_POLL
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/modern_forms/const.py
+++ b/homeassistant/components/modern_forms/const.py
@@ -4,25 +4,11 @@ DOMAIN = "modern_forms"
 
 ATTR_IDENTIFIERS = "identifiers"
 ATTR_MANUFACTURER = "manufacturer"
-ATTR_MODEL = "model"
-ATTR_OWNER = "owner"
-ATTR_IDENTITY = "identity"
-ATTR_MCU_FIRMWARE_VERSION = "mcu_firmware_version"
-ATTR_FIRMWARE_VERSION = "firmware_version"
 
-SIGNAL_INSTANCE_ADD = f"{DOMAIN}_instance_add_signal." "{}"
-SIGNAL_INSTANCE_REMOVE = f"{DOMAIN}_instance_remove_signal." "{}"
-SIGNAL_ENTITY_REMOVE = f"{DOMAIN}_entity_remove_signal." "{}"
-
-CONF_ON_UNLOAD = "ON_UNLOAD"
-
-OPT_BRIGHTNESS = "brightness"
 OPT_ON = "on"
 OPT_SPEED = "speed"
 
 # Services
-SERVICE_SET_LIGHT_SLEEP_TIMER = "set_light_sleep_timer"
-SERVICE_CLEAR_LIGHT_SLEEP_TIMER = "clear_light_sleep_timer"
 SERVICE_SET_FAN_SLEEP_TIMER = "set_fan_sleep_timer"
 SERVICE_CLEAR_FAN_SLEEP_TIMER = "clear_fan_sleep_timer"
 

--- a/homeassistant/components/modern_forms/fan.py
+++ b/homeassistant/components/modern_forms/fan.py
@@ -8,7 +8,6 @@ import voluptuous as vol
 
 from homeassistant.components.fan import SUPPORT_DIRECTION, SUPPORT_SET_SPEED, FanEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
 import homeassistant.helpers.entity_platform as entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import HomeAssistantType
@@ -63,7 +62,9 @@ async def async_setup_entry(
         "async_clear_fan_sleep_timer",
     )
 
-    async_update_fan(config_entry, coordinator, {}, async_add_entities)
+    async_add_entities(
+        [ModernFormsFanEntity(entry_id=config_entry.entry_id, coordinator=coordinator)]
+    )
 
 
 class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
@@ -161,18 +162,3 @@ class ModernFormsFanEntity(FanEntity, ModernFormsDeviceEntity):
     ) -> None:
         """Clear a Modern Forms fan sleep timer."""
         await self.coordinator.modern_forms.fan(sleep=CLEAR_TIMER)
-
-
-@callback
-def async_update_fan(
-    entry: ConfigEntry,
-    coordinator: ModernFormsDataUpdateCoordinator,
-    current: dict[str, ModernFormsFanEntity],
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Update Modern Forms Fan info."""
-    if not current:
-        current[entry.entry_id] = ModernFormsFanEntity(
-            entry_id=entry.entry_id, coordinator=coordinator
-        )
-        async_add_entities([current[entry.entry_id]])

--- a/homeassistant/components/modern_forms/manifest.json
+++ b/homeassistant/components/modern_forms/manifest.json
@@ -9,7 +9,6 @@
   "zeroconf": [
     {"type":"_easylink._tcp.local.", "name":"wac*"}
   ],
-  "dependencies": [],
   "codeowners": [
     "@wonderslug"
   ],

--- a/homeassistant/components/modern_forms/services.yaml
+++ b/homeassistant/components/modern_forms/services.yaml
@@ -15,10 +15,7 @@ set_fan_sleep_timer:
         number:
           min: 1
           max: 1440
-          step: 1
           unit_of_measurement: minutes
-          mode: slider
-
 clear_fan_sleep_timer:
   name: Clear fan sleep timer
   description: Clear the sleep timer on a Modern Forms fan.

--- a/homeassistant/components/modern_forms/strings.json
+++ b/homeassistant/components/modern_forms/strings.json
@@ -1,5 +1,4 @@
 {
-  "title": "Modern Forms",
   "config": {
     "flow_title": "{name}",
     "step": {
@@ -8,9 +7,6 @@
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
         }
-      },
-      "confirm": {
-        "description": "[%key:common::config_flow::description::confirm_setup%]"
       },
       "zeroconf_confirm": {
         "description": "Do you want to add the Modern Forms fan named `{name}` to Home Assistant?",

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -14,8 +14,6 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
-from . import init_integration
-
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -159,45 +157,3 @@ async def test_zeroconf_confirm_connection_error(
 
     assert result.get("type") == RESULT_TYPE_ABORT
     assert result.get("reason") == "cannot_connect"
-
-
-async def test_user_device_exists_abort(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test we abort zeroconf flow if Modern Forms device already configured."""
-    aioclient_mock.post(
-        "http://192.168.1.123:80/mf",
-        text=load_fixture("modern_forms/device_info.json"),
-        headers={"Content-Type": CONTENT_TYPE_JSON},
-    )
-
-    await init_integration(hass, aioclient_mock)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_USER},
-        data={CONF_HOST: "192.168.1.123"},
-    )
-
-    assert result.get("type") == RESULT_TYPE_ABORT
-    assert result.get("reason") == "already_configured"
-
-
-async def test_zeroconf_with_mac_device_exists_abort(
-    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
-) -> None:
-    """Test we abort zeroconf flow if a Modern Forms device already configured."""
-    await init_integration(hass, aioclient_mock)
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": SOURCE_ZEROCONF},
-        data={
-            "host": "192.168.1.123",
-            "hostname": "example.local.",
-            "properties": {CONF_MAC: "AA:BB:CC:DD:EE:FF"},
-        },
-    )
-
-    assert result.get("type") == RESULT_TYPE_ABORT
-    assert result.get("reason") == "already_configured"

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -14,6 +14,8 @@ from homeassistant.data_entry_flow import (
     RESULT_TYPE_FORM,
 )
 
+from . import init_integration
+
 from tests.common import load_fixture
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -157,3 +159,69 @@ async def test_zeroconf_confirm_connection_error(
 
     assert result.get("type") == RESULT_TYPE_ABORT
     assert result.get("reason") == "cannot_connect"
+
+
+async def test_user_device_exists_abort(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test we abort zeroconf flow if Modern Forms device already configured."""
+    aioclient_mock.post(
+        "http://192.168.1.123:80/mf",
+        text=load_fixture("modern_forms/device_info.json"),
+        headers={"Content-Type": CONTENT_TYPE_JSON},
+    )
+
+    await init_integration(hass, aioclient_mock, skip_setup=True)
+
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={
+            "host": "192.168.1.123",
+            "hostname": "example.local.",
+            "properties": {CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={
+            "host": "192.168.1.123",
+            "hostname": "example.local.",
+            "properties": {CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+        },
+    )
+
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "already_configured"
+
+
+async def test_zeroconf_with_mac_device_exists_abort(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test we abort zeroconf flow if a Modern Forms device already configured."""
+    await init_integration(hass, aioclient_mock, skip_setup=True)
+
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={
+            "host": "192.168.1.123",
+            "hostname": "example.local.",
+            "properties": {CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+        },
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data={
+            "host": "192.168.1.123",
+            "hostname": "example.local.",
+            "properties": {CONF_MAC: "AA:BB:CC:DD:EE:FF"},
+        },
+    )
+
+    assert result.get("type") == RESULT_TYPE_ABORT
+    assert result.get("reason") == "already_configured"

--- a/tests/components/modern_forms/test_config_flow.py
+++ b/tests/components/modern_forms/test_config_flow.py
@@ -39,15 +39,20 @@ async def test_full_user_flow_implementation(
     assert result.get("type") == RESULT_TYPE_FORM
     assert "flow_id" in result
 
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_HOST: "192.168.1.123"}
-    )
+    with patch(
+        "homeassistant.components.modern_forms.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={CONF_HOST: "192.168.1.123"}
+        )
 
-    assert result.get("title") == "ModernFormsFan"
-    assert "data" in result
-    assert result.get("type") == RESULT_TYPE_CREATE_ENTRY
-    assert result["data"][CONF_HOST] == "192.168.1.123"
-    assert result["data"][CONF_MAC] == "AA:BB:CC:DD:EE:FF"
+    assert result2.get("title") == "ModernFormsFan"
+    assert "data" in result2
+    assert result2.get("type") == RESULT_TYPE_CREATE_ENTRY
+    assert result2["data"][CONF_HOST] == "192.168.1.123"
+    assert result2["data"][CONF_MAC] == "AA:BB:CC:DD:EE:FF"
+    assert len(mock_setup_entry.mock_calls) == 1
 
 
 async def test_full_zeroconf_flow_implementation(

--- a/tests/components/modern_forms/test_fan.py
+++ b/tests/components/modern_forms/test_fan.py
@@ -48,7 +48,7 @@ async def test_fan_state(
 
     entry = entity_registry.async_get("fan.modernformsfan_fan")
     assert entry
-    assert entry.unique_id == "AA:BB:CC:DD:EE:FF_fan"
+    assert entry.unique_id == "AA:BB:CC:DD:EE:FF"
 
 
 async def test_change_state(

--- a/tests/components/modern_forms/test_init.py
+++ b/tests/components/modern_forms/test_init.py
@@ -39,14 +39,6 @@ async def test_unload_config_entry(
     assert not hass.data.get(DOMAIN)
 
 
-async def test_setting_unique_id(hass, aioclient_mock):
-    """Test we set unique ID if not set yet."""
-    entry = await init_integration(hass, aioclient_mock)
-
-    assert hass.data[DOMAIN]
-    assert entry.unique_id == "AA:BB:CC:DD:EE:FF"
-
-
 async def test_fan_only_device(hass, aioclient_mock):
     """Test we set unique ID if not set yet."""
     await init_integration(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This is a cleanup of hanging code review requests from #51317.  All of the requested changes have been addressed with the following exceptions:

Re: https://github.com/home-assistant/core/pull/51317/files#r647242775
ConfigEntry.unqiue_id is typed str | None so if it is not handled for None then mypy throws an error.  Im assuming some case can arise where it can be None or the typing probably wouldn't be there.

Re: https://github.com/home-assistant/core/pull/51317/files#r647260992
If I add skip_setup=True it is unable to find the fan.turn_on service for testing.  I am unsure how to get around that.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
