### PR TITLE
Implement color_mode support for mysensors

### DIFF
--- a/homeassistant/components/mysensors/light.py
+++ b/homeassistant/components/mysensors/light.py
@@ -1,17 +1,17 @@
 """Support for MySensors lights."""
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Tuple, cast
 
 from homeassistant.components import mysensors
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_WHITE_VALUE,
+    ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    COLOR_MODE_BRIGHTNESS,
+    COLOR_MODE_RGB,
+    COLOR_MODE_RGBW,
     DOMAIN,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -19,14 +19,11 @@ from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-import homeassistant.util.color as color_util
 from homeassistant.util.color import rgb_hex_to_rgb_list
 
 from .const import MYSENSORS_DISCOVERY, DiscoveryInfo, SensorType
 from .device import MySensorsDevice
 from .helpers import on_unload
-
-SUPPORT_MYSENSORS_RGBW = SUPPORT_COLOR | SUPPORT_WHITE_VALUE
 
 
 async def async_setup_entry(
@@ -69,24 +66,6 @@ class MySensorsLight(mysensors.device.MySensorsEntity, LightEntity):
         """Initialize a MySensors Light."""
         super().__init__(*args)
         self._state: bool | None = None
-        self._brightness: int | None = None
-        self._hs: tuple[int, int] | None = None
-        self._white: int | None = None
-
-    @property
-    def brightness(self) -> int | None:
-        """Return the brightness of this light between 0..255."""
-        return self._brightness
-
-    @property
-    def hs_color(self) -> tuple[int, int] | None:
-        """Return the hs color value [int, int]."""
-        return self._hs
-
-    @property
-    def white_value(self) -> int | None:
-        """Return the white value of this light between 0..255."""
-        return self._white
 
     @property
     def is_on(self) -> bool:
@@ -114,7 +93,7 @@ class MySensorsLight(mysensors.device.MySensorsEntity, LightEntity):
 
         if (
             ATTR_BRIGHTNESS not in kwargs
-            or kwargs[ATTR_BRIGHTNESS] == self._brightness
+            or kwargs[ATTR_BRIGHTNESS] == self._attr_brightness
             or set_req.V_DIMMER not in self._values
         ):
             return
@@ -126,48 +105,8 @@ class MySensorsLight(mysensors.device.MySensorsEntity, LightEntity):
 
         if self.assumed_state:
             # optimistically assume that light has changed state
-            self._brightness = brightness
+            self._attr_brightness = brightness
             self._values[set_req.V_DIMMER] = percent
-
-    def _turn_on_rgb_and_w(self, hex_template: str, **kwargs: Any) -> None:
-        """Turn on RGB or RGBW child device."""
-        assert self._hs
-        rgb = list(color_util.color_hs_to_RGB(*self._hs))
-        white = self._white
-        hex_color = self._values.get(self.value_type)
-        hs_color: tuple[float, float] | None = kwargs.get(ATTR_HS_COLOR)
-        new_rgb: tuple[int, int, int] | None
-        if hs_color is not None:
-            new_rgb = color_util.color_hs_to_RGB(*hs_color)
-        else:
-            new_rgb = None
-        new_white: int | None = kwargs.get(ATTR_WHITE_VALUE)
-
-        if new_rgb is None and new_white is None:
-            return
-        if new_rgb is not None:
-            rgb = list(new_rgb)
-        if hex_template == "%02x%02x%02x%02x":
-            if new_white is not None:
-                rgb.append(new_white)
-            elif white is not None:
-                rgb.append(white)
-            else:
-                rgb.append(0)
-        hex_color = hex_template % tuple(rgb)
-        if len(rgb) > 3:
-            white = rgb.pop()
-        self.gateway.set_child_value(
-            self.node_id, self.child_id, self.value_type, hex_color, ack=1
-        )
-
-        if self.assumed_state:
-            # optimistically assume that light has changed state
-            # pylint: disable=no-value-for-parameter
-            # https://github.com/PyCQA/pylint/issues/4546
-            self._hs = color_util.color_RGB_to_hs(*rgb)  # type: ignore[assignment]
-            self._white = white
-            self._values[self.value_type] = hex_color
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the device off."""
@@ -190,27 +129,16 @@ class MySensorsLight(mysensors.device.MySensorsEntity, LightEntity):
         """Update the controller with values from dimmer child."""
         value_type = self.gateway.const.SetReq.V_DIMMER
         if value_type in self._values:
-            self._brightness = round(255 * int(self._values[value_type]) / 100)
-            if self._brightness == 0:
+            self._attr_brightness = round(255 * int(self._values[value_type]) / 100)
+            if self._attr_brightness == 0:
                 self._state = False
-
-    @callback
-    def _async_update_rgb_or_w(self) -> None:
-        """Update the controller with values from RGB or RGBW child."""
-        value = self._values[self.value_type]
-        color_list = rgb_hex_to_rgb_list(value)
-        if len(color_list) > 3:
-            self._white = color_list.pop()
-        self._hs = color_util.color_RGB_to_hs(*color_list)  # type: ignore[assignment]
 
 
 class MySensorsLightDimmer(MySensorsLight):
     """Dimmer child class to MySensorsLight."""
 
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        return SUPPORT_BRIGHTNESS
+    _attr_supported_color_modes = {COLOR_MODE_BRIGHTNESS}
+    _attr_color_mode = COLOR_MODE_BRIGHTNESS
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
@@ -229,21 +157,32 @@ class MySensorsLightDimmer(MySensorsLight):
 class MySensorsLightRGB(MySensorsLight):
     """RGB child class to MySensorsLight."""
 
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        set_req = self.gateway.const.SetReq
-        if set_req.V_DIMMER in self._values:
-            return SUPPORT_BRIGHTNESS | SUPPORT_COLOR
-        return SUPPORT_COLOR
+    _attr_supported_color_modes = {COLOR_MODE_RGB}
+    _attr_color_mode = COLOR_MODE_RGB
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
-        self._turn_on_rgb_and_w("%02x%02x%02x", **kwargs)
+        self._turn_on_rgb(**kwargs)
         if self.assumed_state:
             self.async_write_ha_state()
+
+    def _turn_on_rgb(self, **kwargs: Any) -> None:
+        """Turn on RGB child device."""
+        hex_color = self._values.get(self.value_type)
+        new_rgb: tuple[int, int, int] | None = kwargs.get(ATTR_RGB_COLOR)
+        if new_rgb is None:
+            return
+        hex_color = "%02x%02x%02x" % new_rgb
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, self.value_type, hex_color, ack=1
+        )
+
+        if self.assumed_state:
+            # optimistically assume that light has changed state
+            self._attr_rgb_color = new_rgb
+            self._values[self.value_type] = hex_color
 
     async def async_update(self) -> None:
         """Update the controller with the latest value from a sensor."""
@@ -252,22 +191,49 @@ class MySensorsLightRGB(MySensorsLight):
         self._async_update_dimmer()
         self._async_update_rgb_or_w()
 
+    @callback
+    def _async_update_rgb_or_w(self) -> None:
+        """Update the controller with values from RGB child."""
+        value = self._values[self.value_type]
+        self._attr_rgb_color = cast(
+            Tuple[int, int, int], tuple(rgb_hex_to_rgb_list(value))
+        )
+
 
 class MySensorsLightRGBW(MySensorsLightRGB):
     """RGBW child class to MySensorsLightRGB."""
 
-    @property
-    def supported_features(self) -> int:
-        """Flag supported features."""
-        set_req = self.gateway.const.SetReq
-        if set_req.V_DIMMER in self._values:
-            return SUPPORT_BRIGHTNESS | SUPPORT_MYSENSORS_RGBW
-        return SUPPORT_MYSENSORS_RGBW
+    _attr_supported_color_modes = {COLOR_MODE_RGBW}
+    _attr_color_mode = COLOR_MODE_RGBW
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the device on."""
         self._turn_on_light()
         self._turn_on_dimmer(**kwargs)
-        self._turn_on_rgb_and_w("%02x%02x%02x%02x", **kwargs)
+        self._turn_on_rgbw(**kwargs)
         if self.assumed_state:
             self.async_write_ha_state()
+
+    def _turn_on_rgbw(self, **kwargs: Any) -> None:
+        """Turn on RGBW child device."""
+        hex_color = self._values.get(self.value_type)
+        new_rgbw: tuple[int, int, int, int] | None = kwargs.get(ATTR_RGBW_COLOR)
+        if new_rgbw is None:
+            return
+        hex_color = "%02x%02x%02x%02x" % new_rgbw
+        self.gateway.set_child_value(
+            self.node_id, self.child_id, self.value_type, hex_color, ack=1
+        )
+
+        if self.assumed_state:
+            # optimistically assume that light has changed state
+            self._attr_rgbw_color = new_rgbw
+            self._values[self.value_type] = hex_color
+
+    @callback
+    def _async_update_rgb_or_w(self) -> None:
+        """Update the controller with values from RGBW child."""
+        value = self._values[self.value_type]
+        self._attr_rgbw_color = cast(
+            Tuple[int, int, int, int], tuple(rgb_hex_to_rgb_list(value))
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
mysensors lights no longer supports deprecated `white_value`, use `rgbw_color` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color_mode support to mysensors light.
Flag support for rgbw instead of white_value for lights with red, green, blue and white channels

#### Note:
The driver for this PR is that `white_value` is deprecated, with a plan to warn when it's used in 2021.7, and a complete removal in 2021.10.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
