### PR TITLE
Add preset support to WLED

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -5,7 +5,6 @@ from functools import partial
 from typing import Any, Tuple, cast
 
 import voluptuous as vol
-from wled import Preset
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -218,18 +217,11 @@ class WLEDSegmentLight(WLEDEntity, LightEntity):
         if playlist == -1:
             playlist = None
 
-        preset: int | None = None
-        if isinstance(self.coordinator.data.state.preset, Preset):
-            preset = self.coordinator.data.state.preset.preset_id
-        elif self.coordinator.data.state.preset != -1:
-            preset = self.coordinator.data.state.preset
-
         segment = self.coordinator.data.state.segments[self._segment]
         return {
             ATTR_INTENSITY: segment.intensity,
             ATTR_PALETTE: segment.palette.name,
             ATTR_PLAYLIST: playlist,
-            ATTR_PRESET: preset,
             ATTR_REVERSE: segment.reverse,
             ATTR_SPEED: segment.speed,
         }

--- a/tests/fixtures/wled/rgbw.json
+++ b/tests/fixtures/wled/rgbw.json
@@ -3,7 +3,7 @@
     "on": true,
     "bri": 140,
     "transition": 7,
-    "ps": -1,
+    "ps": 1,
     "pl": -1,
     "nl": {
       "on": false,
@@ -200,5 +200,158 @@
     "Orangery",
     "C9",
     "Sakura"
-  ]
+  ],
+  "presets": {
+    "0": {},
+    "1": {
+      "on": false,
+      "bri": 255,
+      "transition": 7,
+      "mainseg": 0,
+      "seg": [
+        {
+          "id": 0,
+          "start": 0,
+          "stop": 13,
+          "grp": 1,
+          "spc": 0,
+          "on": true,
+          "bri": 255,
+          "col": [
+            [
+              97,
+              144,
+              255
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ],
+          "fx": 9,
+          "sx": 183,
+          "ix": 255,
+          "pal": 1,
+          "sel": true,
+          "rev": false,
+          "mi": false
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        }
+      ],
+      "n": "Preset 1"
+    },
+    "2": {
+      "on": false,
+      "bri": 255,
+      "transition": 7,
+      "mainseg": 0,
+      "seg": [
+        {
+          "id": 0,
+          "start": 0,
+          "stop": 13,
+          "grp": 1,
+          "spc": 0,
+          "on": true,
+          "bri": 255,
+          "col": [
+            [
+              97,
+              144,
+              255
+            ],
+            [
+              0,
+              0,
+              0
+            ],
+            [
+              0,
+              0,
+              0
+            ]
+          ],
+          "fx": 9,
+          "sx": 183,
+          "ix": 255,
+          "pal": 1,
+          "sel": true,
+          "rev": false,
+          "mi": false
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        },
+        {
+          "stop": 0
+        }
+      ],
+      "n": "Preset 2"
+    }
+  }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The `preset` attribute of WLED light entities has been removed.
Presets are not properties of a single light segment, but part of the whole device.

A new select entity is available providing the current state of the selected preset in WLED, but above all, this new entity also provides control of selecting presets from within Home Assistant.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add support to WLED for selecting presets from WLED (using the new Select entity).


![image](https://user-images.githubusercontent.com/195327/123328577-0b57f580-d53c-11eb-9e2e-9416249fd1ea.png)

Additionally, this PR restored the test coverage to 100% (was previously lost, as an intermediate step).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18296

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
