### PR TITLE
Make attestation of supported features easier to read (deCONZ test)

### DIFF
--- a/homeassistant/components/deconz/light.py
+++ b/homeassistant/components/deconz/light.py
@@ -39,6 +39,7 @@ from .deconz_device import DeconzDevice
 from .gateway import get_gateway_from_config_entry
 
 CONTROLLER = ["Configuration tool"]
+DECONZ_GROUP = "is_deconz_group"
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -239,7 +240,7 @@ class DeconzBaseLight(DeconzDevice, LightEntity):
     @property
     def extra_state_attributes(self):
         """Return the device state attributes."""
-        return {"is_deconz_group": self._device.type == "LightGroup"}
+        return {DECONZ_GROUP: self._device.type == "LightGroup"}
 
 
 class DeconzLight(DeconzBaseLight):

--- a/tests/components/deconz/test_light.py
+++ b/tests/components/deconz/test_light.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from homeassistant.components.deconz.const import ATTR_ON, CONF_ALLOW_DECONZ_GROUPS
+from homeassistant.components.deconz.light import DECONZ_GROUP
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_MODE,
@@ -30,6 +31,9 @@ from homeassistant.components.light import (
     FLASH_SHORT,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    SUPPORT_EFFECT,
+    SUPPORT_FLASH,
+    SUPPORT_TRANSITION,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -98,8 +102,10 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
                     ATTR_COLOR_MODE: COLOR_MODE_COLOR_TEMP,
                     ATTR_MIN_MIREDS: 153,
                     ATTR_MAX_MIREDS: 500,
-                    ATTR_SUPPORTED_FEATURES: 44,
-                    "is_deconz_group": False,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION
+                    | SUPPORT_FLASH
+                    | SUPPORT_EFFECT,
+                    DECONZ_GROUP: False,
                 },
             },
         ),
@@ -148,8 +154,10 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
                     ATTR_HS_COLOR: (29.691, 38.039),
                     ATTR_RGB_COLOR: (255, 206, 158),
                     ATTR_XY_COLOR: (0.427, 0.373),
-                    "is_deconz_group": False,
-                    ATTR_SUPPORTED_FEATURES: 44,
+                    DECONZ_GROUP: False,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION
+                    | SUPPORT_FLASH
+                    | SUPPORT_EFFECT,
                 },
             },
         ),
@@ -186,8 +194,10 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
                     ATTR_HS_COLOR: (294.938, 55.294),
                     ATTR_RGB_COLOR: (243, 113, 255),
                     ATTR_XY_COLOR: (0.357, 0.188),
-                    "is_deconz_group": False,
-                    ATTR_SUPPORTED_FEATURES: 44,
+                    DECONZ_GROUP: False,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION
+                    | SUPPORT_FLASH
+                    | SUPPORT_EFFECT,
                 },
             },
         ),
@@ -225,8 +235,8 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
                     ATTR_COLOR_MODE: COLOR_MODE_COLOR_TEMP,
                     ATTR_BRIGHTNESS: 254,
                     ATTR_COLOR_TEMP: 396,
-                    "is_deconz_group": False,
-                    ATTR_SUPPORTED_FEATURES: 40,
+                    DECONZ_GROUP: False,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION | SUPPORT_FLASH,
                 },
             },
         ),
@@ -251,8 +261,8 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
                     ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_BRIGHTNESS],
                     ATTR_COLOR_MODE: COLOR_MODE_BRIGHTNESS,
                     ATTR_BRIGHTNESS: 254,
-                    "is_deconz_group": False,
-                    ATTR_SUPPORTED_FEATURES: 40,
+                    DECONZ_GROUP: False,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION | SUPPORT_FLASH,
                 },
             },
         ),
@@ -276,7 +286,7 @@ async def test_no_lights_or_groups(hass, aioclient_mock):
                 "attributes": {
                     ATTR_SUPPORTED_COLOR_MODES: [COLOR_MODE_ONOFF],
                     ATTR_COLOR_MODE: COLOR_MODE_ONOFF,
-                    "is_deconz_group": False,
+                    DECONZ_GROUP: False,
                     ATTR_SUPPORTED_FEATURES: 0,
                 },
             },
@@ -643,7 +653,7 @@ async def test_configuration_tool(hass, aioclient_mock):
                     ATTR_BRIGHTNESS: 255,
                     ATTR_EFFECT_LIST: [EFFECT_COLORLOOP],
                     "all_on": False,
-                    "is_deconz_group": True,
+                    DECONZ_GROUP: True,
                     ATTR_SUPPORTED_FEATURES: 44,
                 },
             },
@@ -663,8 +673,10 @@ async def test_configuration_tool(hass, aioclient_mock):
                     ATTR_BRIGHTNESS: 50,
                     ATTR_EFFECT_LIST: [EFFECT_COLORLOOP],
                     "all_on": False,
-                    "is_deconz_group": True,
-                    ATTR_SUPPORTED_FEATURES: 44,
+                    DECONZ_GROUP: True,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION
+                    | SUPPORT_FLASH
+                    | SUPPORT_EFFECT,
                 },
             },
         ),
@@ -684,8 +696,10 @@ async def test_configuration_tool(hass, aioclient_mock):
                     ATTR_RGB_COLOR: (255, 221, 0),
                     ATTR_XY_COLOR: (0.5, 0.5),
                     "all_on": False,
-                    "is_deconz_group": True,
-                    ATTR_SUPPORTED_FEATURES: 44,
+                    DECONZ_GROUP: True,
+                    ATTR_SUPPORTED_FEATURES: SUPPORT_TRANSITION
+                    | SUPPORT_FLASH
+                    | SUPPORT_EFFECT,
                 },
             },
         ),
@@ -1138,4 +1152,7 @@ async def test_verify_group_supported_features(hass, aioclient_mock):
     assert len(hass.states.async_all()) == 4
 
     assert hass.states.get("light.group").state == STATE_ON
-    assert hass.states.get("light.group").attributes[ATTR_SUPPORTED_FEATURES] == 44
+    assert (
+        hass.states.get("light.group").attributes[ATTR_SUPPORTED_FEATURES]
+        == SUPPORT_TRANSITION | SUPPORT_FLASH | SUPPORT_EFFECT
+    )


### PR DESCRIPTION
Make is_deconz_group a constant

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow up to #51933

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
