### PR TITLE
2021.6.6

### DIFF
--- a/homeassistant/components/accuweather/sensor.py
+++ b/homeassistant/components/accuweather/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.const import (
     CONF_NAME,
     DEVICE_CLASS_TEMPERATURE,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import StateType
@@ -81,16 +81,11 @@ class AccuWeatherSensor(CoordinatorEntity, SensorEntity):
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
+        self._sensor_data = _get_sensor_data(coordinator.data, forecast_day, kind)
         if forecast_day is None:
             self._description = SENSOR_TYPES[kind]
-            self._sensor_data: dict[str, Any]
-            if kind == "Precipitation":
-                self._sensor_data = coordinator.data["PrecipitationSummary"][kind]
-            else:
-                self._sensor_data = coordinator.data[kind]
         else:
             self._description = FORECAST_SENSOR_TYPES[kind]
-            self._sensor_data = coordinator.data[ATTR_FORECAST][forecast_day][kind]
         self._unit_system = API_METRIC if coordinator.is_metric else API_IMPERIAL
         self._name = name
         self.kind = kind
@@ -182,3 +177,24 @@ class AccuWeatherSensor(CoordinatorEntity, SensorEntity):
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
         return self._description[ATTR_ENABLED]
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle data update."""
+        self._sensor_data = _get_sensor_data(
+            self.coordinator.data, self.forecast_day, self.kind
+        )
+        self.async_write_ha_state()
+
+
+def _get_sensor_data(
+    sensors: dict[str, Any], forecast_day: int | None, kind: str
+) -> Any:
+    """Get sensor data."""
+    if forecast_day is not None:
+        return sensors[ATTR_FORECAST][forecast_day][kind]
+
+    if kind == "Precipitation":
+        return sensors["PrecipitationSummary"][kind]
+
+    return sensors[kind]

--- a/homeassistant/components/daikin/manifest.json
+++ b/homeassistant/components/daikin/manifest.json
@@ -3,7 +3,7 @@
   "name": "Daikin AC",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/daikin",
-  "requirements": ["pydaikin==2.4.2"],
+  "requirements": ["pydaikin==2.4.3"],
   "codeowners": ["@fredrike"],
   "zeroconf": ["_dkapi._tcp.local."],
   "quality_scale": "platinum",

--- a/homeassistant/components/mobile_app/__init__.py
+++ b/homeassistant/components/mobile_app/__init__.py
@@ -160,7 +160,7 @@ def handle_push_notification_channel(hass, connection, msg):
     registered_channels = hass.data[DOMAIN][DATA_PUSH_CHANNEL]
 
     if webhook_id in registered_channels:
-        registered_channels.pop(webhook_id)()
+        registered_channels.pop(webhook_id)
 
     @callback
     def forward_push_notification(data):

--- a/homeassistant/components/omnilogic/switch.py
+++ b/homeassistant/components/omnilogic/switch.py
@@ -153,8 +153,8 @@ class OmniLogicPumpControl(OmniLogicSwitch):
             state_key=state_key,
         )
 
-        self._max_speed = int(coordinator.data[item_id]["Max-Pump-Speed"])
-        self._min_speed = int(coordinator.data[item_id]["Min-Pump-Speed"])
+        self._max_speed = int(coordinator.data[item_id].get("Max-Pump-Speed", 100))
+        self._min_speed = int(coordinator.data[item_id].get("Min-Pump-Speed", 0))
 
         if "Filter-Type" in coordinator.data[item_id]:
             self._pump_type = PUMP_TYPES[coordinator.data[item_id]["Filter-Type"]]

--- a/homeassistant/components/rfxtrx/manifest.json
+++ b/homeassistant/components/rfxtrx/manifest.json
@@ -2,7 +2,7 @@
   "domain": "rfxtrx",
   "name": "RFXCOM RFXtrx",
   "documentation": "https://www.home-assistant.io/integrations/rfxtrx",
-  "requirements": ["pyRFXtrx==0.26.1"],
+  "requirements": ["pyRFXtrx==0.27.0"],
   "codeowners": ["@danielhiversen", "@elupus", "@RobBie1221"],
   "config_flow": true,
   "iot_class": "local_push"

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -382,6 +382,14 @@ class SonosSpeaker:
         """Update device properties from an event."""
         if more_info := event.variables.get("more_info"):
             battery_dict = dict(x.split(":") for x in more_info.split(","))
+            if "BattChg" not in battery_dict:
+                _LOGGER.debug(
+                    "Unknown device properties update for %s (%s), please report an issue: '%s'",
+                    self.zone_name,
+                    self.model_name,
+                    more_info,
+                )
+                return
             await self.async_update_battery_info(battery_dict)
         self.async_write_entity_states()
 

--- a/homeassistant/components/whois/sensor.py
+++ b/homeassistant/components/whois/sensor.py
@@ -118,6 +118,7 @@ class WhoisSensor(SensorEntity):
             expiration_date = response["expiration_date"]
             if isinstance(expiration_date, list):
                 attrs[ATTR_EXPIRES] = expiration_date[0].isoformat()
+                expiration_date = expiration_date[0]
             else:
                 attrs[ATTR_EXPIRES] = expiration_date.isoformat()
 

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -5,7 +5,7 @@ from typing import Final
 
 MAJOR_VERSION: Final = 2021
 MINOR_VERSION: Final = 6
-PATCH_VERSION: Final = "5"
+PATCH_VERSION: Final = "6"
 __short_version__: Final = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 __version__: Final = f"{__short_version__}.{PATCH_VERSION}"
 REQUIRED_PYTHON_VER: Final[tuple[int, int, int]] = (3, 8, 0)

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1253,7 +1253,7 @@ pyMetEireann==0.2
 pyMetno==0.8.3
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.26.1
+pyRFXtrx==0.27.0
 
 # homeassistant.components.switchmate
 # pySwitchmate==0.4.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1352,7 +1352,7 @@ pycsspeechtts==1.0.4
 # pycups==1.9.73
 
 # homeassistant.components.daikin
-pydaikin==2.4.2
+pydaikin==2.4.3
 
 # homeassistant.components.danfoss_air
 pydanfossair==0.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -693,7 +693,7 @@ pyMetEireann==0.2
 pyMetno==0.8.3
 
 # homeassistant.components.rfxtrx
-pyRFXtrx==0.26.1
+pyRFXtrx==0.27.0
 
 # homeassistant.components.tibber
 pyTibber==0.17.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -747,7 +747,7 @@ pycomfoconnect==0.4
 pycoolmasternet-async==0.1.2
 
 # homeassistant.components.daikin
-pydaikin==2.4.2
+pydaikin==2.4.3
 
 # homeassistant.components.deconz
 pydeconz==79

--- a/tests/components/rfxtrx/test_init.py
+++ b/tests/components/rfxtrx/test_init.py
@@ -117,7 +117,7 @@ async def test_fire_event(hass, rfxtrx):
             "type_string": "Byron SX",
             "id_string": "00:90",
             "data": "0716000100900970",
-            "values": {"Command": "Chime", "Rssi numeric": 7, "Sound": 9},
+            "values": {"Command": "Sound 9", "Rssi numeric": 7, "Sound": 9},
             "device_id": device_id_2.id,
         },
     ]


### PR DESCRIPTION
- Fix whois expiration date ([@kantselovich] - [#51868]) ([whois docs])
- Add Omnilogic switch defaults for max_speed and min_speed ([@djtimca] - [#51889]) ([omnilogic docs])
- Bump pyRFXtrx to 0.27.0 ([@RobBie1221] - [#51911]) ([rfxtrx docs])
- Bump pydaikin to 2.4.3 ([@fredrike] - [#51926]) ([daikin docs])
- Fix AccuWeather sensors updates ([@bieniu] - [#52031]) ([accuweather docs])
- Fix double subscriptions for local push notifications ([@balloob] - [#52039]) ([mobile_app docs])
- Catch unexpected battery update payloads on Sonos ([@jjlawren] - [#52040]) ([sonos docs])

[#51868]: https://github.com/home-assistant/core/pull/51868
[#51889]: https://github.com/home-assistant/core/pull/51889
[#51911]: https://github.com/home-assistant/core/pull/51911
[#51926]: https://github.com/home-assistant/core/pull/51926
[#52031]: https://github.com/home-assistant/core/pull/52031
[#52039]: https://github.com/home-assistant/core/pull/52039
[#52040]: https://github.com/home-assistant/core/pull/52040
[@RobBie1221]: https://github.com/RobBie1221
[@balloob]: https://github.com/balloob
[@bieniu]: https://github.com/bieniu
[@djtimca]: https://github.com/djtimca
[@fredrike]: https://github.com/fredrike
[@jjlawren]: https://github.com/jjlawren
[@kantselovich]: https://github.com/kantselovich
[accuweather docs]: https://www.home-assistant.io/integrations/accuweather/
[daikin docs]: https://www.home-assistant.io/integrations/daikin/
[mobile_app docs]: https://www.home-assistant.io/integrations/mobile_app/
[omnilogic docs]: https://www.home-assistant.io/integrations/omnilogic/
[rfxtrx docs]: https://www.home-assistant.io/integrations/rfxtrx/
[sonos docs]: https://www.home-assistant.io/integrations/sonos/
[whois docs]: https://www.home-assistant.io/integrations/whois/