### PR TITLE
Only load requested coinbase accounts

### DIFF
--- a/homeassistant/components/coinbase/__init__.py
+++ b/homeassistant/components/coinbase/__init__.py
@@ -48,12 +48,47 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Coinbase component."""
-    if DOMAIN not in config:
-        return True
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
+def setup(hass, config):
+    """Set up the Coinbase component.
+
+    Will automatically setup sensors to support
+    wallets discovered on the network.
+    """
+    api_key = config[DOMAIN][CONF_API_KEY]
+    api_secret = config[DOMAIN][CONF_API_SECRET]
+    account_currencies = config[DOMAIN].get(CONF_ACCOUNT_CURRENCIES)
+    exchange_currencies = config[DOMAIN][CONF_EXCHANGE_CURRENCIES]
+
+    hass.data[DATA_COINBASE] = coinbase_data = CoinbaseData(api_key, api_secret)
+
+    if not hasattr(coinbase_data, "accounts"):
+        return False
+    if account_currencies is not None:
+        provided_accounts = {}
+        for account in coinbase_data.accounts:
+            provided_accounts[account.currency] = account
+        for user_account in account_currencies:
+            if user_account in provided_accounts:
+                load_platform(
+                    hass,
+                    "sensor",
+                    DOMAIN,
+                    {"account": provided_accounts[user_account]},
+                    config,
+                )
+            else:
+                _LOGGER.warning(
+                    "Account %s not found, please check your API settings on Coinbase",
+                    user_account,
+                )
+    for currency in exchange_currencies:
+        if currency not in coinbase_data.exchange_rates.rates:
+            _LOGGER.warning("Currency %s not found", currency)
+            continue
+        native = coinbase_data.exchange_rates.currency
+        load_platform(
+            hass,
+            "sensor",
             DOMAIN,
             context={"source": SOURCE_IMPORT},
             data=config[DOMAIN],

--- a/homeassistant/components/coinbase/sensor.py
+++ b/homeassistant/components/coinbase/sensor.py
@@ -44,10 +44,10 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         account[API_ACCOUNT_CURRENCY] for account in instance.accounts
     ]
 
+    desired_currencies: list[str] = []
+
     if CONF_CURRENCIES in config_entry.options:
         desired_currencies = config_entry.options[CONF_CURRENCIES]
-    else:
-        desired_currencies = provided_currencies
 
     exchange_native_currency = instance.exchange_rates.currency
 

--- a/homeassistant/components/coinbase/sensor.py
+++ b/homeassistant/components/coinbase/sensor.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         account[API_ACCOUNT_CURRENCY] for account in instance.accounts
     ]
 
-    desired_currencies: list[str] = []
+    desired_currencies = []
 
     if CONF_CURRENCIES in config_entry.options:
         desired_currencies = config_entry.options[CONF_CURRENCIES]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Only accounts explicitly included in `account_balance_currencies` will be loaded. Excluding the option will no longer load all provided accounts as Coinbase's API now provides at least 29 accounts even if they are not configured in your API settings on Coinbase.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since the migration returning paginated results, Coinbase's API now provides a full first page of accounts even if fewer than this limit are configured for the API. The number of accounts returned seems to vary a little previously the first page was 24 it now seems to be 29.

This means in a simple case where a user has two accounts enabled in Coinbase's API settings, we currently create 29 sensors 27 of which are for seemingly random accounts/currencies. This is of course a bug in Coinbase's API.

I opted for not setting the simpler `cv.Required` on `account_balance_currencies` since the case of not wanting any account sensors but wanting the exchange rate sensors seems valid.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#18231

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
