### PR TITLE
Initial support for zwave_js device conditions

### DIFF
--- a/homeassistant/components/zwave_js/const.py
+++ b/homeassistant/components/zwave_js/const.py
@@ -45,6 +45,9 @@ ATTR_EVENT_DATA = "event_data"
 ATTR_DATA_TYPE = "data_type"
 ATTR_WAIT_FOR_RESULT = "wait_for_result"
 
+ATTR_NODE = "node"
+ATTR_ZWAVE_VALUE = "zwave_value"
+
 # service constants
 ATTR_NODES = "nodes"
 

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -16,6 +16,7 @@ from homeassistant.components.zwave_js.const import (
 )
 from homeassistant.const import CONF_CONDITION, CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
@@ -151,7 +152,10 @@ def async_condition_from_config(
         value = node.values[value_id]
         return bool(value.value == config[ATTR_VALUE])
 
-    return test_value
+    if condition_type == VALUE_TYPE:
+        return test_value
+
+    raise HomeAssistantError(f"Unhandled condition type {condition_type}")
 
 
 @callback

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -173,23 +173,11 @@ async def async_get_condition_capabilities(
         min_ = config_value.metadata.min
         max_ = config_value.metadata.max
 
-        if config_value.configuration_value_type == ConfigurationValueType.RANGE:
-            value_schema = vol.Range(min=min_, max=max_)
-        elif (
-            config_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+        if config_value.configuration_value_type in (
+            ConfigurationValueType.RANGE,
+            ConfigurationValueType.MANUAL_ENTRY,
         ):
-            # If there are named states, we'll generate a list of numbers so that we can
-            # include the named states, otherwise we'll generate a range.
-            value_schema = (
-                vol.In(
-                    {
-                        i: config_value.metadata.states.get(str(i)) or i
-                        for i in range(min_, max_ + 1)
-                    }
-                )
-                if config_value.metadata.states
-                else vol.Range(min=min_, max=max_)
-            )
+            value_schema = vol.Range(min=min_, max=max_)
         elif config_value.configuration_value_type == ConfigurationValueType.ENUMERATED:
             value_schema = vol.In(
                 {int(k): v for k, v in config_value.metadata.states.items()}

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -177,13 +177,16 @@ async def async_get_condition_capabilities(
             value_schema = vol.Range(min=min, max=max)
         elif (
             config_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
-            and config_value.metadata.states
         ):
-            value_schema = vol.In(
-                {
-                    i: config_value.metadata.states.get(str(i)) or i
-                    for i in range(min, max + 1)
-                }
+            value_schema = (
+                vol.In(
+                    {
+                        i: config_value.metadata.states.get(str(i)) or i
+                        for i in range(min, max + 1)
+                    }
+                )
+                if config_value.metadata.states
+                else vol.Range(min=min, max=max)
             )
         elif config_value.configuration_value_type == ConfigurationValueType.ENUMERATED:
             value_schema = vol.In(

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -37,22 +37,20 @@ async def async_get_conditions(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
     """List device conditions for Z-Wave JS devices."""
-    base_condition = {
-        CONF_CONDITION: "device",
-        CONF_DEVICE_ID: device_id,
-        CONF_DOMAIN: DOMAIN,
-    }
 
     ent_reg = entity_registry.async_get(hass)
     dev_reg = device_registry.async_get(hass)
     entity_id = async_get_node_status_sensor_entity_id(
         hass, device_id, ent_reg, dev_reg
     )
+    base_condition = {
+        CONF_CONDITION: "device",
+        CONF_DEVICE_ID: device_id,
+        CONF_DOMAIN: DOMAIN,
+        CONF_ENTITY_ID: entity_id,
+    }
 
-    conditions = [
-        {**base_condition, CONF_ENTITY_ID: entity_id, CONF_TYPE: cond}
-        for cond in CONDITION_TYPES
-    ]
+    conditions = [{**base_condition, CONF_TYPE: cond} for cond in CONDITION_TYPES]
 
     return conditions
 

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -81,12 +81,18 @@ async def async_validate_condition_config(
     config = CONDITION_SCHEMA(config)
     node = async_get_node_from_device_id(hass, config[CONF_DEVICE_ID])
     if config[CONF_TYPE] == VALUE_TYPE:
+        endpoint = None
+        if config.get(ATTR_ENDPOINT):
+            endpoint = config[ATTR_ENDPOINT]
+        property_key = None
+        if config.get(ATTR_PROPERTY_KEY):
+            property_key = config[ATTR_PROPERTY_KEY]
         value_id = get_value_id(
             node,
             CommandClass[config[ATTR_COMMAND_CLASS]],
             config[ATTR_PROPERTY],
-            config.get(ATTR_ENDPOINT),
-            config.get(ATTR_PROPERTY_KEY),
+            endpoint,
+            property_key,
         )
         if value_id not in node.values:
             raise vol.Invalid(f"Value {value_id} not found on node {node}")

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -1,35 +1,47 @@
 """Provide the device conditions for Z-Wave JS."""
 from __future__ import annotations
 
-import voluptuous as vol
+from typing import cast
 
-from homeassistant.const import (
-    CONF_CONDITION,
-    CONF_DEVICE_ID,
-    CONF_DOMAIN,
-    CONF_ENTITY_ID,
-    CONF_TYPE,
-)
+import voluptuous as vol
+from zwave_js_server.const import ConfigurationValueType
+from zwave_js_server.model.value import ConfigurationValue
+
+from homeassistant.components.zwave_js.const import ATTR_VALUE
+from homeassistant.const import CONF_CONDITION, CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import (
-    condition,
-    config_validation as cv,
-    device_registry,
-    entity_registry,
-)
+from homeassistant.helpers import condition, config_validation as cv
 from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
 from homeassistant.helpers.typing import ConfigType, TemplateVarsType
 
 from . import DOMAIN
-from .helpers import async_get_node_status_sensor_entity_id
+from .helpers import async_get_node_from_device_id
 
-CONDITION_TYPES = {"asleep", "awake", "dead", "alive"}
+CONF_SUBTYPE = "subtype"
 
-CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+CONF_VALUE_ID = "value_id"
+
+NODE_STATUS_TYPES = {"asleep", "awake", "dead", "alive"}
+CONFIG_PARAMETER_TYPE = "config_parameter"
+CONDITION_TYPES = {*NODE_STATUS_TYPES, CONFIG_PARAMETER_TYPE}
+
+NODE_STATUS_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
-        vol.Required(CONF_TYPE): vol.In(CONDITION_TYPES),
-        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+        vol.Required(CONF_TYPE): vol.In(NODE_STATUS_TYPES),
     }
+)
+
+CONFIG_PARAMETER_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): CONFIG_PARAMETER_TYPE,
+        vol.Required(CONF_VALUE_ID): cv.string,
+        vol.Required(CONF_SUBTYPE): cv.string,
+        vol.Optional(ATTR_VALUE): vol.Coerce(int),
+    }
+)
+
+CONDITION_SCHEMA = vol.Any(
+    NODE_STATUS_CONDITION_SCHEMA, CONFIG_PARAMETER_CONDITION_SCHEMA
 )
 
 
@@ -37,19 +49,29 @@ async def async_get_conditions(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
     """List device conditions for Z-Wave JS devices."""
-    ent_reg = entity_registry.async_get(hass)
-    dev_reg = device_registry.async_get(hass)
-    entity_id = async_get_node_status_sensor_entity_id(
-        hass, device_id, ent_reg, dev_reg
-    )
+    node = async_get_node_from_device_id(hass, device_id)
+
     base_condition = {
         CONF_CONDITION: "device",
         CONF_DEVICE_ID: device_id,
         CONF_DOMAIN: DOMAIN,
-        CONF_ENTITY_ID: entity_id,
     }
 
-    conditions = [{**base_condition, CONF_TYPE: cond} for cond in CONDITION_TYPES]
+    # Node status conditions
+    conditions = [{**base_condition, CONF_TYPE: cond} for cond in NODE_STATUS_TYPES]
+
+    # Config parameter conditions
+    conditions.extend(
+        [
+            {
+                **base_condition,
+                CONF_VALUE_ID: config_value.value_id,
+                CONF_TYPE: CONFIG_PARAMETER_TYPE,
+                CONF_SUBTYPE: f"{config_value.value_id} ({config_value.property_name})",
+            }
+            for config_value in node.get_configuration_values().values()
+        ]
+    )
 
     return conditions
 
@@ -62,18 +84,57 @@ def async_condition_from_config(
     if config_validation:
         config = CONDITION_SCHEMA(config)
 
-    state = config[CONF_TYPE]
+    condition_type = config[CONF_TYPE]
+    device_id = config[CONF_DEVICE_ID]
 
     @callback
-    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
-        """Test if an entity is a certain state."""
-        ent_reg = entity_registry.async_get(hass)
-        entity_id = config[CONF_ENTITY_ID]
+    def test_node_status(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if node status is a certain state."""
+        node = async_get_node_from_device_id(hass, device_id)
+        return bool(node.status.name.lower() == condition_type)
 
-        return (
-            (entity := ent_reg.async_get(entity_id)) is not None
-            and not entity.disabled
-            and condition.state(hass, entity_id, state)
-        )
+    if condition_type in NODE_STATUS_TYPES:
+        return test_node_status
 
-    return test_is_state
+    value_id = config[CONF_VALUE_ID]
+    value = config[ATTR_VALUE]
+
+    @callback
+    def test_config_parameter(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if config parameter is a certain state."""
+        node = async_get_node_from_device_id(hass, device_id)
+        config_value = cast(ConfigurationValue, node.values[value_id])
+        return bool(config_value.value == value)
+
+    return test_config_parameter
+
+
+@callback
+async def async_get_condition_capabilities(
+    hass: HomeAssistant, config: ConfigType
+) -> dict[str, vol.Schema]:
+    """List condition capabilities."""
+    # Add additional fields to the automation trigger UI
+    if config[CONF_TYPE] == CONFIG_PARAMETER_TYPE:
+        device_id = config[CONF_DEVICE_ID]
+        value_id = config[CONF_VALUE_ID]
+        node = async_get_node_from_device_id(hass, device_id)
+        config_value = cast(ConfigurationValue, node.values[value_id])
+
+        if config_value.configuration_value_type in (
+            ConfigurationValueType.RANGE,
+            ConfigurationValueType.MANUAL_ENTRY,
+        ):
+            value_schema = vol.Range(
+                min=config_value.metadata.min, max=config_value.metadata.max
+            )
+        elif config_value.configuration_value_type == ConfigurationValueType.ENUMERATED:
+            value_schema = vol.In(
+                {int(k): v for k, v in config_value.metadata.states.items()}
+            )
+        else:
+            return {}
+
+        return {"extra_fields": vol.Schema({vol.Required(ATTR_VALUE): value_schema})}
+
+    return {}

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -81,7 +81,7 @@ async def async_validate_condition_config(
     if config[CONF_TYPE] == VALUE_TYPE:
         value_id = get_value_id(
             node,
-            config[ATTR_COMMAND_CLASS],
+            CommandClass[config[ATTR_COMMAND_CLASS]],
             config[ATTR_PROPERTY],
             config.get(ATTR_ENDPOINT),
             config.get(ATTR_PROPERTY_KEY),

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -1,0 +1,82 @@
+"""Provide the device conditions for Z-Wave JS."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_ENTITY_ID,
+    CONF_TYPE,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import (
+    condition,
+    config_validation as cv,
+    device_registry,
+    entity_registry,
+)
+from homeassistant.helpers.config_validation import DEVICE_CONDITION_BASE_SCHEMA
+from homeassistant.helpers.typing import ConfigType, TemplateVarsType
+
+from . import DOMAIN
+from .helpers import async_get_node_status_sensor_entity_id
+
+CONDITION_TYPES = {"asleep", "awake", "dead", "alive"}
+
+CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): vol.In(CONDITION_TYPES),
+        vol.Required(CONF_ENTITY_ID): cv.entity_id,
+    }
+)
+
+
+async def async_get_conditions(
+    hass: HomeAssistant, device_id: str
+) -> list[dict[str, str]]:
+    """List device conditions for Z-Wave JS devices."""
+    base_condition = {
+        CONF_CONDITION: "device",
+        CONF_DEVICE_ID: device_id,
+        CONF_DOMAIN: DOMAIN,
+    }
+
+    ent_reg = entity_registry.async_get(hass)
+    dev_reg = device_registry.async_get(hass)
+    entity_id = async_get_node_status_sensor_entity_id(
+        hass, device_id, ent_reg, dev_reg
+    )
+
+    conditions = [
+        {**base_condition, CONF_ENTITY_ID: entity_id, CONF_TYPE: cond}
+        for cond in CONDITION_TYPES
+    ]
+
+    return conditions
+
+
+@callback
+def async_condition_from_config(
+    config: ConfigType, config_validation: bool
+) -> condition.ConditionCheckerType:
+    """Create a function to test a device condition."""
+    if config_validation:
+        config = CONDITION_SCHEMA(config)
+
+    state = config[CONF_TYPE]
+
+    @callback
+    def test_is_state(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if an entity is a certain state."""
+        ent_reg = entity_registry.async_get(hass)
+        entity_id = config[CONF_ENTITY_ID]
+
+        return (
+            (entity := ent_reg.async_get(entity_id)) is not None
+            and not entity.disabled
+            and condition.state(hass, entity_id, state)
+        )
+
+    return test_is_state

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -50,7 +50,7 @@ CONFIG_PARAMETER_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
 VALUE_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
         vol.Required(CONF_TYPE): VALUE_TYPE,
-        vol.Required(ATTR_COMMAND_CLASS): cv.string,
+        vol.Required(ATTR_COMMAND_CLASS): vol.In([cc.name for cc in CommandClass]),
         vol.Required(ATTR_PROPERTY): vol.Any(vol.Coerce(int), cv.string),
         vol.Optional(ATTR_PROPERTY_KEY): vol.Any(vol.Coerce(int), cv.string),
         vol.Optional(ATTR_ENDPOINT): vol.Coerce(int),

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -170,11 +170,11 @@ async def async_get_condition_capabilities(
     if config[CONF_TYPE] == CONFIG_PARAMETER_TYPE:
         value_id = config[CONF_VALUE_ID]
         config_value = cast(ConfigurationValue, node.values[value_id])
-        min = config_value.metadata.min
-        max = config_value.metadata.max
+        min_ = config_value.metadata.min
+        max_ = config_value.metadata.max
 
         if config_value.configuration_value_type == ConfigurationValueType.RANGE:
-            value_schema = vol.Range(min=min, max=max)
+            value_schema = vol.Range(min=min_, max=max_)
         elif (
             config_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
         ):
@@ -182,11 +182,11 @@ async def async_get_condition_capabilities(
                 vol.In(
                     {
                         i: config_value.metadata.states.get(str(i)) or i
-                        for i in range(min, max + 1)
+                        for i in range(min_, max_ + 1)
                     }
                 )
                 if config_value.metadata.states
-                else vol.Range(min=min, max=max)
+                else vol.Range(min=min_, max=max_)
             )
         elif config_value.configuration_value_type == ConfigurationValueType.ENUMERATED:
             value_schema = vol.In(

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -170,13 +170,20 @@ async def async_get_condition_capabilities(
     if config[CONF_TYPE] == CONFIG_PARAMETER_TYPE:
         value_id = config[CONF_VALUE_ID]
         config_value = cast(ConfigurationValue, node.values[value_id])
+        min = config_value.metadata.min
+        max = config_value.metadata.max
 
-        if config_value.configuration_value_type in (
-            ConfigurationValueType.RANGE,
-            ConfigurationValueType.MANUAL_ENTRY,
+        if config_value.configuration_value_type == ConfigurationValueType.RANGE:
+            value_schema = vol.Range(min=min, max=max)
+        elif (
+            config_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
+            and config_value.metadata.states
         ):
-            value_schema = vol.Range(
-                min=config_value.metadata.min, max=config_value.metadata.max
+            value_schema = vol.In(
+                {
+                    i: config_value.metadata.states.get(str(i)) or i
+                    for i in range(min, max + 1)
+                }
             )
         elif config_value.configuration_value_type == ConfigurationValueType.ENUMERATED:
             value_schema = vol.In(

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -37,7 +37,6 @@ async def async_get_conditions(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
     """List device conditions for Z-Wave JS devices."""
-
     ent_reg = entity_registry.async_get(hass)
     dev_reg = device_registry.async_get(hass)
     entity_id = async_get_node_status_sensor_entity_id(

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -75,16 +75,16 @@ async def async_get_conditions(
     hass: HomeAssistant, device_id: str
 ) -> list[dict[str, str]]:
     """List device conditions for Z-Wave JS devices."""
-    node = async_get_node_from_device_id(hass, device_id)
-
+    conditions = []
     base_condition = {
         CONF_CONDITION: "device",
         CONF_DEVICE_ID: device_id,
         CONF_DOMAIN: DOMAIN,
     }
+    node = async_get_node_from_device_id(hass, device_id)
 
     # Any value's value condition
-    conditions = [{**base_condition, CONF_TYPE: VALUE_TYPE}]
+    conditions.append({**base_condition, CONF_TYPE: VALUE_TYPE})
 
     # Node status conditions
     conditions.extend(

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 from typing import cast
 
 import voluptuous as vol
-from zwave_js_server.const import ConfigurationValueType
-from zwave_js_server.model.value import ConfigurationValue
+from zwave_js_server.const import CommandClass, ConfigurationValueType
+from zwave_js_server.model.value import ConfigurationValue, get_value_id
 
-from homeassistant.components.zwave_js.const import ATTR_VALUE
+from homeassistant.components.zwave_js.const import (
+    ATTR_COMMAND_CLASS,
+    ATTR_ENDPOINT,
+    ATTR_PROPERTY,
+    ATTR_PROPERTY_KEY,
+    ATTR_VALUE,
+)
 from homeassistant.const import CONF_CONDITION, CONF_DEVICE_ID, CONF_DOMAIN, CONF_TYPE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import condition, config_validation as cv
@@ -23,7 +29,8 @@ CONF_VALUE_ID = "value_id"
 
 NODE_STATUS_TYPES = {"asleep", "awake", "dead", "alive"}
 CONFIG_PARAMETER_TYPE = "config_parameter"
-CONDITION_TYPES = {*NODE_STATUS_TYPES, CONFIG_PARAMETER_TYPE}
+VALUE_TYPE = "value"
+CONDITION_TYPES = {*NODE_STATUS_TYPES, CONFIG_PARAMETER_TYPE, VALUE_TYPE}
 
 NODE_STATUS_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
     {
@@ -40,8 +47,27 @@ CONFIG_PARAMETER_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
     }
 )
 
+VALUE_CONDITION_SCHEMA = DEVICE_CONDITION_BASE_SCHEMA.extend(
+    {
+        vol.Required(CONF_TYPE): VALUE_TYPE,
+        vol.Required(ATTR_COMMAND_CLASS): cv.string,
+        vol.Required(ATTR_PROPERTY): vol.Any(vol.Coerce(int), cv.string),
+        vol.Optional(ATTR_PROPERTY_KEY): vol.Any(vol.Coerce(int), cv.string),
+        vol.Optional(ATTR_ENDPOINT): vol.Coerce(int),
+        vol.Required(ATTR_VALUE): vol.Any(
+            bool,
+            vol.Coerce(int),
+            vol.Coerce(float),
+            cv.boolean,
+            cv.string,
+        ),
+    }
+)
+
 CONDITION_SCHEMA = vol.Any(
-    NODE_STATUS_CONDITION_SCHEMA, CONFIG_PARAMETER_CONDITION_SCHEMA
+    NODE_STATUS_CONDITION_SCHEMA,
+    CONFIG_PARAMETER_CONDITION_SCHEMA,
+    VALUE_CONDITION_SCHEMA,
 )
 
 
@@ -57,8 +83,13 @@ async def async_get_conditions(
         CONF_DOMAIN: DOMAIN,
     }
 
+    # Any value's value condition
+    conditions = [{**base_condition, CONF_TYPE: VALUE_TYPE}]
+
     # Node status conditions
-    conditions = [{**base_condition, CONF_TYPE: cond} for cond in NODE_STATUS_TYPES]
+    conditions.extend(
+        [{**base_condition, CONF_TYPE: cond} for cond in NODE_STATUS_TYPES]
+    )
 
     # Config parameter conditions
     conditions.extend(
@@ -96,17 +127,31 @@ def async_condition_from_config(
     if condition_type in NODE_STATUS_TYPES:
         return test_node_status
 
-    value_id = config[CONF_VALUE_ID]
-    value = config[ATTR_VALUE]
-
     @callback
     def test_config_parameter(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
         """Test if config parameter is a certain state."""
         node = async_get_node_from_device_id(hass, device_id)
-        config_value = cast(ConfigurationValue, node.values[value_id])
-        return bool(config_value.value == value)
+        config_value = cast(ConfigurationValue, node.values[config[CONF_VALUE_ID]])
+        return bool(config_value.value == config[ATTR_VALUE])
 
-    return test_config_parameter
+    if condition_type == CONFIG_PARAMETER_TYPE:
+        return test_config_parameter
+
+    @callback
+    def test_value(hass: HomeAssistant, variables: TemplateVarsType) -> bool:
+        """Test if value is a certain state."""
+        node = async_get_node_from_device_id(hass, device_id)
+        value_id = get_value_id(
+            node,
+            CommandClass[config[ATTR_COMMAND_CLASS]],
+            config[ATTR_PROPERTY],
+            config.get(ATTR_ENDPOINT) or None,
+            config.get(ATTR_PROPERTY_KEY) or None,
+        )
+        value = node.values[value_id]
+        return bool(value.value == config[ATTR_VALUE])
+
+    return test_value
 
 
 @callback
@@ -114,11 +159,12 @@ async def async_get_condition_capabilities(
     hass: HomeAssistant, config: ConfigType
 ) -> dict[str, vol.Schema]:
     """List condition capabilities."""
+    device_id = config[CONF_DEVICE_ID]
+    node = async_get_node_from_device_id(hass, device_id)
+
     # Add additional fields to the automation trigger UI
     if config[CONF_TYPE] == CONFIG_PARAMETER_TYPE:
-        device_id = config[CONF_DEVICE_ID]
         value_id = config[CONF_VALUE_ID]
-        node = async_get_node_from_device_id(hass, device_id)
         config_value = cast(ConfigurationValue, node.values[value_id])
 
         if config_value.configuration_value_type in (
@@ -136,5 +182,20 @@ async def async_get_condition_capabilities(
             return {}
 
         return {"extra_fields": vol.Schema({vol.Required(ATTR_VALUE): value_schema})}
+
+    if config[CONF_TYPE] == VALUE_TYPE:
+        return {
+            "extra_fields": vol.Schema(
+                {
+                    vol.Required(ATTR_COMMAND_CLASS): vol.In(
+                        [cc.name for cc in CommandClass]
+                    ),
+                    vol.Required(ATTR_PROPERTY): cv.string,
+                    vol.Optional(ATTR_PROPERTY_KEY): cv.string,
+                    vol.Optional(ATTR_ENDPOINT): cv.string,
+                    vol.Required(ATTR_VALUE): cv.string,
+                }
+            )
+        }
 
     return {}

--- a/homeassistant/components/zwave_js/device_condition.py
+++ b/homeassistant/components/zwave_js/device_condition.py
@@ -178,6 +178,8 @@ async def async_get_condition_capabilities(
         elif (
             config_value.configuration_value_type == ConfigurationValueType.MANUAL_ENTRY
         ):
+            # If there are named states, we'll generate a list of numbers so that we can
+            # include the named states, otherwise we'll generate a range.
             value_schema = (
                 vol.In(
                     {

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -7,11 +7,9 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import Value as ZwaveValue
 
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import (
     DeviceRegistry,
     async_get as async_get_dev_reg,
@@ -145,35 +143,3 @@ def async_get_node_from_entity_id(
     # tied to a device
     assert entity_entry.device_id
     return async_get_node_from_device_id(hass, entity_entry.device_id, dev_reg)
-
-
-@callback
-def async_get_node_status_sensor_entity_id(
-    hass: HomeAssistant,
-    device_id: str,
-    ent_reg: EntityRegistry | None = None,
-    dev_reg: DeviceRegistry | None = None,
-) -> str:
-    """Get the node status sensor entity ID for a given Z-Wave JS device."""
-    if not ent_reg:
-        ent_reg = async_get_ent_reg(hass)
-    if not dev_reg:
-        dev_reg = async_get_dev_reg(hass)
-    device = dev_reg.async_get(device_id)
-    if not device:
-        raise HomeAssistantError("Invalid Device ID provided")
-
-    entry_id = next(entry_id for entry_id in device.config_entries)
-    client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
-    node = async_get_node_from_device_id(hass, device_id, dev_reg)
-    entity_id = ent_reg.async_get_entity_id(
-        SENSOR_DOMAIN,
-        DOMAIN,
-        f"{client.driver.controller.home_id}.{node.node_id}.node_status",
-    )
-    if not entity_id:
-        raise HomeAssistantError(
-            "Node status sensor entity not found. Device may not be a zwave_js device"
-        )
-
-    return entity_id

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 from typing import Any, cast
 
+import voluptuous as vol
 from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.node import Node as ZwaveNode
-from zwave_js_server.model.value import Value as ZwaveValue
+from zwave_js_server.model.value import Value as ZwaveValue, get_value_id
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import __version__ as HA_VERSION
@@ -18,8 +19,17 @@ from homeassistant.helpers.entity_registry import (
     EntityRegistry,
     async_get as async_get_ent_reg,
 )
+from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_DATA_COLLECTION_OPTED_IN, DATA_CLIENT, DOMAIN
+from .const import (
+    ATTR_COMMAND_CLASS,
+    ATTR_ENDPOINT,
+    ATTR_PROPERTY,
+    ATTR_PROPERTY_KEY,
+    CONF_DATA_COLLECTION_OPTED_IN,
+    DATA_CLIENT,
+    DOMAIN,
+)
 
 
 @callback
@@ -143,3 +153,23 @@ def async_get_node_from_entity_id(
     # tied to a device
     assert entity_entry.device_id
     return async_get_node_from_device_id(hass, entity_entry.device_id, dev_reg)
+
+
+def get_zwave_value_from_config(node: ZwaveNode, config: ConfigType) -> ZwaveValue:
+    """Get a Z-Wave JS Value from a config."""
+    endpoint = None
+    if config.get(ATTR_ENDPOINT):
+        endpoint = config[ATTR_ENDPOINT]
+    property_key = None
+    if config.get(ATTR_PROPERTY_KEY):
+        property_key = config[ATTR_PROPERTY_KEY]
+    value_id = get_value_id(
+        node,
+        config[ATTR_COMMAND_CLASS],
+        config[ATTR_PROPERTY],
+        endpoint,
+        property_key,
+    )
+    if value_id not in node.values:
+        raise vol.Invalid(f"Value {value_id} can't be found on node {node}")
+    return node.values[value_id]

--- a/homeassistant/components/zwave_js/helpers.py
+++ b/homeassistant/components/zwave_js/helpers.py
@@ -7,9 +7,11 @@ from zwave_js_server.client import Client as ZwaveClient
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.value import Value as ZwaveValue
 
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import (
     DeviceRegistry,
     async_get as async_get_dev_reg,
@@ -143,3 +145,35 @@ def async_get_node_from_entity_id(
     # tied to a device
     assert entity_entry.device_id
     return async_get_node_from_device_id(hass, entity_entry.device_id, dev_reg)
+
+
+@callback
+def async_get_node_status_sensor_entity_id(
+    hass: HomeAssistant,
+    device_id: str,
+    ent_reg: EntityRegistry | None = None,
+    dev_reg: DeviceRegistry | None = None,
+) -> str:
+    """Get the node status sensor entity ID for a given Z-Wave JS device."""
+    if not ent_reg:
+        ent_reg = async_get_ent_reg(hass)
+    if not dev_reg:
+        dev_reg = async_get_dev_reg(hass)
+    device = dev_reg.async_get(device_id)
+    if not device:
+        raise HomeAssistantError("Invalid Device ID provided")
+
+    entry_id = next(entry_id for entry_id in device.config_entries)
+    client = hass.data[DOMAIN][entry_id][DATA_CLIENT]
+    node = async_get_node_from_device_id(hass, device_id, dev_reg)
+    entity_id = ent_reg.async_get_entity_id(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"{client.driver.controller.home_id}.{node.node_id}.node_status",
+    )
+    if not entity_id:
+        raise HomeAssistantError(
+            "Node status sensor entity not found. Device may not be a zwave_js device"
+        )
+
+    return entity_id

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -100,11 +100,11 @@
   },
   "device_automation": {
     "condition_type": {
-      "unknown": "unknown",
-      "asleep": "asleep",
-      "awake": "awake",
-      "dead": "dead",
-      "alive": "alive"
+      "asleep": "Node is asleep",
+      "awake": "Node is awake",
+      "dead": "Node is dead",
+      "alive": "Node is alive",
+      "config_parameter": "Config parameter {subtype} value"
     }
   }
 }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -10,7 +10,9 @@
       "on_supervisor": {
         "title": "Select connection method",
         "description": "Do you want to use the Z-Wave JS Supervisor add-on?",
-        "data": { "use_addon": "Use the Z-Wave JS Supervisor add-on" }
+        "data": {
+          "use_addon": "Use the Z-Wave JS Supervisor add-on"
+        }
       },
       "install_addon": {
         "title": "The Z-Wave JS add-on installation has started"
@@ -22,7 +24,9 @@
           "network_key": "Network Key"
         }
       },
-      "start_addon": { "title": "The Z-Wave JS add-on is starting." },
+      "start_addon": {
+        "title": "The Z-Wave JS add-on is starting."
+      },
       "hassio_confirm": {
         "title": "Set up Z-Wave JS integration with the Z-Wave JS add-on"
       }
@@ -92,6 +96,15 @@
     "progress": {
       "install_addon": "Please wait while the Z-Wave JS add-on installation finishes. This can take several minutes.",
       "start_addon": "Please wait while the Z-Wave JS add-on start completes. This may take some seconds."
+    }
+  },
+  "device_automation": {
+    "condition_type": {
+      "unknown": "unknown",
+      "asleep": "asleep",
+      "awake": "awake",
+      "dead": "dead",
+      "alive": "alive"
     }
   }
 }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -100,10 +100,7 @@
   },
   "device_automation": {
     "condition_type": {
-      "asleep": "Node is asleep",
-      "awake": "Node is awake",
-      "dead": "Node is dead",
-      "alive": "Node is alive",
+      "node_status": "Node status",
       "config_parameter": "Config parameter {subtype} value",
       "value": "Current value of a Z-Wave Value"
     }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -104,7 +104,8 @@
       "awake": "Node is awake",
       "dead": "Node is dead",
       "alive": "Node is alive",
-      "config_parameter": "Config parameter {subtype} value"
+      "config_parameter": "Config parameter {subtype} value",
+      "value": "Z-Wave Value's value"
     }
   }
 }

--- a/homeassistant/components/zwave_js/strings.json
+++ b/homeassistant/components/zwave_js/strings.json
@@ -105,7 +105,7 @@
       "dead": "Node is dead",
       "alive": "Node is alive",
       "config_parameter": "Config parameter {subtype} value",
-      "value": "Z-Wave Value's value"
+      "value": "Current value of a Z-Wave Value"
     }
   }
 }

--- a/homeassistant/components/zwave_js/translations/en.json
+++ b/homeassistant/components/zwave_js/translations/en.json
@@ -107,7 +107,8 @@
             "asleep": "Node is asleep",
             "awake": "Node is awake",
             "config_parameter": "Config parameter {subtype} value",
-            "dead": "Node is dead"
+            "dead": "Node is dead",
+            "value": "Current value of a Z-Wave Value"
         }
     },
     "title": "Z-Wave JS"

--- a/homeassistant/components/zwave_js/translations/en.json
+++ b/homeassistant/components/zwave_js/translations/en.json
@@ -51,7 +51,6 @@
             }
         }
     },
-<<<<<<< HEAD
     "options": {
         "abort": {
             "addon_get_discovery_info_failed": "Failed to get Z-Wave JS add-on discovery info.",
@@ -100,15 +99,15 @@
             "start_addon": {
                 "title": "The Z-Wave JS add-on is starting."
             }
-=======
+        }
+    },
     "device_automation": {
         "condition_type": {
-            "alive": "alive",
-            "asleep": "asleep",
-            "awake": "awake",
-            "dead": "dead",
-            "unknown": "unknown"
->>>>>>> 1f3d4e2824 (Initial support for zwave_js device conditions)
+            "alive": "Node is alive",
+            "asleep": "Node is asleep",
+            "awake": "Node is awake",
+            "config_parameter": "Config parameter {subtype} value",
+            "dead": "Node is dead"
         }
     },
     "title": "Z-Wave JS"

--- a/homeassistant/components/zwave_js/translations/en.json
+++ b/homeassistant/components/zwave_js/translations/en.json
@@ -51,6 +51,7 @@
             }
         }
     },
+<<<<<<< HEAD
     "options": {
         "abort": {
             "addon_get_discovery_info_failed": "Failed to get Z-Wave JS add-on discovery info.",
@@ -99,6 +100,15 @@
             "start_addon": {
                 "title": "The Z-Wave JS add-on is starting."
             }
+=======
+    "device_automation": {
+        "condition_type": {
+            "alive": "alive",
+            "asleep": "asleep",
+            "awake": "awake",
+            "dead": "dead",
+            "unknown": "unknown"
+>>>>>>> 1f3d4e2824 (Initial support for zwave_js device conditions)
         }
     },
     "title": "Z-Wave JS"

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -6,10 +6,7 @@ from zwave_js_server.event import Event
 
 from homeassistant.components import automation
 from homeassistant.components.zwave_js import DOMAIN
-from homeassistant.components.zwave_js.helpers import (
-    async_get_node_status_sensor_entity_id,
-)
-from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.helpers import device_registry
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_get_device_automations, async_mock_service
@@ -27,37 +24,30 @@ async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> 
     device = device_registry.async_entries_for_config_entry(
         dev_reg, integration.entry_id
     )[0]
-    node_sensor_entity_id = async_get_node_status_sensor_entity_id(
-        hass, device.id, dev_reg=dev_reg
-    )
     expected_conditions = [
         {
             "condition": "device",
             "domain": DOMAIN,
             "type": "alive",
             "device_id": device.id,
-            "entity_id": node_sensor_entity_id,
         },
         {
             "condition": "device",
             "domain": DOMAIN,
             "type": "awake",
             "device_id": device.id,
-            "entity_id": node_sensor_entity_id,
         },
         {
             "condition": "device",
             "domain": DOMAIN,
             "type": "asleep",
             "device_id": device.id,
-            "entity_id": node_sensor_entity_id,
         },
         {
             "condition": "device",
             "domain": DOMAIN,
             "type": "dead",
             "device_id": device.id,
-            "entity_id": node_sensor_entity_id,
         },
     ]
     conditions = await async_get_device_automations(hass, "condition", device.id)
@@ -71,13 +61,6 @@ async def test_if_state(hass, client, lock_schlage_be469, integration, calls) ->
     device = device_registry.async_entries_for_config_entry(
         dev_reg, integration.entry_id
     )[0]
-    node_sensor_entity_id = async_get_node_status_sensor_entity_id(
-        hass, device.id, dev_reg=dev_reg
-    )
-
-    ent_reg = entity_registry.async_get(hass)
-    ent_reg.async_update_entity(node_sensor_entity_id, **{"disabled_by": None})
-    await hass.config_entries.async_reload(integration.entry_id)
 
     assert await async_setup_component(
         hass,
@@ -91,7 +74,6 @@ async def test_if_state(hass, client, lock_schlage_be469, integration, calls) ->
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "entity_id": node_sensor_entity_id,
                             "type": "alive",
                         }
                     ],
@@ -109,7 +91,6 @@ async def test_if_state(hass, client, lock_schlage_be469, integration, calls) ->
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "entity_id": node_sensor_entity_id,
                             "type": "awake",
                         }
                     ],
@@ -127,7 +108,6 @@ async def test_if_state(hass, client, lock_schlage_be469, integration, calls) ->
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "entity_id": node_sensor_entity_id,
                             "type": "asleep",
                         }
                     ],
@@ -145,7 +125,6 @@ async def test_if_state(hass, client, lock_schlage_be469, integration, calls) ->
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "entity_id": node_sensor_entity_id,
                             "type": "dead",
                         }
                     ],

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -407,7 +407,7 @@ async def test_get_condition_capabilities_node_status(
 async def test_get_condition_capabilities_value(
     hass, client, lock_schlage_be469, integration
 ):
-    """Test we get the expected capabilities from a config_parameter condition."""
+    """Test we get the expected capabilities from a value condition."""
     dev_reg = device_registry.async_get(hass)
     device = device_registry.async_entries_for_config_entry(
         dev_reg, integration.entry_id

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -347,7 +347,7 @@ async def test_value_state(
                             "domain": DOMAIN,
                             "device_id": device.id,
                             "type": "value",
-                            "command_class": "CONFIGURATION",
+                            "command_class": 112,
                             "property": 3,
                             "value": 255,
                         }
@@ -425,7 +425,7 @@ async def test_get_condition_capabilities_value(
     )
     assert capabilities and "extra_fields" in capabilities
 
-    cc_options = [(cc.name, cc.name) for cc in CommandClass]
+    cc_options = [(cc.value, cc.name) for cc in CommandClass]
 
     assert voluptuous_serialize.convert(
         capabilities["extra_fields"], custom_serializer=cv.custom_serializer

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -1,0 +1,229 @@
+"""The tests for Z-Wave JS device conditions."""
+from __future__ import annotations
+
+import pytest
+from zwave_js_server.event import Event
+
+from homeassistant.components import automation
+from homeassistant.components.zwave_js import DOMAIN
+from homeassistant.components.zwave_js.helpers import (
+    async_get_node_status_sensor_entity_id,
+)
+from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.setup import async_setup_component
+
+from tests.common import async_get_device_automations, async_mock_service
+
+
+@pytest.fixture
+def calls(hass):
+    """Track calls to a mock service."""
+    return async_mock_service(hass, "test", "automation")
+
+
+async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> None:
+    """Test we get the expected conditions from a zwave_js."""
+    dev_reg = device_registry.async_get(hass)
+    device = device_registry.async_entries_for_config_entry(
+        dev_reg, integration.entry_id
+    )[0]
+    node_sensor_entity_id = async_get_node_status_sensor_entity_id(
+        hass, device.id, dev_reg=dev_reg
+    )
+    expected_conditions = [
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "alive",
+            "device_id": device.id,
+            "entity_id": node_sensor_entity_id,
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "awake",
+            "device_id": device.id,
+            "entity_id": node_sensor_entity_id,
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "asleep",
+            "device_id": device.id,
+            "entity_id": node_sensor_entity_id,
+        },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "dead",
+            "device_id": device.id,
+            "entity_id": node_sensor_entity_id,
+        },
+    ]
+    conditions = await async_get_device_automations(hass, "condition", device.id)
+    for condition in expected_conditions:
+        assert condition in conditions
+
+
+async def test_if_state(hass, client, lock_schlage_be469, integration, calls) -> None:
+    """Test for turn_on and turn_off conditions."""
+    dev_reg = device_registry.async_get(hass)
+    device = device_registry.async_entries_for_config_entry(
+        dev_reg, integration.entry_id
+    )[0]
+    node_sensor_entity_id = async_get_node_status_sensor_entity_id(
+        hass, device.id, dev_reg=dev_reg
+    )
+
+    ent_reg = entity_registry.async_get(hass)
+    ent_reg.async_update_entity(node_sensor_entity_id, **{"disabled_by": None})
+    await hass.config_entries.async_reload(integration.entry_id)
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": device.id,
+                            "entity_id": node_sensor_entity_id,
+                            "type": "alive",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "alive - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": device.id,
+                            "entity_id": node_sensor_entity_id,
+                            "type": "awake",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "awake - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event3"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": device.id,
+                            "entity_id": node_sensor_entity_id,
+                            "type": "asleep",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "asleep - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event4"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": device.id,
+                            "entity_id": node_sensor_entity_id,
+                            "type": "dead",
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "dead - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "alive - event - test_event1"
+
+    event = Event(
+        "wake up",
+        data={
+            "source": "node",
+            "event": "wake up",
+            "nodeId": lock_schlage_be469.node_id,
+        },
+    )
+    lock_schlage_be469.receive_event(event)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "awake - event - test_event2"
+
+    event = Event(
+        "sleep",
+        data={"source": "node", "event": "sleep", "nodeId": lock_schlage_be469.node_id},
+    )
+    lock_schlage_be469.receive_event(event)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    await hass.async_block_till_done()
+    assert len(calls) == 3
+    assert calls[2].data["some"] == "asleep - event - test_event3"
+
+    event = Event(
+        "dead",
+        data={"source": "node", "event": "dead", "nodeId": lock_schlage_be469.node_id},
+    )
+    lock_schlage_be469.receive_event(event)
+    await hass.async_block_till_done()
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    hass.bus.async_fire("test_event3")
+    hass.bus.async_fire("test_event4")
+    await hass.async_block_till_done()
+    assert len(calls) == 4
+    assert calls[3].data["some"] == "dead - event - test_event4"
+
+    event = Event(
+        "unknown",
+        data={
+            "source": "node",
+            "event": "unknown",
+            "nodeId": lock_schlage_be469.node_id,
+        },
+    )
+    lock_schlage_be469.receive_event(event)
+    await hass.async_block_till_done()

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -363,6 +363,7 @@ async def test_get_condition_capabilities_config_parameter(
         dev_reg, integration.entry_id
     )[0]
 
+    # Test enumerated type param
     capabilities = await device_condition.async_get_condition_capabilities(
         hass,
         {
@@ -393,6 +394,7 @@ async def test_get_condition_capabilities_config_parameter(
         }
     ]
 
+    # Test range type param
     capabilities = await device_condition.async_get_condition_capabilities(
         hass,
         {
@@ -417,6 +419,7 @@ async def test_get_condition_capabilities_config_parameter(
         }
     ]
 
+    # Test undefined type param
     capabilities = await device_condition.async_get_condition_capabilities(
         hass,
         {

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -34,25 +34,7 @@ async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> 
         {
             "condition": "device",
             "domain": DOMAIN,
-            "type": "alive",
-            "device_id": device.id,
-        },
-        {
-            "condition": "device",
-            "domain": DOMAIN,
-            "type": "awake",
-            "device_id": device.id,
-        },
-        {
-            "condition": "device",
-            "domain": DOMAIN,
-            "type": "asleep",
-            "device_id": device.id,
-        },
-        {
-            "condition": "device",
-            "domain": DOMAIN,
-            "type": "dead",
+            "type": "node_status",
             "device_id": device.id,
         },
         {
@@ -96,7 +78,8 @@ async def test_node_status_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "type": "alive",
+                            "type": "node_status",
+                            "status": "alive",
                         }
                     ],
                     "action": {
@@ -113,7 +96,8 @@ async def test_node_status_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "type": "awake",
+                            "type": "node_status",
+                            "status": "awake",
                         }
                     ],
                     "action": {
@@ -130,7 +114,8 @@ async def test_node_status_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "type": "asleep",
+                            "type": "node_status",
+                            "status": "asleep",
                         }
                     ],
                     "action": {
@@ -147,7 +132,8 @@ async def test_node_status_state(
                             "condition": "device",
                             "domain": DOMAIN,
                             "device_id": device.id,
-                            "type": "dead",
+                            "type": "node_status",
+                            "status": "dead",
                         }
                     ],
                     "action": {
@@ -398,10 +384,25 @@ async def test_get_condition_capabilities_node_status(
             "platform": "device",
             "domain": DOMAIN,
             "device_id": device.id,
-            "type": "alive",
+            "type": "node_status",
         },
     )
-    assert not capabilities
+    assert capabilities and "extra_fields" in capabilities
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "status",
+            "required": True,
+            "type": "select",
+            "options": [
+                ("asleep", "asleep"),
+                ("awake", "awake"),
+                ("dead", "dead"),
+                ("alive", "alive"),
+            ],
+        }
+    ]
 
 
 async def test_get_condition_capabilities_value(

--- a/tests/components/zwave_js/test_device_condition.py
+++ b/tests/components/zwave_js/test_device_condition.py
@@ -2,11 +2,12 @@
 from __future__ import annotations
 
 import pytest
+import voluptuous_serialize
 from zwave_js_server.event import Event
 
 from homeassistant.components import automation
-from homeassistant.components.zwave_js import DOMAIN
-from homeassistant.helpers import device_registry
+from homeassistant.components.zwave_js import DOMAIN, device_condition
+from homeassistant.helpers import config_validation as cv, device_registry
 from homeassistant.setup import async_setup_component
 
 from tests.common import async_get_device_automations, async_mock_service
@@ -19,11 +20,15 @@ def calls(hass):
 
 
 async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> None:
-    """Test we get the expected conditions from a zwave_js."""
+    """Test we get the expected onditions from a zwave_js."""
     dev_reg = device_registry.async_get(hass)
     device = device_registry.async_entries_for_config_entry(
         dev_reg, integration.entry_id
     )[0]
+    config_value = list(lock_schlage_be469.get_configuration_values().values())[0]
+    value_id = config_value.value_id
+    name = config_value.property_name
+
     expected_conditions = [
         {
             "condition": "device",
@@ -49,14 +54,24 @@ async def test_get_conditions(hass, client, lock_schlage_be469, integration) -> 
             "type": "dead",
             "device_id": device.id,
         },
+        {
+            "condition": "device",
+            "domain": DOMAIN,
+            "type": "config_parameter",
+            "device_id": device.id,
+            "value_id": value_id,
+            "subtype": f"{value_id} ({name})",
+        },
     ]
     conditions = await async_get_device_automations(hass, "condition", device.id)
     for condition in expected_conditions:
         assert condition in conditions
 
 
-async def test_if_state(hass, client, lock_schlage_be469, integration, calls) -> None:
-    """Test for turn_on and turn_off conditions."""
+async def test_node_status_state(
+    hass, client, lock_schlage_be469, integration, calls
+) -> None:
+    """Test for node_status conditions."""
     dev_reg = device_registry.async_get(hass)
     device = device_registry.async_entries_for_config_entry(
         dev_reg, integration.entry_id
@@ -206,3 +221,211 @@ async def test_if_state(hass, client, lock_schlage_be469, integration, calls) ->
     )
     lock_schlage_be469.receive_event(event)
     await hass.async_block_till_done()
+
+
+async def test_config_parameter_state(
+    hass, client, lock_schlage_be469, integration, calls
+) -> None:
+    """Test for config_parameter conditions."""
+    dev_reg = device_registry.async_get(hass)
+    device = device_registry.async_entries_for_config_entry(
+        dev_reg, integration.entry_id
+    )[0]
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event1"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": device.id,
+                            "type": "config_parameter",
+                            "value_id": f"{lock_schlage_be469.node_id}-112-0-3",
+                            "subtype": f"{lock_schlage_be469.node_id}-112-0-3 (Beeper)",
+                            "value": 255,
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "Beeper - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+                {
+                    "trigger": {"platform": "event", "event_type": "test_event2"},
+                    "condition": [
+                        {
+                            "condition": "device",
+                            "domain": DOMAIN,
+                            "device_id": device.id,
+                            "type": "config_parameter",
+                            "value_id": f"{lock_schlage_be469.node_id}-112-0-6",
+                            "subtype": f"{lock_schlage_be469.node_id}-112-0-6 (User Slot Status)",
+                            "value": 1,
+                        }
+                    ],
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": "User Slot Status - {{ trigger.platform }} - {{ trigger.event.event_type }}"
+                        },
+                    },
+                },
+            ]
+        },
+    )
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 1
+    assert calls[0].data["some"] == "Beeper - event - test_event1"
+
+    # Flip Beeper state to not match condition
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": lock_schlage_be469.node_id,
+            "args": {
+                "commandClassName": "Configuration",
+                "commandClass": 112,
+                "endpoint": 0,
+                "property": 3,
+                "newValue": 0,
+                "prevValue": 255,
+            },
+        },
+    )
+    lock_schlage_be469.receive_event(event)
+
+    # Flip User Slot Status to match condition
+    event = Event(
+        type="value updated",
+        data={
+            "source": "node",
+            "event": "value updated",
+            "nodeId": lock_schlage_be469.node_id,
+            "args": {
+                "commandClassName": "Configuration",
+                "commandClass": 112,
+                "endpoint": 0,
+                "property": 6,
+                "newValue": 1,
+                "prevValue": 117440512,
+            },
+        },
+    )
+    lock_schlage_be469.receive_event(event)
+
+    hass.bus.async_fire("test_event1")
+    hass.bus.async_fire("test_event2")
+    await hass.async_block_till_done()
+    assert len(calls) == 2
+    assert calls[1].data["some"] == "User Slot Status - event - test_event2"
+
+
+async def test_get_condition_capabilities_node_status(
+    hass, client, lock_schlage_be469, integration
+):
+    """Test we don't get capabilities from a node_status condition."""
+    dev_reg = device_registry.async_get(hass)
+    device = device_registry.async_entries_for_config_entry(
+        dev_reg, integration.entry_id
+    )[0]
+
+    capabilities = await device_condition.async_get_condition_capabilities(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device.id,
+            "type": "alive",
+        },
+    )
+    assert not capabilities
+
+
+async def test_get_condition_capabilities_config_parameter(
+    hass, client, climate_radio_thermostat_ct100_plus, integration
+):
+    """Test we get the expected capabilities from a config_parameter condition."""
+    node = climate_radio_thermostat_ct100_plus
+    dev_reg = device_registry.async_get(hass)
+    device = device_registry.async_entries_for_config_entry(
+        dev_reg, integration.entry_id
+    )[0]
+
+    capabilities = await device_condition.async_get_condition_capabilities(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device.id,
+            "type": "config_parameter",
+            "value_id": f"{node.node_id}-112-0-1",
+            "subtype": f"{node.node_id}-112-0-1 (Temperature Reporting Threshold)",
+        },
+    )
+    assert capabilities and "extra_fields" in capabilities
+
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "value",
+            "required": True,
+            "options": [
+                (0, "Disabled"),
+                (1, "0.5° F"),
+                (2, "1.0° F"),
+                (3, "1.5° F"),
+                (4, "2.0° F"),
+            ],
+            "type": "select",
+        }
+    ]
+
+    capabilities = await device_condition.async_get_condition_capabilities(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device.id,
+            "type": "config_parameter",
+            "value_id": f"{node.node_id}-112-0-10",
+            "subtype": f"{node.node_id}-112-0-10 (Temperature Reporting Filter)",
+        },
+    )
+    assert capabilities and "extra_fields" in capabilities
+
+    assert voluptuous_serialize.convert(
+        capabilities["extra_fields"], custom_serializer=cv.custom_serializer
+    ) == [
+        {
+            "name": "value",
+            "required": True,
+            "valueMin": 0,
+            "valueMax": 124,
+        }
+    ]
+
+    capabilities = await device_condition.async_get_condition_capabilities(
+        hass,
+        {
+            "platform": "device",
+            "domain": DOMAIN,
+            "device_id": device.id,
+            "type": "config_parameter",
+            "value_id": f"{node.node_id}-112-0-2",
+            "subtype": f"{node.node_id}-112-0-2 (HVAC Settings)",
+        },
+    )
+    assert not capabilities


### PR DESCRIPTION
## Proposed change
This adds initial support for device conditions for zwave_js. We are starting with node status, config parameter state, and any Z-Wave value state conditions (the last one is there to give users access to conditions for command classes we don't have native support for yet). I am open to suggestions for more, although I think that's pretty comprehensive.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
