### PR TITLE
Add retries for tplink discovery

### DIFF
--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -7,8 +7,8 @@ from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import device_registry as dr
+import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .common import (

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -8,6 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
 from .common import (
@@ -76,6 +77,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up TPLink from a config entry."""
     config_data = hass.data[DOMAIN].get(ATTR_CONFIG)
 
+    device_registry = dr.async_get(hass)
+    tplink_devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+    qty_tplink_devices = len(tplink_devices)
+
     # These will contain the initialized devices
     lights = hass.data[DOMAIN][CONF_LIGHT] = []
     switches = hass.data[DOMAIN][CONF_SWITCH] = []
@@ -90,7 +95,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:
-        discovered_devices = await async_discover_devices(hass, static_devices)
+        discovered_devices = await async_discover_devices(
+            hass, static_devices, qty_tplink_devices
+        )
 
         lights.extend(discovered_devices.lights)
         switches.extend(discovered_devices.switches)

--- a/homeassistant/components/tplink/__init__.py
+++ b/homeassistant/components/tplink/__init__.py
@@ -79,7 +79,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     device_registry = dr.async_get(hass)
     tplink_devices = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
-    qty_tplink_devices = len(tplink_devices)
+    device_count = len(tplink_devices)
 
     # These will contain the initialized devices
     lights = hass.data[DOMAIN][CONF_LIGHT] = []
@@ -96,7 +96,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Add discovered devices
     if config_data is None or config_data[CONF_DISCOVERY]:
         discovered_devices = await async_discover_devices(
-            hass, static_devices, qty_tplink_devices
+            hass, static_devices, device_count
         )
 
         lights.extend(discovered_devices.lights)

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -68,7 +68,7 @@ async def async_get_discoverable_devices(hass: HomeAssistant) -> dict[str, Smart
 
 
 async def async_discover_devices(
-    hass: HomeAssistant, existing_devices: SmartDevices, target_discovery_qty
+    hass: HomeAssistant, existing_devices: SmartDevices, target_device_count
 ) -> SmartDevices:
     """Get devices through discovery."""
 
@@ -98,27 +98,23 @@ async def async_discover_devices(
             else:
                 _LOGGER.error("Unknown smart device type: %s", type(dev))
 
-    discovery_attempt = 0
     devices = dict()
-
-    while discovery_attempt < MAX_DISCOVERY_RETRIES:
-        discovery_attempt += 1
+    for attempt in range(1, MAX_DISCOVERY_RETRIES + 1):
         _LOGGER.debug(
             "Discovering tplink devices, attempt %s of %s",
-            discovery_attempt,
+            attempt,
             MAX_DISCOVERY_RETRIES,
         )
         discovered_devices = await async_get_discoverable_devices(hass)
         _LOGGER.info(
             "Discovered %s TP-Link of expected %s smart home device(s)",
             len(discovered_devices),
-            target_discovery_qty,
+            target_device_count,
         )
         for ip in discovered_devices:
-            if ip not in devices:
-                devices[ip] = discovered_devices[ip]
+            devices[ip] = discovered_devices[ip]
 
-        if len(discovered_devices) >= target_discovery_qty:
+        if len(discovered_devices) >= target_device_count:
             _LOGGER.info(
                 "Discovered at least as many devices on the network as exist in our device registry, no need to retry"
             )
@@ -127,7 +123,7 @@ async def async_discover_devices(
     _LOGGER.info(
         "Found %s unique TP-Link smart home device(s) after %s discovery attempts",
         len(devices),
-        discovery_attempt,
+        attempt,
     )
     await hass.async_add_executor_job(process_devices)
 

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -100,17 +100,27 @@ async def async_discover_devices(
 
     discovery_attempt = 0
     devices = dict()
-    
+
     while discovery_attempt < MAX_DISCOVERY_RETRIES:
         discovery_attempt += 1
-        _LOGGER.debug("Discovering tplink devices, attempt %s of %s", discovery_attempt, MAX_DISCOVERY_RETRIES)
+        _LOGGER.debug(
+            "Discovering tplink devices, attempt %s of %s",
+            discovery_attempt,
+            MAX_DISCOVERY_RETRIES,
+        )
         discovered_devices = await async_get_discoverable_devices(hass)
-        _LOGGER.info("Discovered %s TP-Link smart home device(s)", len(discovered_devices))
+        _LOGGER.info(
+            "Discovered %s TP-Link smart home device(s)", len(discovered_devices)
+        )
         for ip in discovered_devices:
             if ip not in devices:
                 devices[ip] = discovered_devices[ip]
 
-    _LOGGER.info("Found %s unique TP-Link smart home device(s) after %s discovery attempts", len(devices), discovery_attempt)
+    _LOGGER.info(
+        "Found %s unique TP-Link smart home device(s) after %s discovery attempts",
+        len(devices),
+        discovery_attempt,
+    )
     await hass.async_add_executor_job(process_devices)
 
     return SmartDevices(lights, switches)

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -120,8 +120,7 @@ async def async_discover_devices(
 
         if len(discovered_devices) >= target_discovery_qty:
             _LOGGER.info(
-                "Discovered at least as many devices on the network as exist in our device registry, no need to retry",
-                len(discovered_devices),
+                "Discovered at least as many devices on the network as exist in our device registry, no need to retry"
             )
             break
 

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -68,7 +68,7 @@ async def async_get_discoverable_devices(hass: HomeAssistant) -> dict[str, Smart
 
 
 async def async_discover_devices(
-    hass: HomeAssistant, existing_devices: SmartDevices, target_device_count
+    hass: HomeAssistant, existing_devices: SmartDevices, target_device_count: int
 ) -> SmartDevices:
     """Get devices through discovery."""
 

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -68,7 +68,7 @@ async def async_get_discoverable_devices(hass: HomeAssistant) -> dict[str, Smart
 
 
 async def async_discover_devices(
-    hass: HomeAssistant, existing_devices: SmartDevices
+    hass: HomeAssistant, existing_devices: SmartDevices, target_discovery_qty
 ) -> SmartDevices:
     """Get devices through discovery."""
 
@@ -110,11 +110,20 @@ async def async_discover_devices(
         )
         discovered_devices = await async_get_discoverable_devices(hass)
         _LOGGER.info(
-            "Discovered %s TP-Link smart home device(s)", len(discovered_devices)
+            "Discovered %s TP-Link of expected %s smart home device(s)",
+            len(discovered_devices),
+            target_discovery_qty,
         )
         for ip in discovered_devices:
             if ip not in devices:
                 devices[ip] = discovered_devices[ip]
+
+        if len(discovered_devices) >= target_discovery_qty:
+            _LOGGER.info(
+                "Discovered at least as many devices on the network as exist in our device registry, no need to retry",
+                len(discovered_devices),
+            )
+            break
 
     _LOGGER.info(
         "Found %s unique TP-Link smart home device(s) after %s discovery attempts",

--- a/homeassistant/components/tplink/common.py
+++ b/homeassistant/components/tplink/common.py
@@ -98,7 +98,7 @@ async def async_discover_devices(
             else:
                 _LOGGER.error("Unknown smart device type: %s", type(dev))
 
-    devices = dict()
+    devices = {}
     for attempt in range(1, MAX_DISCOVERY_RETRIES + 1):
         _LOGGER.debug(
             "Discovering tplink devices, attempt %s of %s",
@@ -111,8 +111,8 @@ async def async_discover_devices(
             len(discovered_devices),
             target_device_count,
         )
-        for ip in discovered_devices:
-            devices[ip] = discovered_devices[ip]
+        for device_ip in discovered_devices:
+            devices[device_ip] = discovered_devices[device_ip]
 
         if len(discovered_devices) >= target_device_count:
             _LOGGER.info(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
TPlink Kasa device discovery is unreliable and doesn't always return all devices on the network, which results in some devices not being usable in Home Assistant. This PR performs device discovery 4 times, adding all unique found devices.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
