### PR TITLE
Migrate Switcher entity attributes to sensors

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -122,7 +122,7 @@ omit =
     homeassistant/components/braviatv/__init__.py
     homeassistant/components/braviatv/const.py
     homeassistant/components/braviatv/media_player.py
-    homeassistant/components/braviatv/remote.py    
+    homeassistant/components/braviatv/remote.py
     homeassistant/components/broadlink/__init__.py
     homeassistant/components/broadlink/const.py
     homeassistant/components/broadlink/remote.py
@@ -992,6 +992,7 @@ omit =
     homeassistant/components/swiss_public_transport/sensor.py
     homeassistant/components/swisscom/device_tracker.py
     homeassistant/components/switchbot/switch.py
+    homeassistant/components/switcher_kis/sensor.py
     homeassistant/components/switcher_kis/switch.py
     homeassistant/components/switchmate/switch.py
     homeassistant/components/syncthing/__init__.py

--- a/homeassistant/components/switcher_kis/__init__.py
+++ b/homeassistant/components/switcher_kis/__init__.py
@@ -8,7 +8,6 @@ import logging
 from aioswitcher.bridge import SwitcherV2Bridge
 import voluptuous as vol
 
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import CONF_DEVICE_ID, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
@@ -65,7 +64,8 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
         return False
     hass.data[DOMAIN] = {DATA_DEVICE: device_data}
 
-    hass.async_create_task(async_load_platform(hass, SWITCH_DOMAIN, DOMAIN, {}, config))
+    hass.async_create_task(async_load_platform(hass, "switch", DOMAIN, {}, config))
+    hass.async_create_task(async_load_platform(hass, "sensor", DOMAIN, {}, config))
 
     @callback
     def device_updates(timestamp: datetime | None) -> None:

--- a/homeassistant/components/switcher_kis/const.py
+++ b/homeassistant/components/switcher_kis/const.py
@@ -1,5 +1,4 @@
 """Constants for the Switcher integration."""
-from homeassistant.components.switch import ATTR_CURRENT_POWER_W
 
 DOMAIN = "switcher_kis"
 
@@ -16,13 +15,6 @@ ATTR_REMAINING_TIME = "remaining_time"
 
 CONF_AUTO_OFF = "auto_off"
 CONF_TIMER_MINUTES = "timer_minutes"
-
-DEVICE_PROPERTIES_TO_HA_ATTRIBUTES = {
-    "power_consumption": ATTR_CURRENT_POWER_W,
-    "electric_current": ATTR_ELECTRIC_CURRENT,
-    "remaining_time": ATTR_REMAINING_TIME,
-    "auto_off_set": ATTR_AUTO_OFF_SET,
-}
 
 SERVICE_SET_AUTO_OFF_NAME = "set_auto_off"
 SERVICE_TURN_ON_WITH_TIMER_NAME = "turn_on_with_timer"

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -92,7 +92,7 @@ class SwitcherSensorEntity(SensorEntity):
         device_data: SwitcherV2Device,
         attribute: str,
         description: AttributeDescription,
-    ):
+    ) -> None:
         """Initialize the entity."""
         self._device_data = device_data
         self.attribute = attribute

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -1,0 +1,132 @@
+"""Switcher integration Sensor platform."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from aioswitcher.consts import WAITING_TEXT
+from aioswitcher.devices import SwitcherV2Device
+
+from homeassistant.components.sensor import (
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_POWER,
+    STATE_CLASS_MEASUREMENT,
+    SensorEntity,
+)
+from homeassistant.const import ELECTRICAL_CURRENT_AMPERE, POWER_WATT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DATA_DEVICE, DOMAIN, SIGNAL_SWITCHER_DEVICE_UPDATE
+
+
+@dataclass
+class AttributeDescription:
+    """Class to describe a sensor."""
+
+    name: str
+    icon: str | None = None
+    unit: str | None = None
+    device_class: str | None = None
+    state_class: str | None = None
+    default_enabled: bool = True
+    default_value: float | int | str | None = None
+
+
+POWER_SENSORS = {
+    "power_consumption": AttributeDescription(
+        name="Power Consumption",
+        unit=POWER_WATT,
+        device_class=DEVICE_CLASS_POWER,
+        state_class=STATE_CLASS_MEASUREMENT,
+        default_value=0,
+    ),
+    "electric_current": AttributeDescription(
+        name="Electric Current",
+        unit=ELECTRICAL_CURRENT_AMPERE,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+        default_value=0.0,
+    ),
+}
+
+TIME_SENSORS = {
+    "remaining_time": AttributeDescription(
+        name="Remaining Time",
+        icon="mdi:av-timer",
+        default_value="00:00:00",
+    ),
+    "auto_off_set": AttributeDescription(
+        name="Auto Shutdown",
+        icon="mdi:progress-clock",
+        default_enabled=False,
+        default_value="00:00:00",
+    ),
+}
+
+SENSORS = {**POWER_SENSORS, **TIME_SENSORS}
+
+
+async def async_setup_platform(
+    hass: HomeAssistant,
+    config: dict,
+    async_add_entities: AddEntitiesCallback,
+    discovery_info: dict,
+) -> None:
+    """Set up Switcher sensor from config entry."""
+    device_data = hass.data[DOMAIN][DATA_DEVICE]
+
+    async_add_entities(
+        [
+            SwitcherSensorEntity(device_data, attribute, SENSORS[attribute])
+            for attribute in SENSORS
+        ]
+    )
+
+
+class SwitcherSensorEntity(SensorEntity):
+    """Representation of a Switcher sensor entity."""
+
+    def __init__(
+        self,
+        device_data: SwitcherV2Device,
+        attribute: str,
+        description: AttributeDescription,
+    ):
+        """Initialize the entity."""
+        self._device_data = device_data
+        self.attribute = attribute
+        self.description = description
+
+        # Entity class attributes
+        self._attr_name = f"{self._device_data.name} {self.description.name}"
+        self._attr_icon = self.description.icon
+        self._attr_unit_of_measurement = self.description.unit
+        self._attr_device_class = self.description.device_class
+        self._attr_entity_registry_enabled_default = self.description.default_enabled
+        self._attr_should_poll = False
+
+        self._attr_unique_id = f"{self._device_data.device_id}-{self._device_data.mac_addr}-{self.attribute}"
+
+    @property
+    def state(self):
+        """Return value of sensor."""
+        value = getattr(self._device_data, self.attribute)
+        if value and value is not WAITING_TEXT:
+            return value
+
+        return self.description.default_value
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, SIGNAL_SWITCHER_DEVICE_UPDATE, self.async_update_data
+            )
+        )
+
+    async def async_update_data(self, device_data: SwitcherV2Device) -> None:
+        """Update the entity data."""
+        if device_data:
+            self._device_data = device_data
+            self.async_write_ha_state()

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -71,16 +71,14 @@ async def async_setup_platform(
     hass: HomeAssistant,
     config: dict,
     async_add_entities: AddEntitiesCallback,
-    discovery_info: dict,
+    discovery_info: DiscoveryInfoType,
 ) -> None:
     """Set up Switcher sensor from config entry."""
     device_data = hass.data[DOMAIN][DATA_DEVICE]
 
     async_add_entities(
-        [
-            SwitcherSensorEntity(device_data, attribute, SENSORS[attribute])
-            for attribute in SENSORS
-        ]
+        SwitcherSensorEntity(device_data, attribute, SENSORS[attribute])
+        for attribute in SENSORS
     )
 
 
@@ -109,7 +107,7 @@ class SwitcherSensorEntity(SensorEntity):
         self._attr_unique_id = f"{self._device_data.device_id}-{self._device_data.mac_addr}-{self.attribute}"
 
     @property
-    def state(self):
+    def state(self) -> StateType:
         """Return value of sensor."""
         value = getattr(self._device_data, self.attribute)
         if value and value is not WAITING_TEXT:

--- a/homeassistant/components/switcher_kis/sensor.py
+++ b/homeassistant/components/switcher_kis/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import ELECTRICAL_CURRENT_AMPERE, POWER_WATT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import DiscoveryInfoType, StateType
 
 from .const import DATA_DEVICE, DOMAIN, SIGNAL_SWITCHER_DEVICE_UPDATE
 

--- a/homeassistant/components/switcher_kis/switch.py
+++ b/homeassistant/components/switcher_kis/switch.py
@@ -8,7 +8,6 @@ from aioswitcher.consts import (
     COMMAND_ON,
     STATE_OFF as SWITCHER_STATE_OFF,
     STATE_ON as SWITCHER_STATE_ON,
-    WAITING_TEXT,
 )
 from aioswitcher.devices import SwitcherV2Device
 import voluptuous as vol
@@ -23,7 +22,6 @@ from .const import (
     CONF_AUTO_OFF,
     CONF_TIMER_MINUTES,
     DATA_DEVICE,
-    DEVICE_PROPERTIES_TO_HA_ATTRIBUTES,
     DOMAIN,
     SERVICE_SET_AUTO_OFF_NAME,
     SERVICE_TURN_ON_WITH_TIMER_NAME,
@@ -123,23 +121,6 @@ class SwitcherControl(SwitchEntity):
     def is_on(self) -> bool:
         """Return True if entity is on."""
         return self._state == SWITCHER_STATE_ON
-
-    @property
-    def current_power_w(self) -> int:
-        """Return the current power usage in W."""
-        return self._device_data.power_consumption
-
-    @property
-    def extra_state_attributes(self) -> dict:
-        """Return the optional state attributes."""
-        attribs = {}
-
-        for prop, attr in DEVICE_PROPERTIES_TO_HA_ATTRIBUTES.items():
-            value = getattr(self._device_data, prop)
-            if value and value is not WAITING_TEXT:
-                attribs[attr] = value
-
-        return attribs
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
Migrate attributes to sensors

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
In preparation for multi device support and config flow discovery I am migrating entity attributes into sensors to be later added as device entities. The following switch entity attributes migrated to sensors:

| Attribute | Sensor Name |
| ------------- | ------------- |
| `power_consumption` | Power Consumption |
| `electric_current` | Electric Current |
| `remaining_time` | Remaining Time |
| `auto_off_set` | Auto Shutdown |

The next PR will add config flow support without breaking changes
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This change will allow creating device cards using config flow discovery with the entities showing as sensors on the device card. Historically these were added as entity attributes for the main switch entity and not as sensors. Migrating them to sensors will allow better frontend visualization and simple enable disable of unused sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18224

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
