### PR TITLE
Advantage Air add zone temperature sensors

### DIFF
--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -153,6 +153,11 @@ class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
     _attr_unit_of_measurement = TEMP_CELSIUS
 
     @property
+    def entity_registry_enabled_default(self):
+        """Disable this sensor by default."""
+        return False
+
+    @property
     def name(self):
         """Return the name."""
         return f'{self._zone["name"]} Temperature'

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -173,6 +173,11 @@ class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
         return self._zone["measuredTemp"]
 
     @property
+    def state_class(self):
+        """State class of sensor."""
+        return STATE_CLASS_MEASUREMENT
+
+    @property
     def icon(self):
         """Return a representative icon."""
         return "mdi:thermometer"

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -156,14 +156,10 @@ class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, instance, ac_key, zone_key):
-        """Initialize an Advantage Air Cover Class."""
+        """Initialize an Advantage Air Zone Temp Sensor."""
         super().__init__(instance, ac_key, zone_key)
+        self._attr_name = f'{self._zone["name"]} Temperature'
         self._attr_unique_id = f'{self.coordinator.data["system"]["rid"]}-{self.ac_key}-{self.zone_key}-temp'
-
-    @property
-    def name(self):
-        """Return the name."""
-        return f'{self._zone["name"]} Temperature'
 
     @property
     def state(self):

--- a/homeassistant/components/advantage_air/sensor.py
+++ b/homeassistant/components/advantage_air/sensor.py
@@ -151,11 +151,14 @@ class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
     """Representation of Advantage Air Zone wireless signal sensor."""
 
     _attr_unit_of_measurement = TEMP_CELSIUS
+    _attr_state_class = STATE_CLASS_MEASUREMENT
+    _attr_icon = "mdi:thermometer"
+    _attr_entity_registry_enabled_default = False
 
-    @property
-    def entity_registry_enabled_default(self):
-        """Disable this sensor by default."""
-        return False
+    def __init__(self, instance, ac_key, zone_key):
+        """Initialize an Advantage Air Cover Class."""
+        super().__init__(instance, ac_key, zone_key)
+        self._attr_unique_id = f'{self.coordinator.data["system"]["rid"]}-{self.ac_key}-{self.zone_key}-temp'
 
     @property
     def name(self):
@@ -163,21 +166,6 @@ class AdvantageAirZoneTemp(AdvantageAirEntity, SensorEntity):
         return f'{self._zone["name"]} Temperature'
 
     @property
-    def unique_id(self):
-        """Return a unique id."""
-        return f'{self.coordinator.data["system"]["rid"]}-{self.ac_key}-{self.zone_key}-temp'
-
-    @property
     def state(self):
         """Return the current value of the measured temperature."""
         return self._zone["measuredTemp"]
-
-    @property
-    def state_class(self):
-        """State class of sensor."""
-        return STATE_CLASS_MEASUREMENT
-
-    @property
-    def icon(self):
-        """Return a representative icon."""
-        return "mdi:thermometer"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add (disabled by default) sensor entities that show the temperature of each zone that has a sensor. This can assist with automations and avoid the need for manual template sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: https://community.home-assistant.io/t/advantage-air-zone-actual-temps-as-sensors/316238
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18541

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [X] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
