### PR TITLE
Add Color Palette Select entities to WLED

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from .const import DOMAIN
 from .coordinator import WLEDDataUpdateCoordinator
 
-PLATFORMS = (LIGHT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
+PLATFORMS = (LIGHT_DOMAIN, SELECT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/wled/select.py
+++ b/homeassistant/components/wled/select.py
@@ -1,0 +1,123 @@
+"""Support for LED selects."""
+from __future__ import annotations
+
+from functools import partial
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_registry import (
+    async_get_registry as async_get_entity_registry,
+)
+
+from .const import DOMAIN
+from .coordinator import WLEDDataUpdateCoordinator
+from .helpers import wled_exception_handler
+from .models import WLEDEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up WLED select based on a config entry."""
+    coordinator: WLEDDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    update_segments = partial(
+        async_update_segments,
+        entry,
+        coordinator,
+        {},
+        async_add_entities,
+    )
+    coordinator.async_add_listener(update_segments)
+    update_segments()
+
+
+class WLEDPaletteSelect(WLEDEntity, SelectEntity):
+    """Defines a WLED Palette select."""
+
+    _attr_icon = "mdi:palette-outline"
+    _segment: int
+
+    def __init__(self, coordinator: WLEDDataUpdateCoordinator, segment: int) -> None:
+        """Initialize WLED ."""
+        super().__init__(coordinator=coordinator)
+
+        # If this is the one and only segment, use a simpler name
+        self._attr_name = (
+            f"{coordinator.data.info.name} Segment {segment} Color Palette"
+        )
+        if len(coordinator.data.state.segments) == 1:
+            self._attr_name = f"{coordinator.data.info.name} Color Palette"
+
+        self._attr_unique_id = f"{coordinator.data.info.mac_address}_{segment}"
+        self._attr_options = [
+            palette.name for palette in self.coordinator.data.palettes
+        ]
+        self._segment = segment
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        try:
+            self.coordinator.data.state.segments[self._segment]
+        except IndexError:
+            return False
+
+        return super().available
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the current selected color palette."""
+        return self.coordinator.data.state.segments[self._segment].palette.name
+
+    @wled_exception_handler
+    async def async_select_option(self, option: str) -> None:
+        """Set WLED segment to the selected color palette."""
+        await self.coordinator.wled.segment(segment_id=self._segment, palette=option)
+
+
+@callback
+def async_update_segments(
+    entry: ConfigEntry,
+    coordinator: WLEDDataUpdateCoordinator,
+    current: dict[int, WLEDPaletteSelect],
+    async_add_entities,
+) -> None:
+    """Update segments."""
+    segment_ids = {segment.segment_id for segment in coordinator.data.state.segments}
+    current_ids = set(current)
+
+    new_entities = []
+
+    # Process new segments, add them to Home Assistant
+    for segment_id in segment_ids - current_ids:
+        current[segment_id] = WLEDPaletteSelect(coordinator, segment_id)
+        new_entities.append(current[segment_id])
+
+    if new_entities:
+        async_add_entities(new_entities)
+
+    # Process deleted segments, remove them from Home Assistant
+    for segment_id in current_ids - segment_ids:
+        coordinator.hass.async_create_task(
+            async_remove_entity(segment_id, coordinator, current)
+        )
+
+
+async def async_remove_entity(
+    index: int,
+    coordinator: WLEDDataUpdateCoordinator,
+    current: dict[int, WLEDPaletteSelect],
+) -> None:
+    """Remove WLED segment from Home Assistant."""
+    entity = current[index]
+    await entity.async_remove(force_remove=True)
+    registry = await async_get_entity_registry(coordinator.hass)
+    if entity.entity_id in registry.entities:
+        registry.async_remove(entity.entity_id)
+    del current[index]

--- a/tests/components/wled/test_select.py
+++ b/tests/components/wled/test_select.py
@@ -1,0 +1,198 @@
+"""Tests for the WLED select platform."""
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from wled import Device as WLEDDevice, WLEDConnectionError, WLEDError
+
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.components.select.const import ATTR_OPTION, ATTR_OPTIONS
+from homeassistant.components.wled.const import SCAN_INTERVAL
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_ICON,
+    SERVICE_SELECT_OPTION,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
+
+
+async def test_select_state(
+    hass: HomeAssistant, init_integration: MockConfigEntry
+) -> None:
+    """Test the creation and values of the WLED selects."""
+    entity_registry = er.async_get(hass)
+
+    # First segment of the strip
+    state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:palette-outline"
+    assert state.attributes.get(ATTR_OPTIONS) == [
+        "Analogous",
+        "April Night",
+        "Autumn",
+        "Based on Primary",
+        "Based on Set",
+        "Beach",
+        "Beech",
+        "Breeze",
+        "C9",
+        "Cloud",
+        "Cyane",
+        "Default",
+        "Departure",
+        "Drywet",
+        "Fire",
+        "Forest",
+        "Grintage",
+        "Hult",
+        "Hult 64",
+        "Icefire",
+        "Jul",
+        "Landscape",
+        "Lava",
+        "Light Pink",
+        "Magenta",
+        "Magred",
+        "Ocean",
+        "Orange & Teal",
+        "Orangery",
+        "Party",
+        "Pastel",
+        "Primary Color",
+        "Rainbow",
+        "Rainbow Bands",
+        "Random Cycle",
+        "Red & Blue",
+        "Rewhi",
+        "Rivendell",
+        "Sakura",
+        "Set Colors",
+        "Sherbet",
+        "Splash",
+        "Sunset",
+        "Sunset 2",
+        "Tertiary",
+        "Tiamat",
+        "Vintage",
+        "Yelblu",
+        "Yellowout",
+        "Yelmag",
+    ]
+    assert state.state == "Random Cycle"
+
+    entry = entity_registry.async_get("select.wled_rgb_light_segment_1_color_palette")
+    assert entry
+    assert entry.unique_id == "aabbccddeeff_1"
+
+
+async def test_segment_change_state(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_wled: MagicMock,
+) -> None:
+    """Test the option change of state of the WLED segments."""
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
+            ATTR_OPTION: "Some Other Palette",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert mock_wled.segment.call_count == 1
+    mock_wled.segment.assert_called_with(
+        segment_id=1,
+        palette="Some Other Palette",
+    )
+
+
+async def test_dynamically_handle_segments(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_wled: MagicMock,
+) -> None:
+    """Test if a new/deleted segment is dynamically added/removed."""
+    assert hass.states.get("select.wled_rgb_light_segment_0_color_palette")
+    assert hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+
+    return_value = mock_wled.update.return_value
+    mock_wled.update.return_value = WLEDDevice(
+        json.loads(load_fixture("wled/rgb_single_segment.json"))
+    )
+
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("select.wled_rgb_light_segment_0_color_palette")
+    assert not hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+
+    # Test adding if segment shows up again, including the master entity
+    mock_wled.update.return_value = return_value
+    async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("select.wled_rgb_light_segment_0_color_palette")
+    assert hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+
+
+async def test_select_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_wled: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test error handling of the WLED selects."""
+    mock_wled.segment.side_effect = WLEDError
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
+            ATTR_OPTION: "Whatever",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    assert state
+    assert state.state == "Random Cycle"
+    assert "Invalid response from API" in caplog.text
+    assert mock_wled.segment.call_count == 1
+    mock_wled.segment.assert_called_with(segment_id=1, palette="Whatever")
+
+
+async def test_select_connection_error(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_wled: MagicMock,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test error handling of the WLED selects."""
+    mock_wled.segment.side_effect = WLEDConnectionError
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: "select.wled_rgb_light_segment_1_color_palette",
+            ATTR_OPTION: "Whatever",
+        },
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+    assert "Error communicating with API" in caplog.text
+    assert mock_wled.segment.call_count == 1
+    mock_wled.segment.assert_called_with(segment_id=1, palette="Whatever")

--- a/tests/components/wled/test_select.py
+++ b/tests/components/wled/test_select.py
@@ -7,7 +7,7 @@ from wled import Device as WLEDDevice, WLEDConnectionError, WLEDError
 
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.components.select.const import ATTR_OPTION, ATTR_OPTIONS
-from homeassistant.components.wled.const import SCAN_INTERVAL
+from homeassistant.components.wled.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_ICON,
@@ -21,8 +21,31 @@ import homeassistant.util.dt as dt_util
 from tests.common import MockConfigEntry, async_fire_time_changed, load_fixture
 
 
+@pytest.fixture
+async def enable_all(hass: HomeAssistant) -> None:
+    """Enable all disabled by default select entities."""
+    registry = er.async_get(hass)
+
+    # Pre-create registry entries for disabled by default sensors
+    registry.async_get_or_create(
+        SELECT_DOMAIN,
+        DOMAIN,
+        "aabbccddeeff_palette_0",
+        suggested_object_id="wled_rgb_light_color_palette",
+        disabled_by=None,
+    )
+
+    registry.async_get_or_create(
+        SELECT_DOMAIN,
+        DOMAIN,
+        "aabbccddeeff_palette_1",
+        suggested_object_id="wled_rgb_light_segment_1_color_palette",
+        disabled_by=None,
+    )
+
+
 async def test_select_state(
-    hass: HomeAssistant, init_integration: MockConfigEntry
+    hass: HomeAssistant, enable_all: None, init_integration: MockConfigEntry
 ) -> None:
     """Test the creation and values of the WLED selects."""
     entity_registry = er.async_get(hass)
@@ -87,11 +110,12 @@ async def test_select_state(
 
     entry = entity_registry.async_get("select.wled_rgb_light_segment_1_color_palette")
     assert entry
-    assert entry.unique_id == "aabbccddeeff_1"
+    assert entry.unique_id == "aabbccddeeff_palette_1"
 
 
 async def test_segment_change_state(
     hass: HomeAssistant,
+    enable_all: None,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
@@ -113,37 +137,51 @@ async def test_segment_change_state(
     )
 
 
+@pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
 async def test_dynamically_handle_segments(
     hass: HomeAssistant,
+    enable_all: None,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test if a new/deleted segment is dynamically added/removed."""
-    assert hass.states.get("select.wled_rgb_light_segment_0_color_palette")
-    assert hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    segment0 = hass.states.get("select.wled_rgb_light_color_palette")
+    segment1 = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    assert segment0
+    assert segment0.state == "Default"
+    assert not segment1
 
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice(
-        json.loads(load_fixture("wled/rgb_single_segment.json"))
+        json.loads(load_fixture("wled/rgb.json"))
     )
 
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    assert hass.states.get("select.wled_rgb_light_segment_0_color_palette")
-    assert not hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    segment0 = hass.states.get("select.wled_rgb_light_color_palette")
+    segment1 = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    assert segment0
+    assert segment0.state == "Default"
+    assert segment1
+    assert segment1.state == "Random Cycle"
 
     # Test adding if segment shows up again, including the master entity
     mock_wled.update.return_value = return_value
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    assert hass.states.get("select.wled_rgb_light_segment_0_color_palette")
-    assert hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    segment0 = hass.states.get("select.wled_rgb_light_color_palette")
+    segment1 = hass.states.get("select.wled_rgb_light_segment_1_color_palette")
+    assert segment0
+    assert segment0.state == "Default"
+    assert segment1
+    assert segment1.state == STATE_UNAVAILABLE
 
 
 async def test_select_error(
     hass: HomeAssistant,
+    enable_all: None,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
     caplog: pytest.LogCaptureFixture,
@@ -172,6 +210,7 @@ async def test_select_error(
 
 async def test_select_connection_error(
     hass: HomeAssistant,
+    enable_all: None,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
     caplog: pytest.LogCaptureFixture,
@@ -196,3 +235,25 @@ async def test_select_connection_error(
     assert "Error communicating with API" in caplog.text
     assert mock_wled.segment.call_count == 1
     mock_wled.segment.assert_called_with(segment_id=1, palette="Whatever")
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    (
+        "select.wled_rgb_light_color_palette",
+        "select.wled_rgb_light_segment_1_color_palette",
+    ),
+)
+async def test_disabled_by_default_selects(
+    hass: HomeAssistant, init_integration: MockConfigEntry, entity_id: str
+) -> None:
+    """Test the disabled by default WLED selects."""
+    registry = er.async_get(hass)
+
+    state = hass.states.get(entity_id)
+    assert state is None
+
+    entry = registry.async_get(entity_id)
+    assert entry
+    assert entry.disabled
+    assert entry.disabled_by == er.DISABLED_INTEGRATION


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds the select platform to WLED, providing controls to select the color palette.

![image](https://user-images.githubusercontent.com/195327/122596636-7734ec80-d06a-11eb-91d2-2add55f0cd7f.png)


![image](https://user-images.githubusercontent.com/195327/123251533-9a88ed00-d4eb-11eb-95d6-7ca786e944db.png)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18286

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
