### PR TITLE
Fix missing azure event hub instance name

### DIFF
--- a/homeassistant/components/azure_event_hub/__init__.py
+++ b/homeassistant/components/azure_event_hub/__init__.py
@@ -23,6 +23,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entityfilter import FILTER_SCHEMA
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.json import JSONEncoder
+from homeassistant.helpers.typing import ConfigType
 
 from .const import (
     ADDITIONAL_ARGS,
@@ -43,9 +44,9 @@ CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(
             {
+                vol.Required(CONF_EVENT_HUB_INSTANCE_NAME): cv.string,
                 vol.Exclusive(CONF_EVENT_HUB_CON_STRING, "setup_methods"): cv.string,
                 vol.Exclusive(CONF_EVENT_HUB_NAMESPACE, "setup_methods"): cv.string,
-                vol.Optional(CONF_EVENT_HUB_INSTANCE_NAME): cv.string,
                 vol.Optional(CONF_EVENT_HUB_SAS_POLICY): cv.string,
                 vol.Optional(CONF_EVENT_HUB_SAS_KEY): cv.string,
                 vol.Optional(CONF_SEND_INTERVAL, default=5): cv.positive_int,
@@ -61,20 +62,23 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass, yaml_config):
+async def async_setup(hass: HomeAssistant, yaml_config: ConfigType) -> bool:
     """Activate Azure EH component."""
     config = yaml_config[DOMAIN]
     if config.get(CONF_EVENT_HUB_CON_STRING):
-        client_args = {"conn_str": config[CONF_EVENT_HUB_CON_STRING]}
+        client_args = {
+            "conn_str": config[CONF_EVENT_HUB_CON_STRING],
+            "eventhub_name": config[CONF_EVENT_HUB_INSTANCE_NAME],
+        }
         conn_str_client = True
     else:
         client_args = {
             "fully_qualified_namespace": f"{config[CONF_EVENT_HUB_NAMESPACE]}.servicebus.windows.net",
+            "eventhub_name": config[CONF_EVENT_HUB_INSTANCE_NAME],
             "credential": EventHubSharedKeyCredential(
                 policy=config[CONF_EVENT_HUB_SAS_POLICY],
                 key=config[CONF_EVENT_HUB_SAS_KEY],
             ),
-            "eventhub_name": config[CONF_EVENT_HUB_INSTANCE_NAME],
         }
         conn_str_client = False
 
@@ -115,7 +119,7 @@ class AzureEventHub:
         self._next_send_remover = None
         self.shutdown = False
 
-    async def async_start(self):
+    async def async_start(self) -> None:
         """Start the recorder, suppress logging and register the callbacks and do the first send after five seconds, to capture the startup events."""
         # suppress the INFO and below logging on the underlying packages, they are very verbose, even at INFO
         logging.getLogger("uamqp").setLevel(logging.WARNING)
@@ -128,7 +132,7 @@ class AzureEventHub:
         # schedule the first send after 10 seconds to capture startup events, after that each send will schedule the next after the interval.
         self._next_send_remover = async_call_later(self.hass, 10, self.async_send)
 
-    async def async_shutdown(self, _: Event):
+    async def async_shutdown(self, _: Event) -> None:
         """Shut down the AEH by queueing None and calling send."""
         if self._next_send_remover:
             self._next_send_remover()
@@ -137,14 +141,13 @@ class AzureEventHub:
         await self.queue.put((3, (time.monotonic(), None)))
         await self.async_send(None)
 
-    async def async_listen(self, event: Event):
+    async def async_listen(self, event: Event) -> None:
         """Listen for new messages on the bus and queue them for AEH."""
         await self.queue.put((2, (time.monotonic(), event)))
 
-    async def async_send(self, _):
+    async def async_send(self, _) -> None:
         """Write preprocessed events to eventhub, with retry."""
-        client = self._get_client()
-        async with client:
+        async with self._get_client() as client:
             while not self.queue.empty():
                 data_batch, dequeue_count = await self.fill_batch(client)
                 _LOGGER.debug(
@@ -160,14 +163,13 @@ class AzureEventHub:
                     finally:
                         for _ in range(dequeue_count):
                             self.queue.task_done()
-        await client.close()
 
         if not self.shutdown:
             self._next_send_remover = async_call_later(
                 self.hass, self._send_interval, self.async_send
             )
 
-    async def fill_batch(self, client):
+    async def fill_batch(self, client) -> None:
         """Return a batch of events formatted for writing.
 
         Uses get_nowait instead of await get, because the functions batches and doesn't wait for each single event, the send function is called.
@@ -205,7 +207,7 @@ class AzureEventHub:
 
         return event_batch, dequeue_count
 
-    def _event_to_filtered_event_data(self, event: Event):
+    def _event_to_filtered_event_data(self, event: Event) -> None:
         """Filter event states and create EventData object."""
         state = event.data.get("new_state")
         if (
@@ -216,7 +218,7 @@ class AzureEventHub:
             return None
         return EventData(json.dumps(obj=state, cls=JSONEncoder).encode("utf-8"))
 
-    def _get_client(self):
+    def _get_client(self) -> EventHubProducerClient:
         """Get a Event Producer Client."""
         if self._conn_str_client:
             return EventHubProducerClient.from_connection_string(

--- a/homeassistant/components/azure_event_hub/manifest.json
+++ b/homeassistant/components/azure_event_hub/manifest.json
@@ -2,7 +2,7 @@
   "domain": "azure_event_hub",
   "name": "Azure Event Hub",
   "documentation": "https://www.home-assistant.io/integrations/azure_event_hub",
-  "requirements": ["azure-eventhub==5.1.0"],
+  "requirements": ["azure-eventhub==5.5.0"],
   "codeowners": ["@eavanvalkenburg"],
   "iot_class": "cloud_push"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -331,7 +331,7 @@ av==8.0.3
 axis==44
 
 # homeassistant.components.azure_event_hub
-azure-eventhub==5.1.0
+azure-eventhub==5.5.0
 
 # homeassistant.components.azure_service_bus
 azure-servicebus==0.50.3

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -208,7 +208,7 @@ av==8.0.3
 axis==44
 
 # homeassistant.components.azure_event_hub
-azure-eventhub==5.1.0
+azure-eventhub==5.5.0
 
 # homeassistant.components.homekit
 base36==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
-->

 Fix for using this component with IoTHub, event_hub_name is now a required field, can be filled by the DeviceID when using IoTHub.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Updated the package to azure-eventhub=5.5 (https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/eventhub/azure-eventhub/CHANGELOG.md).
Made a change in the config to fix the issue, now needs to include event_hub_name which has to be filled by the DeviceID when using IoTHub. 
Added typing.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #41437
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18283

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
