### PR TITLE
Add device trigger support to Select entity

### DIFF
--- a/homeassistant/components/select/device_trigger.py
+++ b/homeassistant/components/select/device_trigger.py
@@ -44,22 +44,17 @@ TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
 async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
     """List device triggers for Select devices."""
     registry = await entity_registry.async_get_registry(hass)
-    triggers = []
-
-    # Get all the integrations entities for this device
-    for entry in entity_registry.async_entries_for_device(registry, device_id):
-        if entry.domain != DOMAIN:
-            continue
-
-        base_trigger = {
+    return [
+        {
             CONF_PLATFORM: "device",
             CONF_DEVICE_ID: device_id,
             CONF_DOMAIN: DOMAIN,
             CONF_ENTITY_ID: entry.entity_id,
+            CONF_TYPE: "current_option_changed",
         }
-        triggers.append({**base_trigger, CONF_TYPE: "current_option_changed"})
-
-    return triggers
+        for entry in entity_registry.async_entries_for_device(registry, device_id)
+        if entry.domain == DOMAIN
+    ]
 
 
 async def async_attach_trigger(

--- a/homeassistant/components/select/device_trigger.py
+++ b/homeassistant/components/select/device_trigger.py
@@ -1,0 +1,108 @@
+"""Provides device triggers for Select."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.automation import AutomationActionType
+from homeassistant.components.device_automation import DEVICE_TRIGGER_BASE_SCHEMA
+from homeassistant.components.homeassistant.triggers.state import (
+    CONF_FOR,
+    CONF_FROM,
+    CONF_TO,
+    TRIGGER_SCHEMA as STATE_TRIGGER_SCHEMA,
+    async_attach_trigger as async_attach_state_trigger,
+)
+from homeassistant.components.select.const import ATTR_OPTIONS
+from homeassistant.const import (
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_PLATFORM,
+    CONF_TYPE,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import config_validation as cv, entity_registry
+from homeassistant.helpers.typing import ConfigType
+
+from . import DOMAIN
+
+TRIGGER_TYPES = {"current_option_changed"}
+
+TRIGGER_SCHEMA = DEVICE_TRIGGER_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(TRIGGER_TYPES),
+        vol.Optional(CONF_TO): vol.Any(vol.Coerce(str)),
+        vol.Optional(CONF_FROM): vol.Any(vol.Coerce(str)),
+        vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+    }
+)
+
+
+async def async_get_triggers(hass: HomeAssistant, device_id: str) -> list[dict]:
+    """List device triggers for Select devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    triggers = []
+
+    # Get all the integrations entities for this device
+    for entry in entity_registry.async_entries_for_device(registry, device_id):
+        if entry.domain != DOMAIN:
+            continue
+
+        base_trigger = {
+            CONF_PLATFORM: "device",
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.entity_id,
+        }
+        triggers.append({**base_trigger, CONF_TYPE: "current_option_changed"})
+
+    return triggers
+
+
+async def async_attach_trigger(
+    hass: HomeAssistant,
+    config: ConfigType,
+    action: AutomationActionType,
+    automation_info: dict,
+) -> CALLBACK_TYPE:
+    """Attach a trigger."""
+    state_config = {
+        CONF_PLATFORM: "state",
+        CONF_ENTITY_ID: config[CONF_ENTITY_ID],
+    }
+
+    if CONF_TO in config:
+        state_config[CONF_TO] = config[CONF_TO]
+
+    if CONF_FROM in config:
+        state_config[CONF_FROM] = config[CONF_FROM]
+
+    if CONF_FOR in config:
+        state_config[CONF_FOR] = config[CONF_FOR]
+
+    state_config = STATE_TRIGGER_SCHEMA(state_config)
+    return await async_attach_state_trigger(
+        hass, state_config, action, automation_info, platform_type="device"
+    )
+
+
+async def async_get_trigger_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, Any]:
+    """List trigger capabilities."""
+    state = hass.states.get(config[CONF_ENTITY_ID])
+    if state is None:
+        return {}
+
+    return {
+        "extra_fields": vol.Schema(
+            {
+                vol.Optional(CONF_FROM): vol.In(state.attributes.get(ATTR_OPTIONS, [])),
+                vol.Optional(CONF_TO): vol.In(state.attributes.get(ATTR_OPTIONS, [])),
+                vol.Optional(CONF_FOR): cv.positive_time_period_dict,
+            }
+        )
+    }

--- a/homeassistant/components/select/strings.json
+++ b/homeassistant/components/select/strings.json
@@ -1,3 +1,8 @@
 {
-  "title": "Select"
+  "title": "Select",
+  "device_automation": {
+    "trigger_type": {
+      "current_option_changed": "{entity_name} option changed"
+    }
+  }
 }

--- a/homeassistant/components/select/translations/en.json
+++ b/homeassistant/components/select/translations/en.json
@@ -1,0 +1,8 @@
+{
+    "device_automation": {
+        "trigger_type": {
+            "current_option_changed": "{entity_name} option changed"
+        }
+    },
+    "title": "Select"
+}

--- a/tests/components/select/test_device_trigger.py
+++ b/tests/components/select/test_device_trigger.py
@@ -1,0 +1,217 @@
+"""The tests for Select device triggers."""
+from __future__ import annotations
+
+import pytest
+import voluptuous_serialize
+
+from homeassistant.components import automation
+from homeassistant.components.select import DOMAIN
+from homeassistant.components.select.device_trigger import (
+    async_get_trigger_capabilities,
+)
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv, device_registry
+from homeassistant.helpers.entity_registry import EntityRegistry
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+
+
+@pytest.fixture
+def device_reg(hass: HomeAssistant) -> device_registry.DeviceRegistry:
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass: HomeAssistant) -> EntityRegistry:
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+@pytest.fixture
+def calls(hass: HomeAssistant) -> list[ServiceCall]:
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_triggers(
+    hass: HomeAssistant,
+    device_reg: device_registry.DeviceRegistry,
+    entity_reg: EntityRegistry,
+) -> None:
+    """Test we get the expected triggers from a select."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_triggers = [
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "type": "current_option_changed",
+            "device_id": device_entry.id,
+            "entity_id": f"{DOMAIN}.test_5678",
+        }
+    ]
+    triggers = await async_get_device_automations(hass, "trigger", device_entry.id)
+    assert_lists_same(triggers, expected_triggers)
+
+
+async def test_if_fires_on_state_change(hass, calls):
+    """Test for turn_on and turn_off triggers firing."""
+    hass.states.async_set(
+        "select.entity", "option1", {"options": ["option1", "option2", "option3"]}
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "select.entity",
+                        "type": "current_option_changed",
+                        "to": "option2",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "some": (
+                                "to - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "select.entity",
+                        "type": "current_option_changed",
+                        "from": "option2",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "some": (
+                                "from - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
+                            )
+                        },
+                    },
+                },
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": DOMAIN,
+                        "device_id": "",
+                        "entity_id": "select.entity",
+                        "type": "current_option_changed",
+                        "from": "option3",
+                        "to": "option1",
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data": {
+                            "some": (
+                                "from-to - {{ trigger.platform}} - "
+                                "{{ trigger.entity_id}} - {{ trigger.from_state.state}} - "
+                                "{{ trigger.to_state.state}} - {{ trigger.for }} - "
+                                "{{ trigger.id}}"
+                            )
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    # Test triggering device trigger with a to state
+    hass.states.async_set("select.entity", "option2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data[
+        "some"
+    ] == "to - device - {} - option1 - option2 - None - 0".format("select.entity")
+
+    # Test triggering device trigger with a from state
+    hass.states.async_set("select.entity", "option3")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data[
+        "some"
+    ] == "from - device - {} - option2 - option3 - None - 0".format("select.entity")
+
+    # Test triggering device trigger with both a from and to state
+    hass.states.async_set("select.entity", "option1")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].data[
+        "some"
+    ] == "from-to - device - {} - option3 - option1 - None - 0".format("select.entity")
+
+
+async def test_get_trigger_capabilities(hass: HomeAssistant) -> None:
+    """Test we get the expected capabilities from a select trigger."""
+    config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": "current_option_changed",
+        "entity_id": "select.test",
+        "to": "option1",
+    }
+
+    # Test when entity doesn't exists
+    capabilities = await async_get_trigger_capabilities(hass, config)
+    assert capabilities == {}
+
+    # Mock an entity
+    hass.states.async_set("select.test", "option1", {"options": ["option1", "option2"]})
+
+    # Test if we get the right capabilities now
+    capabilities = await async_get_trigger_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "from",
+            "optional": True,
+            "type": "select",
+            "options": [("option1", "option1"), ("option2", "option2")],
+        },
+        {
+            "name": "to",
+            "optional": True,
+            "type": "select",
+            "options": [("option1", "option1"), ("option2", "option2")],
+        },
+        {
+            "name": "for",
+            "optional": True,
+            "type": "positive_time_period_dict",
+            "optional": True,
+        },
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds device trigger abilities for the select entity (introduced in #51849) to allow device-based automation triggers from the UI.


```yaml
trigger:
  - platform: device
    device_id: 04341d33b41d249818bbb5d16dc2b57e
    domain: select
    entity_id: select.speed
    type: current_option_changed
    from: light_speed    # Optional
    to: ludicrous_speed  # Optional
    for: 10              # Optional
```


![image](https://user-images.githubusercontent.com/195327/122575396-ff0dfd00-d050-11eb-9fb2-b4412fba659d.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
