### PR TITLE
Suppress duplicate mdns discovery from netdisco

### DIFF
--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -219,7 +219,7 @@ def _discover(netdisco, zeroconf_instance, zeroconf_types):
     results = []
     try:
         netdisco.scan(
-            zeroconf_instance=zeroconf_instance, suppress_mdns_services=zeroconf_types
+            zeroconf_instance=zeroconf_instance, suppress_mdns_types=zeroconf_types
         )
 
         for disc in netdisco.discover():

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.core import callback
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.discovery import async_discover, async_load_platform
 from homeassistant.helpers.event import async_track_point_in_utc_time
+from homeassistant.loader import async_get_zeroconf
 import homeassistant.util.dt as dt_util
 
 DOMAIN = "discovery"
@@ -139,6 +140,10 @@ async def async_setup(hass, config):
             )
 
     zeroconf_instance = await zeroconf.async_get_instance(hass)
+    # Do not scan for types that have already been converted
+    # as it will generate excess network traffic for questions
+    # the zeroconf instance already knows the answers
+    zeroconf_types = list(await async_get_zeroconf(hass))
 
     async def new_service_found(service, info):
         """Handle a new service if one is found."""
@@ -187,7 +192,7 @@ async def async_setup(hass, config):
         """Scan for devices."""
         try:
             results = await hass.async_add_executor_job(
-                _discover, netdisco, zeroconf_instance
+                _discover, netdisco, zeroconf_instance, zeroconf_types
             )
 
             for result in results:
@@ -209,11 +214,13 @@ async def async_setup(hass, config):
     return True
 
 
-def _discover(netdisco, zeroconf_instance):
+def _discover(netdisco, zeroconf_instance, zeroconf_types):
     """Discover devices."""
     results = []
     try:
-        netdisco.scan(zeroconf_instance=zeroconf_instance)
+        netdisco.scan(
+            zeroconf_instance=zeroconf_instance, suppress_mdns_services=zeroconf_types
+        )
 
         for disc in netdisco.discover():
             for service in netdisco.get_info(disc):

--- a/homeassistant/components/discovery/manifest.json
+++ b/homeassistant/components/discovery/manifest.json
@@ -2,7 +2,7 @@
   "domain": "discovery",
   "name": "Discovery",
   "documentation": "https://www.home-assistant.io/integrations/discovery",
-  "requirements": ["netdisco==2.8.3"],
+  "requirements": ["netdisco==2.9.0"],
   "after_dependencies": ["zeroconf"],
   "codeowners": [],
   "quality_scale": "internal"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1005,7 +1005,7 @@ nessclient==0.9.15
 netdata==0.2.0
 
 # homeassistant.components.discovery
-netdisco==2.8.3
+netdisco==2.9.0
 
 # homeassistant.components.nam
 nettigo-air-monitor==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -559,7 +559,7 @@ ndms2_client==0.1.1
 nessclient==0.9.15
 
 # homeassistant.components.discovery
-netdisco==2.8.3
+netdisco==2.9.0
 
 # homeassistant.components.nam
 nettigo-air-monitor==1.0.0

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -60,7 +60,7 @@ async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
 async def test_unknown_service(hass):
     """Test that unknown service is ignored."""
 
-    def discover(netdisco, zeroconf_instance):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
         """Fake discovery."""
         return [("this_service_will_never_be_supported", {"info": "some"})]
 
@@ -73,7 +73,7 @@ async def test_unknown_service(hass):
 async def test_load_platform(hass):
     """Test load a platform."""
 
-    def discover(netdisco, zeroconf_instance):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
         """Fake discovery."""
         return [(SERVICE, SERVICE_INFO)]
 
@@ -89,7 +89,7 @@ async def test_load_platform(hass):
 async def test_load_component(hass):
     """Test load a component."""
 
-    def discover(netdisco, zeroconf_instance):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
@@ -109,7 +109,7 @@ async def test_load_component(hass):
 async def test_ignore_service(hass):
     """Test ignore service."""
 
-    def discover(netdisco, zeroconf_instance):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
@@ -122,7 +122,7 @@ async def test_ignore_service(hass):
 async def test_discover_duplicates(hass):
     """Test load a component."""
 
-    def discover(netdisco, zeroconf_instance):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
         """Fake discovery."""
         return [
             (SERVICE_NO_PLATFORM, SERVICE_INFO),
@@ -147,7 +147,7 @@ async def test_discover_config_flow(hass):
     """Test discovery triggering a config flow."""
     discovery_info = {"hello": "world"}
 
-    def discover(netdisco, zeroconf_instance):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
         """Fake discovery."""
         return [("mock-service", discovery_info)]
 

--- a/tests/components/discovery/test_init.py
+++ b/tests/components/discovery/test_init.py
@@ -60,7 +60,7 @@ async def mock_discovery(hass, discoveries, config=BASE_CONFIG):
 async def test_unknown_service(hass):
     """Test that unknown service is ignored."""
 
-    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_types):
         """Fake discovery."""
         return [("this_service_will_never_be_supported", {"info": "some"})]
 
@@ -73,7 +73,7 @@ async def test_unknown_service(hass):
 async def test_load_platform(hass):
     """Test load a platform."""
 
-    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_types):
         """Fake discovery."""
         return [(SERVICE, SERVICE_INFO)]
 
@@ -89,7 +89,7 @@ async def test_load_platform(hass):
 async def test_load_component(hass):
     """Test load a component."""
 
-    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_types):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
@@ -109,7 +109,7 @@ async def test_load_component(hass):
 async def test_ignore_service(hass):
     """Test ignore service."""
 
-    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_types):
         """Fake discovery."""
         return [(SERVICE_NO_PLATFORM, SERVICE_INFO)]
 
@@ -122,7 +122,7 @@ async def test_ignore_service(hass):
 async def test_discover_duplicates(hass):
     """Test load a component."""
 
-    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_types):
         """Fake discovery."""
         return [
             (SERVICE_NO_PLATFORM, SERVICE_INFO),
@@ -147,7 +147,7 @@ async def test_discover_config_flow(hass):
     """Test discovery triggering a config flow."""
     discovery_info = {"hello": "world"}
 
-    def discover(netdisco, zeroconf_instance, suppress_mdns_services):
+    def discover(netdisco, zeroconf_instance, suppress_mdns_types):
         """Fake discovery."""
         return [("mock-service", discovery_info)]
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When we are already running a ServiceBrowser for services that netdisco scans for
we will already have all the answers we expect to get in the cache. By scanning
for these services again, we generate additional network traffic. Since the
known answer list was not shared between ServiceBrowsers in earlier versions
of zeroconf, we will send an empty list which will cause every services we
already have in the cache to be re-populated.

Requires https://github.com/home-assistant-libs/netdisco/pull/256

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
