### PR TITLE
Support setting hvac_mode and temp in same homekit_controller set_temperature service call

### DIFF
--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -19,6 +19,7 @@ from homeassistant.components.climate import (
     ClimateEntity,
 )
 from homeassistant.components.climate.const import (
+    ATTR_HVAC_MODE,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     CURRENT_HVAC_COOL,
@@ -347,16 +348,27 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
 
     async def async_set_temperature(self, **kwargs):
         """Set new target temperature."""
+        chars = {}
+
+        value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
+        mode = MODE_HOMEKIT_TO_HASS.get(value)
+
+        if kwargs.get(ATTR_HVAC_MODE, mode) != mode:
+            mode = kwargs[ATTR_HVAC_MODE]
+            chars[CharacteristicsTypes.HEATING_COOLING_TARGET] = MODE_HASS_TO_HOMEKIT[
+                mode
+            ]
+
         temp = kwargs.get(ATTR_TEMPERATURE)
         heat_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         cool_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
-        value = self.service.value(CharacteristicsTypes.HEATING_COOLING_TARGET)
-        if (MODE_HOMEKIT_TO_HASS.get(value) in {HVAC_MODE_HEAT_COOL}) and (
+
+        if (mode in {HVAC_MODE_HEAT_COOL}) and (
             SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
         ):
             if temp is None:
                 temp = (cool_temp + heat_temp) / 2
-            await self.async_put_characteristics(
+            chars.update(
                 {
                     CharacteristicsTypes.TEMPERATURE_HEATING_THRESHOLD: heat_temp,
                     CharacteristicsTypes.TEMPERATURE_COOLING_THRESHOLD: cool_temp,
@@ -364,9 +376,9 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
                 }
             )
         else:
-            await self.async_put_characteristics(
-                {CharacteristicsTypes.TEMPERATURE_TARGET: temp}
-            )
+            chars.update({CharacteristicsTypes.TEMPERATURE_TARGET: temp})
+
+        await self.async_put_characteristics(chars)
 
     async def async_set_humidity(self, humidity):
         """Set new target humidity."""

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -376,7 +376,7 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
                 }
             )
         else:
-            chars.update({CharacteristicsTypes.TEMPERATURE_TARGET: temp})
+            chars[CharacteristicsTypes.TEMPERATURE_TARGET] = temp
 
         await self.async_put_characteristics(chars)
 

--- a/homeassistant/components/homekit_controller/climate.py
+++ b/homeassistant/components/homekit_controller/climate.py
@@ -363,7 +363,7 @@ class HomeKitClimateEntity(HomeKitEntity, ClimateEntity):
         heat_temp = kwargs.get(ATTR_TARGET_TEMP_LOW)
         cool_temp = kwargs.get(ATTR_TARGET_TEMP_HIGH)
 
-        if (mode in {HVAC_MODE_HEAT_COOL}) and (
+        if (mode == HVAC_MODE_HEAT_COOL) and (
             SUPPORT_TARGET_TEMPERATURE_RANGE & self.supported_features
         ):
             if temp is None:

--- a/tests/components/homekit_controller/test_climate.py
+++ b/tests/components/homekit_controller/test_climate.py
@@ -274,7 +274,6 @@ async def test_climate_cannot_set_thermostat_temp_range_in_wrong_mode(hass, utcn
         SERVICE_SET_TEMPERATURE,
         {
             "entity_id": "climate.testdevice",
-            "hvac_mode": HVAC_MODE_HEAT_COOL,
             "temperature": 22,
             "target_temp_low": 20,
             "target_temp_high": 24,
@@ -378,12 +377,42 @@ async def test_climate_set_thermostat_temp_on_sspa_device(hass, utcnow):
         SERVICE_SET_TEMPERATURE,
         {
             "entity_id": "climate.testdevice",
+            "temperature": 22,
+        },
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_TARGET].value == 22
+
+
+async def test_climate_set_mode_via_temp(hass, utcnow):
+    """Test setting temperature and mode at same tims."""
+    helper = await setup_test_component(hass, create_thermostat_single_set_point_auto)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            "entity_id": "climate.testdevice",
+            "temperature": 21,
+            "hvac_mode": HVAC_MODE_HEAT,
+        },
+        blocking=True,
+    )
+    assert helper.characteristics[TEMPERATURE_TARGET].value == 21
+    assert helper.characteristics[HEATING_COOLING_TARGET].value == 1
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            "entity_id": "climate.testdevice",
             "hvac_mode": HVAC_MODE_HEAT_COOL,
             "temperature": 22,
         },
         blocking=True,
     )
     assert helper.characteristics[TEMPERATURE_TARGET].value == 22
+    assert helper.characteristics[HEATING_COOLING_TARGET].value == 3
 
 
 async def test_climate_change_thermostat_humidity(hass, utcnow):


### PR DESCRIPTION
## Proposed change

Support setting hvac_mode and temp in same set_temperature service call.

This fixes https://github.com/home-assistant/core/issues/51208.

CC @Tediore


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/51208
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
