### PR TITLE
ESPHome rework EsphomeEnumMapper for safe enum mappings

### DIFF
--- a/homeassistant/components/esphome/fan.py
+++ b/homeassistant/components/esphome/fan.py
@@ -24,7 +24,7 @@ from homeassistant.util.percentage import (
 
 from . import (
     EsphomeEntity,
-    esphome_map_enum,
+    EsphomeEnumMapper,
     esphome_state_property,
     platform_async_setup_entry,
 )
@@ -47,12 +47,12 @@ async def async_setup_entry(
     )
 
 
-@esphome_map_enum
-def _fan_directions():
-    return {
+_FAN_DIRECTIONS: EsphomeEnumMapper[FanDirection] = EsphomeEnumMapper(
+    {
         FanDirection.FORWARD: DIRECTION_FORWARD,
         FanDirection.REVERSE: DIRECTION_REVERSE,
     }
+)
 
 
 class EsphomeFan(EsphomeEntity, FanEntity):
@@ -115,7 +115,7 @@ class EsphomeFan(EsphomeEntity, FanEntity):
     async def async_set_direction(self, direction: str):
         """Set direction of the fan."""
         await self._client.fan_command(
-            key=self._static_info.key, direction=_fan_directions.from_hass(direction)
+            key=self._static_info.key, direction=_FAN_DIRECTIONS.from_hass(direction)
         )
 
     # https://github.com/PyCQA/pylint/issues/3150 for all @esphome_state_property
@@ -149,18 +149,18 @@ class EsphomeFan(EsphomeEntity, FanEntity):
         return self._static_info.supported_speed_levels
 
     @esphome_state_property
-    def oscillating(self) -> None:
+    def oscillating(self) -> bool | None:
         """Return the oscillation state."""
         if not self._static_info.supports_oscillation:
             return None
         return self._state.oscillating
 
     @esphome_state_property
-    def current_direction(self) -> None:
+    def current_direction(self) -> str | None:
         """Return the current fan direction."""
         if not self._static_info.supports_direction:
             return None
-        return _fan_directions.from_esphome(self._state.direction)
+        return _FAN_DIRECTIONS.from_esphome(self._state.direction)
 
     @property
     def supported_features(self) -> int:

--- a/homeassistant/components/esphome/manifest.json
+++ b/homeassistant/components/esphome/manifest.json
@@ -3,7 +3,7 @@
   "name": "ESPHome",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/esphome",
-  "requirements": ["aioesphomeapi==2.8.0"],
+  "requirements": ["aioesphomeapi==2.9.0"],
   "zeroconf": ["_esphomelib._tcp.local."],
   "codeowners": ["@OttoWinter"],
   "after_dependencies": ["zeroconf", "tag"],

--- a/homeassistant/components/esphome/sensor.py
+++ b/homeassistant/components/esphome/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.util import dt
 
 from . import (
     EsphomeEntity,
-    esphome_map_enum,
+    EsphomeEnumMapper,
     esphome_state_property,
     platform_async_setup_entry,
 )
@@ -61,12 +61,12 @@ async def async_setup_entry(
 # pylint: disable=invalid-overridden-method
 
 
-@esphome_map_enum
-def _state_classes():
-    return {
+_STATE_CLASSES: EsphomeEnumMapper[SensorStateClass] = EsphomeEnumMapper(
+    {
         SensorStateClass.NONE: None,
         SensorStateClass.MEASUREMENT: STATE_CLASS_MEASUREMENT,
     }
+)
 
 
 class EsphomeSensor(EsphomeEntity, SensorEntity):
@@ -122,7 +122,7 @@ class EsphomeSensor(EsphomeEntity, SensorEntity):
         """Return the state class of this entity."""
         if not self._static_info.state_class:
             return None
-        return _state_classes.from_esphome(self._static_info.state_class)
+        return _STATE_CLASSES.from_esphome(self._static_info.state_class)
 
 
 class EsphomeTextSensor(EsphomeEntity, SensorEntity):

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -160,7 +160,7 @@ aioeafm==0.1.2
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==2.8.0
+aioesphomeapi==2.9.0
 
 # homeassistant.components.flo
 aioflo==0.4.1

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -100,7 +100,7 @@ aioeafm==0.1.2
 aioemonitor==1.0.5
 
 # homeassistant.components.esphome
-aioesphomeapi==2.8.0
+aioesphomeapi==2.9.0
 
 # homeassistant.components.flo
 aioflo==0.4.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the ESPHome client device has a higher API version (with new enum fields) than HA core, errors are thrown for unmappable enum types (https://github.com/esphome/aioesphomeapi/issues/35#issuecomment-863252999)

This PR fixes that by allowing `None` values from https://github.com/esphome/aioesphomeapi/pull/37 in the mapping conversion. It also refactors the `EsphomeEnumMapper` class (it's old design was before the days where global package imports were possible), because it would have been more difficult to change without a refactor.

~~Note: depends on https://github.com/esphome/aioesphomeapi/pull/37 and dependency bump of aioesphomeapi~~ Done


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
