### PR TITLE
Change dynamic segment handling of WLED

### DIFF
--- a/homeassistant/components/wled/__init__.py
+++ b/homeassistant/components/wled/__init__.py
@@ -5,7 +5,6 @@ from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
@@ -16,7 +15,7 @@ PLATFORMS = (LIGHT_DOMAIN, SENSOR_DOMAIN, SWITCH_DOMAIN)
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up WLED from a config entry."""
-    coordinator = WLEDDataUpdateCoordinator(hass, host=entry.data[CONF_HOST])
+    coordinator = WLEDDataUpdateCoordinator(hass, entry=entry)
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})

--- a/homeassistant/components/wled/coordinator.py
+++ b/homeassistant/components/wled/coordinator.py
@@ -6,28 +6,37 @@ from typing import Callable
 
 from wled import WLED, Device as WLEDDevice, WLEDConnectionClosed, WLEDError
 
-from homeassistant.const import EVENT_HOMEASSISTANT_STOP
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, LOGGER, SCAN_INTERVAL
+from .const import (
+    CONF_KEEP_MASTER_LIGHT,
+    DEFAULT_KEEP_MASTER_LIGHT,
+    DOMAIN,
+    LOGGER,
+    SCAN_INTERVAL,
+)
 
 
 class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
     """Class to manage fetching WLED data from single endpoint."""
 
-    master_light: Entity | None = None
+    keep_master_light: bool
 
     def __init__(
         self,
         hass: HomeAssistant,
         *,
-        host: str,
+        entry: ConfigEntry,
     ) -> None:
         """Initialize global WLED data updater."""
-        self.wled = WLED(host, session=async_get_clientsession(hass))
+        self.keep_master_light = entry.options.get(
+            CONF_KEEP_MASTER_LIGHT, DEFAULT_KEEP_MASTER_LIGHT
+        )
+        self.wled = WLED(entry.data[CONF_HOST], session=async_get_clientsession(hass))
         self.unsub: Callable | None = None
 
         super().__init__(
@@ -38,12 +47,10 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
         )
 
     @property
-    def has_active_master_light(self) -> bool:
-        """Return if the coordinated device has an active master light."""
-        return (
-            self.master_light is not None
-            and self.master_light.enabled
-            and self.master_light.available
+    def has_master_light(self) -> bool:
+        """Return if the coordinated device has an master light."""
+        return self.keep_master_light or (
+            self.data is not None and len(self.data.state.segments) > 1
         )
 
     def update_listeners(self) -> None:

--- a/homeassistant/components/wled/coordinator.py
+++ b/homeassistant/components/wled/coordinator.py
@@ -9,6 +9,7 @@ from wled import WLED, Device as WLEDDevice, WLEDConnectionClosed, WLEDError
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER, SCAN_INTERVAL
@@ -16,6 +17,8 @@ from .const import DOMAIN, LOGGER, SCAN_INTERVAL
 
 class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
     """Class to manage fetching WLED data from single endpoint."""
+
+    master_light: Entity | None = None
 
     def __init__(
         self,
@@ -32,6 +35,15 @@ class WLEDDataUpdateCoordinator(DataUpdateCoordinator[WLEDDevice]):
             LOGGER,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
+        )
+
+    @property
+    def has_active_master_light(self) -> bool:
+        """Return if the coordinated device has an active master light."""
+        return (
+            self.master_light is not None
+            and self.master_light.enabled
+            and self.master_light.available
         )
 
     def update_listeners(self) -> None:

--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -123,12 +123,7 @@ class WLEDMasterLight(WLEDEntity, LightEntity):
 
     @property
     def available(self) -> bool:
-        """Return if this master light is available or not.
-
-        It is either available when the user explicitly set to keep master light
-        controls, even with a single segment or when we have multiple segments
-        available.
-        """
+        """Return if this master light is available or not."""
         return self.coordinator.has_master_light and super().available
 
     @wled_exception_handler

--- a/tests/components/wled/test_light.py
+++ b/tests/components/wled/test_light.py
@@ -50,7 +50,7 @@ async def test_rgb_light_state(
     entity_registry = er.async_get(hass)
 
     # First segment of the strip
-    state = hass.states.get("light.wled_rgb_light_segment_0")
+    state = hass.states.get("light.wled_rgb_light")
     assert state
     assert state.attributes.get(ATTR_BRIGHTNESS) == 127
     assert state.attributes.get(ATTR_EFFECT) == "Solid"
@@ -64,7 +64,7 @@ async def test_rgb_light_state(
     assert state.attributes.get(ATTR_SPEED) == 32
     assert state.state == STATE_ON
 
-    entry = entity_registry.async_get("light.wled_rgb_light_segment_0")
+    entry = entity_registry.async_get("light.wled_rgb_light")
     assert entry
     assert entry.unique_id == "aabbccddeeff_0"
 
@@ -107,7 +107,7 @@ async def test_segment_change_state(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_TRANSITION: 5},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_TRANSITION: 5},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -124,7 +124,7 @@ async def test_segment_change_state(
         {
             ATTR_BRIGHTNESS: 42,
             ATTR_EFFECT: "Chase",
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_RGB_COLOR: [255, 0, 0],
             ATTR_TRANSITION: 5,
         },
@@ -211,36 +211,53 @@ async def test_master_change_state(
     )
 
 
+@pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
 async def test_dynamically_handle_segments(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,
     mock_wled: MagicMock,
 ) -> None:
     """Test if a new/deleted segment is dynamically added/removed."""
-    assert hass.states.get("light.wled_rgb_light_master")
-    assert hass.states.get("light.wled_rgb_light_segment_0")
-    assert hass.states.get("light.wled_rgb_light_segment_1")
+    master = hass.states.get("light.wled_rgb_light_master")
+    segment0 = hass.states.get("light.wled_rgb_light")
+    segment1 = hass.states.get("light.wled_rgb_light_segment_1")
+    assert segment0
+    assert segment0.state == STATE_ON
+    assert not master
+    assert not segment1
 
     return_value = mock_wled.update.return_value
     mock_wled.update.return_value = WLEDDevice(
-        json.loads(load_fixture("wled/rgb_single_segment.json"))
+        json.loads(load_fixture("wled/rgb.json"))
     )
 
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.wled_rgb_light_segment_0")
-    assert not hass.states.get("light.wled_rgb_light_segment_1")
-    assert not hass.states.get("light.wled_rgb_light_master")
+    master = hass.states.get("light.wled_rgb_light_master")
+    segment0 = hass.states.get("light.wled_rgb_light")
+    segment1 = hass.states.get("light.wled_rgb_light_segment_1")
+    assert master
+    assert master.state == STATE_ON
+    assert segment0
+    assert segment0.state == STATE_ON
+    assert segment1
+    assert segment1.state == STATE_ON
 
     # Test adding if segment shows up again, including the master entity
     mock_wled.update.return_value = return_value
     async_fire_time_changed(hass, dt_util.utcnow() + SCAN_INTERVAL)
     await hass.async_block_till_done()
 
-    assert hass.states.get("light.wled_rgb_light_master")
-    assert hass.states.get("light.wled_rgb_light_segment_0")
-    assert hass.states.get("light.wled_rgb_light_segment_1")
+    master = hass.states.get("light.wled_rgb_light_master")
+    segment0 = hass.states.get("light.wled_rgb_light")
+    segment1 = hass.states.get("light.wled_rgb_light_segment_1")
+    assert master
+    assert master.state == STATE_UNAVAILABLE
+    assert segment0
+    assert segment0.state == STATE_ON
+    assert segment1
+    assert segment1.state == STATE_UNAVAILABLE
 
 
 @pytest.mark.parametrize("mock_wled", ["wled/rgb_single_segment.json"], indirect=True)
@@ -320,12 +337,12 @@ async def test_light_error(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0"},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light"},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("light.wled_rgb_light_segment_0")
+    state = hass.states.get("light.wled_rgb_light")
     assert state
     assert state.state == STATE_ON
     assert "Invalid response from API" in caplog.text
@@ -345,12 +362,12 @@ async def test_light_connection_error(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0"},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light"},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("light.wled_rgb_light_segment_0")
+    state = hass.states.get("light.wled_rgb_light")
     assert state
     assert state.state == STATE_UNAVAILABLE
     assert "Error communicating with API" in caplog.text
@@ -395,7 +412,7 @@ async def test_effect_service(
         SERVICE_EFFECT,
         {
             ATTR_EFFECT: "Rainbow",
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_INTENSITY: 200,
             ATTR_PALETTE: "Tiamat",
             ATTR_REVERSE: True,
@@ -417,7 +434,7 @@ async def test_effect_service(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_EFFECT,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_EFFECT: 9},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_EFFECT: 9},
         blocking=True,
     )
     await hass.async_block_till_done()
@@ -435,7 +452,7 @@ async def test_effect_service(
         DOMAIN,
         SERVICE_EFFECT,
         {
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_INTENSITY: 200,
             ATTR_REVERSE: True,
             ATTR_SPEED: 100,
@@ -458,7 +475,7 @@ async def test_effect_service(
         SERVICE_EFFECT,
         {
             ATTR_EFFECT: "Rainbow",
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_PALETTE: "Tiamat",
             ATTR_REVERSE: True,
             ATTR_SPEED: 100,
@@ -481,7 +498,7 @@ async def test_effect_service(
         SERVICE_EFFECT,
         {
             ATTR_EFFECT: "Rainbow",
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_INTENSITY: 200,
             ATTR_SPEED: 100,
         },
@@ -503,7 +520,7 @@ async def test_effect_service(
         SERVICE_EFFECT,
         {
             ATTR_EFFECT: "Rainbow",
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_INTENSITY: 200,
             ATTR_REVERSE: True,
         },
@@ -533,12 +550,12 @@ async def test_effect_service_error(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_EFFECT,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_EFFECT: 9},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_EFFECT: 9},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("light.wled_rgb_light_segment_0")
+    state = hass.states.get("light.wled_rgb_light")
     assert state
     assert state.state == STATE_ON
     assert "Invalid response from API" in caplog.text
@@ -556,7 +573,7 @@ async def test_preset_service(
         DOMAIN,
         SERVICE_PRESET,
         {
-            ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0",
+            ATTR_ENTITY_ID: "light.wled_rgb_light",
             ATTR_PRESET: 1,
         },
         blocking=True,
@@ -591,12 +608,12 @@ async def test_preset_service_error(
     await hass.services.async_call(
         DOMAIN,
         SERVICE_PRESET,
-        {ATTR_ENTITY_ID: "light.wled_rgb_light_segment_0", ATTR_PRESET: 1},
+        {ATTR_ENTITY_ID: "light.wled_rgb_light", ATTR_PRESET: 1},
         blocking=True,
     )
     await hass.async_block_till_done()
 
-    state = hass.states.get("light.wled_rgb_light_segment_0")
+    state = hass.states.get("light.wled_rgb_light")
     assert state
     assert state.state == STATE_ON
     assert "Invalid response from API" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

WLED controls LED strips and allow users to split a single strip into multiple segments.

- Home Assistant dynamically adjusts to the number of segments.
- Each of such a segment results in light in Home Assistant.
- When having more than 1 segment, master light/control is added to control the whole strip (on/off & global brightness).

What this PR changes:
---

Previously, light entities (both for segments & the master light), were removed and cleaned from the entity registry, once the segment was removed from WLED.

This became problematic for users who have e.g., different presets (since WLED 0.11) that change the segments; or people that are adjusting the segments programmatically.

In those cases, the segments would appear/disappear at will, removing/losing customizations to those entities in the process.

This PR adjusts the behavior to not clean up the entity registry, as the segments (and thus master control), might reappear later. Therefore, they are now marked unavailable when the segment is removed (and thus can be removed by the user if the entity is orphaned).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
