### PR TITLE
Simplify WLED segment tracking

### DIFF
--- a/homeassistant/components/wled/light.py
+++ b/homeassistant/components/wled/light.py
@@ -370,16 +370,16 @@ def async_update_segments(
     segment_ids = {light.segment_id for light in coordinator.data.state.segments}
     new_entities: list[WLEDMasterLight | WLEDSegmentLight] = []
 
+    # More than 1 segment now? No master? Add master controls
+    if not coordinator.keep_master_light and (
+        len(current_ids) < 2 and len(segment_ids) > 1
+    ):
+        new_entities.append(WLEDMasterLight(coordinator))
+
     # Process new segments, add them to Home Assistant
     for segment_id in segment_ids - current_ids:
         current_ids.add(segment_id)
         new_entities.append(WLEDSegmentLight(coordinator, segment_id))
-
-    # More than 1 segment now? No master? Add master controls
-    if not coordinator.keep_master_light and (
-        len(current_ids) > 1 and len(segment_ids) > 1
-    ):
-        new_entities.append(WLEDMasterLight(coordinator))
 
     if new_entities:
         async_add_entities(new_entities)

--- a/homeassistant/components/wled/select.py
+++ b/homeassistant/components/wled/select.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     update_segments = partial(
         async_update_segments,
         coordinator,
-        {},
+        set(),
         async_add_entities,
     )
     coordinator.async_add_listener(update_segments)
@@ -118,19 +118,18 @@ class WLEDPaletteSelect(WLEDEntity, SelectEntity):
 @callback
 def async_update_segments(
     coordinator: WLEDDataUpdateCoordinator,
-    current: dict[int, WLEDPaletteSelect],
+    current_ids: set[int],
     async_add_entities,
 ) -> None:
     """Update segments."""
     segment_ids = {segment.segment_id for segment in coordinator.data.state.segments}
-    current_ids = set(current)
 
     new_entities = []
 
     # Process new segments, add them to Home Assistant
     for segment_id in segment_ids - current_ids:
-        current[segment_id] = WLEDPaletteSelect(coordinator, segment_id)
-        new_entities.append(current[segment_id])
+        current_ids.add(segment_id)
+        new_entities.append(WLEDPaletteSelect(coordinator, segment_id))
 
     if new_entities:
         async_add_entities(new_entities)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

As pointed out by @MartinHjelmare in a recent review comment, WLED doesn't need to track its entity objects.

This was recently changed due to the way we now handle multiple segments, therefore keeping the object references is no longer needed.

This PR provides a small cleanup/refactoring for that.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [x] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
