### PR TITLE
DSMR: Remove Gas derivative sensor

### DIFF
--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -15,12 +15,7 @@ import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA, SensorEntity
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    EVENT_HOMEASSISTANT_STOP,
-    TIME_HOURS,
-)
+from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import Throttle
@@ -172,7 +167,7 @@ async def async_setup_entry(
         else:
             gas_obis = obis_ref.GAS_METER_READING
 
-        # Add gas meter reading and derivative for usage
+        # Add gas meter reading
         devices += [
             DSMREntity(
                 "Gas Consumption",
@@ -181,15 +176,7 @@ async def async_setup_entry(
                 gas_obis,
                 config,
                 True,
-            ),
-            DerivativeDSMREntity(
-                "Hourly Gas Consumption",
-                DEVICE_NAME_GAS,
-                config[CONF_SERIAL_ID_GAS],
-                gas_obis,
-                config,
-                False,
-            ),
+            )
         ]
 
     async_add_entities(devices)
@@ -374,66 +361,3 @@ class DSMREntity(SensorEntity):
             return "low"
 
         return None
-
-
-class DerivativeDSMREntity(DSMREntity):
-    """Calculated derivative for values where the DSMR doesn't offer one.
-
-    Gas readings are only reported per hour and don't offer a rate only
-    the current meter reading. This entity converts subsequents readings
-    into a hourly rate.
-    """
-
-    _previous_reading = None
-    _previous_timestamp = None
-    _state = None
-
-    @property
-    def state(self):
-        """Return the calculated current hourly rate."""
-        return self._state
-
-    @property
-    def force_update(self):
-        """Disable force update."""
-        return False
-
-    @property
-    def should_poll(self):
-        """Enable polling."""
-        return True
-
-    async def async_update(self):
-        """Recalculate hourly rate if timestamp has changed.
-
-        DSMR updates gas meter reading every hour. Along with the new
-        value a timestamp is provided for the reading. Test if the last
-        known timestamp differs from the current one then calculate a
-        new rate for the previous hour.
-
-        """
-        # check if the timestamp for the object differs from the previous one
-        timestamp = self.get_dsmr_object_attr("datetime")
-        if timestamp and timestamp != self._previous_timestamp:
-            current_reading = self.get_dsmr_object_attr("value")
-
-            if self._previous_reading is None:
-                # Can't calculate rate without previous datapoint
-                # just store current point
-                pass
-            else:
-                # Recalculate the rate
-                diff = current_reading - self._previous_reading
-                timediff = timestamp - self._previous_timestamp
-                total_seconds = timediff.total_seconds()
-                self._state = round(float(diff) / total_seconds * 3600, 3)
-
-            self._previous_reading = current_reading
-            self._previous_timestamp = timestamp
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, per hour, if any."""
-        unit = self.get_dsmr_object_attr("unit")
-        if unit:
-            return f"{unit}/{TIME_HOURS}"

--- a/tests/components/dsmr/test_sensor.py
+++ b/tests/components/dsmr/test_sensor.py
@@ -13,13 +13,8 @@ from unittest.mock import DEFAULT, MagicMock
 
 from homeassistant import config_entries
 from homeassistant.components.dsmr.const import DOMAIN
-from homeassistant.components.dsmr.sensor import DerivativeDSMREntity
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.const import (
-    ENERGY_KILO_WATT_HOUR,
-    VOLUME_CUBIC_METERS,
-    VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR,
-)
+from homeassistant.const import ENERGY_KILO_WATT_HOUR, VOLUME_CUBIC_METERS
 from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
@@ -177,46 +172,6 @@ async def test_setup_only_energy(hass, dsmr_connection_fixture):
 
     entry = registry.async_get("sensor.gas_consumption")
     assert not entry
-
-
-async def test_derivative():
-    """Test calculation of derivative value."""
-    from dsmr_parser.objects import MBusObject
-
-    config = {"platform": "dsmr"}
-
-    entity = DerivativeDSMREntity("test", "test_device", "5678", "1.0.0", config, False)
-    await entity.async_update()
-
-    assert entity.state is None, "initial state not unknown"
-
-    entity.telegram = {
-        "1.0.0": MBusObject(
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642213)},
-                {"value": Decimal(745.695), "unit": VOLUME_CUBIC_METERS},
-            ]
-        )
-    }
-    await entity.async_update()
-
-    assert entity.state is None, "state after first update should still be unknown"
-
-    entity.telegram = {
-        "1.0.0": MBusObject(
-            [
-                {"value": datetime.datetime.fromtimestamp(1551642543)},
-                {"value": Decimal(745.698), "unit": VOLUME_CUBIC_METERS},
-            ]
-        )
-    }
-    await entity.async_update()
-
-    assert (
-        abs(entity.state - 0.033) < 0.00001
-    ), "state should be hourly usage calculated from first and second update"
-
-    assert entity.unit_of_measurement == VOLUME_FLOW_RATE_CUBIC_METERS_PER_HOUR
 
 
 async def test_v4_meter(hass, dsmr_connection_fixture):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The Hourly Gas Consumption sensor has been removed from the DSMR integration.
This sensor was calculated and it is not an actual datapoint from the energy meter.

If you are looking for a replacement, you can use the [Derivative integration](https://www.home-assistant.io/integrations/derivative/) to re-create the hourly (or any other timeframe)
sensor based on the total Gas consumption sensor.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR removes the hourly gas consumption sensor from the DSMR integration, as it was a calculated/virtual sensor that doesn't originate from the device/service the integration is connected to.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
