### PR TITLE
Add fixture in modbus to handle mock restore state

### DIFF
--- a/tests/components/modbus/conftest.py
+++ b/tests/components/modbus/conftest.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
 from homeassistant.setup import async_setup_component
 import homeassistant.util.dt as dt_util
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_time_changed, mock_restore_cache
 
 TEST_MODBUS_NAME = "modbusTest"
 _LOGGER = logging.getLogger(__name__)
@@ -59,6 +59,13 @@ async def mock_modbus(hass, do_config):
         assert await async_setup_component(hass, DOMAIN, config) is True
         await hass.async_block_till_done()
         yield mock_pb
+
+
+@pytest.fixture
+async def mock_test_state(hass, request):
+    """Mock restore cache."""
+    mock_restore_cache(hass, request.param)
+    return request.param
 
 
 # dataclass

--- a/tests/components/modbus/test_binary_sensor.py
+++ b/tests/components/modbus/test_binary_sensor.py
@@ -19,9 +19,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import State
 
-from .conftest import ReadResult, base_config_test, base_test, prepare_service_update
+from .conftest import ReadResult, base_test, prepare_service_update
 
-from tests.common import mock_restore_cache
+sensor_name = "test_binary_sensor"
+entity_id = f"{SENSOR_DOMAIN}.{sensor_name}"
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,7 @@ from tests.common import mock_restore_cache
         {
             CONF_BINARY_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                 }
             ]
@@ -38,7 +39,7 @@ from tests.common import mock_restore_cache
         {
             CONF_BINARY_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_SLAVE: 10,
                     CONF_INPUT_TYPE: CALL_TYPE_DISCRETE,
@@ -85,7 +86,6 @@ async def test_config_binary_sensor(hass, mock_modbus):
 )
 async def test_all_binary_sensor(hass, do_type, regs, expected):
     """Run test for given config."""
-    sensor_name = "modbus_test_binary_sensor"
     state = await base_test(
         hass,
         {CONF_NAME: sensor_name, CONF_ADDRESS: 1234, CONF_INPUT_TYPE: do_type},
@@ -104,11 +104,10 @@ async def test_all_binary_sensor(hass, do_type, regs, expected):
 async def test_service_binary_sensor_update(hass, mock_pymodbus):
     """Run test for service homeassistant.update_entity."""
 
-    entity_id = "binary_sensor.test"
     config = {
         CONF_BINARY_SENSORS: [
             {
-                CONF_NAME: "test",
+                CONF_NAME: sensor_name,
                 CONF_ADDRESS: 1234,
                 CONF_INPUT_TYPE: CALL_TYPE_COIL,
             }
@@ -132,24 +131,24 @@ async def test_service_binary_sensor_update(hass, mock_pymodbus):
     assert hass.states.get(entity_id).state == STATE_ON
 
 
-async def test_restore_state_binary_sensor(hass):
+@pytest.mark.parametrize(
+    "mock_test_state",
+    [(State(entity_id, STATE_ON),)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_BINARY_SENSORS: [
+                {
+                    CONF_NAME: sensor_name,
+                    CONF_ADDRESS: 51,
+                }
+            ]
+        },
+    ],
+)
+async def test_restore_state_binary_sensor(hass, mock_test_state, mock_modbus):
     """Run test for binary sensor restore state."""
-
-    sensor_name = "test_binary_sensor"
-    test_value = STATE_ON
-    config_sensor = {CONF_NAME: sensor_name, CONF_ADDRESS: 17}
-    mock_restore_cache(
-        hass,
-        (State(f"{SENSOR_DOMAIN}.{sensor_name}", test_value),),
-    )
-    await base_config_test(
-        hass,
-        config_sensor,
-        sensor_name,
-        SENSOR_DOMAIN,
-        CONF_BINARY_SENSORS,
-        None,
-        method_discovery=True,
-    )
-    entity_id = f"{SENSOR_DOMAIN}.{sensor_name}"
-    assert hass.states.get(entity_id).state == test_value
+    assert hass.states.get(entity_id).state == mock_test_state[0].state

--- a/tests/components/modbus/test_fan.py
+++ b/tests/components/modbus/test_fan.py
@@ -32,9 +32,10 @@ from homeassistant.const import (
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
 
-from .conftest import ReadResult, base_config_test, base_test, prepare_service_update
+from .conftest import ReadResult, base_test, prepare_service_update
 
-from tests.common import mock_restore_cache
+fan_name = "test_fan"
+entity_id = f"{FAN_DOMAIN}.{fan_name}"
 
 
 @pytest.mark.parametrize(
@@ -43,7 +44,7 @@ from tests.common import mock_restore_cache
         {
             CONF_FANS: [
                 {
-                    CONF_NAME: "test_fan",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 1234,
                 }
             ]
@@ -51,7 +52,7 @@ from tests.common import mock_restore_cache
         {
             CONF_FANS: [
                 {
-                    CONF_NAME: "test_fan",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 1234,
                     CONF_WRITE_TYPE: CALL_TYPE_COIL,
                 }
@@ -60,7 +61,7 @@ from tests.common import mock_restore_cache
         {
             CONF_FANS: [
                 {
-                    CONF_NAME: "test_fan",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -77,7 +78,7 @@ from tests.common import mock_restore_cache
         {
             CONF_FANS: [
                 {
-                    CONF_NAME: "test_fan",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -94,7 +95,7 @@ from tests.common import mock_restore_cache
         {
             CONF_FANS: [
                 {
-                    CONF_NAME: "test_fan",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -111,7 +112,7 @@ from tests.common import mock_restore_cache
         {
             CONF_FANS: [
                 {
-                    CONF_NAME: "test_fan",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -160,7 +161,6 @@ async def test_config_fan(hass, mock_modbus):
 )
 async def test_all_fan(hass, call_type, regs, verify, expected):
     """Run test for given config."""
-    fan_name = "modbus_test_fan"
     state = await base_test(
         hass,
         {
@@ -182,34 +182,33 @@ async def test_all_fan(hass, call_type, regs, verify, expected):
     assert state == expected
 
 
-async def test_restore_state_fan(hass):
+@pytest.mark.parametrize(
+    "mock_test_state",
+    [(State(entity_id, STATE_ON),)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_FANS: [
+                {
+                    CONF_NAME: fan_name,
+                    CONF_ADDRESS: 1234,
+                }
+            ]
+        },
+    ],
+)
+async def test_restore_state_fan(hass, mock_test_state, mock_modbus):
     """Run test for fan restore state."""
-
-    fan_name = "test_fan"
-    entity_id = f"{FAN_DOMAIN}.{fan_name}"
-    test_value = STATE_ON
-    config_fan = {CONF_NAME: fan_name, CONF_ADDRESS: 17}
-    mock_restore_cache(
-        hass,
-        (State(f"{entity_id}", test_value),),
-    )
-    await base_config_test(
-        hass,
-        config_fan,
-        fan_name,
-        FAN_DOMAIN,
-        CONF_FANS,
-        None,
-        method_discovery=True,
-    )
-    assert hass.states.get(entity_id).state == test_value
+    assert hass.states.get(entity_id).state == STATE_ON
 
 
 async def test_fan_service_turn(hass, caplog, mock_pymodbus):
     """Run test for service turn_on/turn_off."""
 
-    entity_id1 = f"{FAN_DOMAIN}.fan1"
-    entity_id2 = f"{FAN_DOMAIN}.fan2"
+    entity_id2 = f"{FAN_DOMAIN}.{fan_name}2"
     config = {
         MODBUS_DOMAIN: {
             CONF_TYPE: "tcp",
@@ -217,12 +216,12 @@ async def test_fan_service_turn(hass, caplog, mock_pymodbus):
             CONF_PORT: 5501,
             CONF_FANS: [
                 {
-                    CONF_NAME: "fan1",
+                    CONF_NAME: fan_name,
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                 },
                 {
-                    CONF_NAME: "fan2",
+                    CONF_NAME: f"{fan_name}2",
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                     CONF_VERIFY: {},
@@ -234,17 +233,17 @@ async def test_fan_service_turn(hass, caplog, mock_pymodbus):
     await hass.async_block_till_done()
     assert MODBUS_DOMAIN in hass.config.components
 
-    assert hass.states.get(entity_id1).state == STATE_OFF
+    assert hass.states.get(entity_id).state == STATE_OFF
     await hass.services.async_call(
-        "fan", "turn_on", service_data={"entity_id": entity_id1}
+        "fan", "turn_on", service_data={"entity_id": entity_id}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id1).state == STATE_ON
+    assert hass.states.get(entity_id).state == STATE_ON
     await hass.services.async_call(
-        "fan", "turn_off", service_data={"entity_id": entity_id1}
+        "fan", "turn_off", service_data={"entity_id": entity_id}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id1).state == STATE_OFF
+    assert hass.states.get(entity_id).state == STATE_OFF
 
     mock_pymodbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(entity_id2).state == STATE_OFF
@@ -268,20 +267,19 @@ async def test_fan_service_turn(hass, caplog, mock_pymodbus):
     assert hass.states.get(entity_id2).state == STATE_UNAVAILABLE
     mock_pymodbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "fan", "turn_off", service_data={"entity_id": entity_id1}
+        "fan", "turn_off", service_data={"entity_id": entity_id}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id1).state == STATE_UNAVAILABLE
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
 async def test_service_fan_update(hass, mock_pymodbus):
     """Run test for service homeassistant.update_entity."""
 
-    entity_id = "fan.test"
     config = {
         CONF_FANS: [
             {
-                CONF_NAME: "test",
+                CONF_NAME: fan_name,
                 CONF_ADDRESS: 1234,
                 CONF_WRITE_TYPE: CALL_TYPE_COIL,
                 CONF_VERIFY: {},

--- a/tests/components/modbus/test_light.py
+++ b/tests/components/modbus/test_light.py
@@ -32,9 +32,10 @@ from homeassistant.const import (
 from homeassistant.core import State
 from homeassistant.setup import async_setup_component
 
-from .conftest import ReadResult, base_config_test, base_test, prepare_service_update
+from .conftest import ReadResult, base_test, prepare_service_update
 
-from tests.common import mock_restore_cache
+light_name = "test_light"
+entity_id = f"{LIGHT_DOMAIN}.{light_name}"
 
 
 @pytest.mark.parametrize(
@@ -43,7 +44,7 @@ from tests.common import mock_restore_cache
         {
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "test_light",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 1234,
                 }
             ]
@@ -51,7 +52,7 @@ from tests.common import mock_restore_cache
         {
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "test_light",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 1234,
                     CONF_WRITE_TYPE: CALL_TYPE_COIL,
                 }
@@ -60,7 +61,7 @@ from tests.common import mock_restore_cache
         {
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "test_light",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -77,7 +78,7 @@ from tests.common import mock_restore_cache
         {
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "test_light",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -94,7 +95,7 @@ from tests.common import mock_restore_cache
         {
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "test_light",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -111,7 +112,7 @@ from tests.common import mock_restore_cache
         {
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "test_light",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 1234,
                     CONF_SLAVE: 1,
                     CONF_COMMAND_OFF: 0x00,
@@ -160,7 +161,6 @@ async def test_config_light(hass, mock_modbus):
 )
 async def test_all_light(hass, call_type, regs, verify, expected):
     """Run test for given config."""
-    light_name = "modbus_test_light"
     state = await base_test(
         hass,
         {
@@ -182,34 +182,33 @@ async def test_all_light(hass, call_type, regs, verify, expected):
     assert state == expected
 
 
-async def test_restore_state_light(hass):
+@pytest.mark.parametrize(
+    "mock_test_state",
+    [(State(entity_id, STATE_ON),)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_LIGHTS: [
+                {
+                    CONF_NAME: light_name,
+                    CONF_ADDRESS: 1234,
+                }
+            ]
+        },
+    ],
+)
+async def test_restore_state_light(hass, mock_test_state, mock_modbus):
     """Run test for sensor restore state."""
-
-    light_name = "test_light"
-    entity_id = f"{LIGHT_DOMAIN}.{light_name}"
-    test_value = STATE_ON
-    config_light = {CONF_NAME: light_name, CONF_ADDRESS: 17}
-    mock_restore_cache(
-        hass,
-        (State(f"{entity_id}", test_value),),
-    )
-    await base_config_test(
-        hass,
-        config_light,
-        light_name,
-        LIGHT_DOMAIN,
-        CONF_LIGHTS,
-        None,
-        method_discovery=True,
-    )
-    assert hass.states.get(entity_id).state == test_value
+    assert hass.states.get(entity_id).state == mock_test_state[0].state
 
 
 async def test_light_service_turn(hass, caplog, mock_pymodbus):
     """Run test for service turn_on/turn_off."""
 
-    entity_id1 = f"{LIGHT_DOMAIN}.light1"
-    entity_id2 = f"{LIGHT_DOMAIN}.light2"
+    entity_id2 = f"{entity_id}2"
     config = {
         MODBUS_DOMAIN: {
             CONF_TYPE: "tcp",
@@ -217,12 +216,12 @@ async def test_light_service_turn(hass, caplog, mock_pymodbus):
             CONF_PORT: 5501,
             CONF_LIGHTS: [
                 {
-                    CONF_NAME: "light1",
+                    CONF_NAME: light_name,
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                 },
                 {
-                    CONF_NAME: "light2",
+                    CONF_NAME: f"{light_name}2",
                     CONF_ADDRESS: 17,
                     CONF_WRITE_TYPE: CALL_TYPE_REGISTER_HOLDING,
                     CONF_VERIFY: {},
@@ -234,17 +233,17 @@ async def test_light_service_turn(hass, caplog, mock_pymodbus):
     await hass.async_block_till_done()
     assert MODBUS_DOMAIN in hass.config.components
 
-    assert hass.states.get(entity_id1).state == STATE_OFF
+    assert hass.states.get(entity_id).state == STATE_OFF
     await hass.services.async_call(
-        "light", "turn_on", service_data={"entity_id": entity_id1}
+        "light", "turn_on", service_data={"entity_id": entity_id}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id1).state == STATE_ON
+    assert hass.states.get(entity_id).state == STATE_ON
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity_id1}
+        "light", "turn_off", service_data={"entity_id": entity_id}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id1).state == STATE_OFF
+    assert hass.states.get(entity_id).state == STATE_OFF
 
     mock_pymodbus.read_holding_registers.return_value = ReadResult([0x01])
     assert hass.states.get(entity_id2).state == STATE_OFF
@@ -268,20 +267,19 @@ async def test_light_service_turn(hass, caplog, mock_pymodbus):
     assert hass.states.get(entity_id2).state == STATE_UNAVAILABLE
     mock_pymodbus.write_coil.side_effect = ModbusException("fail write_")
     await hass.services.async_call(
-        "light", "turn_off", service_data={"entity_id": entity_id1}
+        "light", "turn_off", service_data={"entity_id": entity_id}
     )
     await hass.async_block_till_done()
-    assert hass.states.get(entity_id1).state == STATE_UNAVAILABLE
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
 
 async def test_service_light_update(hass, mock_pymodbus):
     """Run test for service homeassistant.update_entity."""
 
-    entity_id = "light.test"
     config = {
         CONF_LIGHTS: [
             {
-                CONF_NAME: "test",
+                CONF_NAME: light_name,
                 CONF_ADDRESS: 1234,
                 CONF_WRITE_TYPE: CALL_TYPE_COIL,
                 CONF_VERIFY: {},

--- a/tests/components/modbus/test_sensor.py
+++ b/tests/components/modbus/test_sensor.py
@@ -38,7 +38,8 @@ from homeassistant.core import State
 
 from .conftest import ReadResult, base_config_test, base_test, prepare_service_update
 
-from tests.common import mock_restore_cache
+sensor_name = "test_sensor"
+entity_id = f"{SENSOR_DOMAIN}.{sensor_name}"
 
 
 @pytest.mark.parametrize(
@@ -47,7 +48,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                 }
             ]
@@ -55,7 +56,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_SLAVE: 10,
                     CONF_COUNT: 1,
@@ -71,7 +72,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_SLAVE: 10,
                     CONF_COUNT: 1,
@@ -87,7 +88,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_COUNT: 1,
                     CONF_SWAP: CONF_SWAP_NONE,
@@ -97,7 +98,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_COUNT: 1,
                     CONF_SWAP: CONF_SWAP_BYTE,
@@ -107,7 +108,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_COUNT: 2,
                     CONF_SWAP: CONF_SWAP_WORD,
@@ -117,7 +118,7 @@ from tests.common import mock_restore_cache
         {
             CONF_SENSORS: [
                 {
-                    CONF_NAME: "test_sensor",
+                    CONF_NAME: sensor_name,
                     CONF_ADDRESS: 51,
                     CONF_COUNT: 2,
                     CONF_SWAP: CONF_SWAP_WORD_BYTE,
@@ -210,7 +211,6 @@ async def test_config_wrong_struct_sensor(
 ):
     """Run test for sensor with wrong struct."""
 
-    sensor_name = "test_sensor"
     config_sensor = {
         CONF_NAME: sensor_name,
         **do_config,
@@ -505,7 +505,6 @@ async def test_config_wrong_struct_sensor(
 async def test_all_sensor(hass, cfg, regs, expected):
     """Run test for sensor."""
 
-    sensor_name = "modbus_test_sensor"
     state = await base_test(
         hass,
         {CONF_NAME: sensor_name, CONF_ADDRESS: 1234, **cfg},
@@ -560,7 +559,6 @@ async def test_all_sensor(hass, cfg, regs, expected):
 async def test_struct_sensor(hass, cfg, regs, expected):
     """Run test for sensor struct."""
 
-    sensor_name = "modbus_test_sensor"
     state = await base_test(
         hass,
         {CONF_NAME: sensor_name, CONF_ADDRESS: 1234, **cfg},
@@ -576,27 +574,27 @@ async def test_struct_sensor(hass, cfg, regs, expected):
     assert state == expected
 
 
-async def test_restore_state_sensor(hass):
+@pytest.mark.parametrize(
+    "mock_test_state",
+    [(State(entity_id, "117"),)],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "do_config",
+    [
+        {
+            CONF_SENSORS: [
+                {
+                    CONF_NAME: sensor_name,
+                    CONF_ADDRESS: 51,
+                }
+            ]
+        },
+    ],
+)
+async def test_restore_state_sensor(hass, mock_test_state, mock_modbus):
     """Run test for sensor restore state."""
-
-    sensor_name = "test_sensor"
-    test_value = "117"
-    config_sensor = {CONF_NAME: sensor_name, CONF_ADDRESS: 17}
-    mock_restore_cache(
-        hass,
-        (State(f"{SENSOR_DOMAIN}.{sensor_name}", test_value),),
-    )
-    await base_config_test(
-        hass,
-        config_sensor,
-        sensor_name,
-        SENSOR_DOMAIN,
-        CONF_SENSORS,
-        None,
-        method_discovery=True,
-    )
-    entity_id = f"{SENSOR_DOMAIN}.{sensor_name}"
-    assert hass.states.get(entity_id).state == test_value
+    assert hass.states.get(entity_id).state == mock_test_state[0].state
 
 
 @pytest.mark.parametrize(
@@ -604,11 +602,11 @@ async def test_restore_state_sensor(hass):
     [
         (
             CONF_SWAP_WORD,
-            "Error in sensor modbus_test_sensor swap(word) not possible due to the registers count: 1, needed: 2",
+            f"Error in sensor {sensor_name} swap(word) not possible due to the registers count: 1, needed: 2",
         ),
         (
             CONF_SWAP_WORD_BYTE,
-            "Error in sensor modbus_test_sensor swap(word_byte) not possible due to the registers count: 1, needed: 2",
+            f"Error in sensor {sensor_name} swap(word_byte) not possible due to the registers count: 1, needed: 2",
         ),
     ],
 )
@@ -616,7 +614,6 @@ async def test_swap_sensor_wrong_config(
     hass, caplog, swap_type, error_message, mock_pymodbus
 ):
     """Run test for sensor swap."""
-    sensor_name = "modbus_test_sensor"
     config = {
         CONF_NAME: sensor_name,
         CONF_ADDRESS: 1234,
@@ -642,12 +639,10 @@ async def test_swap_sensor_wrong_config(
 
 async def test_service_sensor_update(hass, mock_pymodbus):
     """Run test for service homeassistant.update_entity."""
-
-    entity_id = "sensor.test"
     config = {
         CONF_SENSORS: [
             {
-                CONF_NAME: "test",
+                CONF_NAME: sensor_name,
                 CONF_ADDRESS: 1234,
                 CONF_INPUT_TYPE: CALL_TYPE_REGISTER_INPUT,
             }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use a simple fixture instead of internal test harness to test restore_state for each platform.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
