### PR TITLE
Avoid drift in recorder purge cut-off

### DIFF
--- a/homeassistant/components/recorder/__init__.py
+++ b/homeassistant/components/recorder/__init__.py
@@ -306,7 +306,7 @@ def _async_register_services(hass, instance):
 class PurgeTask(NamedTuple):
     """Object to store information about purge task."""
 
-    keep_days: int
+    purge_before: datetime
     repack: bool
     apply_filter: bool
 
@@ -451,7 +451,8 @@ class Recorder(threading.Thread):
         repack = kwargs.get(ATTR_REPACK)
         apply_filter = kwargs.get(ATTR_APPLY_FILTER)
 
-        self.queue.put(PurgeTask(keep_days, repack, apply_filter))
+        purge_before = dt_util.utcnow() - timedelta(days=keep_days)
+        self.queue.put(PurgeTask(purge_before, repack, apply_filter))
 
     def do_adhoc_purge_entities(self, entity_ids, domains, entity_globs):
         """Trigger an adhoc purge of requested entities."""
@@ -538,7 +539,8 @@ class Recorder(threading.Thread):
             # Purge will schedule the perodic cleanups
             # after it completes to ensure it does not happen
             # until after the database is vacuumed
-            self.queue.put(PurgeTask(self.keep_days, repack=False, apply_filter=False))
+            purge_before = dt_util.utcnow() - timedelta(days=self.keep_days)
+            self.queue.put(PurgeTask(purge_before, repack=False, apply_filter=False))
         else:
             self.queue.put(PerodicCleanupTask())
 
@@ -696,16 +698,16 @@ class Recorder(threading.Thread):
             self.migration_in_progress = False
             persistent_notification.dismiss(self.hass, "recorder_database_migration")
 
-    def _run_purge(self, keep_days, repack, apply_filter):
+    def _run_purge(self, purge_before, repack, apply_filter):
         """Purge the database."""
-        if purge.purge_old_data(self, keep_days, repack, apply_filter):
+        if purge.purge_old_data(self, purge_before, repack, apply_filter):
             # We always need to do the db cleanups after a purge
             # is finished to ensure the WAL checkpoint and other
             # tasks happen after a vacuum.
             perodic_db_cleanups(self)
             return
         # Schedule a new purge task if this one didn't finish
-        self.queue.put(PurgeTask(keep_days, repack, apply_filter))
+        self.queue.put(PurgeTask(purge_before, repack, apply_filter))
 
     def _run_purge_entities(self, entity_filter):
         """Purge entities from the database."""
@@ -724,7 +726,7 @@ class Recorder(threading.Thread):
     def _process_one_event(self, event):
         """Process one event."""
         if isinstance(event, PurgeTask):
-            self._run_purge(event.keep_days, event.repack, event.apply_filter)
+            self._run_purge(event.purge_before, event.repack, event.apply_filter)
             return
         if isinstance(event, PurgeEntitiesTask):
             self._run_purge_entities(event.entity_filter)

--- a/homeassistant/components/recorder/purge.py
+++ b/homeassistant/components/recorder/purge.py
@@ -1,14 +1,12 @@
 """Purge old data helper."""
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 from typing import TYPE_CHECKING, Callable
 
 from sqlalchemy.orm.session import Session
 from sqlalchemy.sql.expression import distinct
-
-import homeassistant.util.dt as dt_util
 
 from .const import MAX_ROWS_TO_PURGE
 from .models import Events, RecorderRuns, States
@@ -23,13 +21,12 @@ _LOGGER = logging.getLogger(__name__)
 
 @retryable_database_job("purge")
 def purge_old_data(
-    instance: Recorder, purge_days: int, repack: bool, apply_filter: bool = False
+    instance: Recorder, purge_before: datetime, repack: bool, apply_filter: bool = False
 ) -> bool:
-    """Purge events and states older than purge_days ago.
+    """Purge events and states older than purge_before.
 
     Cleans up an timeframe of an hour, based on the oldest record.
     """
-    purge_before = dt_util.utcnow() - timedelta(days=purge_days)
     _LOGGER.debug(
         "Purging states and events before target %s",
         purge_before.isoformat(sep=" ", timespec="seconds"),

--- a/tests/components/recorder/test_purge.py
+++ b/tests/components/recorder/test_purge.py
@@ -43,8 +43,10 @@ async def test_purge_old_states(
         events = session.query(Events).filter(Events.event_type == "state_changed")
         assert events.count() == 6
 
+        purge_before = dt_util.utcnow() - timedelta(days=4)
+
         # run purge_old_data()
-        finished = purge_old_data(instance, 4, repack=False)
+        finished = purge_old_data(instance, purge_before, repack=False)
         assert not finished
         assert states.count() == 2
 
@@ -52,7 +54,7 @@ async def test_purge_old_states(
         assert states_after_purge[1].old_state_id == states_after_purge[0].state_id
         assert states_after_purge[0].old_state_id is None
 
-        finished = purge_old_data(instance, 4, repack=False)
+        finished = purge_old_data(instance, purge_before, repack=False)
         assert finished
         assert states.count() == 2
 
@@ -162,13 +164,15 @@ async def test_purge_old_events(
         events = session.query(Events).filter(Events.event_type.like("EVENT_TEST%"))
         assert events.count() == 6
 
+        purge_before = dt_util.utcnow() - timedelta(days=4)
+
         # run purge_old_data()
-        finished = purge_old_data(instance, 4, repack=False)
+        finished = purge_old_data(instance, purge_before, repack=False)
         assert not finished
         assert events.count() == 2
 
         # we should only have 2 events left
-        finished = purge_old_data(instance, 4, repack=False)
+        finished = purge_old_data(instance, purge_before, repack=False)
         assert finished
         assert events.count() == 2
 
@@ -186,11 +190,13 @@ async def test_purge_old_recorder_runs(
         recorder_runs = session.query(RecorderRuns)
         assert recorder_runs.count() == 7
 
+        purge_before = dt_util.utcnow()
+
         # run purge_old_data()
-        finished = purge_old_data(instance, 0, repack=False)
+        finished = purge_old_data(instance, purge_before, repack=False)
         assert not finished
 
-        finished = purge_old_data(instance, 0, repack=False)
+        finished = purge_old_data(instance, purge_before, repack=False)
         assert finished
         assert recorder_runs.count() == 1
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The recorder `purge` service call operates in a series of 1,000 record batches until all of the old records have been deleted. At the start of each purge batch, the cut-off date is re-calculated based on current time - `keep_days`. As a consequence, the purge cut-off date can "drift" forward by an amount equal to the previous iteration's duration. This can have the undesired effect of deleting records that are less than `keep_days` old relative to the time of the service call. In extreme cases, it could result in a never-ending purge if there are recorded states and events more frequent than the purge iteration time. This PR looks to keep constant - rather than re-calculate - the cut-off time across each iteration.

I think this partially addresses #51689 but from the commentary and logs it looks like there are other problems as the purge batches are taking around 9 seconds to complete. This could be down to the volume of records being filtered (e.g. the `keep_days` period is 64) or something peculiar to the postgres implementation.

@bdraco , @cdce8p , appreciate any thoughts/insight on this one. Unfortunately, I don't have any experience with postgres to know if the iteration times are as expected or could be optimised.

@deepcoder, appreciate if you are able to try this out in your environment to see if it helps and/or identify if any other factors are at play.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #51689
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [X] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
