### PR TITLE
Add Select entity component platform

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -61,6 +61,7 @@ homeassistant.components.recorder.repack
 homeassistant.components.recorder.statistics
 homeassistant.components.remote.*
 homeassistant.components.scene.*
+homeassistant.components.select.*
 homeassistant.components.sensor.*
 homeassistant.components.slack.*
 homeassistant.components.sonos.media_player

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -423,6 +423,7 @@ homeassistant/components/scrape/* @fabaff
 homeassistant/components/screenlogic/* @dieselrabbit
 homeassistant/components/script/* @home-assistant/core
 homeassistant/components/search/* @home-assistant/core
+homeassistant/components/select/* @home-assistant/core
 homeassistant/components/sense/* @kbickar
 homeassistant/components/sensibo/* @andrey-git
 homeassistant/components/sentry/* @dcramer @frenck

--- a/homeassistant/components/demo/__init__.py
+++ b/homeassistant/components/demo/__init__.py
@@ -20,6 +20,7 @@ COMPONENTS_WITH_CONFIG_ENTRY_DEMO_PLATFORM = [
     "lock",
     "media_player",
     "number",
+    "select",
     "sensor",
     "switch",
     "vacuum",

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -26,6 +26,7 @@ async def async_setup_platform(
                 unique_id="speed",
                 name="Speed",
                 icon="mdi:volume-high",
+                device_class="demo__speed",
                 current_option="ridiculous_speed",
                 options=[
                     "light_speed",
@@ -56,6 +57,7 @@ class DemoSelect(SelectEntity):
         unique_id: str,
         name: str,
         icon: str,
+        device_class: str | None,
         current_option: str | None,
         options: list[str],
     ) -> None:
@@ -64,6 +66,7 @@ class DemoSelect(SelectEntity):
         self._attr_name = name or DEVICE_DEFAULT_NAME
         self._attr_current_option = current_option
         self._attr_icon = icon
+        self._attr_device_class = device_class
         self._attr_options = options
         self._attr_device_info = {
             "identifiers": {(DOMAIN, unique_id)},

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -19,7 +19,7 @@ async def async_setup_platform(
     async_add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType = None,
 ) -> None:
-    """Set up the demo Number entity."""
+    """Set up the demo Select entity."""
     async_add_entities(
         [
             DemoSelect(

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -25,7 +25,7 @@ async def async_setup_platform(
             DemoSelect(
                 unique_id="speed",
                 name="Speed",
-                icon="mdi:volume-high",
+                icon="mdi:speedometer",
                 device_class="demo__speed",
                 current_option="ridiculous_speed",
                 options=[

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -1,0 +1,79 @@
+"""Demo platform that offers a fake select entity."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import DEVICE_DEFAULT_NAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+from . import DOMAIN
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType = None,
+) -> None:
+    """Set up the demo Number entity."""
+    async_add_entities(
+        [
+            DemoSelect(
+                unique_id="speed",
+                name="Speed",
+                icon="mdi:volume-high",
+                current_option="ridiculous_speed",
+                options=[
+                    "light_speed",
+                    "ridiculous_speed",
+                    "ludicrous_speed",
+                ],
+            ),
+        ]
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the Demo config entry."""
+    await async_setup_platform(hass, {}, async_add_entities)
+
+
+class DemoSelect(SelectEntity):
+    """Representation of a demo select entity."""
+
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        unique_id: str,
+        name: str,
+        icon: str,
+        current_option: str | None,
+        options: list[str],
+    ) -> None:
+        """Initialize the Demo select entity."""
+        self._attr_unique_id = unique_id
+        self._attr_name = name or DEVICE_DEFAULT_NAME
+        self._attr_current_option = current_option
+        self._attr_icon = icon
+        self._attr_options = options
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, unique_id)},
+            "name": name,
+        }
+
+    async def async_select_option(self, option: str | None) -> None:
+        """Update the current selected option."""
+        if option not in self.options:
+            raise vol.Invalid(f"Invalid option for {self.entity_id}: {option}")
+
+        self._attr_current_option = option
+        self.async_write_ha_state()

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -26,6 +26,7 @@ async def async_setup_platform(
                 unique_id="speed",
                 name="Speed",
                 icon="mdi:speedometer",
+                device_class="demo__speed",
                 current_option="ridiculous_speed",
                 options=[
                     "light_speed",
@@ -56,6 +57,7 @@ class DemoSelect(SelectEntity):
         unique_id: str,
         name: str,
         icon: str,
+        device_class: str | None,
         current_option: str | None,
         options: list[str],
     ) -> None:
@@ -64,6 +66,7 @@ class DemoSelect(SelectEntity):
         self._attr_name = name or DEVICE_DEFAULT_NAME
         self._attr_current_option = current_option
         self._attr_icon = icon
+        self._attr_device_class = device_class
         self._attr_options = options
         self._attr_device_info = {
             "identifiers": {(DOMAIN, unique_id)},

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -26,7 +26,6 @@ async def async_setup_platform(
                 unique_id="speed",
                 name="Speed",
                 icon="mdi:speedometer",
-                device_class="demo__speed",
                 current_option="ridiculous_speed",
                 options=[
                     "light_speed",
@@ -57,7 +56,6 @@ class DemoSelect(SelectEntity):
         unique_id: str,
         name: str,
         icon: str,
-        device_class: str | None,
         current_option: str | None,
         options: list[str],
     ) -> None:
@@ -66,7 +64,6 @@ class DemoSelect(SelectEntity):
         self._attr_name = name or DEVICE_DEFAULT_NAME
         self._attr_current_option = current_option
         self._attr_icon = icon
-        self._attr_device_class = device_class
         self._attr_options = options
         self._attr_device_info = {
             "identifiers": {(DOMAIN, unique_id)},

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -71,7 +71,7 @@ class DemoSelect(SelectEntity):
             "name": name,
         }
 
-    async def async_select_option(self, option: str | None) -> None:
+    async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
         if option not in self.options:
             raise ValueError(f"Invalid option for {self.entity_id}: {option}")

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -1,8 +1,6 @@
 """Demo platform that offers a fake select entity."""
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEVICE_DEFAULT_NAME
@@ -76,7 +74,7 @@ class DemoSelect(SelectEntity):
     async def async_select_option(self, option: str | None) -> None:
         """Update the current selected option."""
         if option not in self.options:
-            raise vol.Invalid(f"Invalid option for {self.entity_id}: {option}")
+            raise ValueError(f"Invalid option for {self.entity_id}: {option}")
 
         self._attr_current_option = option
         self.async_write_ha_state()

--- a/homeassistant/components/demo/strings.select.json
+++ b/homeassistant/components/demo/strings.select.json
@@ -1,0 +1,9 @@
+{
+  "state": {
+    "demo__speed": {
+      "light_speed": "Light Speed",
+      "ludicrous_speed": "Ludicrous Speed",
+      "ridiculous_speed": "Ridiculous Speed"
+    }
+  }
+}

--- a/homeassistant/components/demo/strings.select.json
+++ b/homeassistant/components/demo/strings.select.json
@@ -1,6 +1,6 @@
 {
   "state": {
-    "demo__speed": {
+    "_": {
       "light_speed": "Light Speed",
       "ludicrous_speed": "Ludicrous Speed",
       "ridiculous_speed": "Ridiculous Speed"

--- a/homeassistant/components/demo/strings.select.json
+++ b/homeassistant/components/demo/strings.select.json
@@ -1,6 +1,6 @@
 {
   "state": {
-    "_": {
+    "demo__speed": {
       "light_speed": "Light Speed",
       "ludicrous_speed": "Ludicrous Speed",
       "ridiculous_speed": "Ridiculous Speed"

--- a/homeassistant/components/demo/translations/select.en.json
+++ b/homeassistant/components/demo/translations/select.en.json
@@ -1,0 +1,9 @@
+{
+    "state": {
+        "demo__speed": {
+            "light_speed": "Light Speed",
+            "ludicrous_speed": "Ludicrous Speed",
+            "ridiculous_speed": "Ridiculous Speed"
+        }
+    }
+}

--- a/homeassistant/components/demo/translations/select.en.json
+++ b/homeassistant/components/demo/translations/select.en.json
@@ -1,6 +1,6 @@
 {
     "state": {
-        "_": {
+        "demo__speed": {
             "light_speed": "Light Speed",
             "ludicrous_speed": "Ludicrous Speed",
             "ridiculous_speed": "Ridiculous Speed"

--- a/homeassistant/components/demo/translations/select.en.json
+++ b/homeassistant/components/demo/translations/select.en.json
@@ -1,6 +1,6 @@
 {
     "state": {
-        "demo__speed": {
+        "_": {
             "light_speed": "Light Speed",
             "ludicrous_speed": "Ludicrous Speed",
             "ridiculous_speed": "Ridiculous Speed"

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -1,0 +1,96 @@
+"""Component to allow selecting an option from a list as platforms."""
+from __future__ import annotations
+
+from datetime import timedelta
+import logging
+from typing import Any, cast, final
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.config_validation import (  # noqa: F401
+    PLATFORM_SCHEMA,
+    PLATFORM_SCHEMA_BASE,
+)
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.typing import ConfigType
+
+from .const import ATTR_OPTION, ATTR_OPTIONS, DOMAIN, SERVICE_SELECT_OPTION
+
+SCAN_INTERVAL = timedelta(seconds=30)
+
+ENTITY_ID_FORMAT = DOMAIN + ".{}"
+
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up Select entities."""
+    component = hass.data[DOMAIN] = EntityComponent(
+        _LOGGER, DOMAIN, hass, SCAN_INTERVAL
+    )
+    await component.async_setup(config)
+
+    component.async_register_entity_service(
+        SERVICE_SELECT_OPTION,
+        {vol.Required(ATTR_OPTION): cv.string},
+        "async_select_option",
+    )
+
+    return True
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up a config entry."""
+    return cast(bool, await hass.data[DOMAIN].async_setup_entry(entry))
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a config entry."""
+    return cast(bool, await hass.data[DOMAIN].async_unload_entry(entry))
+
+
+class SelectEntity(Entity):
+    """Representation of a Select entity."""
+
+    _attr_current_option: str | None
+    _attr_options: list[str]
+    _attr_state: None = None
+
+    @property
+    def capability_attributes(self) -> dict[str, Any]:
+        """Return capability attributes."""
+        return {
+            ATTR_OPTIONS: self.options,
+        }
+
+    @property
+    @final
+    def state(self) -> str | None:
+        """Return the entity state."""
+        if self.current_option is None or self.current_option not in self.options:
+            return None
+        return self.current_option
+
+    @property
+    def options(self) -> list[str]:
+        """Return a set of selectable options."""
+        return self._attr_options
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected entity option to represent the entity state."""
+        return self._attr_current_option
+
+    def select_option(self, option: str | None) -> None:
+        """Change the selected option."""
+        raise NotImplementedError()
+
+    async def async_select_option(self, option: str | None) -> None:
+        """Change the selected option."""
+        await self.hass.async_add_executor_job(self.select_option, option)

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -89,10 +89,10 @@ class SelectEntity(Entity):
         """Return the selected entity option to represent the entity state."""
         return self._attr_current_option
 
-    def select_option(self, option: str | None) -> None:
+    def select_option(self, option: str) -> None:
         """Change the selected option."""
         raise NotImplementedError()
 
-    async def async_select_option(self, option: str | None) -> None:
+    async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         await self.hass.async_add_executor_job(self.select_option, option)

--- a/homeassistant/components/select/__init__.py
+++ b/homeassistant/components/select/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any, cast, final
+from typing import Any, final
 
 import voluptuous as vol
 
@@ -47,12 +47,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up a config entry."""
-    return cast(bool, await hass.data[DOMAIN].async_setup_entry(entry))
+    component: EntityComponent = hass.data[DOMAIN]
+    return await component.async_setup_entry(entry)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    return cast(bool, await hass.data[DOMAIN].async_unload_entry(entry))
+    component: EntityComponent = hass.data[DOMAIN]
+    return await component.async_unload_entry(entry)
 
 
 class SelectEntity(Entity):

--- a/homeassistant/components/select/const.py
+++ b/homeassistant/components/select/const.py
@@ -1,0 +1,8 @@
+"""Provides the constants needed for the component."""
+
+DOMAIN = "select"
+
+ATTR_OPTIONS = "options"
+ATTR_OPTION = "option"
+
+SERVICE_SELECT_OPTION = "select_option"

--- a/homeassistant/components/select/manifest.json
+++ b/homeassistant/components/select/manifest.json
@@ -1,0 +1,7 @@
+{
+  "domain": "select",
+  "name": "Select",
+  "documentation": "https://www.home-assistant.io/integrations/select",
+  "codeowners": ["@home-assistant/core"],
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/select/services.yaml
+++ b/homeassistant/components/select/services.yaml
@@ -1,0 +1,14 @@
+select_option:
+  name: Select
+  description: Select an option of an select entity.
+  target:
+    entity:
+      domain: select
+  fields:
+    option:
+      name: Option
+      description: Option to be selected.
+      required: true
+      example: '"Item A"'
+      selector:
+        text:

--- a/homeassistant/components/select/strings.json
+++ b/homeassistant/components/select/strings.json
@@ -1,0 +1,3 @@
+{
+  "title": "Select"
+}

--- a/mypy.ini
+++ b/mypy.ini
@@ -682,6 +682,17 @@ no_implicit_optional = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.select.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+no_implicit_optional = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.sensor.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -91,6 +91,7 @@ NO_IOT_CLASS = [
     "scene",
     "script",
     "search",
+    "select",
     "sensor",
     "stt",
     "switch",

--- a/tests/components/demo/test_select.py
+++ b/tests/components/demo/test_select.py
@@ -1,0 +1,74 @@
+"""The tests for the demo select component."""
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.components.select.const import (
+    ATTR_OPTION,
+    ATTR_OPTIONS,
+    DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+
+ENTITY_SPEED = "select.speed"
+
+
+@pytest.fixture(autouse=True)
+async def setup_demo_select(hass: HomeAssistant) -> None:
+    """Initialize setup demo Number entity."""
+    assert await async_setup_component(hass, DOMAIN, {"select": {"platform": "demo"}})
+    await hass.async_block_till_done()
+
+
+def test_setup_params(hass: HomeAssistant) -> None:
+    """Test the initial parameters."""
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ridiculous_speed"
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "light_speed",
+        "ridiculous_speed",
+        "ludicrous_speed",
+    ]
+
+
+async def test_select_option_bad_attr(hass: HomeAssistant) -> None:
+    """Test selecting a different option with invalid option value."""
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ridiculous_speed"
+
+    with pytest.raises(vol.Invalid):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {ATTR_OPTION: "slow_speed", ATTR_ENTITY_ID: ENTITY_SPEED},
+            blocking=True,
+        )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ridiculous_speed"
+
+
+async def test_select_option(hass: HomeAssistant) -> None:
+    """Test selecting of a option."""
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "ridiculous_speed"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_OPTION: "light_speed", ATTR_ENTITY_ID: ENTITY_SPEED},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_SPEED)
+    assert state
+    assert state.state == "light_speed"

--- a/tests/components/demo/test_select.py
+++ b/tests/components/demo/test_select.py
@@ -18,7 +18,7 @@ ENTITY_SPEED = "select.speed"
 
 @pytest.fixture(autouse=True)
 async def setup_demo_select(hass: HomeAssistant) -> None:
-    """Initialize setup demo Number entity."""
+    """Initialize setup demo select entity."""
     assert await async_setup_component(hass, DOMAIN, {"select": {"platform": "demo"}})
     await hass.async_block_till_done()
 

--- a/tests/components/demo/test_select.py
+++ b/tests/components/demo/test_select.py
@@ -1,7 +1,6 @@
 """The tests for the demo select component."""
 
 import pytest
-import voluptuous as vol
 
 from homeassistant.components.select.const import (
     ATTR_OPTION,

--- a/tests/components/demo/test_select.py
+++ b/tests/components/demo/test_select.py
@@ -41,7 +41,7 @@ async def test_select_option_bad_attr(hass: HomeAssistant) -> None:
     assert state
     assert state.state == "ridiculous_speed"
 
-    with pytest.raises(vol.Invalid):
+    with pytest.raises(ValueError):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SELECT_OPTION,

--- a/tests/components/select/__init__.py
+++ b/tests/components/select/__init__.py
@@ -1,0 +1,1 @@
+"""The tests for the Select integration."""

--- a/tests/components/select/test_init.py
+++ b/tests/components/select/test_init.py
@@ -1,0 +1,17 @@
+"""The tests for the Select component."""
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+
+
+class MockSelectEntity(SelectEntity):
+    """Mock SelectEntity to use in tests."""
+
+    _attr_current_option = "option_one"
+    _attr_options = ["option_one", "option_two", "option_three"]
+
+
+async def test_select(hass: HomeAssistant) -> None:
+    """Test getting data from the mocked select entity."""
+    select = MockSelectEntity()
+    assert select.current_option == "option_one"
+    assert select.options == ["option_one", "option_two", "option_three"]

--- a/tests/components/select/test_init.py
+++ b/tests/components/select/test_init.py
@@ -14,4 +14,15 @@ async def test_select(hass: HomeAssistant) -> None:
     """Test getting data from the mocked select entity."""
     select = MockSelectEntity()
     assert select.current_option == "option_one"
+    assert select.state == "option_one"
     assert select.options == ["option_one", "option_two", "option_three"]
+
+    # Test none selected
+    select._attr_current_option = None
+    assert select.current_option is None
+    assert select.state is None
+
+    # Test none existing selected
+    select._attr_current_option = "option_four"
+    assert select.current_option == "option_four"
+    assert select.state is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add the `SelectEntity` component to Home Assistant, providing an entity similar to `input_select`, but usable for other integrations.

The current implementation has been limited as much as possible, providing a list of options and the possibility to select the current option.

The difference with `input_select`:

- Usable by other integrations
- Options are provided by the integration and not user modifiable (`input_select` are mutable via service).
- Options/states are translatable.

This component would provide a use case for all situations where we have to deal with more than 2 states. In those cases, a switch doesn't suffice and currently, we use a sensor entity + an additional service. This can be simplified using this component.

In follow-up PRs things like device triggers/actions, "reproduce state" and "significant change" can be implemented.

![image](https://user-images.githubusercontent.com/195327/121935210-78070f00-cd48-11eb-99cc-6cdbeaafa470.png)

![image](https://user-images.githubusercontent.com/195327/121935249-82c1a400-cd48-11eb-90d6-9e5c75bb1180.png)

![image](https://user-images.githubusercontent.com/195327/121935272-89501b80-cd48-11eb-9568-4cbb3ffa7221.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/9422
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18194
- Link to brands pull request: https://github.com/home-assistant/brands/pull/2636
- Link to developer docs pull request: https://github.com/home-assistant/developers.home-assistant/pull/969


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
