### PR TITLE
Fix Daikin integration power sensors 

### DIFF
--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -8,7 +8,7 @@ from homeassistant.const import (
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
-    ENERGY_KILO_WATT_HOUR,
+    FREQUENCY_HERTZ,
     PERCENTAGE,
     POWER_KILO_WATT,
     TEMP_CELSIUS,
@@ -20,10 +20,11 @@ ATTR_TARGET_TEMPERATURE = "target_temperature"
 ATTR_INSIDE_TEMPERATURE = "inside_temperature"
 ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"
 ATTR_TOTAL_POWER = "total_power"
-ATTR_COOL_ENERGY = "cool_energy"
-ATTR_HEAT_ENERGY = "heat_energy"
+ATTR_COOL_POWER = "cool_power"
+ATTR_HEAT_POWER = "heat_power"
 ATTR_HUMIDITY = "humidity"
 ATTR_TARGET_HUMIDITY = "target_humidity"
+ATTR_COMPRESSOR_FREQUENCY = "compressor_frequency"
 
 ATTR_STATE_ON = "on"
 ATTR_STATE_OFF = "off"
@@ -31,7 +32,7 @@ ATTR_STATE_OFF = "off"
 SENSOR_TYPE_TEMPERATURE = "temperature"
 SENSOR_TYPE_HUMIDITY = "humidity"
 SENSOR_TYPE_POWER = "power"
-SENSOR_TYPE_ENERGY = "energy"
+SENSOR_TYPE_FREQUENCY = "frequency"
 
 SENSOR_TYPES = {
     ATTR_INSIDE_TEMPERATURE: {
@@ -64,17 +65,25 @@ SENSOR_TYPES = {
         CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
         CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
     },
-    ATTR_COOL_ENERGY: {
-        CONF_NAME: "Cool Energy Consumption",
-        CONF_TYPE: SENSOR_TYPE_ENERGY,
+    ATTR_COOL_POWER: {
+        CONF_NAME: "Cool Power Consumption",
+        CONF_TYPE: SENSOR_TYPE_POWER,
         CONF_ICON: "mdi:snowflake",
-        CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
+        CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
     },
-    ATTR_HEAT_ENERGY: {
-        CONF_NAME: "Heat Energy Consumption",
-        CONF_TYPE: SENSOR_TYPE_ENERGY,
+    ATTR_HEAT_POWER: {
+        CONF_NAME: "Heat Power Consumption",
+        CONF_TYPE: SENSOR_TYPE_POWER,
         CONF_ICON: "mdi:fire",
-        CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
+        CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
+    },
+    ATTR_COMPRESSOR_FREQUENCY: {
+        CONF_NAME: "Compressor Frequency",
+        CONF_TYPE: SENSOR_TYPE_FREQUENCY,
+        CONF_ICON: "mdi:fan",
+        CONF_UNIT_OF_MEASUREMENT: FREQUENCY_HERTZ,
     },
 }
 

--- a/homeassistant/components/daikin/const.py
+++ b/homeassistant/components/daikin/const.py
@@ -5,9 +5,11 @@ from homeassistant.const import (
     CONF_NAME,
     CONF_TYPE,
     CONF_UNIT_OF_MEASUREMENT,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_HUMIDITY,
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    ENERGY_KILO_WATT_HOUR,
     FREQUENCY_HERTZ,
     PERCENTAGE,
     POWER_KILO_WATT,
@@ -20,8 +22,8 @@ ATTR_TARGET_TEMPERATURE = "target_temperature"
 ATTR_INSIDE_TEMPERATURE = "inside_temperature"
 ATTR_OUTSIDE_TEMPERATURE = "outside_temperature"
 ATTR_TOTAL_POWER = "total_power"
-ATTR_COOL_POWER = "cool_power"
-ATTR_HEAT_POWER = "heat_power"
+ATTR_COOL_ENERGY = "cool_energy"
+ATTR_HEAT_ENERGY = "heat_energy"
 ATTR_HUMIDITY = "humidity"
 ATTR_TARGET_HUMIDITY = "target_humidity"
 ATTR_COMPRESSOR_FREQUENCY = "compressor_frequency"
@@ -32,6 +34,7 @@ ATTR_STATE_OFF = "off"
 SENSOR_TYPE_TEMPERATURE = "temperature"
 SENSOR_TYPE_HUMIDITY = "humidity"
 SENSOR_TYPE_POWER = "power"
+SENSOR_TYPE_ENERGY = "energy"
 SENSOR_TYPE_FREQUENCY = "frequency"
 
 SENSOR_TYPES = {
@@ -65,19 +68,19 @@ SENSOR_TYPES = {
         CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
         CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
     },
-    ATTR_COOL_POWER: {
-        CONF_NAME: "Cool Power Consumption",
-        CONF_TYPE: SENSOR_TYPE_POWER,
+    ATTR_COOL_ENERGY: {
+        CONF_NAME: "Cool Energy Consumption",
+        CONF_TYPE: SENSOR_TYPE_ENERGY,
         CONF_ICON: "mdi:snowflake",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
+        CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
-    ATTR_HEAT_POWER: {
-        CONF_NAME: "Heat Power Consumption",
-        CONF_TYPE: SENSOR_TYPE_POWER,
+    ATTR_HEAT_ENERGY: {
+        CONF_NAME: "Heat Energy Consumption",
+        CONF_TYPE: SENSOR_TYPE_ENERGY,
         CONF_ICON: "mdi:fire",
-        CONF_DEVICE_CLASS: DEVICE_CLASS_POWER,
-        CONF_UNIT_OF_MEASUREMENT: POWER_KILO_WATT,
+        CONF_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
+        CONF_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
     },
     ATTR_COMPRESSOR_FREQUENCY: {
         CONF_NAME: "Compressor Frequency",

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin AC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pydaikin==2.4.3"],
+  "requirements": ["pydaikin==2.4.4"],
   "codeowners": ["@fredrike"],
   "zeroconf": ["_dkapi._tcp.local."],
   "quality_scale": "platinum",

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -146,7 +146,7 @@ class DaikinPowerSensor(DaikinSensor):
         if self._device_attribute == ATTR_TOTAL_POWER:
             return round(self._api.device.current_total_power_consumption, 2)
         if self._device_attribute == ATTR_COOL_ENERGY:
-            return round(self._api.device.last_hour_cool_power_consumption, 2)
+            return round(self._api.device.last_hour_cool_energy_consumption, 2)
         if self._device_attribute == ATTR_HEAT_ENERGY:
-            return round(self._api.device.last_hour_heat_power_consumption, 2)
+            return round(self._api.device.last_hour_heat_energy_consumption, 2)
         return None

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -11,13 +11,14 @@ from homeassistant.const import (
 from . import DOMAIN as DAIKIN_DOMAIN, DaikinApi
 from .const import (
     ATTR_COMPRESSOR_FREQUENCY,
-    ATTR_COOL_POWER,
-    ATTR_HEAT_POWER,
+    ATTR_COOL_ENERGY,
+    ATTR_HEAT_ENERGY,
     ATTR_HUMIDITY,
     ATTR_INSIDE_TEMPERATURE,
     ATTR_OUTSIDE_TEMPERATURE,
     ATTR_TARGET_HUMIDITY,
     ATTR_TOTAL_POWER,
+    SENSOR_TYPE_ENERGY,
     SENSOR_TYPE_FREQUENCY,
     SENSOR_TYPE_HUMIDITY,
     SENSOR_TYPE_POWER,
@@ -42,8 +43,8 @@ async def async_setup_entry(hass, entry, async_add_entities):
         sensors.append(ATTR_OUTSIDE_TEMPERATURE)
     if daikin_api.device.support_energy_consumption:
         sensors.append(ATTR_TOTAL_POWER)
-        sensors.append(ATTR_COOL_POWER)
-        sensors.append(ATTR_HEAT_POWER)
+        sensors.append(ATTR_COOL_ENERGY)
+        sensors.append(ATTR_HEAT_ENERGY)
     if daikin_api.device.support_humidity:
         sensors.append(ATTR_HUMIDITY)
         sensors.append(ATTR_TARGET_HUMIDITY)
@@ -62,6 +63,7 @@ class DaikinSensor(SensorEntity):
             SENSOR_TYPE_TEMPERATURE: DaikinClimateSensor,
             SENSOR_TYPE_HUMIDITY: DaikinClimateSensor,
             SENSOR_TYPE_POWER: DaikinPowerSensor,
+            SENSOR_TYPE_ENERGY: DaikinPowerSensor,
             SENSOR_TYPE_FREQUENCY: DaikinClimateSensor,
         }[SENSOR_TYPES[monitored_state][CONF_TYPE]]
         return cls(api, monitored_state)
@@ -143,8 +145,8 @@ class DaikinPowerSensor(DaikinSensor):
         """Return the state of the sensor."""
         if self._device_attribute == ATTR_TOTAL_POWER:
             return round(self._api.device.current_total_power_consumption, 2)
-        if self._device_attribute == ATTR_COOL_POWER:
+        if self._device_attribute == ATTR_COOL_ENERGY:
             return round(self._api.device.last_hour_cool_power_consumption, 2)
-        if self._device_attribute == ATTR_HEAT_POWER:
+        if self._device_attribute == ATTR_HEAT_ENERGY:
             return round(self._api.device.last_hour_heat_power_consumption, 2)
         return None

--- a/homeassistant/components/daikin/sensor.py
+++ b/homeassistant/components/daikin/sensor.py
@@ -10,14 +10,15 @@ from homeassistant.const import (
 
 from . import DOMAIN as DAIKIN_DOMAIN, DaikinApi
 from .const import (
-    ATTR_COOL_ENERGY,
-    ATTR_HEAT_ENERGY,
+    ATTR_COMPRESSOR_FREQUENCY,
+    ATTR_COOL_POWER,
+    ATTR_HEAT_POWER,
     ATTR_HUMIDITY,
     ATTR_INSIDE_TEMPERATURE,
     ATTR_OUTSIDE_TEMPERATURE,
     ATTR_TARGET_HUMIDITY,
     ATTR_TOTAL_POWER,
-    SENSOR_TYPE_ENERGY,
+    SENSOR_TYPE_FREQUENCY,
     SENSOR_TYPE_HUMIDITY,
     SENSOR_TYPE_POWER,
     SENSOR_TYPE_TEMPERATURE,
@@ -41,11 +42,13 @@ async def async_setup_entry(hass, entry, async_add_entities):
         sensors.append(ATTR_OUTSIDE_TEMPERATURE)
     if daikin_api.device.support_energy_consumption:
         sensors.append(ATTR_TOTAL_POWER)
-        sensors.append(ATTR_COOL_ENERGY)
-        sensors.append(ATTR_HEAT_ENERGY)
+        sensors.append(ATTR_COOL_POWER)
+        sensors.append(ATTR_HEAT_POWER)
     if daikin_api.device.support_humidity:
         sensors.append(ATTR_HUMIDITY)
         sensors.append(ATTR_TARGET_HUMIDITY)
+    if daikin_api.device.support_compressor_frequency:
+        sensors.append(ATTR_COMPRESSOR_FREQUENCY)
     async_add_entities([DaikinSensor.factory(daikin_api, sensor) for sensor in sensors])
 
 
@@ -59,7 +62,7 @@ class DaikinSensor(SensorEntity):
             SENSOR_TYPE_TEMPERATURE: DaikinClimateSensor,
             SENSOR_TYPE_HUMIDITY: DaikinClimateSensor,
             SENSOR_TYPE_POWER: DaikinPowerSensor,
-            SENSOR_TYPE_ENERGY: DaikinPowerSensor,
+            SENSOR_TYPE_FREQUENCY: DaikinClimateSensor,
         }[SENSOR_TYPES[monitored_state][CONF_TYPE]]
         return cls(api, monitored_state)
 
@@ -125,6 +128,10 @@ class DaikinClimateSensor(DaikinSensor):
             return self._api.device.humidity
         if self._device_attribute == ATTR_TARGET_HUMIDITY:
             return self._api.device.target_humidity
+
+        if self._device_attribute == ATTR_COMPRESSOR_FREQUENCY:
+            return self._api.device.compressor_frequency
+
         return None
 
 
@@ -135,9 +142,9 @@ class DaikinPowerSensor(DaikinSensor):
     def state(self):
         """Return the state of the sensor."""
         if self._device_attribute == ATTR_TOTAL_POWER:
-            return round(self._api.device.current_total_power_consumption, 3)
-        if self._device_attribute == ATTR_COOL_ENERGY:
-            return round(self._api.device.last_hour_cool_energy_consumption, 3)
-        if self._device_attribute == ATTR_HEAT_ENERGY:
-            return round(self._api.device.last_hour_heat_energy_consumption, 3)
+            return round(self._api.device.current_total_power_consumption, 2)
+        if self._device_attribute == ATTR_COOL_POWER:
+            return round(self._api.device.last_hour_cool_power_consumption, 2)
+        if self._device_attribute == ATTR_HEAT_POWER:
+            return round(self._api.device.last_hour_heat_power_consumption, 2)
         return None

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1363,7 +1363,7 @@ pycsspeechtts==1.0.4
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==2.4.3
+pydaikin==2.4.4
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -758,7 +758,7 @@ pycomfoconnect==0.4
 pycoolmasternet-async==0.1.2
 
 # homeassistant.components.daikin
-pydaikin==2.4.3
+pydaikin==2.4.4
 
 # homeassistant.components.deconz
 pydeconz==80


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

* The latest version of pydaikin 2.4.2 integrated in https://github.com/home-assistant/core/pull/51797 and merged in the 2021.6 release introduced some breaking changes as the sensor methods have been renamed; the power sensors do not work anymore (see https://bitbucket.org/mustang51/pydaikin/diff/pydaikin/daikin_base.py?at=v2.4.2&diff1=0c4045e6c2eb413fbfed64a04cf211519cb1c173&diff2=a02e50f363cbf56a9cfd88427e734988d28712ee)
* A compressor frequency sensor has also been added and monitors the load of the outside compressor.

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51976 #52082 #52053
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18241

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
