### PR TITLE
Remove YAML configuration import from Sony Bravia TV

### DIFF
--- a/homeassistant/components/braviatv/config_flow.py
+++ b/homeassistant/components/braviatv/config_flow.py
@@ -1,6 +1,5 @@
 """Adds config flow for Bravia TV integration."""
 import ipaddress
-import logging
 import re
 
 from bravia_tv import BraviaRC
@@ -21,8 +20,6 @@ from .const import (
     DOMAIN,
     NICKNAME,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 
 def host_valid(host):
@@ -74,27 +71,6 @@ class BraviaTVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     def async_get_options_flow(config_entry):
         """Bravia TV options callback."""
         return BraviaTVOptionsFlowHandler(config_entry)
-
-    async def async_step_import(self, user_input=None):
-        """Handle configuration by yaml file."""
-        self.host = user_input[CONF_HOST]
-        self.braviarc = BraviaRC(self.host)
-
-        try:
-            await self.init_device(user_input[CONF_PIN])
-        except CannotConnect:
-            _LOGGER.error("Import aborted, cannot connect to %s", self.host)
-            return self.async_abort(reason="cannot_connect")
-        except NoIPControl:
-            _LOGGER.error("IP Control is disabled in the TV settings")
-            return self.async_abort(reason="no_ip_control")
-        except ModelNotSupported:
-            _LOGGER.error("Import aborted, your TV is not supported")
-            return self.async_abort(reason="unsupported_model")
-
-        user_input[CONF_MAC] = self.mac
-
-        return self.async_create_entry(title=self.title, data=user_input)
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""

--- a/homeassistant/components/braviatv/media_player.py
+++ b/homeassistant/components/braviatv/media_player.py
@@ -1,13 +1,5 @@
 """Support for interface with a Bravia TV."""
-import logging
-
-import voluptuous as vol
-
-from homeassistant.components.media_player import (
-    DEVICE_CLASS_TV,
-    PLATFORM_SCHEMA,
-    MediaPlayerEntity,
-)
+from homeassistant.components.media_player import DEVICE_CLASS_TV, MediaPlayerEntity
 from homeassistant.components.media_player.const import (
     SUPPORT_NEXT_TRACK,
     SUPPORT_PAUSE,
@@ -21,22 +13,10 @@ from homeassistant.components.media_player.const import (
     SUPPORT_VOLUME_SET,
     SUPPORT_VOLUME_STEP,
 )
-from homeassistant.config_entries import SOURCE_IMPORT
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_NAME,
-    CONF_PIN,
-    STATE_OFF,
-    STATE_PAUSED,
-    STATE_PLAYING,
-)
-import homeassistant.helpers.config_validation as cv
+from homeassistant.const import STATE_OFF, STATE_PAUSED, STATE_PLAYING
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.json import load_json
 
-from .const import ATTR_MANUFACTURER, BRAVIA_CONFIG_FILE, DEFAULT_NAME, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .const import ATTR_MANUFACTURER, DEFAULT_NAME, DOMAIN
 
 SUPPORT_BRAVIA = (
     SUPPORT_PAUSE
@@ -51,43 +31,6 @@ SUPPORT_BRAVIA = (
     | SUPPORT_PLAY
     | SUPPORT_STOP
 )
-
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
-    {
-        vol.Required(CONF_HOST): cv.string,
-        vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    }
-)
-
-
-async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
-    """Set up the Bravia TV platform."""
-    host = config[CONF_HOST]
-
-    bravia_config_file_path = hass.config.path(BRAVIA_CONFIG_FILE)
-    bravia_config = await hass.async_add_executor_job(
-        load_json, bravia_config_file_path
-    )
-    if not bravia_config:
-        _LOGGER.error(
-            "Configuration import failed, there is no bravia.conf file in the configuration folder"
-        )
-        return
-
-    while bravia_config:
-        # Import a configured TV
-        host_ip, host_config = bravia_config.popitem()
-        if host_ip == host:
-            pin = host_config[CONF_PIN]
-
-            hass.async_create_task(
-                hass.config_entries.flow.async_init(
-                    DOMAIN,
-                    context={"source": SOURCE_IMPORT},
-                    data={CONF_HOST: host, CONF_PIN: pin},
-                )
-            )
-            return
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):

--- a/tests/components/braviatv/test_config_flow.py
+++ b/tests/components/braviatv/test_config_flow.py
@@ -5,7 +5,7 @@ from bravia_tv.braviarc import NoIPControl
 
 from homeassistant import data_entry_flow
 from homeassistant.components.braviatv.const import CONF_IGNORED_SOURCES, DOMAIN
-from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PIN
 
 from tests.common import MockConfigEntry
@@ -31,9 +31,6 @@ BRAVIA_SOURCE_LIST = {
     "AV/Component": "extInput:component?port=1",
 }
 
-IMPORT_CONFIG_HOSTNAME = {CONF_HOST: "bravia-host", CONF_PIN: "1234"}
-IMPORT_CONFIG_IP = {CONF_HOST: "10.10.10.12", CONF_PIN: "1234"}
-
 
 async def test_show_form(hass):
     """Test that the form is served with no input."""
@@ -43,92 +40,6 @@ async def test_show_form(hass):
 
     assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
     assert result["step_id"] == SOURCE_USER
-
-
-async def test_import(hass):
-    """Test that the import works."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch(
-        "bravia_tv.BraviaRC.get_system_info", return_value=BRAVIA_SYSTEM_INFO
-    ), patch(
-        "homeassistant.components.braviatv.async_setup_entry", return_value=True
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=IMPORT_CONFIG_HOSTNAME
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["result"].unique_id == "very_unique_string"
-        assert result["title"] == "TV-Model"
-        assert result["data"] == {
-            CONF_HOST: "bravia-host",
-            CONF_PIN: "1234",
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
-        }
-
-
-async def test_import_cannot_connect(hass):
-    """Test that errors are shown when cannot connect to the host during import."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=False
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=IMPORT_CONFIG_HOSTNAME
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "cannot_connect"
-
-
-async def test_import_model_unsupported(hass):
-    """Test that errors are shown when the TV is not supported during import."""
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_system_info", return_value={}):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=IMPORT_CONFIG_IP
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "unsupported_model"
-
-
-async def test_import_no_ip_control(hass):
-    """Test that errors are shown when IP Control is disabled on the TV during import."""
-    with patch("bravia_tv.BraviaRC.connect", side_effect=NoIPControl("No IP Control")):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=IMPORT_CONFIG_IP
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "no_ip_control"
-
-
-async def test_import_duplicate_error(hass):
-    """Test that errors are shown when duplicates are added during import."""
-    config_entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="very_unique_string",
-        data={
-            CONF_HOST: "bravia-host",
-            CONF_PIN: "1234",
-            CONF_MAC: "AA:BB:CC:DD:EE:FF",
-        },
-        title="TV-Model",
-    )
-    config_entry.add_to_hass(hass)
-
-    with patch("bravia_tv.BraviaRC.connect", return_value=True), patch(
-        "bravia_tv.BraviaRC.is_connected", return_value=True
-    ), patch("bravia_tv.BraviaRC.get_system_info", return_value=BRAVIA_SYSTEM_INFO):
-
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": SOURCE_IMPORT}, data=IMPORT_CONFIG_HOSTNAME
-        )
-
-        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
-        assert result["reason"] == "already_configured"
 
 
 async def test_user_invalid_host(hass):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
From April 2020, the integration allows only the import of existing YAML configurations. New YAML configurations were not possible.
Your configuration has been imported to the UI in the previous releases and can now safely be removed from your YAML configuration files.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR removes YAML configuration import for the Sony Bravia TV integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18281

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
