### PR TITLE
Add `to_yaml` and `from_yaml` template helpers

### DIFF
--- a/homeassistant/helpers/template.py
+++ b/homeassistant/helpers/template.py
@@ -26,6 +26,7 @@ from jinja2 import contextfunction, pass_context
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from jinja2.utils import Namespace
 import voluptuous as vol
+import yaml
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -1315,6 +1316,16 @@ def to_json(value):
     return json.dumps(value)
 
 
+def from_yaml(value):
+    """Convert a YAML string to an object."""
+    return yaml.load(value, Loader=yaml.SafeLoader)
+
+
+def to_yaml(value):
+    """Convert an object to a YAML string."""
+    return yaml.dump(value, Dumper=yaml.SafeDumper)
+
+
 @pass_context
 def random_every_time(context, values):
     """Choose a random value.
@@ -1428,6 +1439,8 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         self.filters["timestamp_utc"] = timestamp_utc
         self.filters["to_json"] = to_json
         self.filters["from_json"] = from_json
+        self.filters["to_yaml"] = to_yaml
+        self.filters["from_yaml"] = from_yaml
         self.filters["is_defined"] = fail_when_undefined
         self.filters["max"] = max
         self.filters["min"] = min

--- a/tests/helpers/test_template.py
+++ b/tests/helpers/test_template.py
@@ -590,6 +590,30 @@ def test_from_json(hass):
     assert actual_result == expected_result
 
 
+def test_to_yaml(hass):
+    """Test the object to YAML string filter."""
+
+    # Note that we're not testing the actual yaml.load and yaml.dump methods,
+    # only the filters, so we don't need to be exhaustive with our sample YAML.
+    expected_result = "Foo: Bar"
+    actual_result = template.Template(
+        "{{ {'Foo': 'Bar'} | to_yaml }}", hass
+    ).async_render()
+    assert actual_result == expected_result
+
+
+def test_from_yaml(hass):
+    """Test the YAML string to object filter."""
+
+    # Note that we're not testing the actual yaml.load and yaml.dump methods,
+    # only the filters, so we don't need to be exhaustive with our sample YAML.
+    expected_result = "Bar"
+    actual_result = template.Template(
+        "{{ ('Foo: Bar' | from_yaml).Foo }}", hass
+    ).async_render()
+    assert actual_result == expected_result
+
+
 def test_min(hass):
     """Test the min filter."""
     assert template.Template("{{ [1, 2, 3] | min }}", hass).async_render() == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add `to_yaml` and `from_yaml` template helpers which behave like `to_json` and `from_json`.

For my use case, I have a [`notify.slack`](https://home-assistant.io/integrations/slack/#slack-service-data) service call which I would like to have conditional blocks. Since `blocks` is an array, this sort of functionality is difficult. With this PR, I can use a `variables` action to template out the correct YAML, then in the actual service call, I can simply call:
```yaml
service: notify.slack
data:
  data:
    blocks: {{ .blocks | from_yaml }}
...
```

As I was thinking through the rationale for adding this, I realized this sort of functionality could be useful in a lot of places now that templates can output native types.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#18245

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x]  Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
