### PR TITLE
Add WLED live override service

### DIFF
--- a/homeassistant/components/wled/const.py
+++ b/homeassistant/components/wled/const.py
@@ -18,6 +18,7 @@ ATTR_DURATION = "duration"
 ATTR_FADE = "fade"
 ATTR_INTENSITY = "intensity"
 ATTR_LED_COUNT = "led_count"
+ATTR_LIVE = "live"
 ATTR_MAX_POWER = "max_power"
 ATTR_ON = "on"
 ATTR_PALETTE = "palette"
@@ -35,4 +36,5 @@ CURRENT_MA = "mA"
 
 # Services
 SERVICE_EFFECT = "effect"
+SERVICE_LIVE = "live"
 SERVICE_PRESET = "preset"

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -5,7 +5,6 @@ from functools import partial
 from typing import Any, Tuple, cast
 
 import voluptuous as vol
-
 from wled import Live
 
 from homeassistant.components.light import (

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -6,6 +6,8 @@ from typing import Any, Tuple, cast
 
 import voluptuous as vol
 
+from wled import Live
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_EFFECT,
@@ -30,6 +32,7 @@ from homeassistant.helpers.entity_registry import (
 from .const import (
     ATTR_COLOR_PRIMARY,
     ATTR_INTENSITY,
+    ATTR_LIVE,
     ATTR_ON,
     ATTR_PALETTE,
     ATTR_PLAYLIST,
@@ -41,6 +44,7 @@ from .const import (
     DEFAULT_KEEP_MASTER_LIGHT,
     DOMAIN,
     SERVICE_EFFECT,
+    SERVICE_LIVE,
     SERVICE_PRESET,
 )
 from .coordinator import WLEDDataUpdateCoordinator
@@ -74,6 +78,14 @@ async def async_setup_entry(
             ),
         },
         "async_effect",
+    )
+
+    platform.async_register_entity_service(
+        SERVICE_LIVE,
+        {
+            vol.Required(ATTR_LIVE): vol.Coerce(cv.string),
+        },
+        "async_live",
     )
 
     platform.async_register_entity_service(
@@ -164,6 +176,13 @@ class WLEDMasterLight(WLEDEntity, LightEntity):
     ) -> None:
         """Set the effect of a WLED light."""
         # Master light does not have an effect setting.
+
+    async def async_live(
+        self,
+        live: str | None = None,
+    ) -> None:
+        """Set the live override mode of a WLED light."""
+        # Master light does not have an live override setting.
 
     @wled_exception_handler
     async def async_preset(
@@ -382,6 +401,15 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
             data[ATTR_SPEED] = speed
 
         await self.coordinator.wled.segment(**data)  # type: ignore[arg-type]
+
+    @wled_exception_handler
+    async def async_live(
+        self,
+        live: str,
+    ) -> None:
+        """Set a WLED light to a specific live override mode."""
+
+        await self.coordinator.wled.live(Live[live.upper()])
 
     @wled_exception_handler
     async def async_preset(

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -249,9 +249,12 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         if preset == -1:
             preset = None
 
+        lor: int | None = self.coordinator.data.state.lor
+
         segment = self.coordinator.data.state.segments[self._segment]
         return {
             ATTR_INTENSITY: segment.intensity,
+            ATTR_LIVE: lor,
             ATTR_PALETTE: segment.palette.name,
             ATTR_PLAYLIST: playlist,
             ATTR_PRESET: preset,

--- a/homeassistant/components/wled/services.yaml
+++ b/homeassistant/components/wled/services.yaml
@@ -34,8 +34,7 @@ effect:
           max: 255
     reverse:
       name: Reverse effect
-      description:
-        Reverse the effect. Either true to reverse or false otherwise.
+      description: Reverse the effect. Either true to reverse or false otherwise.
       default: false
       selector:
         boolean:
@@ -54,9 +53,9 @@ live:
       selector:
         select:
           options:
-            - Off
-            - On
-            - Off until Reboot
+            - "Off"
+            - "On"
+            - "Off until Reboot"
 
 preset:
   name: Set preset

--- a/homeassistant/components/wled/services.yaml
+++ b/homeassistant/components/wled/services.yaml
@@ -40,6 +40,24 @@ effect:
       selector:
         boolean:
 
+live:
+  name: Set live override mode
+  description: Set the live override mode for the WLED device.
+  target:
+    entity:
+      integration: wled
+      domain: light
+  fields:
+    live:
+      name: Live Override Mode
+      description: Mode for live override
+      selector:
+        select:
+          options:
+            - Off
+            - On
+            - Off until Reboot
+
 preset:
   name: Set preset
   description: Set a preset for the WLED device.

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -608,7 +608,7 @@ async def test_live_service(
     )
     await hass.async_block_till_done()
     assert mock_wled.live.call_count == 1
-    mock_wled.live.assert_called_with(live="off")
+    mock_wled.live.assert_called_with(live=0)
 
     await hass.services.async_call(
         DOMAIN,
@@ -621,7 +621,7 @@ async def test_live_service(
     )
     await hass.async_block_till_done()
     assert mock_wled.live.call_count == 2
-    mock_wled.live.assert_called_with(live="on")
+    mock_wled.live.assert_called_with(live=1)
 
     await hass.services.async_call(
         DOMAIN,
@@ -634,7 +634,7 @@ async def test_live_service(
     )
     await hass.async_block_till_done()
     assert mock_wled.live.call_count == 3
-    mock_wled.live.assert_called_with(live="off_until_reboot")
+    mock_wled.live.assert_called_with(live=2)
 
 
 async def test_live_service_error(

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -601,7 +601,7 @@ async def test_live_service(
         DOMAIN,
         SERVICE_LIVE,
         {
-            ATTR_ENTITY_ID: "light.wled_rgb_light_master",
+            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
             ATTR_LIVE: "off",
         },
         blocking=True,
@@ -614,7 +614,7 @@ async def test_live_service(
         DOMAIN,
         SERVICE_LIVE,
         {
-            ATTR_ENTITY_ID: "light.wled_rgb_light_master",
+            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
             ATTR_LIVE: "on",
         },
         blocking=True,
@@ -627,7 +627,7 @@ async def test_live_service(
         DOMAIN,
         SERVICE_LIVE,
         {
-            ATTR_ENTITY_ID: "light.wled_rgb_light_master",
+            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
             ATTR_LIVE: "off_until_reboot",
         },
         blocking=True,
@@ -649,14 +649,14 @@ async def test_live_service_error(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_LIVE,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_master", ATTR_LIVE: "off"},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_LIVE: "off"},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("light.wled_rgb_light_master")
+    state = hass.states.get("light.wled_rgb_light_segment_0")
     assert state
-    assert state.lor == Live.OFF
+    assert state.live == Live.OFF
     assert "Invalid response from API" in caplog.text
     assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live="off")

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -3,7 +3,7 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from wled import Device as WLEDDevice, WLEDConnectionError, WLEDError, Live
+from wled import Device as WLEDDevice, Live, WLEDConnectionError, WLEDError
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -607,7 +607,7 @@ async def test_live_service(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert mock_wled.live.call_count == 2
+    assert mock_wled.live.call_count == 1
     mock_wled.live.assert_called_with(live="off")
 
     await hass.services.async_call(
@@ -620,7 +620,7 @@ async def test_live_service(
         blocking=True,
     )
     await hass.async_block_till_done()
-    assert mock_wled.live.call_count == 1
+    assert mock_wled.live.call_count == 2
     mock_wled.live.assert_called_with(live="on")
 
     await hass.services.async_call(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds a switch to WLED that allows control over the "live override" (i.e. UDP or E1.31 control) status of a WLED light.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
