### PR TITLE
Add color_mode support to Kuler Sky light

### DIFF
--- a/homeassistant/components/kulersky/light.py
+++ b/homeassistant/components/kulersky/light.py
@@ -8,11 +8,8 @@ import pykulersky
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_HS_COLOR,
-    ATTR_WHITE_VALUE,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
+    ATTR_RGBW_COLOR,
+    COLOR_MODE_RGBW,
     LightEntity,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -20,13 +17,10 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
-import homeassistant.util.color as color_util
 
 from .const import DATA_ADDRESSES, DATA_DISCOVERY_SUBSCRIPTION, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-SUPPORT_KULERSKY = SUPPORT_BRIGHTNESS | SUPPORT_COLOR | SUPPORT_WHITE_VALUE
 
 DISCOVERY_INTERVAL = timedelta(seconds=60)
 
@@ -71,10 +65,9 @@ class KulerskyLight(LightEntity):
     def __init__(self, light: pykulersky.Light) -> None:
         """Initialize a Kuler Sky light."""
         self._light = light
-        self._hs_color = None
-        self._brightness = None
-        self._white_value = None
         self._available = None
+        self._attr_supported_color_modes = {COLOR_MODE_RGBW}
+        self._attr_color_mode = COLOR_MODE_RGBW
 
     async def async_added_to_hass(self) -> None:
         """Run when entity about to be added to hass."""
@@ -113,29 +106,9 @@ class KulerskyLight(LightEntity):
         }
 
     @property
-    def supported_features(self):
-        """Flag supported features."""
-        return SUPPORT_KULERSKY
-
-    @property
-    def brightness(self):
-        """Return the brightness of the light."""
-        return self._brightness
-
-    @property
-    def hs_color(self):
-        """Return the hs color."""
-        return self._hs_color
-
-    @property
-    def white_value(self):
-        """Return the white value of this light between 0..255."""
-        return self._white_value
-
-    @property
     def is_on(self):
         """Return true if light is on."""
-        return self._brightness > 0 or self._white_value > 0
+        return self.brightness > 0
 
     @property
     def available(self) -> bool:
@@ -144,24 +117,21 @@ class KulerskyLight(LightEntity):
 
     async def async_turn_on(self, **kwargs):
         """Instruct the light to turn on."""
-        default_hs = (0, 0) if self._hs_color is None else self._hs_color
-        hue_sat = kwargs.get(ATTR_HS_COLOR, default_hs)
+        default_rgbw = (255,) * 4 if self.rgbw_color is None else self.rgbw_color
+        rgbw = kwargs.get(ATTR_RGBW_COLOR, default_rgbw)
 
-        default_brightness = 0 if self._brightness is None else self._brightness
+        default_brightness = 0 if self.brightness is None else self.brightness
         brightness = kwargs.get(ATTR_BRIGHTNESS, default_brightness)
 
-        default_white_value = 255 if self._white_value is None else self._white_value
-        white_value = kwargs.get(ATTR_WHITE_VALUE, default_white_value)
-
-        if brightness == 0 and white_value == 0 and not kwargs:
+        if brightness == 0 and not kwargs:
             # If the light would be off, and no additional parameters were
             # passed, just turn the light on full brightness.
             brightness = 255
-            white_value = 255
+            rgbw = (255,) * 4
 
-        rgb = color_util.color_hsv_to_RGB(*hue_sat, brightness / 255 * 100)
+        rgbw_scaled = [round(x * brightness / 255) for x in rgbw]
 
-        await self._light.set_color(*rgb, white_value)
+        await self._light.set_color(*rgbw_scaled)
 
     async def async_turn_off(self, **kwargs):
         """Instruct the light to turn off."""
@@ -173,7 +143,7 @@ class KulerskyLight(LightEntity):
             if not self._available:
                 await self._light.connect()
             # pylint: disable=invalid-name
-            r, g, b, w = await self._light.get_color()
+            rgbw = await self._light.get_color()
         except pykulersky.PykulerskyException as exc:
             if self._available:
                 _LOGGER.warning("Unable to connect to %s: %s", self._light.address, exc)
@@ -183,7 +153,10 @@ class KulerskyLight(LightEntity):
             _LOGGER.info("Reconnected to %s", self._light.address)
 
         self._available = True
-        hsv = color_util.color_RGB_to_hsv(r, g, b)
-        self._hs_color = hsv[:2]
-        self._brightness = int(round((hsv[2] / 100) * 255))
-        self._white_value = w
+        brightness = max(rgbw)
+        if not brightness:
+            rgbw_normalized = [0, 0, 0, 0]
+        else:
+            rgbw_normalized = [round(x * 255 / brightness) for x in rgbw]
+        self._attr_brightness = brightness
+        self._attr_rgbw_color = tuple(rgbw_normalized)

--- a/tests/components/kulersky/test_light.py
+++ b/tests/components/kulersky/test_light.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 
 import pykulersky
 import pytest
+from pytest import approx
 
 from homeassistant import setup
 from homeassistant.components.kulersky.const import (
@@ -17,14 +18,9 @@ from homeassistant.components.light import (
     ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
     ATTR_SUPPORTED_COLOR_MODES,
-    ATTR_WHITE_VALUE,
     ATTR_XY_COLOR,
-    COLOR_MODE_HS,
     COLOR_MODE_RGBW,
     SCAN_INTERVAL,
-    SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR,
-    SUPPORT_WHITE_VALUE,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -72,12 +68,10 @@ async def test_init(hass, mock_light):
     """Test platform setup."""
     state = hass.states.get("light.bedroom")
     assert state.state == STATE_OFF
-    assert state.attributes == {
+    assert dict(state.attributes) == {
         ATTR_FRIENDLY_NAME: "Bedroom",
-        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
-        | SUPPORT_COLOR
-        | SUPPORT_WHITE_VALUE,
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_RGBW],
+        ATTR_SUPPORTED_FEATURES: 0,
     }
 
     with patch.object(hass.loop, "stop"):
@@ -129,7 +123,7 @@ async def test_light_turn_on(hass, mock_light):
     await hass.async_block_till_done()
     mock_light.set_color.assert_called_with(255, 255, 255, 255)
 
-    mock_light.get_color.return_value = (50, 50, 50, 255)
+    mock_light.get_color.return_value = (50, 50, 50, 50)
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -137,9 +131,33 @@ async def test_light_turn_on(hass, mock_light):
         blocking=True,
     )
     await hass.async_block_till_done()
-    mock_light.set_color.assert_called_with(50, 50, 50, 255)
+    mock_light.set_color.assert_called_with(50, 50, 50, 50)
 
-    mock_light.get_color.return_value = (50, 45, 25, 255)
+    mock_light.get_color.return_value = (50, 25, 13, 6)
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {ATTR_ENTITY_ID: "light.bedroom", ATTR_RGBW_COLOR: (255, 128, 64, 32)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_light.set_color.assert_called_with(50, 25, 13, 6)
+
+    # RGB color is converted to RGBW by assigning the white component to the white
+    # channel, see color_rgb_to_rgbw
+    mock_light.get_color.return_value = (0, 17, 50, 17)
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {ATTR_ENTITY_ID: "light.bedroom", ATTR_RGB_COLOR: (64, 128, 255)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    mock_light.set_color.assert_called_with(0, 17, 50, 17)
+
+    # HS color is converted to RGBW by assigning the white component to the white
+    # channel, see color_rgb_to_rgbw
+    mock_light.get_color.return_value = (50, 41, 0, 50)
     await hass.services.async_call(
         "light",
         "turn_on",
@@ -147,18 +165,7 @@ async def test_light_turn_on(hass, mock_light):
         blocking=True,
     )
     await hass.async_block_till_done()
-
-    mock_light.set_color.assert_called_with(50, 45, 25, 255)
-
-    mock_light.get_color.return_value = (220, 201, 110, 180)
-    await hass.services.async_call(
-        "light",
-        "turn_on",
-        {ATTR_ENTITY_ID: "light.bedroom", ATTR_WHITE_VALUE: 180},
-        blocking=True,
-    )
-    await hass.async_block_till_done()
-    mock_light.set_color.assert_called_with(50, 45, 25, 180)
+    mock_light.set_color.assert_called_with(50, 41, 0, 50)
 
 
 async def test_light_turn_off(hass, mock_light):
@@ -180,12 +187,10 @@ async def test_light_update(hass, mock_light):
 
     state = hass.states.get("light.bedroom")
     assert state.state == STATE_OFF
-    assert state.attributes == {
+    assert dict(state.attributes) == {
         ATTR_FRIENDLY_NAME: "Bedroom",
-        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
-        | SUPPORT_COLOR
-        | SUPPORT_WHITE_VALUE,
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_RGBW],
+        ATTR_SUPPORTED_FEATURES: 0,
     }
 
     # Test an exception during discovery
@@ -196,12 +201,50 @@ async def test_light_update(hass, mock_light):
 
     state = hass.states.get("light.bedroom")
     assert state.state == STATE_UNAVAILABLE
-    assert state.attributes == {
+    assert dict(state.attributes) == {
         ATTR_FRIENDLY_NAME: "Bedroom",
-        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
-        | SUPPORT_COLOR
-        | SUPPORT_WHITE_VALUE,
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_RGBW],
+        ATTR_SUPPORTED_FEATURES: 0,
+    }
+
+    mock_light.get_color.side_effect = None
+    mock_light.get_color.return_value = (80, 160, 255, 0)
+    utcnow = utcnow + SCAN_INTERVAL
+    async_fire_time_changed(hass, utcnow)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.bedroom")
+    assert state.state == STATE_ON
+    assert dict(state.attributes) == {
+        ATTR_FRIENDLY_NAME: "Bedroom",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_RGBW],
+        ATTR_SUPPORTED_FEATURES: 0,
+        ATTR_COLOR_MODE: COLOR_MODE_RGBW,
+        ATTR_BRIGHTNESS: 255,
+        ATTR_HS_COLOR: (approx(212.571), approx(68.627)),
+        ATTR_RGB_COLOR: (80, 160, 255),
+        ATTR_RGBW_COLOR: (80, 160, 255, 0),
+        ATTR_XY_COLOR: (approx(0.17), approx(0.193)),
+    }
+
+    mock_light.get_color.side_effect = None
+    mock_light.get_color.return_value = (80, 160, 200, 255)
+    utcnow = utcnow + SCAN_INTERVAL
+    async_fire_time_changed(hass, utcnow)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("light.bedroom")
+    assert state.state == STATE_ON
+    assert dict(state.attributes) == {
+        ATTR_FRIENDLY_NAME: "Bedroom",
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_RGBW],
+        ATTR_SUPPORTED_FEATURES: 0,
+        ATTR_COLOR_MODE: COLOR_MODE_RGBW,
+        ATTR_BRIGHTNESS: 255,
+        ATTR_HS_COLOR: (approx(199.701), approx(26.275)),
+        ATTR_RGB_COLOR: (188, 233, 255),
+        ATTR_RGBW_COLOR: (80, 160, 200, 255),
+        ATTR_XY_COLOR: (approx(0.259), approx(0.306)),
     }
 
     mock_light.get_color.side_effect = None
@@ -212,17 +255,14 @@ async def test_light_update(hass, mock_light):
 
     state = hass.states.get("light.bedroom")
     assert state.state == STATE_ON
-    assert state.attributes == {
+    assert dict(state.attributes) == {
         ATTR_FRIENDLY_NAME: "Bedroom",
-        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_HS, COLOR_MODE_RGBW],
-        ATTR_SUPPORTED_FEATURES: SUPPORT_BRIGHTNESS
-        | SUPPORT_COLOR
-        | SUPPORT_WHITE_VALUE,
+        ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_RGBW],
+        ATTR_SUPPORTED_FEATURES: 0,
         ATTR_COLOR_MODE: COLOR_MODE_RGBW,
-        ATTR_BRIGHTNESS: 200,
-        ATTR_HS_COLOR: (200, 60),
-        ATTR_RGB_COLOR: (102, 203, 255),
-        ATTR_RGBW_COLOR: (102, 203, 255, 240),
-        ATTR_WHITE_VALUE: 240,
-        ATTR_XY_COLOR: (0.184, 0.261),
+        ATTR_BRIGHTNESS: 240,
+        ATTR_HS_COLOR: (approx(200.0), approx(27.059)),
+        ATTR_RGB_COLOR: (186, 232, 255),
+        ATTR_RGBW_COLOR: (85, 170, 212, 255),
+        ATTR_XY_COLOR: (approx(0.257), approx(0.305)),
     }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
Kuler Sky lights no longer supports deprecated `white_value`, use `rgbw_color` instead.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add color_mode support to Kuler Sky light
Flag support for rgbw instead of white_value for lights with red, green, blue and white channels

#### Note:
The driver for this PR is that `white_value` is deprecated, with a plan to warn when it's used in 2021.7, and a complete removal in 2021.10.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
