### PR TITLE
Create service to enable Continuous Mode on Nuki Opener

### DIFF
--- a/homeassistant/components/nuki/const.py
+++ b/homeassistant/components/nuki/const.py
@@ -4,6 +4,7 @@ DOMAIN = "nuki"
 # Attributes
 ATTR_BATTERY_CRITICAL = "battery_critical"
 ATTR_NUKI_ID = "nuki_id"
+ATTR_ENABLE = "enable"
 ATTR_UNLATCH = "unlatch"
 
 # Data

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import config_validation as cv, entity_platform
 from . import NukiEntity
 from .const import (
     ATTR_BATTERY_CRITICAL,
+    ATTR_ENABLE,
     ATTR_NUKI_ID,
     ATTR_UNLATCH,
     DATA_COORDINATOR,
@@ -58,6 +59,11 @@ async def async_setup_entry(hass, entry, async_add_entities):
             vol.Optional(ATTR_UNLATCH, default=False): cv.boolean,
         },
         "lock_n_go",
+        "set_continuous_mode",
+        {
+            vol.Optional(ATTR_ENABLE, default=False): cv.boolean,
+        },
+        "set_continuous_mode",
     )
 
 
@@ -165,3 +171,12 @@ class NukiOpenerEntity(NukiDeviceEntity):
 
     def lock_n_go(self, unlatch):
         """Stub service."""
+
+    def set_continuous_mode(self, enable):
+        """Continuous Mode.
+
+        This feature will cause the door to automatically open when anyone
+        rings the bell. This is similar to ring-to-open, except that it does
+        not automatically deactivate
+        """
+        self._nuki_device.activate_continuous_mode() if enable else self._nuki_device.deactivate_continuous_mode()

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -179,4 +179,7 @@ class NukiOpenerEntity(NukiDeviceEntity):
         rings the bell. This is similar to ring-to-open, except that it does
         not automatically deactivate
         """
-        self._nuki_device.activate_continuous_mode() if enable else self._nuki_device.deactivate_continuous_mode()
+        if enable:
+            self._nuki_device.activate_continuous_mode()
+        else:
+            self._nuki_device.deactivate_continuous_mode()

--- a/homeassistant/components/nuki/lock.py
+++ b/homeassistant/components/nuki/lock.py
@@ -61,7 +61,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         "lock_n_go",
         "set_continuous_mode",
         {
-            vol.Optional(ATTR_ENABLE, default=False): cv.boolean,
+            vol.Required(ATTR_ENABLE): cv.boolean,
         },
         "set_continuous_mode",
     )

--- a/homeassistant/components/nuki/services.yaml
+++ b/homeassistant/components/nuki/services.yaml
@@ -12,3 +12,17 @@ lock_n_go:
       default: false
       selector:
         boolean:
+set_continuous_mode:
+  name: Set Continuous Mode
+  description: "Enable or disable Continuous Mode on Nuki Opener"
+  target:
+    entity:
+      integration: nuki
+      domain: lock
+  fields:
+    enable:
+      name: Enable
+      description: Whether to enable or disable the feature
+      default: false
+      selector:
+        boolean:


### PR DESCRIPTION
## Proposed change

This PR enables enabling / disabling Continuous Mode on the Nuki Opener. This mode is similar to ring-to-open, which opens the door when the buzzer is pressed but only for a certain amount of time, except that continuous mode simply will _always_ open the door when enabled, similar to a business during the day.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18207

## Checklist

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
