### PR TITLE
Add Lutron fan platform

### DIFF
--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -10,6 +10,9 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import slugify
 
+import homeassistant.components.fan as fan
+
+
 DOMAIN = "lutron"
 
 PLATFORMS = ["light", "cover", "switch", "scene", "binary_sensor"]
@@ -45,6 +48,7 @@ def setup(hass, base_config):
     hass.data[LUTRON_DEVICES] = {
         "light": [],
         "cover": [],
+        "fan": [],
         "switch": [],
         "scene": [],
         "binary_sensor": [],
@@ -64,6 +68,8 @@ def setup(hass, base_config):
         for output in area.outputs:
             if output.type == "SYSTEM_SHADE":
                 hass.data[LUTRON_DEVICES]["cover"].append((area.name, output))
+            elif output.type == "CEILING_FAN_TYPE":
+                hass.data[LUTRON_DEVICES]["fan"].append(LutronFan(area.name, output, hass.data[LUTRON_CONTROLLER]))
             elif output.is_dimmable:
                 hass.data[LUTRON_DEVICES]["light"].append((area.name, output))
             else:
@@ -94,8 +100,8 @@ def setup(hass, base_config):
                 (area.name, area.occupancy_group)
             )
 
-    for platform in PLATFORMS:
-        discovery.load_platform(hass, platform, DOMAIN, {}, base_config)
+    for component in ("light", "fan", "cover", "switch", "scene", "binary_sensor"):
+        discovery.load_platform(hass, component, DOMAIN, {}, base_config)
     return True
 
 
@@ -127,6 +133,66 @@ class LutronDevice(Entity):
     def should_poll(self):
         """No polling needed."""
         return False
+
+
+class LutronFan(LutronDevice, fan.FanEntity):
+    """Representation of a Lutron Fan controller. Including Fan Speed."""
+    FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH = 0, 25, 50, 75, 100
+
+    SPEED_MEDIUM_HIGH = "medium high"
+
+    VALUE_TO_SPEED = {
+        None: fan.SPEED_OFF,
+        FAN_HIGH: fan.SPEED_OFF,
+        FAN_LOW: fan.SPEED_LOW,
+        FAN_MEDIUM: fan.SPEED_MEDIUM,
+        FAN_MEDIUM_HIGH: SPEED_MEDIUM_HIGH,
+        FAN_HIGH: fan.SPEED_HIGH,
+    }
+
+    SPEED_TO_VALUE = {
+        SPEED_OFF: FAN_OFF,
+        SPEED_LOW: FAN_LOW,
+        SPEED_MEDIUM: FAN_MEDIUM,
+        SPEED_MEDIUM_HIGH: FAN_MEDIUM_HIGH,
+        SPEED_HIGH: FAN_HIGH,
+    }
+
+    FAN_SPEEDS = [fan.SPEED_OFF, fan.SPEED_LOW, fan.SPEED_MEDIUM, SPEED_MEDIUM_HIGH, fan.SPEED_HIGH]
+
+    def __init__(self, area_name, lutron_device, controller):
+        """Initialize the fan device."""
+        super(self, LutronDevice).__init__(area_name, lutron_device, controller)
+        super(self, fan.FanEntity).__init__()
+
+    @property
+    def speed(self) -> Optional[str]:
+        """Return the current speed."""
+        return VALUE_TO_SPEED[int(self._lutron_device.level)]
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return FAN_SPEEDS
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features. Speed Only."""
+        return fan.SUPPORT_SET_SPEED
+
+    async def async_turn_on(self, speed: str = None, **kwargs) -> None:
+        """Turn the fan on."""
+        if speed is None:
+            speed = fan.SPEED_MEDIUM
+        await self.async_set_speed(speed)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the fan off."""
+        await self.async_set_speed(SPEED_OFF)
+
+    async def async_set_speed(self, speed: str) -> None:
+        """Set the speed of the fan."""
+        await self._lutron_device.level = SPEED_TO_VALUE[speed]
 
 
 class LutronButton:

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -131,6 +131,11 @@ class LutronDevice(Entity):
         """No polling needed."""
         return False
 
+    @property
+    def unique_id(self):
+        """Return the unique ID of the device."""
+        return f"{DOMAIN}_{self._controller.guid}_{self._lutron_device.uuid}_{self._lutron_device.id}"
+
 
 class LutronButton:
     """Representation of a button on a Lutron keypad.

--- a/homeassistant/components/lutron/__init__.py
+++ b/homeassistant/components/lutron/__init__.py
@@ -134,7 +134,7 @@ class LutronDevice(Entity):
     @property
     def unique_id(self):
         """Return the unique ID of the device."""
-        return f"{DOMAIN}_{self._controller.guid}_{self._lutron_device.uuid}_{self._lutron_device.id}"
+        return f"{DOMAIN}_{self._controller.guid}_{ getattr(self._lutron_device, 'uuid', '')}_{getattr(self._lutron_device, 'id', '')}"
 
 
 class LutronButton:

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,17 +1,10 @@
 """Support for Lutron fans."""
 
 from homeassistant.components.fan import DOMAIN, SUPPORT_SET_SPEED, FanEntity
-from homeassistant.util.percentage import (
-    ordered_list_item_to_percentage,
-    percentage_to_ordered_list_item,
-)
-
 from . import DOMAIN as LUTRON_DOMAIN, LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
-FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH = 0, 25, 50, 75, 100
 
 DEFAULT_ON_PERCENTAGE = 50
-ORDERED_NAMED_FAN_SPEEDS = [FAN_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH]
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
@@ -35,14 +28,9 @@ class LutronFan(LutronDevice, FanEntity):
         super().__init__(area_name, lutron_device, controller)
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes."""
         return {"lutron_integration_id": self._lutron_device.id}
-
-    @property
-    def speed_count(self) -> int:
-        """Return the number of speeds the fan supports."""
-        return len(ORDERED_NAMED_FAN_SPEEDS)
 
     @property
     def supported_features(self) -> int:
@@ -74,16 +62,8 @@ class LutronFan(LutronDevice, FanEntity):
 
     def turn_off(self, **kwargs) -> None:
         """Turn the fan off."""
-        self.set_percentage(0)
+        self._lutron_device.level = 0
 
     def set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan."""
-
-        if percentage == 0:
-            named_speed = FAN_OFF
-        else:
-            named_speed = percentage_to_ordered_list_item(
-                ORDERED_NAMED_FAN_SPEEDS, percentage
-            )
-
         self._lutron_device.level = percentage

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -12,7 +12,7 @@ from homeassistant.components.fan import (
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
-"""This currently omits the Medium-High setting of 75%."""
+# This currently omits the Medium-High setting of 75%.
 FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH = 0, 25, 50, 100
 
 VALUE_TO_SPEED = {

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -9,13 +9,13 @@ from homeassistant.components.fan import (
 )
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+from typing import Optional
 
 """This currently omits the Medium-High setting of 75%"""
 FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH = 0, 25, 50, 100
 
 VALUE_TO_SPEED = {
     None: SPEED_OFF,
-    FAN_HIGH: SPEED_OFF,
     FAN_LOW: SPEED_LOW,
     FAN_MEDIUM: SPEED_MEDIUM,
     FAN_HIGH: SPEED_HIGH,
@@ -89,7 +89,7 @@ class LutronFan(LutronDevice, FanEntity):
         """Return true if device is on."""
         return self._lutron_device.last_level() > 0
 
-    async def async_turn_on(self, speed: str = None, **kwargs) -> None:
+    def turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn the fan on."""
         if speed is not None:
             new_speed = speed
@@ -99,12 +99,12 @@ class LutronFan(LutronDevice, FanEntity):
             new_speed = self._prev_speed
 
         self._prev_speed = new_speed
-        await self.async_set_speed(new_speed)
+        self.set_speed(new_speed)
 
-    async def async_turn_off(self, **kwargs) -> None:
+    def turn_off(self, **kwargs) -> None:
         """Turn the fan off."""
-        await self.async_set_speed(SPEED_OFF)
+        self.set_speed(SPEED_OFF)
 
-    async def async_set_speed(self, speed: str) -> None:
+    def set_speed(self, speed: str) -> None:
         """Set the speed of the fan"""
-        await self._lutron_device.level = to_lutron_speed(speed)
+        self._lutron_device.level = to_lutron_speed(speed)

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -12,7 +12,7 @@ from homeassistant.components.fan import (
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
-"""This currently omits the Medium-High setting of 75%"""
+"""This currently omits the Medium-High setting of 75%."""
 FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH = 0, 25, 50, 100
 
 VALUE_TO_SPEED = {
@@ -107,5 +107,5 @@ class LutronFan(LutronDevice, FanEntity):
         self.set_speed(SPEED_OFF)
 
     def set_speed(self, speed: str) -> None:
-        """Set the speed of the fan"""
+        """Set the speed of the fan."""
         self._lutron_device.level = to_lutron_speed(speed)

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,4 +1,6 @@
 """Support for Lutron fans."""
+from typing import Optional
+
 from homeassistant.components.fan import (
     SPEED_HIGH,
     SPEED_LOW,
@@ -9,7 +11,6 @@ from homeassistant.components.fan import (
 )
 
 from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
-from typing import Optional
 
 """This currently omits the Medium-High setting of 75%"""
 FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH = 0, 25, 50, 100

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -30,6 +30,7 @@ SPEED_TO_VALUE = {
 
 FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
+
 def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     """Set up the Lutron switches."""
     devs = []
@@ -41,6 +42,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
 
     add_entities(devs, True)
 
+
 def to_lutron_speed(speed: str) -> int:
     """Convert the given Home Assistant fan speed (off, low, medium, high) to Lutron (0.0-100.0)."""
     return SPEED_TO_VALUE[speed]
@@ -50,8 +52,10 @@ def to_hass_speed(speed: int) -> str:
     """Convert the given Lutron (0.0-100.0) light level to Home Assistant (0-255)."""
     return VALUE_TO_SPEED[int(speed)]
 
+
 class LutronFan(LutronDevice, FanEntity):
     """Representation of a Lutron Fan controller. Including Fan Speed."""
+
     def __init__(self, area_name, lutron_device, controller):
         """Initialize the fan device."""
         self._prev_speed = None

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,6 +1,6 @@
 """Support for Lutron fans."""
-from typing import Optional
 from bisect import bisect_left
+from typing import Optional
 
 from homeassistant.components.fan import (
     SPEED_HIGH,

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,21 +1,18 @@
 """Support for Lutron fans."""
 
-from homeassistant.components.fan import (
-    DOMAIN,
-    SUPPORT_SET_SPEED,
-    FanEntity,
-)
+from homeassistant.components.fan import DOMAIN, SUPPORT_SET_SPEED, FanEntity
 from homeassistant.util.percentage import (
     ordered_list_item_to_percentage,
     percentage_to_ordered_list_item,
 )
 
-from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice, DOMAIN as LUTRON_DOMAIN
+from . import DOMAIN as LUTRON_DOMAIN, LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
 
 FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH = 0, 25, 50, 75, 100
 
 DEFAULT_ON_PERCENTAGE = 50
 ORDERED_NAMED_FAN_SPEEDS = [FAN_LOW, FAN_MEDIUM, FAN_MEDIUM_HIGH, FAN_HIGH]
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
     """Set up the Lutron fans."""
@@ -27,6 +24,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
         devs.append(dev)
 
     add_entities(devs, True)
+
 
 class LutronFan(LutronDevice, FanEntity):
     """Representation of a Lutron Fan controller. Including Fan Speed."""

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,0 +1,106 @@
+"""Support for Lutron switches."""
+from homeassistant.components.fan import (
+    SPEED_HIGH,
+    SPEED_LOW,
+    SPEED_MEDIUM,
+    SPEED_OFF,
+    SUPPORT_SET_SPEED,
+    FanEntity,
+)
+
+from . import LUTRON_CONTROLLER, LUTRON_DEVICES, LutronDevice
+
+"""This currently omits the Medium-High setting of 75%"""
+FAN_OFF, FAN_LOW, FAN_MEDIUM, FAN_HIGH = 0, 25, 50, 100
+
+VALUE_TO_SPEED = {
+    None: SPEED_OFF,
+    FAN_HIGH: SPEED_OFF,
+    FAN_LOW: SPEED_LOW,
+    FAN_MEDIUM: SPEED_MEDIUM,
+    FAN_HIGH: SPEED_HIGH,
+}
+
+SPEED_TO_VALUE = {
+    SPEED_OFF: FAN_OFF,
+    SPEED_LOW: FAN_LOW,
+    SPEED_MEDIUM: FAN_MEDIUM,
+    SPEED_HIGH: FAN_HIGH,
+}
+
+FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
+
+def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
+    """Set up the Lutron switches."""
+    devs = []
+
+    # Add Lutron Fans
+    for (area_name, device) in hass.data[LUTRON_DEVICES]["fan"]:
+        dev = LutronFan(area_name, device, hass.data[LUTRON_CONTROLLER])
+        devs.append(dev)
+
+    add_entities(devs, True)
+
+def to_lutron_speed(speed: str) -> int:
+    """Convert the given Home Assistant fan speed (off, low, medium, high) to Lutron (0.0-100.0)."""
+    return SPEED_TO_VALUE[speed]
+
+
+def to_hass_speed(speed: int) -> str:
+    """Convert the given Lutron (0.0-100.0) light level to Home Assistant (0-255)."""
+    return VALUE_TO_SPEED[int(speed)]
+
+class LutronFan(LutronDevice, FanEntity):
+    """Representation of a Lutron Fan controller. Including Fan Speed."""
+    def __init__(self, area_name, lutron_device, controller):
+        """Initialize the fan device."""
+        self._prev_speed = None
+        super().__init__(area_name, lutron_device, controller)
+
+    @property
+    def device_state_attributes(self):
+        """Return the state attributes."""
+        return {"lutron_integration_id": self._lutron_device.id}
+
+    @property
+    def supported_features(self) -> int:
+        """Flag supported features. Speed Only."""
+        return SUPPORT_SET_SPEED
+
+    @property
+    def speed(self) -> Optional[str]:
+        """Return the speed of the fan."""
+        new_speed = to_hass_speed(self._lutron_device.last_level())
+        if new_speed != SPEED_OFF:
+            self._prev_speed = new_speed
+        return new_speed
+
+    @property
+    def speed_list(self) -> list:
+        """Get the list of available speeds."""
+        return FAN_SPEEDS
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if device is on."""
+        return self._lutron_device.last_level() > 0
+
+    async def async_turn_on(self, speed: str = None, **kwargs) -> None:
+        """Turn the fan on."""
+        if speed is not None:
+            new_speed = speed
+        elif self._prev_speed == 0:
+            new_speed = SPEED_MEDIUM
+        else:
+            new_speed = self._prev_speed
+
+        self._prev_speed = new_speed
+        await self.async_set_speed(new_speed)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the fan off."""
+        await self.async_set_speed(SPEED_OFF)
+
+    async def async_set_speed(self, speed: str) -> None:
+        """Set the speed of the fan"""
+        await self._lutron_device.level = to_lutron_speed(speed)

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -1,4 +1,4 @@
-"""Support for Lutron switches."""
+"""Support for Lutron fans."""
 from homeassistant.components.fan import (
     SPEED_HIGH,
     SPEED_LOW,
@@ -32,7 +32,7 @@ FAN_SPEEDS = [SPEED_OFF, SPEED_LOW, SPEED_MEDIUM, SPEED_HIGH]
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None) -> None:
-    """Set up the Lutron switches."""
+    """Set up the Lutron fans."""
     devs = []
 
     # Add Lutron Fans

--- a/homeassistant/components/lutron/fan.py
+++ b/homeassistant/components/lutron/fan.py
@@ -53,9 +53,9 @@ def to_lutron_speed(speed: str) -> int:
 
 def to_hass_speed(speed: float) -> str:
     """Convert the given Lutron (0.0-100.0) light level to Home Assistant (0-255)."""
-    discrete_speeds=list(VALUE_TO_SPEED.keys())
+    discrete_speeds = list(VALUE_TO_SPEED.keys())
     discrete_speeds.remove(None)
-    idx=bisect_left(discrete_speeds, speed)
+    idx = bisect_left(discrete_speeds, speed)
 
     return VALUE_TO_SPEED[discrete_speeds[idx]]
 


### PR DESCRIPTION
Revisiting an old PR (#43915) that I didn't get around to finishing.

<!--
- Adds LutronFan class
- Moved fan controller into separate file
- Fixed black formatting
- Fix typos
- Remove asyncio, which was incorrect
- Fix import sorts
- First lines end with periods
- change string to comment
- Fix discrete speed logic
- Fix formatting
- Fix isort
- Updated to use new Fan API
-->

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Previously, Lutron Fans were treated like any other dimmer. Now the fan objects will be correctly recognized as ceiling fans with discrete speeds. If user automations previously relied on the dimmer functionality, those automations _might_ break. The percentage value would still work via the new API.

This also adds a `unique_id` to the LutronDevice object.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This change creates the discrete states for a four-speed fan controller and fan entity type.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
