### PR TITLE
Abort samsungtv config flow for existing hosts when the unique id is set

### DIFF
--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -20,6 +20,7 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_TOKEN,
 )
+from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.typing import DiscoveryInfoType
 
@@ -48,6 +49,10 @@ SUPPORTED_METHODS = [METHOD_LEGACY, METHOD_WEBSOCKET]
 
 def _strip_uuid(udn):
     return udn[5:] if udn.startswith("uuid:") else udn
+
+
+def _entry_is_complete(entry):
+    return bool(entry.unique_id and entry.data.get(CONF_MAC))
 
 
 class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -92,18 +97,23 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not await self._async_get_and_check_device_info():
             raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
         await self._async_set_unique_id_from_udn(raise_on_progress)
+        self._async_update_and_abort_for_matching_unique_id()
 
     async def _async_set_unique_id_from_udn(self, raise_on_progress=True):
         """Set the unique id from the udn."""
         assert self._host is not None
         await self.async_set_unique_id(self._udn, raise_on_progress=raise_on_progress)
-        existing_entry = await self._async_update_existing_host_entry(self._host)
+        if (entry := self._async_update_existing_host_entry()) and _entry_is_complete(
+            entry
+        ):
+            raise data_entry_flow.AbortFlow("already_configured")
+
+    def _async_update_and_abort_for_matching_unique_id(self):
+        """Abort and update host and mac if we have it."""
         updates = {CONF_HOST: self._host}
         if self._mac:
             updates[CONF_MAC] = self._mac
         self._abort_if_unique_id_configured(updates=updates)
-        if existing_entry:
-            raise data_entry_flow.AbortFlow("already_configured")
 
     def _try_connect(self):
         """Try to connect and check auth."""
@@ -178,39 +188,50 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
-    async def _async_update_existing_host_entry(self, host):
+    @callback
+    def _async_update_existing_host_entry(self):
+        """Check existing entries and update them.
+
+        Returns the existing entry if it was updated.
+        """
         for entry in self._async_current_entries(include_ignore=False):
-            if entry.data[CONF_HOST] != host:
+            if entry.data[CONF_HOST] != self._host:
                 continue
             entry_kw_args = {}
             if self.unique_id and entry.unique_id is None:
                 entry_kw_args["unique_id"] = self.unique_id
             if self._mac and not entry.data.get(CONF_MAC):
-                data_copy = dict(entry.data)
-                data_copy[CONF_MAC] = self._mac
-                entry_kw_args["data"] = data_copy
+                entry_kw_args["data"] = {**entry.data, CONF_MAC: self._mac}
             if entry_kw_args:
                 self.hass.config_entries.async_update_entry(entry, **entry_kw_args)
                 self.hass.async_create_task(
                     self.hass.config_entries.async_reload(entry.entry_id)
                 )
-            return entry
+                return entry
         return None
 
-    async def _async_start_discovery(self):
+    async def _async_start_discovery_with_mac_address(self):
         """Start discovery."""
         assert self._host is not None
-        if entry := await self._async_update_existing_host_entry(self._host):
-            if entry.unique_id:
-                # Let the flow continue to fill the missing
-                # unique id as we may be able to obtain it
-                # in the next step
-                raise data_entry_flow.AbortFlow("already_configured")
+        if (entry := self._async_update_existing_host_entry()) and entry.unique_id:
+            # If we have the unique id and the mac we abort
+            # as we do not need anything else
+            raise data_entry_flow.AbortFlow("already_configured")
+        self._async_abort_if_host_already_in_progress()
 
+    @callback
+    def _async_abort_if_host_already_in_progress(self):
         self.context[CONF_HOST] = self._host
         for progress in self._async_in_progress():
             if progress.get("context", {}).get(CONF_HOST) == self._host:
                 raise data_entry_flow.AbortFlow("already_in_progress")
+
+    @callback
+    def _abort_if_manufacturer_is_not_samsung(self):
+        if not self._manufacturer or not self._manufacturer.lower().startswith(
+            "samsung"
+        ):
+            raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
 
     async def async_step_ssdp(self, discovery_info: DiscoveryInfoType):
         """Handle a flow initialized by ssdp discovery."""
@@ -219,16 +240,14 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._udn = _strip_uuid(discovery_info[ATTR_UPNP_UDN])
         self._host = urlparse(discovery_info[ATTR_SSDP_LOCATION]).hostname
         await self._async_set_unique_id_from_udn()
-        await self._async_start_discovery()
         self._manufacturer = discovery_info[ATTR_UPNP_MANUFACTURER]
-        if not self._manufacturer or not self._manufacturer.lower().startswith(
-            "samsung"
-        ):
-            raise data_entry_flow.AbortFlow(RESULT_NOT_SUPPORTED)
+        self._abort_if_manufacturer_is_not_samsung()
         if not await self._async_get_and_check_device_info():
             # If we cannot get device info for an SSDP discovery
             # its likely a legacy tv.
             self._name = self._title = self._model = model_name
+        self._async_update_and_abort_for_matching_unique_id()
+        self._async_abort_if_host_already_in_progress()
         self.context["title_placeholders"] = {"device": self._title}
         return await self.async_step_confirm()
 
@@ -237,7 +256,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         LOGGER.debug("Samsung device found via DHCP: %s", discovery_info)
         self._mac = discovery_info[MAC_ADDRESS]
         self._host = discovery_info[IP_ADDRESS]
-        await self._async_start_discovery()
+        await self._async_start_discovery_with_mac_address()
         await self._async_set_device_unique_id()
         self.context["title_placeholders"] = {"device": self._title}
         return await self.async_step_confirm()
@@ -247,7 +266,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         LOGGER.debug("Samsung device found via ZEROCONF: %s", discovery_info)
         self._mac = format_mac(discovery_info[ATTR_PROPERTIES]["deviceid"])
         self._host = discovery_info[CONF_HOST]
-        await self._async_start_discovery()
+        await self._async_start_discovery_with_mac_address()
         await self._async_set_device_unique_id()
         self.context["title_placeholders"] = {"device": self._title}
         return await self.async_step_confirm()

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -191,7 +191,9 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 entry_kw_args["data"] = data_copy
             if entry_kw_args:
                 self.hass.config_entries.async_update_entry(entry, **entry_kw_args)
-                await self.hass.config_entries.async_reload(entry.entry_id)
+                self.hass.async_create_task(
+                    self.hass.config_entries.async_reload(entry.entry_id)
+                )
             return entry
         return None
 

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -52,6 +52,7 @@ def _strip_uuid(udn):
 
 
 def _entry_is_complete(entry):
+    """Return True if the config entry information is complete."""
     return bool(entry.unique_id and entry.data.get(CONF_MAC))
 
 

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -20,7 +20,6 @@ from homeassistant.const import (
     CONF_PORT,
     CONF_TOKEN,
 )
-from homeassistant.core import callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.typing import DiscoveryInfoType
 
@@ -98,7 +97,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Set the unique id from the udn."""
         assert self._host is not None
         await self.async_set_unique_id(self._udn, raise_on_progress=raise_on_progress)
-        existing_entry = self._async_update_existing_host_entry(self._host)
+        existing_entry = await self._async_update_existing_host_entry(self._host)
         updates = {CONF_HOST: self._host}
         if self._mac:
             updates[CONF_MAC] = self._mac
@@ -179,8 +178,7 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(step_id="user", data_schema=DATA_SCHEMA)
 
-    @callback
-    def _async_update_existing_host_entry(self, host):
+    async def _async_update_existing_host_entry(self, host):
         for entry in self._async_current_entries(include_ignore=False):
             if entry.data[CONF_HOST] != host:
                 continue
@@ -193,13 +191,14 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 entry_kw_args["data"] = data_copy
             if entry_kw_args:
                 self.hass.config_entries.async_update_entry(entry, **entry_kw_args)
+                await self.hass.config_entries.async_reload(entry.entry_id)
             return entry
         return None
 
     async def _async_start_discovery(self):
         """Start discovery."""
         assert self._host is not None
-        if entry := self._async_update_existing_host_entry(self._host):
+        if entry := await self._async_update_existing_host_entry(self._host):
             if entry.unique_id:
                 # Let the flow continue to fill the missing
                 # unique id as we may be able to obtain it

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -98,11 +98,13 @@ class SamsungTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """Set the unique id from the udn."""
         assert self._host is not None
         await self.async_set_unique_id(self._udn, raise_on_progress=raise_on_progress)
-        self._async_update_existing_host_entry(self._host)
+        existing_entry = self._async_update_existing_host_entry(self._host)
         updates = {CONF_HOST: self._host}
         if self._mac:
             updates[CONF_MAC] = self._mac
         self._abort_if_unique_id_configured(updates=updates)
+        if existing_entry:
+            raise data_entry_flow.AbortFlow("already_configured")
 
     def _try_connect(self):
         """Try to connect and check auth."""

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -894,12 +894,22 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_DHCP},
-        data=MOCK_DHCP_DATA,
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.samsungtv.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.samsungtv.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_DHCP},
+            data=MOCK_DHCP_DATA,
+        )
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
+
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
@@ -910,12 +920,21 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: 
     """Test missing mac and unique id added."""
     entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
     entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_ZEROCONF},
-        data=MOCK_ZEROCONF_DATA,
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.samsungtv.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.samsungtv.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=MOCK_ZEROCONF_DATA,
+        )
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
@@ -932,12 +951,21 @@ async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(
         unique_id="0d1cef00-00dc-1000-9c80-4844f7b172de",
     )
     entry.add_to_hass(hass)
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_ZEROCONF},
-        data=MOCK_ZEROCONF_DATA,
-    )
-    await hass.async_block_till_done()
+    with patch(
+        "homeassistant.components.samsungtv.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.samsungtv.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data=MOCK_ZEROCONF_DATA,
+        )
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -907,9 +907,6 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock
             data=MOCK_DHCP_DATA,
         )
         await hass.async_block_till_done()
-        import pprint
-
-        pprint.pprint(result)
         assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/components/samsungtv/test_config_flow.py
+++ b/tests/components/samsungtv/test_config_flow.py
@@ -907,6 +907,9 @@ async def test_update_missing_mac_unique_id_added_from_dhcp(hass, remotews: Mock
             data=MOCK_DHCP_DATA,
         )
         await hass.async_block_till_done()
+        import pprint
+
+        pprint.pprint(result)
         assert len(mock_setup.mock_calls) == 1
         assert len(mock_setup_entry.mock_calls) == 1
 
@@ -939,6 +942,32 @@ async def test_update_missing_mac_unique_id_added_from_zeroconf(hass, remotews: 
     assert result["reason"] == "already_configured"
     assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
     assert entry.unique_id == "be9554b9-c9fb-41f4-8920-22da015376a4"
+
+
+async def test_update_missing_mac_unique_id_added_from_ssdp(hass, remotews: Mock):
+    """Test missing mac and unique id added via ssdp."""
+    entry = MockConfigEntry(domain=DOMAIN, data=MOCK_OLD_ENTRY, unique_id=None)
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.samsungtv.async_setup",
+        return_value=True,
+    ) as mock_setup, patch(
+        "homeassistant.components.samsungtv.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_SSDP},
+            data=MOCK_SSDP_DATA,
+        )
+        await hass.async_block_till_done()
+        assert len(mock_setup.mock_calls) == 1
+        assert len(mock_setup_entry.mock_calls) == 1
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_MAC] == "aa:bb:cc:dd:ee:ff"
+    assert entry.unique_id == "0d1cef00-00dc-1000-9c80-4844f7b172de"
 
 
 async def test_update_missing_mac_added_unique_id_preserved_from_zeroconf(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
If there was an existing host we wouldn't abort if it was discovered via SSDP after we set the missing unique id

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
