### PR TITLE
Add device action support to Select entity

### DIFF
--- a/homeassistant/components/select/const.py
+++ b/homeassistant/components/select/const.py
@@ -5,4 +5,6 @@ DOMAIN = "select"
 ATTR_OPTIONS = "options"
 ATTR_OPTION = "option"
 
+CONF_OPTION = "option"
+
 SERVICE_SELECT_OPTION = "select_option"

--- a/homeassistant/components/select/device_action.py
+++ b/homeassistant/components/select/device_action.py
@@ -1,0 +1,80 @@
+"""Provides device actions for Select."""
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.helpers import entity_registry
+import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.typing import ConfigType
+
+from .const import ATTR_OPTION, ATTR_OPTIONS, CONF_OPTION, DOMAIN, SERVICE_SELECT_OPTION
+
+ACTION_TYPES = {"select_option"}
+
+ACTION_SCHEMA = cv.DEVICE_ACTION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(ACTION_TYPES),
+        vol.Required(CONF_ENTITY_ID): cv.entity_domain(DOMAIN),
+        vol.Required(CONF_OPTION): str,
+    }
+)
+
+
+async def async_get_actions(hass: HomeAssistant, device_id: str) -> list[dict]:
+    """List device actions for Select devices."""
+    registry = await entity_registry.async_get_registry(hass)
+    return [
+        {
+            CONF_DEVICE_ID: device_id,
+            CONF_DOMAIN: DOMAIN,
+            CONF_ENTITY_ID: entry.entity_id,
+            CONF_TYPE: "select_option",
+        }
+        for entry in entity_registry.async_entries_for_device(registry, device_id)
+        if entry.domain == DOMAIN
+    ]
+
+
+async def async_call_action_from_config(
+    hass: HomeAssistant, config: dict, variables: dict, context: Context | None
+) -> None:
+    """Execute a device action."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: config[CONF_ENTITY_ID],
+            ATTR_OPTION: config[CONF_OPTION],
+        },
+        blocking=True,
+        context=context,
+    )
+
+
+async def async_get_action_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, Any]:
+    """List action capabilities."""
+    state = hass.states.get(config[CONF_ENTITY_ID])
+    if state is None:
+        return {}
+
+    return {
+        "extra_fields": vol.Schema(
+            {
+                vol.Required(CONF_OPTION): vol.In(
+                    state.attributes.get(ATTR_OPTIONS, [])
+                ),
+            }
+        )
+    }

--- a/homeassistant/components/select/strings.json
+++ b/homeassistant/components/select/strings.json
@@ -3,6 +3,9 @@
   "device_automation": {
     "trigger_type": {
       "current_option_changed": "{entity_name} option changed"
+    },
+    "action_type": {
+      "select_option": "Change {entity_name} option"
     }
   }
 }

--- a/homeassistant/components/select/translations/en.json
+++ b/homeassistant/components/select/translations/en.json
@@ -1,5 +1,8 @@
 {
     "device_automation": {
+        "action_type": {
+            "select_option": "Change {entity_name} option"
+        },
         "trigger_type": {
             "current_option_changed": "{entity_name} option changed"
         }

--- a/tests/components/select/test_device_action.py
+++ b/tests/components/select/test_device_action.py
@@ -1,0 +1,127 @@
+"""The tests for Select device actions."""
+import pytest
+import voluptuous_serialize
+
+from homeassistant.components import automation
+from homeassistant.components.select import DOMAIN
+from homeassistant.components.select.device_action import async_get_action_capabilities
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry,
+    entity_registry,
+)
+from homeassistant.setup import async_setup_component
+
+from tests.common import (
+    MockConfigEntry,
+    assert_lists_same,
+    async_get_device_automations,
+    async_mock_service,
+    mock_device_registry,
+    mock_registry,
+)
+
+
+@pytest.fixture
+def device_reg(hass: HomeAssistant) -> device_registry.DeviceRegistry:
+    """Return an empty, loaded, registry."""
+    return mock_device_registry(hass)
+
+
+@pytest.fixture
+def entity_reg(hass: HomeAssistant) -> entity_registry.EntityRegistry:
+    """Return an empty, loaded, registry."""
+    return mock_registry(hass)
+
+
+async def test_get_actions(
+    hass: HomeAssistant,
+    device_reg: device_registry.DeviceRegistry,
+    entity_reg: entity_registry.EntityRegistry,
+) -> None:
+    """Test we get the expected actions from a select."""
+    config_entry = MockConfigEntry(domain="test", data={})
+    config_entry.add_to_hass(hass)
+    device_entry = device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(device_registry.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    entity_reg.async_get_or_create(DOMAIN, "test", "5678", device_id=device_entry.id)
+    expected_actions = [
+        {
+            "domain": DOMAIN,
+            "type": "select_option",
+            "device_id": device_entry.id,
+            "entity_id": "select.test_5678",
+        }
+    ]
+    actions = await async_get_device_automations(hass, "action", device_entry.id)
+    assert_lists_same(actions, expected_actions)
+
+
+async def test_action(hass: HomeAssistant) -> None:
+    """Test for select_option action."""
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "event",
+                        "event_type": "test_event",
+                    },
+                    "action": {
+                        "domain": DOMAIN,
+                        "device_id": "abcdefgh",
+                        "entity_id": "select.entity",
+                        "type": "select_option",
+                        "option": "option1",
+                    },
+                },
+            ]
+        },
+    )
+
+    select_calls = async_mock_service(hass, DOMAIN, "select_option")
+
+    hass.bus.async_fire("test_event")
+    await hass.async_block_till_done()
+    assert len(select_calls) == 1
+    assert select_calls[0].domain == DOMAIN
+    assert select_calls[0].service == "select_option"
+    assert select_calls[0].data == {"entity_id": "select.entity", "option": "option1"}
+
+
+async def test_get_trigger_capabilities(hass: HomeAssistant) -> None:
+    """Test we get the expected capabilities from a select action."""
+    config = {
+        "platform": "device",
+        "domain": DOMAIN,
+        "type": "select_option",
+        "entity_id": "select.test",
+        "option": "option1",
+    }
+
+    # Test when entity doesn't exists
+    capabilities = await async_get_action_capabilities(hass, config)
+    assert capabilities == {}
+
+    # Mock an entity
+    hass.states.async_set("select.test", "option1", {"options": ["option1", "option2"]})
+
+    # Test if we get the right capabilities now
+    capabilities = await async_get_action_capabilities(hass, config)
+    assert capabilities
+    assert "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "option",
+            "required": True,
+            "type": "select",
+            "options": [("option1", "option1"), ("option2", "option2")],
+        },
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds device trigger abilities for the select entity (introduced in #51849) to allow device-based automation triggers from the UI.


```yaml
device_id: 04341d33b41d249818bbb5d16dc2b57e
domain: select
entity_id: select.speed
type: select_option
option: ludicrous_speed
```

![image](https://user-images.githubusercontent.com/195327/122582466-7d21d200-d058-11eb-889b-0a787b0c257a.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
