### PR TITLE
Add color_mode support to ozw light

### DIFF
--- a/tests/components/ozw/test_light.py
+++ b/tests/components/ozw/test_light.py
@@ -1,4 +1,5 @@
 """Test Z-Wave Lights."""
+from homeassistant.components.light import SUPPORT_TRANSITION
 from homeassistant.components.ozw.light import byte_to_zwave_brightness
 
 from .common import setup_ozw
@@ -12,6 +13,8 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "off"
+    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
+    assert state.attributes["supported_color_modes"] == ["color_temp", "hs"]
 
     # Test turning on
     # Beware that due to rounding, a roundtrip conversion does not always work
@@ -51,6 +54,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["brightness"] == new_brightness
+    assert state.attributes["color_mode"] == "color_temp"
 
     # Test turning off
     new_transition = 6553
@@ -119,6 +123,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["brightness"] == new_brightness
+    assert state.attributes["color_mode"] == "color_temp"
 
     # Test set brightness to 0
     new_brightness = 0
@@ -183,6 +188,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["rgb_color"] == (0, 0, 255)
+    assert state.attributes["color_mode"] == "hs"
 
     # Test setting hs_color
     new_color = [300, 70]
@@ -216,6 +222,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["hs_color"] == (300.0, 70.196)
+    assert state.attributes["color_mode"] == "hs"
 
     # Test setting rgb_color
     new_color = [255, 154, 0]
@@ -249,6 +256,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["rgb_color"] == (255, 153, 0)
+    assert state.attributes["color_mode"] == "hs"
 
     # Test setting xy_color
     new_color = [0.52, 0.43]
@@ -282,6 +290,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["xy_color"] == (0.519, 0.429)
+    assert state.attributes["color_mode"] == "hs"
 
     # Test setting color temp
     new_color = 200
@@ -315,6 +324,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["color_temp"] == 200
+    assert state.attributes["color_mode"] == "color_temp"
 
     # Test setting invalid color temp
     new_color = 120
@@ -348,6 +358,7 @@ async def test_light(hass, light_data, light_msg, light_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["color_temp"] == 153
+    assert state.attributes["color_mode"] == "color_temp"
 
 
 async def test_pure_rgb_dimmer_light(
@@ -360,7 +371,9 @@ async def test_pure_rgb_dimmer_light(
     state = hass.states.get("light.kitchen_rgb_strip_level")
     assert state is not None
     assert state.state == "on"
-    assert state.attributes["supported_features"] == 17
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes["supported_color_modes"] == ["hs"]
+    assert state.attributes["color_mode"] == "hs"
 
     # Test setting hs_color
     new_color = [300, 70]
@@ -390,6 +403,7 @@ async def test_pure_rgb_dimmer_light(
     assert state is not None
     assert state.state == "on"
     assert state.attributes["hs_color"] == (300.0, 70.196)
+    assert state.attributes["color_mode"] == "hs"
 
 
 async def test_no_rgb_light(hass, light_data, light_no_rgb_msg, sent_messages):
@@ -400,6 +414,8 @@ async def test_no_rgb_light(hass, light_data, light_no_rgb_msg, sent_messages):
     state = hass.states.get("light.master_bedroom_l_level")
     assert state is not None
     assert state.state == "off"
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes["supported_color_modes"] == ["brightness"]
 
     # Turn on the light
     new_brightness = 44
@@ -429,6 +445,7 @@ async def test_no_rgb_light(hass, light_data, light_no_rgb_msg, sent_messages):
     assert state is not None
     assert state.state == "on"
     assert state.attributes["brightness"] == new_brightness
+    assert state.attributes["color_mode"] == "brightness"
 
 
 async def test_no_ww_light(
@@ -441,6 +458,8 @@ async def test_no_ww_light(
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "off"
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes["supported_color_modes"] == ["rgbw"]
 
     # Turn on the light
     white_color = 190
@@ -449,7 +468,7 @@ async def test_no_ww_light(
         "turn_on",
         {
             "entity_id": "light.led_bulb_6_multi_colour_level",
-            "white_value": white_color,
+            "rgbw_color": [0, 0, 0, white_color],
         },
         blocking=True,
     )
@@ -472,7 +491,8 @@ async def test_no_ww_light(
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "on"
-    assert state.attributes["white_value"] == 190
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (0, 0, 0, 190)
 
 
 async def test_no_cw_light(
@@ -485,6 +505,8 @@ async def test_no_cw_light(
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "off"
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes["supported_color_modes"] == ["rgbw"]
 
     # Turn on the light
     white_color = 190
@@ -493,7 +515,7 @@ async def test_no_cw_light(
         "turn_on",
         {
             "entity_id": "light.led_bulb_6_multi_colour_level",
-            "white_value": white_color,
+            "rgbw_color": [0, 0, 0, white_color],
         },
         blocking=True,
     )
@@ -516,7 +538,8 @@ async def test_no_cw_light(
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "on"
-    assert state.attributes["white_value"] == 190
+    assert state.attributes["color_mode"] == "rgbw"
+    assert state.attributes["rgbw_color"] == (0, 0, 0, 190)
 
 
 async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_messages):
@@ -527,6 +550,8 @@ async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_mess
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "off"
+    assert state.attributes["supported_features"] == 0
+    assert state.attributes["supported_color_modes"] == ["color_temp", "hs"]
 
     assert state.attributes["min_mireds"] == 153
     assert state.attributes["max_mireds"] == 370
@@ -559,6 +584,7 @@ async def test_wc_light(hass, light_wc_data, light_msg, light_rgb_msg, sent_mess
     assert state is not None
     assert state.state == "on"
     assert state.attributes["color_temp"] == 190
+    assert state.attributes["color_mode"] == "color_temp"
 
 
 async def test_new_ozw_light(hass, light_new_ozw_data, light_msg, sent_messages):
@@ -569,6 +595,8 @@ async def test_new_ozw_light(hass, light_new_ozw_data, light_msg, sent_messages)
     state = hass.states.get("light.led_bulb_6_multi_colour_level")
     assert state is not None
     assert state.state == "off"
+    assert state.attributes["supported_features"] == SUPPORT_TRANSITION
+    assert state.attributes["supported_color_modes"] == ["color_temp", "hs"]
 
     # Test turning on with new duration (newer openzwave)
     new_transition = 4180
@@ -597,6 +625,8 @@ async def test_new_ozw_light(hass, light_new_ozw_data, light_msg, sent_messages)
     light_msg.encode()
     receive_message(light_msg)
     await hass.async_block_till_done()
+    state = hass.states.get("light.led_bulb_6_multi_colour_level")
+    assert state.attributes["color_mode"] == "color_temp"
 
     # Test turning off with new duration (newer openzwave)(new max)
     await hass.services.async_call(
@@ -649,3 +679,5 @@ async def test_new_ozw_light(hass, light_new_ozw_data, light_msg, sent_messages)
     light_msg.encode()
     receive_message(light_msg)
     await hass.async_block_till_done()
+    state = hass.states.get("light.led_bulb_6_multi_colour_level")
+    assert state.attributes["color_mode"] == "color_temp"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
ozw lights no longer supports deprecated `white_value`, use `rgbw_color` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color_mode support to ozw light.
Flag support for rgbw instead of white_value for lights with red, green, blue and a single white channel

#### Note:
The driver for this PR is that `white_value` is deprecated, with a plan to warn when it's used in 2021.7, and a complete removal in 2021.10.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
