### PR TITLE
Fix issue where last PVOutput reading for day is retained

### DIFF
--- a/homeassistant/components/pvoutput/sensor.py
+++ b/homeassistant/components/pvoutput/sensor.py
@@ -1,5 +1,6 @@
 """Support for getting collected information from PVOutput."""
 from collections import namedtuple
+import datetime
 from datetime import timedelta
 import logging
 
@@ -125,7 +126,18 @@ class PvoutputSensor(SensorEntity):
     def _async_update_from_rest_data(self):
         """Update state from the rest data."""
         try:
-            self.pvcoutput = self.status._make(self.rest.data.split(","))
+            raw_data = self.rest.data.split(",")
+            # ["20210615", "21:20", "23608", "24", "NaN", "NaN", "0.007", "56.5", "242.0"]
+            # If the retrieved datetime is older than 5 minutes, set the power to 0.
+            reading_datetime = datetime.datetime.strptime(
+                raw_data[0] + raw_data[1], "%Y%m%d%H:%M"
+            )
+            if datetime.datetime.now() > reading_datetime + timedelta(minutes=5):
+                _LOGGER.debug(
+                    "Collected data was older than 5 minutes, so set the power to 0"
+                )
+                raw_data[3] = "NaN"
+            self.pvcoutput = self.status._make(raw_data)
         except TypeError:
             self.pvcoutput = None
             _LOGGER.error("Unable to fetch data from PVOutput. %s", self.rest.data)


### PR DESCRIPTION
Fix issue where last PVOutput reading for the day is returned after the inverter stops sending updated data.
_(PVOutput will provide last positive reading value, not zeros when generation ends for the day)_

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change aims to fix a 'bug' in the way that the last data available from PVOutput's API when an inverter goes offline is the last reading it was given, this could be a low wattage amount even after its not generating.
This means that during the night (when generation is actually zero), the entity data is still showing very low readings - the last positive reading that PVOuput saw, and not a true reflection of 'nothing'
The datetime stamp of the value returned by the PVOutput API is actually the last positive reading it was sent - confirming why this happens.

The fix proposed is to implement if the data returned from the API is over 5 minutes old, set the power reading to 0 to reflect that PVOutput is not actually sending a current value.

_See linked issue for screenshots of cards and entities displaiying old, inaccurate reading data for the middle of the night._


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #51914 
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
