### PR TITLE
Modern forms switch platform

### DIFF
--- a/homeassistant/components/modern_forms/__init__.py
+++ b/homeassistant/components/modern_forms/__init__.py
@@ -13,6 +13,7 @@ from aiomodernforms.models import Device as ModernFormsDeviceState
 
 from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_MODEL, ATTR_NAME, ATTR_SW_VERSION, CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -30,6 +31,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 PLATFORMS = [
     LIGHT_DOMAIN,
     FAN_DOMAIN,
+    SWITCH_DOMAIN,
 ]
 _LOGGER = logging.getLogger(__name__)
 

--- a/homeassistant/components/modern_forms/manifest.json
+++ b/homeassistant/components/modern_forms/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/modern_forms",
   "requirements": [
-    "aiomodernforms==0.1.6"
+    "aiomodernforms==0.1.7"
   ],
   "zeroconf": [
     {"type":"_easylink._tcp.local.", "name":"wac*"}

--- a/homeassistant/components/modern_forms/manifest.json
+++ b/homeassistant/components/modern_forms/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/modern_forms",
   "requirements": [
-    "aiomodernforms==0.1.5"
+    "aiomodernforms==0.1.6"
   ],
   "zeroconf": [
     {"type":"_easylink._tcp.local.", "name":"wac*"}

--- a/homeassistant/components/modern_forms/manifest.json
+++ b/homeassistant/components/modern_forms/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/modern_forms",
   "requirements": [
-    "aiomodernforms==0.1.7"
+    "aiomodernforms==0.1.8"
   ],
   "zeroconf": [
     {"type":"_easylink._tcp.local.", "name":"wac*"}

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -1,0 +1,113 @@
+"""Support for Modern Forms switches."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import (
+    ModernFormsDataUpdateCoordinator,
+    ModernFormsDeviceEntity,
+    modernforms_exception_handler,
+)
+from .const import DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Modern Forms switch based on a config entry."""
+    coordinator: ModernFormsDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+
+    switches = [
+        ModernFormsAwaySwitch(entry.entry_id, coordinator),
+        ModernFormsAdaptiveLearningSwitch(entry.entry_id, coordinator),
+    ]
+    async_add_entities(switches)
+
+
+class ModernFormsSwitch(ModernFormsDeviceEntity, SwitchEntity):
+    """Defines a Modern Forms switch."""
+
+    def __init__(
+        self,
+        *,
+        entry_id: str,
+        coordinator: ModernFormsDataUpdateCoordinator,
+        name: str,
+        icon: str,
+        key: str,
+    ) -> None:
+        """Initialize Modern Forms switch."""
+        self._key = key
+        super().__init__(
+            entry_id=entry_id, coordinator=coordinator, name=name, icon=icon
+        )
+        self._attr_unique_id = f"{self.coordinator.data.info.mac_address}_{self._key}"
+
+
+class ModernFormsAwaySwitch(ModernFormsSwitch):
+    """Defines a Modern Forms Away mode switch."""
+
+    def __init__(
+        self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator
+    ) -> None:
+        """Initialize Modern Forms Away mode switch."""
+        super().__init__(
+            coordinator=coordinator,
+            entry_id=entry_id,
+            icon="mdi:airplane-takeoff",
+            key="away_mode",
+            name=f"{coordinator.data.info.device_name} Away Mode",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the switch."""
+        return bool(self.coordinator.data.state.away_mode_enabled)
+
+    @modernforms_exception_handler
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the Modern Forms Away mode switch."""
+        await self.coordinator.modern_forms.away(away=False)
+
+    @modernforms_exception_handler
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the Modern Forms Away mode switch."""
+        await self.coordinator.modern_forms.away(away=True)
+
+
+class ModernFormsAdaptiveLearningSwitch(ModernFormsSwitch):
+    """Defines a Modern Forms Adaptive Learning switch."""
+
+    def __init__(
+        self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator
+    ) -> None:
+        """Initialize Modern Forms Adaptive Learning switch."""
+        super().__init__(
+            coordinator=coordinator,
+            entry_id=entry_id,
+            icon="mdi:school-outline",
+            key="adaptive_learning",
+            name=f"{coordinator.data.info.device_name} Adaptive Learning",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return the state of the switch."""
+        return bool(self.coordinator.data.state.adaptive_learning_enabled)
+
+    @modernforms_exception_handler
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the Modern Forms Adaptive Learning switch."""
+        await self.coordinator.modern_forms.adaptive_learning(adaptive_learning=False)
+
+    @modernforms_exception_handler
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the Modern Forms Adaptive Learning switch."""
+        await self.coordinator.modern_forms.adaptive_learning(adaptive_learning=True)

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -137,7 +137,7 @@ class ModernFormsRebootSwitch(ModernFormsSwitch):
     @modernforms_exception_handler
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the Modern Forms reboot switch."""
-        pass
+        pass  # pylint: disable=unnecessary-pass
 
     @modernforms_exception_handler
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -27,7 +27,6 @@ async def async_setup_entry(
     switches = [
         ModernFormsAwaySwitch(entry.entry_id, coordinator),
         ModernFormsAdaptiveLearningSwitch(entry.entry_id, coordinator),
-        ModernFormsRebootSwitch(entry.entry_id, coordinator),
     ]
     async_add_entities(switches)
 
@@ -112,34 +111,3 @@ class ModernFormsAdaptiveLearningSwitch(ModernFormsSwitch):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Modern Forms Adaptive Learning switch."""
         await self.coordinator.modern_forms.adaptive_learning(adaptive_learning=True)
-
-
-class ModernFormsRebootSwitch(ModernFormsSwitch):
-    """Defines a Modern Forms Reboot switch."""
-
-    def __init__(
-        self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator
-    ) -> None:
-        """Initialize Modern Forms Reboot switch."""
-        super().__init__(
-            coordinator=coordinator,
-            entry_id=entry_id,
-            icon="mdi:restart",
-            key="reboot",
-            name=f"{coordinator.data.info.device_name} Reboot",
-        )
-
-    @property
-    def is_on(self) -> bool:
-        """Return false as the switch will never be on."""
-        return False
-
-    @modernforms_exception_handler
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn off the Modern Forms reboot switch."""
-        pass  # pylint: disable=unnecessary-pass
-
-    @modernforms_exception_handler
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn on the Modern Forms Reboot switch."""
-        await self.coordinator.modern_forms.reboot()

--- a/homeassistant/components/modern_forms/switch.py
+++ b/homeassistant/components/modern_forms/switch.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
     switches = [
         ModernFormsAwaySwitch(entry.entry_id, coordinator),
         ModernFormsAdaptiveLearningSwitch(entry.entry_id, coordinator),
+        ModernFormsRebootSwitch(entry.entry_id, coordinator),
     ]
     async_add_entities(switches)
 
@@ -111,3 +112,34 @@ class ModernFormsAdaptiveLearningSwitch(ModernFormsSwitch):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the Modern Forms Adaptive Learning switch."""
         await self.coordinator.modern_forms.adaptive_learning(adaptive_learning=True)
+
+
+class ModernFormsRebootSwitch(ModernFormsSwitch):
+    """Defines a Modern Forms Reboot switch."""
+
+    def __init__(
+        self, entry_id: str, coordinator: ModernFormsDataUpdateCoordinator
+    ) -> None:
+        """Initialize Modern Forms Reboot switch."""
+        super().__init__(
+            coordinator=coordinator,
+            entry_id=entry_id,
+            icon="mdi:restart",
+            key="reboot",
+            name=f"{coordinator.data.info.device_name} Reboot",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return false as the switch will never be on."""
+        return False
+
+    @modernforms_exception_handler
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the Modern Forms reboot switch."""
+        pass
+
+    @modernforms_exception_handler
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the Modern Forms Reboot switch."""
+        await self.coordinator.modern_forms.reboot()

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ aiolip==1.1.4
 aiolyric==1.0.7
 
 # homeassistant.components.modern_forms
-aiomodernforms==0.1.5
+aiomodernforms==0.1.6
 
 # homeassistant.components.yamaha_musiccast
 aiomusiccast==0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ aiolip==1.1.4
 aiolyric==1.0.7
 
 # homeassistant.components.modern_forms
-aiomodernforms==0.1.6
+aiomodernforms==0.1.7
 
 # homeassistant.components.yamaha_musiccast
 aiomusiccast==0.6

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -206,7 +206,7 @@ aiolip==1.1.4
 aiolyric==1.0.7
 
 # homeassistant.components.modern_forms
-aiomodernforms==0.1.7
+aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
 aiomusiccast==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,7 +131,7 @@ aiolip==1.1.4
 aiolyric==1.0.7
 
 # homeassistant.components.modern_forms
-aiomodernforms==0.1.5
+aiomodernforms==0.1.6
 
 # homeassistant.components.yamaha_musiccast
 aiomusiccast==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,7 +131,7 @@ aiolip==1.1.4
 aiolyric==1.0.7
 
 # homeassistant.components.modern_forms
-aiomodernforms==0.1.7
+aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
 aiomusiccast==0.6

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -131,7 +131,7 @@ aiolip==1.1.4
 aiolyric==1.0.7
 
 # homeassistant.components.modern_forms
-aiomodernforms==0.1.6
+aiomodernforms==0.1.7
 
 # homeassistant.components.yamaha_musiccast
 aiomusiccast==0.6

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -1,0 +1,144 @@
+"""Tests for the Modern Forms switch platform."""
+from unittest.mock import patch
+
+from aiomodernforms import ModernFormsConnectionError
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_ICON,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.components.modern_forms import init_integration
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+async def test_switch_state(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the creation and values of the Modern Forms switches."""
+    await init_integration(hass, aioclient_mock)
+
+    entity_registry = er.async_get(hass)
+
+    state = hass.states.get("switch.modernformsfan_away_mode")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:airplane-takeoff"
+    assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get("switch.modernformsfan_away_mode")
+    assert entry
+    assert entry.unique_id == "AA:BB:CC:DD:EE:FF_away_mode"
+
+    state = hass.states.get("switch.modernformsfan_adaptive_learning")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:school-outline"
+    assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get("switch.modernformsfan_adaptive_learning")
+    assert entry
+    assert entry.unique_id == "AA:BB:CC:DD:EE:FF_adaptive_learning"
+
+
+async def test_switch_change_state(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test the change of state of the Modern Forms switches."""
+    await init_integration(hass, aioclient_mock)
+
+    # Away Mode
+    with patch("aiomodernforms.ModernFormsDevice.away") as away_mock:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_away_mode"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        away_mock.assert_called_once_with(away=True)
+
+    with patch("aiomodernforms.ModernFormsDevice.away") as away_mock:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_away_mode"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        away_mock.assert_called_once_with(away=False)
+
+    # Adaptive Learning
+    with patch(
+        "aiomodernforms.ModernFormsDevice.adaptive_learning"
+    ) as adaptive_learning_mock:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_adaptive_learning"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        adaptive_learning_mock.assert_called_once_with(adaptive_learning=True)
+
+    with patch(
+        "aiomodernforms.ModernFormsDevice.adaptive_learning"
+    ) as adaptive_learning_mock:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_adaptive_learning"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        adaptive_learning_mock.assert_called_once_with(adaptive_learning=False)
+
+
+async def test_switch_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker, caplog
+) -> None:
+    """Test error handling of the Modern Forms switches."""
+    await init_integration(hass, aioclient_mock)
+
+    aioclient_mock.clear_requests()
+    aioclient_mock.post("http://192.168.1.123:80/mf", text="", status=400)
+
+    with patch("homeassistant.components.modern_forms.ModernFormsDevice.update"):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_away_mode"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("switch.modernformsfan_away_mode")
+        assert state.state == STATE_OFF
+        assert "Invalid response from API" in caplog.text
+
+
+async def test_switch_connection_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test error handling of the Modern Forms switches."""
+    await init_integration(hass, aioclient_mock)
+
+    with patch("homeassistant.components.modern_forms.ModernFormsDevice.update"), patch(
+        "homeassistant.components.modern_forms.ModernFormsDevice.away",
+        side_effect=ModernFormsConnectionError,
+    ):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_away_mode"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get("switch.modernformsfan_away_mode")
+        assert state.state == STATE_UNAVAILABLE

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -45,6 +45,15 @@ async def test_switch_state(
     assert entry
     assert entry.unique_id == "AA:BB:CC:DD:EE:FF_adaptive_learning"
 
+    state = hass.states.get("switch.modernformsfan_reboot")
+    assert state
+    assert state.attributes.get(ATTR_ICON) == "mdi:restart"
+    assert state.state == STATE_OFF
+
+    entry = entity_registry.async_get("switch.modernformsfan_reboot")
+    assert entry
+    assert entry.unique_id == "AA:BB:CC:DD:EE:FF_reboot"
+
 
 async def test_switch_change_state(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
@@ -97,6 +106,28 @@ async def test_switch_change_state(
         )
         await hass.async_block_till_done()
         adaptive_learning_mock.assert_called_once_with(adaptive_learning=False)
+
+    # Reboot
+    with patch("aiomodernforms.ModernFormsDevice.reboot") as reboot_mock:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_reboot"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        reboot_mock.assert_called_once()
+
+    # Reboot
+    with patch("aiomodernforms.ModernFormsDevice.reboot") as reboot_mock:
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: "switch.modernformsfan_reboot"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        reboot_mock.assert_not_called()
 
 
 async def test_switch_error(

--- a/tests/components/modern_forms/test_switch.py
+++ b/tests/components/modern_forms/test_switch.py
@@ -45,15 +45,6 @@ async def test_switch_state(
     assert entry
     assert entry.unique_id == "AA:BB:CC:DD:EE:FF_adaptive_learning"
 
-    state = hass.states.get("switch.modernformsfan_reboot")
-    assert state
-    assert state.attributes.get(ATTR_ICON) == "mdi:restart"
-    assert state.state == STATE_OFF
-
-    entry = entity_registry.async_get("switch.modernformsfan_reboot")
-    assert entry
-    assert entry.unique_id == "AA:BB:CC:DD:EE:FF_reboot"
-
 
 async def test_switch_change_state(
     hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
@@ -106,28 +97,6 @@ async def test_switch_change_state(
         )
         await hass.async_block_till_done()
         adaptive_learning_mock.assert_called_once_with(adaptive_learning=False)
-
-    # Reboot
-    with patch("aiomodernforms.ModernFormsDevice.reboot") as reboot_mock:
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: "switch.modernformsfan_reboot"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        reboot_mock.assert_called_once()
-
-    # Reboot
-    with patch("aiomodernforms.ModernFormsDevice.reboot") as reboot_mock:
-        await hass.services.async_call(
-            SWITCH_DOMAIN,
-            SERVICE_TURN_OFF,
-            {ATTR_ENTITY_ID: "switch.modernformsfan_reboot"},
-            blocking=True,
-        )
-        await hass.async_block_till_done()
-        reboot_mock.assert_not_called()
 
 
 async def test_switch_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds support for to the Modern Forms fan for several switches to control
the behaviour of the fan.

The following switches are added with the platform

- Away Mode - Sets the fan to away mode to turn on and off to simulate presence.
- Adaptive Learning - Turns on or off learning of patterns to be used by away mode
- Reboot - A toggle to reboot the internal controller.  Forces reconnect to wifi and controllers.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#18130, home-assistant/home-assistant.io#18271

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
