### PR TITLE
Upgrade wled to 0.7.0

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -5,6 +5,7 @@ from functools import partial
 from typing import Any, Tuple, cast
 
 import voluptuous as vol
+from wled import Preset
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -222,9 +223,11 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         if playlist == -1:
             playlist = None
 
-        preset: int | None = self.coordinator.data.state.preset
-        if preset == -1:
-            preset = None
+        preset: int | None = None
+        if isinstance(self.coordinator.data.state.preset, Preset):
+            preset = self.coordinator.data.state.preset.preset_id
+        elif self.coordinator.data.state.preset != -1:
+            preset = self.coordinator.data.state.preset
 
         segment = self.coordinator.data.state.segments[self._segment]
         return {

--- a/homeassistant/components/wled/manifest.json
+++ b/homeassistant/components/wled/manifest.json
@@ -3,7 +3,7 @@
   "name": "WLED",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/wled",
-  "requirements": ["wled==0.6.0"],
+  "requirements": ["wled==0.7.0"],
   "zeroconf": ["_wled._tcp.local."],
   "codeowners": ["@frenck"],
   "quality_scale": "platinum",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2365,7 +2365,7 @@ wirelesstagpy==0.4.1
 withings-api==2.3.2
 
 # homeassistant.components.wled
-wled==0.6.0
+wled==0.7.0
 
 # homeassistant.components.wolflink
 wolf_smartset==0.1.11

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1283,7 +1283,7 @@ wiffi==1.0.1
 withings-api==2.3.2
 
 # homeassistant.components.wled
-wled==0.6.0
+wled==0.7.0
 
 # homeassistant.components.wolflink
 wolf_smartset==0.1.11


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR bumps the `wled` package to version 0.7.0.
Release notes: <https://github.com/frenck/python-wled/releases/tag/v0.7.0>

It prepares for supporting WLED user presets and adds the capability to reboot a WLED device remotely.

This change will drop the test coverage with 2 lines, however, these lines are to be removed again in a follow-up PR (when actually implementing the preset features).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
