### PR TITLE
Raise bad request when receiving HTTP request from untrusted proxy

### DIFF
--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -47,7 +47,8 @@ def async_setup_forwarded(
 
     Additionally:
       - If no X-Forwarded-For header is found, the processing of all headers is skipped.
-      - Log a warning when untrusted connected peer provides X-Forwarded-For headers.
+      - Throw HTTP 400 status when untrusted connected peer provides
+        X-Forwarded-For headers.
       - If multiple instances of X-Forwarded-For, X-Forwarded-Proto or
         X-Forwarded-Host are found, an HTTP 400 status code is thrown.
       - If malformed or invalid (IP) data in X-Forwarded-For header is found,
@@ -87,26 +88,22 @@ def async_setup_forwarded(
 
         # We have X-Forwarded-For, but config does not agree
         if not use_x_forwarded_for:
-            _LOGGER.warning(
+            _LOGGER.error(
                 "A request from a reverse proxy was received from %s, but your "
-                "HTTP integration is not set-up for reverse proxies; "
-                "This request will be blocked in Home Assistant 2021.7 unless "
-                "you configure your HTTP integration to allow this header",
+                "HTTP integration is not set-up for reverse proxies",
                 connected_ip,
             )
             # Block this request in the future, for now we pass.
-            return await handler(request)
+            raise HTTPBadRequest
 
         # Ensure the IP of the connected peer is trusted
         if not any(connected_ip in trusted_proxy for trusted_proxy in trusted_proxies):
-            _LOGGER.warning(
-                "Received X-Forwarded-For header from untrusted proxy %s, headers not processed; "
-                "This request will be blocked in Home Assistant 2021.7 unless you configure "
-                "your HTTP integration to allow this proxy to reverse your Home Assistant instance",
+            _LOGGER.error(
+                "Received X-Forwarded-For header from an untrusted proxy %s",
                 connected_ip,
             )
             # Not trusted, Block this request in the future, continue as normal
-            return await handler(request)
+            raise HTTPBadRequest
 
         # Multiple X-Forwarded-For headers
         if len(forwarded_for_headers) > 1:

--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -93,7 +93,6 @@ def async_setup_forwarded(
                 "HTTP integration is not set-up for reverse proxies",
                 connected_ip,
             )
-            # Block this request in the future, for now we pass.
             raise HTTPBadRequest
 
         # Ensure the IP of the connected peer is trusted
@@ -102,7 +101,6 @@ def async_setup_forwarded(
                 "Received X-Forwarded-For header from an untrusted proxy %s",
                 connected_ip,
             )
-            # Not trusted, Block this request in the future, continue as normal
             raise HTTPBadRequest
 
         # Multiple X-Forwarded-For headers


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Home Assistant will now block HTTP requests when a misconfigured reverse proxy, or misconfigured Home Assistant instance when using a reverse proxy, has been detected.

If you are using a reverse proxy, please make sure you have configured `use_x_forwarded_for` and `trusted_proxies` in your HTTP integration configuration.

For more information, see the [HTTP integration documentation](https://www.home-assistant.io/integrations/http#use_x_forwarded_for).


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Followup of #51332, now blocking requests from untrusted proxies by raising an HTTPBadRequest

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
