### PR TITLE
Support dynamic schema validation in device conditions and actions

### DIFF
--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from collections.abc import MutableMapping
 from functools import wraps
+from types import ModuleType
 from typing import Any
 
 import voluptuous as vol
@@ -73,7 +74,7 @@ async def async_setup(hass, config):
 
 async def async_get_device_automation_platform(
     hass: HomeAssistant, domain: str, automation_type: str
-) -> Any:
+) -> ModuleType:
     """Load device automation platform for integration.
 
     Throws InvalidDeviceAutomationConfig if the integration is not found or does not support device automation.

--- a/homeassistant/components/device_automation/__init__.py
+++ b/homeassistant/components/device_automation/__init__.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import asyncio
 from collections.abc import MutableMapping
 from functools import wraps
-from types import ModuleType
 from typing import Any
 
 import voluptuous as vol
@@ -74,7 +73,7 @@ async def async_setup(hass, config):
 
 async def async_get_device_automation_platform(
     hass: HomeAssistant, domain: str, automation_type: str
-) -> ModuleType:
+) -> Any:
     """Load device automation platform for integration.
 
     Throws InvalidDeviceAutomationConfig if the integration is not found or does not support device automation.

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -926,7 +926,7 @@ async def async_device_from_config(
     return trace_condition_function(
         cast(
             ConditionCheckerType,
-            platform.async_condition_from_config(config, config_validation),
+            platform.async_condition_from_config(config, config_validation),  # type: ignore
         )
     )
 
@@ -974,7 +974,7 @@ async def async_validate_condition_config(
         )
         if hasattr(platform, "async_validate_condition_config"):
             return await platform.async_validate_condition_config(hass, config)  # type: ignore
-        return cast(ConfigType, platform.CONDITION_SCHEMA(config))
+        return cast(ConfigType, platform.CONDITION_SCHEMA(config))  # type: ignore
 
     return config
 

--- a/homeassistant/helpers/condition.py
+++ b/homeassistant/helpers/condition.py
@@ -926,7 +926,7 @@ async def async_device_from_config(
     return trace_condition_function(
         cast(
             ConditionCheckerType,
-            platform.async_condition_from_config(config, config_validation),  # type: ignore
+            platform.async_condition_from_config(config, config_validation),
         )
     )
 
@@ -972,7 +972,9 @@ async def async_validate_condition_config(
         platform = await async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], "condition"
         )
-        return cast(ConfigType, platform.CONDITION_SCHEMA(config))  # type: ignore
+        if hasattr(platform, "async_validate_condition_config"):
+            return await platform.async_validate_condition_config(hass, config)  # type: ignore
+        return cast(ConfigType, platform.CONDITION_SCHEMA(config))
 
     return config
 

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -257,16 +257,16 @@ async def async_validate_action_config(
             hass, config[CONF_DOMAIN], "action"
         )
         if hasattr(platform, "async_validate_action_config"):
-            config = await platform.async_validate_action_config(hass, config)
+            config = await platform.async_validate_action_config(hass, config)  # type: ignore
         else:
-            config = platform.ACTION_SCHEMA(config)
+            config = platform.ACTION_SCHEMA(config)  # type: ignore
 
     elif action_type == cv.SCRIPT_ACTION_CHECK_CONDITION:
         if config[CONF_CONDITION] == "device":
             platform = await device_automation.async_get_device_automation_platform(
                 hass, config[CONF_DOMAIN], "condition"
             )
-            config = platform.CONDITION_SCHEMA(config)
+            config = platform.CONDITION_SCHEMA(config)  # type: ignore
 
     elif action_type == cv.SCRIPT_ACTION_WAIT_FOR_TRIGGER:
         config[CONF_WAIT_FOR_TRIGGER] = await async_validate_trigger_config(

--- a/homeassistant/helpers/script.py
+++ b/homeassistant/helpers/script.py
@@ -256,14 +256,17 @@ async def async_validate_action_config(
         platform = await device_automation.async_get_device_automation_platform(
             hass, config[CONF_DOMAIN], "action"
         )
-        config = platform.ACTION_SCHEMA(config)  # type: ignore
+        if hasattr(platform, "async_validate_action_config"):
+            config = await platform.async_validate_action_config(hass, config)
+        else:
+            config = platform.ACTION_SCHEMA(config)
 
     elif action_type == cv.SCRIPT_ACTION_CHECK_CONDITION:
         if config[CONF_CONDITION] == "device":
             platform = await device_automation.async_get_device_automation_platform(
                 hass, config[CONF_DOMAIN], "condition"
             )
-            config = platform.CONDITION_SCHEMA(config)  # type: ignore
+            config = platform.CONDITION_SCHEMA(config)
 
     elif action_type == cv.SCRIPT_ACTION_WAIT_FOR_TRIGGER:
         config[CONF_WAIT_FOR_TRIGGER] = await async_validate_trigger_config(

--- a/tests/helpers/test_condition.py
+++ b/tests/helpers/test_condition.py
@@ -1,13 +1,20 @@
 """Test the condition helper."""
 from datetime import datetime
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from homeassistant.components import sun
 import homeassistant.components.automation as automation
 from homeassistant.components.sensor import DEVICE_CLASS_TIMESTAMP
-from homeassistant.const import ATTR_DEVICE_CLASS, SUN_EVENT_SUNRISE, SUN_EVENT_SUNSET
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    CONF_CONDITION,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    SUN_EVENT_SUNRISE,
+    SUN_EVENT_SUNSET,
+)
 from homeassistant.exceptions import ConditionError, HomeAssistantError
 from homeassistant.helpers import condition, trace
 from homeassistant.helpers.template import Template
@@ -2843,3 +2850,16 @@ async def test_trigger(hass):
     assert not test(hass, {"other_var": "123456"})
     assert not test(hass, {"trigger": {"trigger_id": "123456"}})
     assert test(hass, {"trigger": {"id": "123456"}})
+
+
+async def test_platform_async_validate_condition_config(hass):
+    """Test platform.async_validate_condition_config will be called if it exists."""
+    config = {CONF_DEVICE_ID: "test", CONF_DOMAIN: "test", CONF_CONDITION: "device"}
+    platform = AsyncMock()
+    with patch(
+        "homeassistant.helpers.condition.async_get_device_automation_platform",
+        return_value=platform,
+    ):
+        platform.async_validate_condition_config.return_value = config
+        await condition.async_validate_condition_config(hass, config)
+        platform.async_validate_condition_config.assert_awaited()


### PR DESCRIPTION
## Proposed change
I apologize in advance if I am wasting anyone's time because there is a reason why we don't support this, but:

While working on https://github.com/home-assistant/core/pull/52003 I learned that device triggers have a way to do dynamic schema validation but conditions and actions don't. This change would allow integrations to provide dynamic schema validation for those device automation types as well. I came across this because I have a need to do dynamic schema validation in a device condition.

TODO:
- [ ] Update the docs


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
