### PR TITLE
Use test fixture for configuration testing

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -40,7 +40,7 @@ def mock_pymodbus():
 
 
 @pytest.fixture
-async def mock_modbus(hass, mock_pymodbus):
+async def mock_modbus(hass, do_config):
     """Load integration modbus using mocked pymodbus."""
     config = {
         DOMAIN: [
@@ -49,12 +49,16 @@ async def mock_modbus(hass, mock_pymodbus):
                 CONF_HOST: "modbusTestHost",
                 CONF_PORT: 5501,
                 CONF_NAME: TEST_MODBUS_NAME,
+                **do_config,
             }
         ]
     }
-    assert await async_setup_component(hass, DOMAIN, config) is True
-    await hass.async_block_till_done()
-    yield mock_pymodbus
+    with mock.patch(
+        "homeassistant.components.modbus.modbus.ModbusTcpClient", autospec=True
+    ) as mock_pb:
+        assert await async_setup_component(hass, DOMAIN, config) is True
+        await hass.async_block_till_done()
+        yield mock_pb
 
 
 # dataclass

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -50,6 +50,7 @@ from tests.common import mock_restore_cache
 )
 async def test_config_binary_sensor(hass, mock_modbus):
     """Run config test for binary sensor."""
+    assert SENSOR_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize("do_type", [CALL_TYPE_COIL, CALL_TYPE_DISCRETE])

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -25,33 +25,31 @@ from tests.common import mock_restore_cache
 
 
 @pytest.mark.parametrize(
-    "do_options",
+    "do_config",
     [
-        {},
         {
-            CONF_SLAVE: 10,
-            CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
-            CONF_DEVICE_CLASS: "door",
+            CONF_BINARY_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                }
+            ]
+        },
+        {
+            CONF_BINARY_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_SLAVE: 10,
+                    CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+                    CONF_DEVICE_CLASS: "door",
+                }
+            ]
         },
     ],
 )
-async def test_config_binary_sensor(hass, do_options):
-    """Run test for binary sensor."""
-    sensor_name = "test_sensor"
-    config_sensor = {
-        CONF_NAME: sensor_name,
-        CONF_ADDRESS: 51,
-        **do_options,
-    }
-    await base_config_test(
-        hass,
-        config_sensor,
-        sensor_name,
-        SENSOR_DOMAIN,
-        CONF_BINARY_SENSORS,
-        None,
-        method_discovery=True,
-    )
+async def test_config_binary_sensor(hass, mock_modbus):
+    """Run config test for binary sensor."""
 
 
 @pytest.mark.parametrize("do_type", [CALL_TYPE_COIL, CALL_TYPE_DISCRETE])

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -20,34 +20,34 @@ from tests.common import mock_restore_cache
 
 
 @pytest.mark.parametrize(
-    "do_options",
+    "do_config",
     [
-        {},
         {
-            CONF_SCAN_INTERVAL: 20,
-            CONF_COUNT: 2,
+            CONF_CLIMATES: [
+                {
+                    CONF_NAME: "test_climate",
+                    CONF_TARGET_TEMP: 117,
+                    CONF_ADDRESS: 117,
+                    CONF_SLAVE: 10,
+                }
+            ],
+        },
+        {
+            CONF_CLIMATES: [
+                {
+                    CONF_NAME: "test_climate",
+                    CONF_TARGET_TEMP: 117,
+                    CONF_ADDRESS: 117,
+                    CONF_SLAVE: 10,
+                    CONF_SCAN_INTERVAL: 20,
+                    CONF_COUNT: 2,
+                }
+            ],
         },
     ],
 )
-async def test_config_climate(hass, do_options):
-    """Run test for climate."""
-    device_name = "test_climate"
-    device_config = {
-        CONF_NAME: device_name,
-        CONF_TARGET_TEMP: 117,
-        CONF_ADDRESS: 117,
-        CONF_SLAVE: 10,
-        **do_options,
-    }
-    await base_config_test(
-        hass,
-        device_config,
-        device_name,
-        CLIMATE_DOMAIN,
-        CONF_CLIMATES,
-        None,
-        method_discovery=True,
-    )
+async def test_config_climate(hass, mock_modbus):
+    """Run configuration test for climate."""
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_climate.py
+++ b/tests/components/modbus/test_climate.py
@@ -48,6 +48,7 @@ from tests.common import mock_restore_cache
 )
 async def test_config_climate(hass, mock_modbus):
     """Run configuration test for climate."""
+    assert CLIMATE_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -61,6 +61,7 @@ from tests.common import mock_restore_cache
 )
 async def test_config_cover(hass, mock_modbus):
     """Run configuration test for cover."""
+    assert COVER_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_cover.py
+++ b/tests/components/modbus/test_cover.py
@@ -35,34 +35,32 @@ from tests.common import mock_restore_cache
 
 
 @pytest.mark.parametrize(
-    "do_options",
+    "do_config",
     [
-        {},
         {
-            CONF_SLAVE: 10,
-            CONF_SCAN_INTERVAL: 20,
+            CONF_COVERS: [
+                {
+                    CONF_NAME: "test_cover",
+                    CONF_ADDRESS: 1234,
+                    CONF_INPUT_TYPE: CALL_TYPE_COIL,
+                }
+            ]
+        },
+        {
+            CONF_COVERS: [
+                {
+                    CONF_NAME: "test_cover",
+                    CONF_ADDRESS: 1234,
+                    CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_SLAVE: 10,
+                    CONF_SCAN_INTERVAL: 20,
+                }
+            ]
         },
     ],
 )
-@pytest.mark.parametrize("read_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])
-async def test_config_cover(hass, do_options, read_type):
-    """Run test for cover."""
-    device_name = "test_cover"
-    device_config = {
-        CONF_NAME: device_name,
-        CONF_ADDRESS: 1234,
-        CONF_INPUT_TYPE: read_type,
-        **do_options,
-    }
-    await base_config_test(
-        hass,
-        device_config,
-        device_name,
-        COVER_DOMAIN,
-        CONF_COVERS,
-        None,
-        method_discovery=True,
-    )
+async def test_config_cover(hass, mock_modbus):
+    """Run configuration test for cover."""
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -41,75 +41,89 @@ from tests.common import mock_restore_cache
     "do_config",
     [
         {
-            CONF_ADDRESS: 1234,
+            CONF_FANS: [
+                {
+                    CONF_NAME: "test_fan",
+                    CONF_ADDRESS: 1234,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_WRITE_TYPE: CALL_TYPE_COIL,
+            CONF_FANS: [
+                {
+                    CONF_NAME: "test_fan",
+                    CONF_ADDRESS: 1234,
+                    CONF_WRITE_TYPE: CALL_TYPE_COIL,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_FANS: [
+                {
+                    CONF_NAME: "test_fan",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_FANS: [
+                {
+                    CONF_NAME: "test_fan",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_FANS: [
+                {
+                    CONF_NAME: "test_fan",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: None,
+            CONF_FANS: [
+                {
+                    CONF_NAME: "test_fan",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: None,
+                }
+            ]
         },
     ],
 )
-async def test_config_fan(hass, do_config):
-    """Run test for fan."""
-    device_name = "test_fan"
-
-    device_config = {
-        CONF_NAME: device_name,
-        **do_config,
-    }
-
-    await base_config_test(
-        hass,
-        device_config,
-        device_name,
-        FAN_DOMAIN,
-        CONF_FANS,
-        None,
-        method_discovery=True,
-    )
+async def test_config_fan(hass, mock_modbus):
+    """Run configuration test for fan."""
 
 
 @pytest.mark.parametrize("call_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -124,6 +124,7 @@ from tests.common import mock_restore_cache
 )
 async def test_config_fan(hass, mock_modbus):
     """Run configuration test for fan."""
+    assert FAN_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize("call_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -124,6 +124,7 @@ from tests.common import mock_restore_cache
 )
 async def test_config_light(hass, mock_modbus):
     """Run configuration test for light."""
+    assert LIGHT_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize("call_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -41,75 +41,89 @@ from tests.common import mock_restore_cache
     "do_config",
     [
         {
-            CONF_ADDRESS: 1234,
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: "test_light",
+                    CONF_ADDRESS: 1234,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_WRITE_TYPE: CALL_TYPE_COIL,
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: "test_light",
+                    CONF_ADDRESS: 1234,
+                    CONF_WRITE_TYPE: CALL_TYPE_COIL,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: "test_light",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: "test_light",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: "test_light",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_VERIFY: None,
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: "test_light",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_VERIFY: None,
+                }
+            ]
         },
     ],
 )
-async def test_config_light(hass, do_config):
-    """Run test for light."""
-    device_name = "test_light"
-
-    device_config = {
-        CONF_NAME: device_name,
-        **do_config,
-    }
-
-    await base_config_test(
-        hass,
-        device_config,
-        device_name,
-        LIGHT_DOMAIN,
-        CONF_LIGHTS,
-        None,
-        method_discovery=True,
-    )
+async def test_config_light(hass, mock_modbus):
+    """Run configuration test for light."""
 
 
 @pytest.mark.parametrize("call_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -45,68 +45,89 @@ from tests.common import mock_restore_cache
     "do_config",
     [
         {
-            CONF_ADDRESS: 51,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 51,
-            CONF_SLAVE: 10,
-            CONF_COUNT: 1,
-            CONF_DATA_TYPE: "int",
-            CONF_PRECISION: 0,
-            CONF_SCALE: 1,
-            CONF_OFFSET: 0,
-            CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-            CONF_DEVICE_CLASS: "battery",
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_SLAVE: 10,
+                    CONF_COUNT: 1,
+                    CONF_DATA_TYPE: "int",
+                    CONF_PRECISION: 0,
+                    CONF_SCALE: 1,
+                    CONF_OFFSET: 0,
+                    CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                    CONF_DEVICE_CLASS: "battery",
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 51,
-            CONF_SLAVE: 10,
-            CONF_COUNT: 1,
-            CONF_DATA_TYPE: "int",
-            CONF_PRECISION: 0,
-            CONF_SCALE: 1,
-            CONF_OFFSET: 0,
-            CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
-            CONF_DEVICE_CLASS: "battery",
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_SLAVE: 10,
+                    CONF_COUNT: 1,
+                    CONF_DATA_TYPE: "int",
+                    CONF_PRECISION: 0,
+                    CONF_SCALE: 1,
+                    CONF_OFFSET: 0,
+                    CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
+                    CONF_DEVICE_CLASS: "battery",
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 51,
-            CONF_COUNT: 1,
-            CONF_SWAP: CONF_SWAP_NONE,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_COUNT: 1,
+                    CONF_SWAP: CONF_SWAP_NONE,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 51,
-            CONF_COUNT: 1,
-            CONF_SWAP: CONF_SWAP_BYTE,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_COUNT: 1,
+                    CONF_SWAP: CONF_SWAP_BYTE,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 51,
-            CONF_COUNT: 2,
-            CONF_SWAP: CONF_SWAP_WORD,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_COUNT: 2,
+                    CONF_SWAP: CONF_SWAP_WORD,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 51,
-            CONF_COUNT: 2,
-            CONF_SWAP: CONF_SWAP_WORD_BYTE,
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: "test_sensor",
+                    CONF_ADDRESS: 51,
+                    CONF_COUNT: 2,
+                    CONF_SWAP: CONF_SWAP_WORD_BYTE,
+                }
+            ]
         },
     ],
 )
-async def test_config_sensor(hass, do_config):
-    """Run test for sensor."""
-    sensor_name = "test_sensor"
-    config_sensor = {
-        CONF_NAME: sensor_name,
-        **do_config,
-    }
-    await base_config_test(
-        hass,
-        config_sensor,
-        sensor_name,
-        SENSOR_DOMAIN,
-        CONF_SENSORS,
-        CONF_REGISTERS,
-        method_discovery=True,
-    )
+async def test_config_sensor(hass, mock_modbus):
+    """Run configuration test for sensor."""
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -128,6 +128,7 @@ from tests.common import mock_restore_cache
 )
 async def test_config_sensor(hass, mock_modbus):
     """Run configuration test for sensor."""
+    assert SENSOR_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize(

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -137,6 +137,7 @@ from tests.common import async_fire_time_changed, mock_restore_cache
 )
 async def test_config_switch(hass, mock_modbus):
     """Run configurationtest for switch."""
+    assert SWITCH_DOMAIN in hass.config.components
 
 
 @pytest.mark.parametrize("call_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])

--- a/tests/components/modbus/test_switch.py
+++ b/tests/components/modbus/test_switch.py
@@ -48,81 +48,95 @@ from tests.common import async_fire_time_changed, mock_restore_cache
     "do_config",
     [
         {
-            CONF_ADDRESS: 1234,
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: "test_switch",
+                    CONF_ADDRESS: 1234,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_WRITE_TYPE: CALL_TYPE_COIL,
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: "test_switch",
+                    CONF_ADDRESS: 1234,
+                    CONF_WRITE_TYPE: CALL_TYPE_COIL,
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_DEVICE_CLASS: "switch",
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: "test_switch",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_DEVICE_CLASS: "switch",
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_HOLDING,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_DEVICE_CLASS: "switch",
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-                CONF_DELAY: 10,
-            },
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: "test_switch",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_DEVICE_CLASS: "switch",
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                        CONF_DELAY: 10,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_DEVICE_CLASS: "switch",
-            CONF_VERIFY: {
-                CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
-                CONF_ADDRESS: 1235,
-                CONF_STATE_OFF: 0,
-                CONF_STATE_ON: 1,
-            },
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: "test_switch",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_DEVICE_CLASS: "switch",
+                    CONF_VERIFY: {
+                        CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
+                        CONF_ADDRESS: 1235,
+                        CONF_STATE_OFF: 0,
+                        CONF_STATE_ON: 1,
+                    },
+                }
+            ]
         },
         {
-            CONF_ADDRESS: 1234,
-            CONF_SLAVE: 1,
-            CONF_COMMAND_OFF: 0x00,
-            CONF_COMMAND_ON: 0x01,
-            CONF_DEVICE_CLASS: "switch",
-            CONF_SCAN_INTERVAL: 0,
-            CONF_VERIFY: None,
+            CONF_SWITCHES: [
+                {
+                    CONF_NAME: "test_switch",
+                    CONF_ADDRESS: 1234,
+                    CONF_SLAVE: 1,
+                    CONF_COMMAND_OFF: 0x00,
+                    CONF_COMMAND_ON: 0x01,
+                    CONF_DEVICE_CLASS: "switch",
+                    CONF_SCAN_INTERVAL: 0,
+                    CONF_VERIFY: None,
+                }
+            ]
         },
     ],
 )
-async def test_config_switch(hass, do_config):
-    """Run test for switch."""
-    device_name = "test_switch"
-
-    device_config = {
-        CONF_NAME: device_name,
-        **do_config,
-    }
-
-    await base_config_test(
-        hass,
-        device_config,
-        device_name,
-        SWITCH_DOMAIN,
-        CONF_SWITCHES,
-        None,
-        method_discovery=True,
-    )
+async def test_config_switch(hass, mock_modbus):
+    """Run configurationtest for switch."""
 
 
 @pytest.mark.parametrize("call_type", [CALL_TYPE_COIL, CALL_TYPE_REGISTER_HOLDING])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Replace old configuration test harness that allowed both old style and current style configurations, with a slimmer easier to read fixture.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
