### PR TITLE
Define NumberEntity entity attributes as class variables

### DIFF
--- a/homeassistant/components/demo/number.py
+++ b/homeassistant/components/demo/number.py
@@ -1,4 +1,6 @@
 """Demo platform that offers a fake Number entity."""
+from __future__ import annotations
+
 import voluptuous as vol
 
 from homeassistant.components.number import NumberEntity
@@ -40,26 +42,32 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
 class DemoNumber(NumberEntity):
     """Representation of a demo Number entity."""
 
+    _attr_should_poll = False
+
     def __init__(
         self,
-        unique_id,
-        name,
-        state,
-        icon,
-        assumed,
-        min_value=None,
-        max_value=None,
+        unique_id: str,
+        name: str,
+        state: float,
+        icon: str,
+        assumed: bool,
+        min_value: float | None = None,
+        max_value: float | None = None,
         step=None,
     ):
         """Initialize the Demo Number entity."""
-        self._unique_id = unique_id
-        self._name = name or DEVICE_DEFAULT_NAME
-        self._state = state
-        self._icon = icon
-        self._assumed = assumed
-        self._min_value = min_value
-        self._max_value = max_value
-        self._step = step
+        self._attr_assumed_state = assumed
+        self._attr_icon = icon
+        self._attr_name = name or DEVICE_DEFAULT_NAME
+        self._attr_unique_id = unique_id
+        self._attr_value = state
+
+        if min_value is not None:
+            self._attr_min_value = min_value
+        if max_value is not None:
+            self._attr_max_value = max_value
+        if step is not None:
+            self._attr_step = step
 
     @property
     def device_info(self):
@@ -72,51 +80,6 @@ class DemoNumber(NumberEntity):
             "name": self.name,
         }
 
-    @property
-    def unique_id(self):
-        """Return the unique id."""
-        return self._unique_id
-
-    @property
-    def should_poll(self):
-        """No polling needed for a demo Number entity."""
-        return False
-
-    @property
-    def name(self):
-        """Return the name of the device if any."""
-        return self._name
-
-    @property
-    def icon(self):
-        """Return the icon to use for device if any."""
-        return self._icon
-
-    @property
-    def assumed_state(self):
-        """Return if the state is based on assumptions."""
-        return self._assumed
-
-    @property
-    def value(self):
-        """Return the current value."""
-        return self._state
-
-    @property
-    def min_value(self):
-        """Return the minimum value."""
-        return self._min_value or super().min_value
-
-    @property
-    def max_value(self):
-        """Return the maximum value."""
-        return self._max_value or super().max_value
-
-    @property
-    def step(self):
-        """Return the value step."""
-        return self._step or super().step
-
     async def async_set_value(self, value):
         """Update the current value."""
         num_value = float(value)
@@ -126,5 +89,5 @@ class DemoNumber(NumberEntity):
                 f"Invalid value for {self.entity_id}: {value} (range {self.min_value} - {self.max_value})"
             )
 
-        self._state = num_value
+        self._attr_value = num_value
         self.async_write_ha_state()

--- a/homeassistant/components/demo/number.py
+++ b/homeassistant/components/demo/number.py
@@ -54,7 +54,7 @@ class DemoNumber(NumberEntity):
         min_value: float | None = None,
         max_value: float | None = None,
         step=None,
-    ):
+    ) -> None:
         """Initialize the Demo Number entity."""
         self._attr_assumed_state = assumed
         self._attr_icon = icon

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -1,10 +1,9 @@
 """Component to allow numeric input for platforms."""
 from __future__ import annotations
 
-from abc import abstractmethod
 from datetime import timedelta
 import logging
-from typing import Any
+from typing import Any, final
 
 import voluptuous as vol
 
@@ -68,6 +67,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 class NumberEntity(Entity):
     """Representation of a Number entity."""
 
+    _attr_max_value: float = DEFAULT_MAX_VALUE
+    _attr_min_value: float = DEFAULT_MIN_VALUE
+    _attr_state: None = None
+    _attr_step: float
+    _attr_value: float
+
     @property
     def capability_attributes(self) -> dict[str, Any]:
         """Return capability attributes."""
@@ -80,16 +85,18 @@ class NumberEntity(Entity):
     @property
     def min_value(self) -> float:
         """Return the minimum value."""
-        return DEFAULT_MIN_VALUE
+        return self._attr_min_value
 
     @property
     def max_value(self) -> float:
         """Return the maximum value."""
-        return DEFAULT_MAX_VALUE
+        return self._attr_max_value
 
     @property
     def step(self) -> float:
         """Return the increment/decrement step."""
+        if hasattr(self, "_attr_step"):
+            return self._attr_step
         step = DEFAULT_STEP
         value_range = abs(self.max_value - self.min_value)
         if value_range != 0:
@@ -98,14 +105,15 @@ class NumberEntity(Entity):
         return step
 
     @property
+    @final
     def state(self) -> float:
         """Return the entity state."""
         return self.value
 
     @property
-    @abstractmethod
     def value(self) -> float:
         """Return the entity value to represent the entity state."""
+        return self._attr_value
 
     def set_value(self, value: float) -> None:
         """Set new value."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Defines `NumberEntity` entity attributes as class variables,
followup of the implementation started in #50925

For full context #50925 is the best place to take a look.

The demo integration humidifier was added as a small reference implementation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
