### PR TITLE
Update Tile unique ID to include username

### DIFF
--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -44,7 +44,7 @@ async def async_setup_entry(hass, entry):
     for entity in [
         e
         for e in ent_reg.entities.values()
-        if e.platform == DOMAIN
+        if e.config_entry_id == entry.entry_id
         and not e.unique_id.startswith(entry.data[CONF_USERNAME])
     ]:
         new_unique_id = f"{entry.data[CONF_USERNAME]}_".join(

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, entry):
         e
         for e in ent_reg.entities.values()
         if e.platform == DOMAIN
-        and not e.unique_id.startswith(f"{DOMAIN}_{entry.data[CONF_USERNAME]}")
+        and not e.unique_id.startswith(f"{entry.data[CONF_USERNAME]}")
     ]:
         new_unique_id = f"{entry.data[CONF_USERNAME]}_".join(
             entity.unique_id.split(f"{DOMAIN}_")

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -37,7 +37,7 @@ async def async_setup_entry(hass, entry):
     # change:
     #
     # Old: tile_{uuid}
-    # New: tile_{username}_{uuid}
+    # New: {username}_{uuid}
     #
     # Find any entities with the old format and update them:
     ent_reg = entity_registry.async_get(hass)

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -47,9 +47,8 @@ async def async_setup_entry(hass, entry):
         if e.platform == DOMAIN
         and not e.unique_id.startswith(f"{DOMAIN}_{entry.data[CONF_USERNAME]}")
     ]:
-        split = f"{DOMAIN}_"
-        new_unique_id = (split + f"{entry.data[CONF_USERNAME]}_").join(
-            entity.unique_id.split(split)
+        new_unique_id = f"{entry.data[CONF_USERNAME]}_".join(
+            entity.unique_id.split(f"{DOMAIN}_")
         )
         LOGGER.debug(
             "Migrating entity %s from old unique ID '%s' to new unique ID '%s'",

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -45,7 +45,7 @@ async def async_setup_entry(hass, entry):
         e
         for e in ent_reg.entities.values()
         if e.platform == DOMAIN
-        and not e.unique_id.startswith(f"{entry.data[CONF_USERNAME]}")
+        and not e.unique_id.startswith(entry.data[CONF_USERNAME])
     ]:
         new_unique_id = f"{entry.data[CONF_USERNAME]}_".join(
             entity.unique_id.split(f"{DOMAIN}_")

--- a/homeassistant/components/tile/__init__.py
+++ b/homeassistant/components/tile/__init__.py
@@ -7,7 +7,7 @@ from pytile.errors import InvalidAuthError, SessionExpiredError, TileError
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers import aiohttp_client, entity_registry
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.async_ import gather_with_concurrency
 
@@ -32,6 +32,32 @@ async def async_setup_entry(hass, entry):
     """Set up Tile as config entry."""
     hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id] = {}
     hass.data[DOMAIN][DATA_TILE][entry.entry_id] = {}
+
+    # The existence of shared Tiles across multiple accounts requires an entity ID
+    # change:
+    #
+    # Old: tile_{uuid}
+    # New: tile_{username}_{uuid}
+    #
+    # Find any entities with the old format and update them:
+    ent_reg = entity_registry.async_get(hass)
+    for entity in [
+        e
+        for e in ent_reg.entities.values()
+        if e.platform == DOMAIN
+        and not e.unique_id.startswith(f"{DOMAIN}_{entry.data[CONF_USERNAME]}")
+    ]:
+        split = f"{DOMAIN}_"
+        new_unique_id = (split + f"{entry.data[CONF_USERNAME]}_").join(
+            entity.unique_id.split(split)
+        )
+        LOGGER.debug(
+            "Migrating entity %s from old unique ID '%s' to new unique ID '%s'",
+            entity.entity_id,
+            entity.unique_id,
+            new_unique_id,
+        )
+        ent_reg.async_update_entity(entity.entity_id, new_unique_id=new_unique_id)
 
     websession = aiohttp_client.async_get_clientsession(hass)
 

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -114,12 +114,12 @@ class TileDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def name(self):
         """Return the name."""
-        return f"{self._entry.data[CONF_USERNAME]}: {self._tile.name}"
+        return self._tile.name
 
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return f"tile_{self._entry.data[CONF_USERNAME]}_{self._tile.uuid}"
+        return f"{DOMAIN}_{self._entry.data[CONF_USERNAME]}_{self._tile.uuid}"
 
     @property
     def source_type(self):

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -119,7 +119,7 @@ class TileDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return f"{DOMAIN}_{self._entry.data[CONF_USERNAME]}_{self._tile.uuid}"
+        return f"{self._entry.data[CONF_USERNAME]}_{self._tile.uuid}"
 
     @property
     def source_type(self):

--- a/homeassistant/components/tile/device_tracker.py
+++ b/homeassistant/components/tile/device_tracker.py
@@ -30,7 +30,9 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities(
         [
             TileDeviceTracker(
-                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][tile_uuid], tile
+                entry,
+                hass.data[DOMAIN][DATA_COORDINATOR][entry.entry_id][tile_uuid],
+                tile,
             )
             for tile_uuid, tile in hass.data[DOMAIN][DATA_TILE][entry.entry_id].items()
         ]
@@ -61,10 +63,11 @@ async def async_setup_scanner(hass, config, async_see, discovery_info=None):
 class TileDeviceTracker(CoordinatorEntity, TrackerEntity):
     """Representation of a network infrastructure device."""
 
-    def __init__(self, coordinator, tile):
+    def __init__(self, entry, coordinator, tile):
         """Initialize."""
         super().__init__(coordinator)
         self._attrs = {ATTR_ATTRIBUTION: DEFAULT_ATTRIBUTION}
+        self._entry = entry
         self._tile = tile
 
     @property
@@ -111,12 +114,12 @@ class TileDeviceTracker(CoordinatorEntity, TrackerEntity):
     @property
     def name(self):
         """Return the name."""
-        return self._tile.name
+        return f"{self._entry.data[CONF_USERNAME]}: {self._tile.name}"
 
     @property
     def unique_id(self):
         """Return the unique ID of the entity."""
-        return f"tile_{self._tile.uuid}"
+        return f"tile_{self._entry.data[CONF_USERNAME]}_{self._tile.uuid}"
 
     @property
     def source_type(self):

--- a/homeassistant/components/tile/manifest.json
+++ b/homeassistant/components/tile/manifest.json
@@ -3,7 +3,7 @@
   "name": "Tile",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/tile",
-  "requirements": ["pytile==5.2.0"],
+  "requirements": ["pytile==5.2.2"],
   "codeowners": ["@bachya"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1911,7 +1911,7 @@ python_opendata_transport==0.2.1
 pythonegardia==1.0.40
 
 # homeassistant.components.tile
-pytile==5.2.0
+pytile==5.2.2
 
 # homeassistant.components.touchline
 pytouchline==0.7

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -1048,7 +1048,7 @@ python-velbus==2.1.2
 python_awair==0.2.1
 
 # homeassistant.components.tile
-pytile==5.2.0
+pytile==5.2.2
 
 # homeassistant.components.traccar
 pytraccar==0.9.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
It turns out that Tiles can be shared across accounts (e.g., two spouses might share a single Tile for a set of keys). Since the integration currently uses the Tile's UUID as the entity `unique_id`, attempting to add both Tile accounts will cause "duplicate entity" issues. This PR updates the `unique_id` to include the UUID _and_ the account username that it's associated with.

Note that this is _not_ a breaking change, as the entity IDs are remaining the same and the unique IDs are updated in the background upon startup.

https://github.com/bachya/pytile/compare/5.2.0...5.2.2

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/52064
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
