### PR TITLE
Add quantiles to Statistics integration

### DIFF
--- a/homeassistant/components/statistics/sensor.py
+++ b/homeassistant/components/statistics/sensor.py
@@ -39,6 +39,7 @@ ATTR_MEAN = "mean"
 ATTR_MEDIAN = "median"
 ATTR_MIN_AGE = "min_age"
 ATTR_MIN_VALUE = "min_value"
+ATTR_QUANTILES = "quantiles"
 ATTR_SAMPLING_SIZE = "sampling_size"
 ATTR_STANDARD_DEVIATION = "standard_deviation"
 ATTR_TOTAL = "total"
@@ -47,10 +48,14 @@ ATTR_VARIANCE = "variance"
 CONF_SAMPLING_SIZE = "sampling_size"
 CONF_MAX_AGE = "max_age"
 CONF_PRECISION = "precision"
+CONF_QUANTILE_INTERVALS = "quantile_intervals"
+CONF_QUANTILE_METHOD = "quantile_method"
 
 DEFAULT_NAME = "Stats"
 DEFAULT_SIZE = 20
 DEFAULT_PRECISION = 2
+DEFAULT_QUANTILE_INTERVALS = 4
+DEFAULT_QUANTILE_METHOD = "exclusive"
 ICON = "mdi:calculator"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -62,6 +67,12 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         ),
         vol.Optional(CONF_MAX_AGE): cv.time_period,
         vol.Optional(CONF_PRECISION, default=DEFAULT_PRECISION): vol.Coerce(int),
+        vol.Optional(
+            CONF_QUANTILE_INTERVALS, default=DEFAULT_QUANTILE_INTERVALS
+        ): vol.All(vol.Coerce(int), vol.Range(min=2)),
+        vol.Optional(CONF_QUANTILE_METHOD, default=DEFAULT_QUANTILE_METHOD): vol.In(
+            ["exclusive", "inclusive"]
+        ),
     }
 )
 
@@ -76,9 +87,22 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     sampling_size = config.get(CONF_SAMPLING_SIZE)
     max_age = config.get(CONF_MAX_AGE)
     precision = config.get(CONF_PRECISION)
+    quantile_intervals = config.get(CONF_QUANTILE_INTERVALS)
+    quantile_method = config.get(CONF_QUANTILE_METHOD)
 
     async_add_entities(
-        [StatisticsSensor(entity_id, name, sampling_size, max_age, precision)], True
+        [
+            StatisticsSensor(
+                entity_id,
+                name,
+                sampling_size,
+                max_age,
+                precision,
+                quantile_intervals,
+                quantile_method,
+            )
+        ],
+        True,
     )
 
     return True
@@ -87,7 +111,16 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
 class StatisticsSensor(SensorEntity):
     """Representation of a Statistics sensor."""
 
-    def __init__(self, entity_id, name, sampling_size, max_age, precision):
+    def __init__(
+        self,
+        entity_id,
+        name,
+        sampling_size,
+        max_age,
+        precision,
+        quantile_intervals,
+        quantile_method,
+    ):
         """Initialize the Statistics sensor."""
         self._entity_id = entity_id
         self.is_binary = self._entity_id.split(".")[0] == "binary_sensor"
@@ -95,12 +128,14 @@ class StatisticsSensor(SensorEntity):
         self._sampling_size = sampling_size
         self._max_age = max_age
         self._precision = precision
+        self._quantile_intervals = quantile_intervals
+        self._quantile_method = quantile_method
         self._unit_of_measurement = None
         self.states = deque(maxlen=self._sampling_size)
         self.ages = deque(maxlen=self._sampling_size)
 
         self.count = 0
-        self.mean = self.median = self.stdev = self.variance = None
+        self.mean = self.median = self.quantiles = self.stdev = self.variance = None
         self.total = self.min = self.max = None
         self.min_age = self.max_age = None
         self.change = self.average_change = self.change_rate = None
@@ -191,6 +226,7 @@ class StatisticsSensor(SensorEntity):
                 ATTR_COUNT: self.count,
                 ATTR_MEAN: self.mean,
                 ATTR_MEDIAN: self.median,
+                ATTR_QUANTILES: self.quantiles,
                 ATTR_STANDARD_DEVIATION: self.stdev,
                 ATTR_VARIANCE: self.variance,
                 ATTR_TOTAL: self.total,
@@ -257,9 +293,18 @@ class StatisticsSensor(SensorEntity):
             try:  # require at least two data points
                 self.stdev = round(statistics.stdev(self.states), self._precision)
                 self.variance = round(statistics.variance(self.states), self._precision)
+                if self._quantile_intervals < self.count:
+                    self.quantiles = [
+                        round(quantile, self._precision)
+                        for quantile in statistics.quantiles(
+                            self.states,
+                            n=self._quantile_intervals,
+                            method=self._quantile_method,
+                        )
+                    ]
             except statistics.StatisticsError as err:
                 _LOGGER.debug("%s: %s", self.entity_id, err)
-                self.stdev = self.variance = STATE_UNKNOWN
+                self.stdev = self.variance = self.quantiles = STATE_UNKNOWN
 
             if self.states:
                 self.total = round(sum(self.states), self._precision)

--- a/tests/components/statistics/test_sensor.py
+++ b/tests/components/statistics/test_sensor.py
@@ -48,6 +48,9 @@ class TestStatisticsSensor(unittest.TestCase):
         self.median = round(statistics.median(self.values), 2)
         self.deviation = round(statistics.stdev(self.values), 2)
         self.variance = round(statistics.variance(self.values), 2)
+        self.quantiles = [
+            round(quantile, 2) for quantile in statistics.quantiles(self.values)
+        ]
         self.change = round(self.values[-1] - self.values[0], 2)
         self.average_change = round(self.change / (len(self.values) - 1), 2)
         self.change_rate = round(self.change / (60 * (self.count - 1)), 2)
@@ -112,6 +115,7 @@ class TestStatisticsSensor(unittest.TestCase):
         assert self.variance == state.attributes.get("variance")
         assert self.median == state.attributes.get("median")
         assert self.deviation == state.attributes.get("standard_deviation")
+        assert self.quantiles == state.attributes.get("quantiles")
         assert self.mean == state.attributes.get("mean")
         assert self.count == state.attributes.get("count")
         assert self.total == state.attributes.get("total")
@@ -188,6 +192,7 @@ class TestStatisticsSensor(unittest.TestCase):
         # require at least two data points
         assert state.attributes.get("variance") == STATE_UNKNOWN
         assert state.attributes.get("standard_deviation") == STATE_UNKNOWN
+        assert state.attributes.get("quantiles") == STATE_UNKNOWN
 
     def test_max_age(self):
         """Test value deprecation."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add quantiles to the attributes of the Statistics integration.  Quantiles are returned as a `list` of size `n - 1`, in which `n` is the quantile intervals (`quantile_intervals`) computed via either exclusive or inclusive methods (`quantile_method`).  Both the quantile intervals and method can be changed in the configuration file.

Other noteworthy observations:
- Changes do not break existing configurations for the Statistics sensor. The default values are set for quartiles with exclusive method.

- The `statistics.quantiles()` function was added in Python 3.8 and can now be included in the Statistics integration without adding new dependencies, as the current distribution metrics also make use of the `statistics` module from the Python standard library.

- The PR is related to a comment made by @fabaff (https://github.com/home-assistant/core/issues/3513#issuecomment-249541775) about the possibility and usefulness of expanding the Statistics integration with new distribution metrics.  The possibility is provided by the Python standard library since 3.8.  Quantiles are useful because they give users the means for building new and more informative graphical representations of the distribution of states (e.g., using quartiles to generate [box plots](https://en.wikipedia.org/wiki/Box_plot)).

- Tests for the Statistics sensor (`tests/components/statistics/test_sensor.py`) were updated to include reference to quantiles.  However, new tests were not included.

- Merging this PR requires editing the docs for the [Statistics integration](https://www.home-assistant.io/integrations/statistics) to reference the new configuration variables--namely, `quantile_intervals:` and `quantile_method`. *Edited*: A PR to amend the Statistics doc has been made.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18314

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
