### PR TITLE
Clean up stream refactor

### DIFF
--- a/homeassistant/components/stream/fmp4utils.py
+++ b/homeassistant/components/stream/fmp4utils.py
@@ -5,7 +5,7 @@ from collections.abc import Generator
 
 
 def find_box(
-    mp4_bytes: bytes | memoryview, target_type: bytes, box_start: int = 0
+    mp4_bytes: bytes, target_type: bytes, box_start: int = 0
 ) -> Generator[int, None, None]:
     """Find location of first box (or sub_box if box_start provided) of given type."""
     if box_start == 0:

--- a/homeassistant/components/stream/hls.py
+++ b/homeassistant/components/stream/hls.py
@@ -173,8 +173,9 @@ class HlsInitView(StreamView):
         track = stream.add_provider(HLS_PROVIDER)
         if not (segments := track.get_segments()):
             return web.HTTPNotFound()
-        headers = {"Content-Type": "video/mp4"}
-        return web.Response(body=segments[0].init, headers=headers)
+        return web.Response(
+            body=segments[0].init, headers={"Content-Type": "video/mp4"}
+        )
 
 
 class HlsSegmentView(StreamView):

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -43,7 +43,7 @@ class SegmentBuffer:
         self._sequence = -1
         self._segment_start_dts: int = cast(int, None)
         self._memory_file: BytesIO = cast(BytesIO, None)
-        self._memory_file_pos: int = cast(int, None)
+        self._memory_file_pos = 0
         self._av_output: av.container.OutputContainer = None
         self._input_video_stream: av.video.VideoStream = None
         self._input_audio_stream: Any | None = None  # av.audio.AudioStream | None

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -173,7 +173,7 @@ class SegmentBuffer:
             )
         )
         # The next two lines aren't actually needed for the stub part, as the
-        # variables will get immediately reset in reset()
+        # variables will get reset in reset(), but keeping them here is cleaner
         self._memory_file_pos = self._memory_file.tell()
         self._part_start_dts = packet.dts
         self._part_has_keyframe = False

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -164,7 +164,7 @@ class SegmentBuffer:
             # We could put the next two lines in self.flush_part, but they are
             # already done by reset() in the case of flushing the stub part,
             # so doing it here avoids doing it twice for the stub part.
-            self._memory_file_pos = self._memory_file.tell()
+            self._memory_file_pos = byte_position
             self._part_start_dts = packet.dts
 
     def flush_part(self, packet: av.Packet) -> None:

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -183,6 +183,8 @@ class SegmentBuffer:
 
     def flush(self, duration: Fraction, packet: av.Packet) -> None:
         """Close the segment and give it a duration, making it complete."""
+        # Closing the av_output will write the remaining buffered data to the
+        # memory_file as a new moof/mdat.
         self._av_output.close()
         self.flush_part(packet, self._memory_file.tell())
         self._memory_file.close()  # We don't need the BytesIO object anymore

--- a/tests/components/stream/test_hls.py
+++ b/tests/components/stream/test_hls.py
@@ -264,7 +264,6 @@ async def test_hls_playlist_view(hass, hls_stream, stream_worker_sync):
     stream = create_stream(hass, STREAM_SOURCE, {})
     stream_worker_sync.pause()
     hls = stream.add_provider(HLS_PROVIDER)
-
     for i in range(2):
         segment = Segment(sequence=i, duration=SEGMENT_DURATION, start_time=FAKE_TIME)
         hls.put(segment)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
#49608 implements LL-HLS in stream, but that PR is too large, making it hard to review. This an intermediate PR which cleans up the stream refactor to reduce the diff with #49608.
There are a few main changes:
- Clean up `target_duration` method
- Consolidate the `Part` creation in one place and read from the memory file with a `BytesIO.read()`
- Adjust the signature of the `flush()` method to not take a `duration` parameter anymore as that can just be calculated again. Also add a `last_part` boolean parameter to distinguish between the normal and the last_part cases.
- Rename `self._segment_last_write_pos` to `self._memory_file_pos`
- Move reset of `self._part_start_dts` out of `reset()` to where the `Segment` is created (it is not needed before that)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
