### PR TITLE
WIP: Add websocket API for Plex recently added items

### DIFF
--- a/homeassistant/components/plex/sensor.py
+++ b/homeassistant/components/plex/sensor.py
@@ -1,4 +1,5 @@
 """Support for Plex media server monitoring."""
+import json
 import logging
 
 from plexapi.exceptions import NotFound
@@ -33,6 +34,20 @@ LIBRARY_ICON_LOOKUP = {
     "photo": "mdi:image",
     "show": "mdi:television",
 }
+
+RECENTLY_ADDED_LOOKUP = {
+    "artist": "album",
+    "show": "episode",
+}
+
+RECENTLY_ADDED_COMMON_ATTRS = {
+    "title": "title",
+    "added": "addedAt",
+    "rating": "rating",
+    "released": "originallyAvailableAt",
+    "thumb_url": "thumbUrl",
+}
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -186,6 +201,41 @@ class PlexLibrarySectionSensor(SensorEntity):
             self._attributes[f"{libtype}s"] = self.library_section.totalViewSize(
                 libtype=libtype, includeCollections=False
             )
+
+        self._attributes["recently_added"] = []
+        itemtype = RECENTLY_ADDED_LOOKUP.get(self.library_type, self.library_type)
+        recents = self.library_section.recentlyAdded(libtype=itemtype, maxresults=5)
+        for item in recents:
+            itemdict = {}
+            for key, attr in RECENTLY_ADDED_COMMON_ATTRS.items():
+                if value := getattr(item, attr, None):
+                    itemdict[key] = value
+
+            itemdict["media_content_id"] = json.dumps(
+                {
+                    "plex_server": self.server_name,
+                    "plex_key": item.ratingKey,
+                }
+            )
+
+            if itemtype == "album":
+                runtime = trackcount = 0
+                for track in item:
+                    trackcount += 1
+                    runtime += track.duration
+                itemdict["tracks"] = trackcount
+                itemdict["artist"] = item.parentTitle
+            else:
+                runtime = item.duration
+
+            itemdict["runtime"] = int(runtime / 1000)  # Seconds
+
+            if itemtype == "episode":
+                itemdict["episode"] = item.seasonEpisode
+                itemdict["show"] = item.grandparentTitle
+                itemdict["show_thumb_url"] = item.season().thumbUrl
+
+            self._attributes["recently_added"].append(itemdict)
 
     @property
     def available(self):

--- a/homeassistant/components/plex/server.py
+++ b/homeassistant/components/plex/server.py
@@ -22,6 +22,7 @@ from homeassistant.components.media_player.const import (
 )
 from homeassistant.const import CONF_CLIENT_ID, CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL
 from homeassistant.core import callback
+from homeassistant.helpers import entity_registry
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -531,6 +532,20 @@ class PlexServer:
             self.hass,
             PLEX_UPDATE_SENSOR_SIGNAL.format(self.machine_identifier),
         )
+
+    @callback
+    def async_available_media_players(self):
+        """Return a list of controllable media_player entity_ids."""
+        available_entities = []
+        ent_reg = entity_registry.async_get(self.hass)
+        for client_id in self._known_clients:
+            client_unique_id = f"{self.machine_identifier}:{client_id}"
+            if entity_id := ent_reg.async_get_entity_id(
+                MP_DOMAIN, DOMAIN, client_unique_id
+            ):
+                available_entities.append(entity_id)
+
+        return available_entities
 
     @property
     def plex_server(self):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a websocket API endpoint for recently added items to the Plex integration which can be used by new UI cards.

Provides information on the X most recent items from each library with information such as title, datetime added, release date, rating, and duration. Currently supports movies, episodes, and albums.

Also provides:
* `thumb_url` which holds a link to a media image (movie poster, album art, etc) hosted by the Plex server
* `media_content_id` which can be used directly in a call to `media_player.play_media` targeting any Plex `media_player` entity, or any Chromecast device by prepending "plex://" [as documented](https://www.home-assistant.io/integrations/cast/#plex)
* `available_media_players`, a list of `media_player` entity IDs to use as potential targets
* A `trigger_entity_id` which can be monitored for state changes to request updates on new items

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
