### PR TITLE
Support bitmask as a value

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -51,6 +51,7 @@ from .const import (
     EVENT_DEVICE_ADDED_TO_REGISTRY,
 )
 from .helpers import async_enable_statistics, update_data_collection_preference
+from .services import BITMASK_SCHEMA
 
 # general API constants
 ID = "id"
@@ -924,7 +925,7 @@ async def websocket_refresh_node_cc_values(
         vol.Required(NODE_ID): int,
         vol.Required(PROPERTY): int,
         vol.Optional(PROPERTY_KEY): int,
-        vol.Required(VALUE): int,
+        vol.Required(VALUE): vol.Any(int, BITMASK_SCHEMA),
     }
 )
 @websocket_api.async_response

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -177,7 +177,7 @@ class ZWaveServices:
                             vol.Coerce(int), BITMASK_SCHEMA
                         ),
                         vol.Required(const.ATTR_CONFIG_VALUE): vol.Any(
-                            vol.Coerce(int), cv.string
+                            vol.Coerce(int), BITMASK_SCHEMA, cv.string
                         ),
                     },
                     cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
@@ -204,7 +204,7 @@ class ZWaveServices:
                             {
                                 vol.Any(
                                     vol.Coerce(int), BITMASK_SCHEMA, cv.string
-                                ): vol.Any(vol.Coerce(int), cv.string)
+                                ): vol.Any(vol.Coerce(int), BITMASK_SCHEMA, cv.string)
                             },
                         ),
                     },
@@ -224,7 +224,7 @@ class ZWaveServices:
                         vol.Required(ATTR_ENTITY_ID): cv.entity_ids,
                         vol.Optional(
                             const.ATTR_REFRESH_ALL_VALUES, default=False
-                        ): bool,
+                        ): cv.boolean,
                     },
                     validate_entities,
                 )
@@ -251,9 +251,15 @@ class ZWaveServices:
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
                         vol.Required(const.ATTR_VALUE): vol.Any(
-                            bool, vol.Coerce(int), vol.Coerce(float), cv.string
+                            vol.Coerce(int),
+                            vol.Coerce(float),
+                            cv.boolean,
+                            BITMASK_SCHEMA,
+                            cv.string,
                         ),
-                        vol.Optional(const.ATTR_WAIT_FOR_RESULT): vol.Coerce(bool),
+                        vol.Optional(const.ATTR_WAIT_FOR_RESULT): vol.Coerce(
+                            cv.boolean
+                        ),
                     },
                     cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
                     get_nodes_from_service_data,
@@ -282,7 +288,7 @@ class ZWaveServices:
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
                         vol.Required(const.ATTR_VALUE): vol.Any(
-                            bool, vol.Coerce(int), vol.Coerce(float), cv.string
+                            vol.Coerce(int), vol.Coerce(float), cv.boolean, cv.string
                         ),
                     },
                     vol.Any(

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -66,6 +66,14 @@ BITMASK_SCHEMA = vol.All(
     lambda value: int(value, 16),
 )
 
+VALUE_SCHEMA = vol.Any(
+    vol.Coerce(int),
+    vol.Coerce(float),
+    cv.boolean,
+    BITMASK_SCHEMA,
+    cv.string,
+)
+
 
 class ZWaveServices:
     """Class that holds our services (Zwave Commands) that should be published to hass."""
@@ -250,13 +258,7 @@ class ZWaveServices:
                             vol.Coerce(int), str
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
-                        vol.Required(const.ATTR_VALUE): vol.Any(
-                            vol.Coerce(int),
-                            vol.Coerce(float),
-                            cv.boolean,
-                            BITMASK_SCHEMA,
-                            cv.string,
-                        ),
+                        vol.Required(const.ATTR_VALUE): VALUE_SCHEMA,
                         vol.Optional(const.ATTR_WAIT_FOR_RESULT): vol.Coerce(
                             cv.boolean
                         ),
@@ -287,9 +289,7 @@ class ZWaveServices:
                             vol.Coerce(int), str
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
-                        vol.Required(const.ATTR_VALUE): vol.Any(
-                            vol.Coerce(int), vol.Coerce(float), cv.boolean, cv.string
-                        ),
+                        vol.Required(const.ATTR_VALUE): VALUE_SCHEMA,
                     },
                     vol.Any(
                         cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),

--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -67,9 +67,9 @@ BITMASK_SCHEMA = vol.All(
 )
 
 VALUE_SCHEMA = vol.Any(
+    bool,
     vol.Coerce(int),
     vol.Coerce(float),
-    cv.boolean,
     BITMASK_SCHEMA,
     cv.string,
 )
@@ -259,9 +259,7 @@ class ZWaveServices:
                         ),
                         vol.Optional(const.ATTR_ENDPOINT): vol.Coerce(int),
                         vol.Required(const.ATTR_VALUE): VALUE_SCHEMA,
-                        vol.Optional(const.ATTR_WAIT_FOR_RESULT): vol.Coerce(
-                            cv.boolean
-                        ),
+                        vol.Optional(const.ATTR_WAIT_FOR_RESULT): cv.boolean,
                     },
                     cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
                     get_nodes_from_service_data,

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -1179,13 +1179,62 @@ async def test_set_config_parameter(
 
     client.async_send_command_no_wait.reset_mock()
 
+    # Test that hex strings are accepted and converted as expected
+    client.async_send_command_no_wait.return_value = None
+
+    await ws_client.send_json(
+        {
+            ID: 2,
+            TYPE: "zwave_js/set_config_parameter",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 52,
+            PROPERTY: 102,
+            PROPERTY_KEY: 1,
+            VALUE: "0x1",
+        }
+    )
+
+    msg = await ws_client.receive_json()
+    assert msg["success"]
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClassName": "Configuration",
+        "commandClass": 112,
+        "endpoint": 0,
+        "property": 102,
+        "propertyName": "Group 2: Send battery reports",
+        "propertyKey": 1,
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "valueSize": 4,
+            "min": 0,
+            "max": 1,
+            "default": 1,
+            "format": 0,
+            "allowManualEntry": True,
+            "label": "Group 2: Send battery reports",
+            "description": "Include battery information in periodic reports to Group 2",
+            "isFromConfig": True,
+        },
+        "value": 0,
+    }
+    assert args["value"] == 1
+
+    client.async_send_command_no_wait.reset_mock()
+
     with patch(
         "homeassistant.components.zwave_js.api.async_set_config_parameter",
     ) as set_param_mock:
         set_param_mock.side_effect = InvalidNewValue("test")
         await ws_client.send_json(
             {
-                ID: 2,
+                ID: 3,
                 TYPE: "zwave_js/set_config_parameter",
                 ENTRY_ID: entry.entry_id,
                 NODE_ID: 52,
@@ -1205,7 +1254,7 @@ async def test_set_config_parameter(
         set_param_mock.side_effect = NotFoundError("test")
         await ws_client.send_json(
             {
-                ID: 3,
+                ID: 4,
                 TYPE: "zwave_js/set_config_parameter",
                 ENTRY_ID: entry.entry_id,
                 NODE_ID: 52,
@@ -1225,7 +1274,7 @@ async def test_set_config_parameter(
         set_param_mock.side_effect = SetValueFailed("test")
         await ws_client.send_json(
             {
-                ID: 4,
+                ID: 5,
                 TYPE: "zwave_js/set_config_parameter",
                 ENTRY_ID: entry.entry_id,
                 NODE_ID: 52,
@@ -1245,7 +1294,7 @@ async def test_set_config_parameter(
     # Test getting non-existent node fails
     await ws_client.send_json(
         {
-            ID: 5,
+            ID: 6,
             TYPE: "zwave_js/set_config_parameter",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 9999,
@@ -1264,7 +1313,7 @@ async def test_set_config_parameter(
 
     await ws_client.send_json(
         {
-            ID: 6,
+            ID: 7,
             TYPE: "zwave_js/set_config_parameter",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 52,

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -89,6 +89,50 @@ async def test_set_config_parameter(hass, client, multisensor_6, integration):
 
     client.async_send_command_no_wait.reset_mock()
 
+    # Test setting config parameter value in hex
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_CONFIG_PARAMETER,
+        {
+            ATTR_ENTITY_ID: AIR_TEMPERATURE_SENSOR,
+            ATTR_CONFIG_PARAMETER: 102,
+            ATTR_CONFIG_PARAMETER_BITMASK: 1,
+            ATTR_CONFIG_VALUE: "0x1",
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClassName": "Configuration",
+        "commandClass": 112,
+        "endpoint": 0,
+        "property": 102,
+        "propertyName": "Group 2: Send battery reports",
+        "propertyKey": 1,
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "valueSize": 4,
+            "min": 0,
+            "max": 1,
+            "default": 1,
+            "format": 0,
+            "allowManualEntry": True,
+            "label": "Group 2: Send battery reports",
+            "description": "Include battery information in periodic reports to Group 2",
+            "isFromConfig": True,
+        },
+        "value": 0,
+    }
+    assert args["value"] == 1
+
+    client.async_send_command_no_wait.reset_mock()
+
     # Test setting parameter by property name
     await hass.services.async_call(
         DOMAIN,
@@ -419,6 +463,36 @@ async def test_bulk_set_config_parameters(hass, client, multisensor_6, integrati
 
     client.async_send_command_no_wait.reset_mock()
 
+    # Test using hex values for config parameter values
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
+        {
+            ATTR_ENTITY_ID: AIR_TEMPERATURE_SENSOR,
+            ATTR_CONFIG_PARAMETER: 102,
+            ATTR_CONFIG_VALUE: {
+                1: "0x1",
+                16: "0x1",
+                32: "0x1",
+                64: "0x1",
+                128: "0x1",
+            },
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command_no_wait.call_args_list) == 1
+    args = client.async_send_command_no_wait.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 52
+    assert args["valueId"] == {
+        "commandClass": 112,
+        "property": 102,
+    }
+    assert args["value"] == 241
+
+    client.async_send_command_no_wait.reset_mock()
+
     await hass.services.async_call(
         DOMAIN,
         SERVICE_BULK_SET_PARTIAL_CONFIG_PARAMETERS,
@@ -535,6 +609,21 @@ async def test_poll_value(
     )
     assert len(client.async_send_command.call_args_list) == 8
 
+    client.async_send_command.reset_mock()
+
+    # Test polling all watched values using string for boolean
+    client.async_send_command.return_value = {"result": 2}
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_REFRESH_VALUE,
+        {
+            ATTR_ENTITY_ID: CLIMATE_RADIO_THERMOSTAT_ENTITY,
+            ATTR_REFRESH_ALL_VALUES: "true",
+        },
+        blocking=True,
+    )
+    assert len(client.async_send_command.call_args_list) == 8
+
     # Test polling against an invalid entity raises MultipleInvalid
     with pytest.raises(vol.MultipleInvalid):
         await hass.services.async_call(
@@ -585,6 +674,44 @@ async def test_set_value(hass, client, climate_danfoss_lc_13, integration):
     assert args["value"] == 2
 
     client.async_send_command_no_wait.reset_mock()
+
+    # Test bitmask as value and non bool as bool
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: CLIMATE_DANFOSS_LC13_ENTITY,
+            ATTR_COMMAND_CLASS: 117,
+            ATTR_PROPERTY: "local",
+            ATTR_VALUE: "0x2",
+            ATTR_WAIT_FOR_RESULT: 1,
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "node.set_value"
+    assert args["nodeId"] == 5
+    assert args["valueId"] == {
+        "commandClassName": "Protection",
+        "commandClass": 117,
+        "endpoint": 0,
+        "property": "local",
+        "propertyName": "local",
+        "ccVersion": 2,
+        "metadata": {
+            "type": "number",
+            "readable": True,
+            "writeable": True,
+            "label": "Local protection state",
+            "states": {"0": "Unprotected", "2": "NoOperationPossible"},
+        },
+        "value": 0,
+    }
+    assert args["value"] == 2
+
+    client.async_send_command.reset_mock()
 
     # Test that when a command fails we raise an exception
     client.async_send_command.return_value = {"success": False}
@@ -677,6 +804,68 @@ async def test_multicast_set_value(
         "property": "local",
     }
     assert args["value"] == 2
+
+    client.async_send_command.reset_mock()
+
+    # Test successful multicast call with hex value
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_MULTICAST_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: [
+                CLIMATE_DANFOSS_LC13_ENTITY,
+                CLIMATE_RADIO_THERMOSTAT_ENTITY,
+            ],
+            ATTR_COMMAND_CLASS: 117,
+            ATTR_PROPERTY: "local",
+            ATTR_VALUE: "0x2",
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "multicast_group.set_value"
+    assert args["nodeIDs"] == [
+        climate_radio_thermostat_ct100_plus_different_endpoints.node_id,
+        climate_danfoss_lc_13.node_id,
+    ]
+    assert args["valueId"] == {
+        "commandClass": 117,
+        "property": "local",
+    }
+    assert args["value"] == 2
+
+    client.async_send_command.reset_mock()
+
+    # Test successful multicast call with "bool"
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_MULTICAST_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: [
+                CLIMATE_DANFOSS_LC13_ENTITY,
+                CLIMATE_RADIO_THERMOSTAT_ENTITY,
+            ],
+            ATTR_COMMAND_CLASS: 117,
+            ATTR_PROPERTY: "local",
+            ATTR_VALUE: "1",
+        },
+        blocking=True,
+    )
+
+    assert len(client.async_send_command.call_args_list) == 1
+    args = client.async_send_command.call_args[0][0]
+    assert args["command"] == "multicast_group.set_value"
+    assert args["nodeIDs"] == [
+        climate_radio_thermostat_ct100_plus_different_endpoints.node_id,
+        climate_danfoss_lc_13.node_id,
+    ]
+    assert args["valueId"] == {
+        "commandClass": 117,
+        "property": "local",
+    }
+    assert args["value"] is True
 
     client.async_send_command.reset_mock()
 

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -849,7 +849,7 @@ async def test_multicast_set_value(
             ],
             ATTR_COMMAND_CLASS: 117,
             ATTR_PROPERTY: "local",
-            ATTR_VALUE: "1",
+            ATTR_VALUE: "true",
         },
         blocking=True,
     )

--- a/tests/components/zwave_js/test_services.py
+++ b/tests/components/zwave_js/test_services.py
@@ -838,37 +838,6 @@ async def test_multicast_set_value(
 
     client.async_send_command.reset_mock()
 
-    # Test successful multicast call with "bool"
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_MULTICAST_SET_VALUE,
-        {
-            ATTR_ENTITY_ID: [
-                CLIMATE_DANFOSS_LC13_ENTITY,
-                CLIMATE_RADIO_THERMOSTAT_ENTITY,
-            ],
-            ATTR_COMMAND_CLASS: 117,
-            ATTR_PROPERTY: "local",
-            ATTR_VALUE: "true",
-        },
-        blocking=True,
-    )
-
-    assert len(client.async_send_command.call_args_list) == 1
-    args = client.async_send_command.call_args[0][0]
-    assert args["command"] == "multicast_group.set_value"
-    assert args["nodeIDs"] == [
-        climate_radio_thermostat_ct100_plus_different_endpoints.node_id,
-        climate_danfoss_lc_13.node_id,
-    ]
-    assert args["valueId"] == {
-        "commandClass": 117,
-        "property": "local",
-    }
-    assert args["value"] is True
-
-    client.async_send_command.reset_mock()
-
     # Test successful broadcast call
     await hass.services.async_call(
         DOMAIN,


### PR DESCRIPTION
## Proposed change
See this comment for context: https://github.com/zwave-js/node-zwave-js/issues/2634#issuecomment-860307720

TLDR - At least one device requires the user to use a hex format to set a config parameter. We currently only accept decimal, otherwise we treat it as a boolean/string. In this change, in all places we accept a new value, we also accept a bitmask/hex value which will automatically get converted to a decimal as part of the validation, meaning no changes within the lib are required.

I also switched from `bool` to `cv.boolean` in the validations because it covers more scenarios and switched the order to avoid falsely calling an `int` a `bool`.

~~I didn't add any tests here since we already test `BITMASK_SCHEMA` in other tests, but happy to add some if needed.~~

Also, for now, I think it's ok to leave this feature undocumented because of how narrow of a use case it is. But that's just my opinion.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
