### PR TITLE
Convert Nanoleaf yaml and discovery to config flow

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -685,7 +685,9 @@ omit =
     homeassistant/components/myq/cover.py
     homeassistant/components/myq/light.py
     homeassistant/components/nad/media_player.py
+    homeassistant/components/nanoleaf/__init__.py
     homeassistant/components/nanoleaf/light.py
+    homeassistant/components/nanoleaf/util.py
     homeassistant/components/neato/__init__.py
     homeassistant/components/neato/api.py
     homeassistant/components/neato/camera.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -326,6 +326,7 @@ homeassistant/components/myq/* @bdraco @ehendrix23
 homeassistant/components/mysensors/* @MartinHjelmare @functionpointer
 homeassistant/components/mystrom/* @fabaff
 homeassistant/components/nam/* @bieniu
+homeassistant/components/nanoleaf/* @milanmeu
 homeassistant/components/neato/* @dshokouhi @Santobert
 homeassistant/components/nederlandse_spoorwegen/* @YarmoM
 homeassistant/components/nello/* @pschmitt

--- a/homeassistant/components/discovery/__init__.py
+++ b/homeassistant/components/discovery/__init__.py
@@ -55,7 +55,6 @@ SERVICE_HANDLERS = {
     "bose_soundtouch": ("media_player", "soundtouch"),
     "bluesound": ("media_player", "bluesound"),
     "lg_smart_device": ("media_player", "lg_soundbar"),
-    "nanoleaf_aurora": ("light", "nanoleaf"),
 }
 
 OPTIONAL_SERVICE_HANDLERS = {SERVICE_DLNA_DMR: ("media_player", "dlna_dmr")}
@@ -87,6 +86,7 @@ MIGRATED_SERVICE_HANDLERS = [
     SERVICE_XIAOMI_GW,
     "volumio",
     SERVICE_YEELIGHT,
+    "nanoleaf_aurora",
 ]
 
 DEFAULT_ENABLED = (

--- a/homeassistant/components/nanoleaf/__init__.py
+++ b/homeassistant/components/nanoleaf/__init__.py
@@ -1,1 +1,11 @@
-"""The nanoleaf component."""
+"""The Nanoleaf integration."""
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Nanoleaf from a config entry."""
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(entry, "light")
+    )
+    return True

--- a/homeassistant/components/nanoleaf/__init__.py
+++ b/homeassistant/components/nanoleaf/__init__.py
@@ -1,10 +1,30 @@
 """The Nanoleaf integration."""
+from pynanoleaf.pynanoleaf import Nanoleaf, Unavailable
+
+from homeassistant.components.nanoleaf.util import pynanoleaf_get_info
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+
+from .const import DEVICE, DOMAIN, NAME, SERIAL_NO
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Nanoleaf from a config entry."""
+    nanoleaf = Nanoleaf(entry.data[CONF_HOST])
+    nanoleaf.token = entry.data[CONF_TOKEN]
+    try:
+        info = await hass.async_add_executor_job(pynanoleaf_get_info, nanoleaf)
+    except Unavailable:
+        raise ConfigEntryNotReady
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
+        DEVICE: nanoleaf,
+        NAME: info["name"],
+        SERIAL_NO: info["serialNo"],
+    }
+
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(entry, "light")
     )

--- a/homeassistant/components/nanoleaf/__init__.py
+++ b/homeassistant/components/nanoleaf/__init__.py
@@ -1,13 +1,13 @@
 """The Nanoleaf integration."""
 from pynanoleaf.pynanoleaf import Nanoleaf, Unavailable
 
-from homeassistant.components.nanoleaf.util import pynanoleaf_get_info
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
 from .const import DEVICE, DOMAIN, NAME, SERIAL_NO
+from .util import pynanoleaf_get_info
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -16,8 +16,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     nanoleaf.token = entry.data[CONF_TOKEN]
     try:
         info = await hass.async_add_executor_job(pynanoleaf_get_info, nanoleaf)
-    except Unavailable:
-        raise ConfigEntryNotReady
+    except Unavailable as err:
+        raise ConfigEntryNotReady from err
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
         DEVICE: nanoleaf,

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -1,0 +1,272 @@
+"""Config flow to configure the Nuki integration."""
+from __future__ import annotations
+
+import logging
+from typing import Any, Final
+
+from pynanoleaf import InvalidToken, Nanoleaf, NotAuthorizingNewTokens, Unavailable
+import voluptuous as vol
+
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_MODE, CONF_TOKEN
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.util.json import load_json, save_json
+
+from .const import DOMAIN
+from .util import pynanoleaf_get_info
+
+_LOGGER = logging.getLogger(__name__)
+
+# For discovery integration import
+CONFIG_FILE: Final = ".nanoleaf.conf"
+
+CONF_AUTO: Final = "auto"
+CONF_MANUAL: Final = "manual"
+
+CONF_STEP_USER: Final = "user"
+CONF_STEP_AUTO: Final = "auto"
+CONF_STEP_MANUAL: Final = "manual"
+
+SIMPLE_USER_SCHEMA: Final = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+    }
+)
+
+ADVANCED_USER_SCHEMA: Final = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_MODE, default=CONF_AUTO): vol.In(
+            {
+                CONF_AUTO: "Request a new token (recommended)",
+                CONF_MANUAL: "Enter a token manually",
+            }
+        ),
+    }
+)
+
+MANUAL_SCHEMA: Final = vol.Schema(
+    {
+        vol.Required(CONF_TOKEN): str,
+    }
+)
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Nanoleaf config flow."""
+
+    VERSION = 1
+
+    user_data_schema: vol.Schema
+    nanoleaf: Nanoleaf
+
+    # For discovery integration import
+    discovery_conf: dict
+    device_id: str
+
+    def __init__(self) -> None:
+        """Initialize a Nanoleaf flow."""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle Nanoleaf flow initiated by the user."""
+        self.user_data_schema = (
+            ADVANCED_USER_SCHEMA if self.show_advanced_options else SIMPLE_USER_SCHEMA
+        )
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=self.user_data_schema, last_step=False
+            )
+        self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+        self.nanoleaf = Nanoleaf(user_input[CONF_HOST])
+        try:
+            await self.hass.async_add_executor_job(self.nanoleaf.authorize)
+        except Unavailable:
+            _LOGGER.warning("Nanoleaf is not available at %s", self.nanoleaf.host)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.user_data_schema,
+                errors={"base": "cannot_connect"},
+                last_step=False,
+            )
+        except NotAuthorizingNewTokens:
+            pass
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unknown error connecting to Nanoleaf")
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.user_data_schema,
+                last_step=False,
+                errors={"base": "unknown"},
+            )
+        if user_input.get(CONF_MODE) == CONF_MANUAL:
+            return self.async_show_form(step_id="manual", data_schema=MANUAL_SCHEMA)
+        return self.async_show_form(step_id="link")
+
+    async def async_step_zeroconf(
+        self, discovery_info: DiscoveryInfoType
+    ) -> FlowResult:
+        """Handle Nanoleaf Zeroconf discovery."""
+        _LOGGER.debug("Zeroconf discovered: %s", discovery_info)
+        return await self._async_discovery_handler(discovery_info)
+
+    async def async_step_homekit(self, discovery_info: DiscoveryInfoType) -> FlowResult:
+        """Handle Nanoleaf Homekit discovery."""
+        _LOGGER.debug("Homekit discovered: %s", discovery_info)
+        return await self._async_discovery_handler(discovery_info)
+
+    async def _async_discovery_handler(
+        self, discovery_info: DiscoveryInfoType
+    ) -> FlowResult:
+        """Handle Nanoleaf discovery."""
+        host = discovery_info["host"]
+        name = discovery_info["name"].replace(f".{discovery_info['type']}", "")
+        await self.async_set_unique_id(name)
+        self._abort_if_unique_id_configured({CONF_HOST: host})
+        self.nanoleaf = Nanoleaf(host)
+
+        # Import from discovery integration
+        self.device_id = discovery_info["properties"]["id"]
+        self.discovery_conf = dict(load_json(self.hass.config.path(CONFIG_FILE)))
+        self.nanoleaf.token = self.discovery_conf.get(host, {}).get("token")  # < 2021.4
+        self.nanoleaf.token = self.discovery_conf.get(self.device_id, {}).get(
+            "token", self.nanoleaf.token
+        )  # >= 2021.4
+        if self.nanoleaf.token is not None:
+            self.context["source"] = config_entries.SOURCE_INTEGRATION_DISCOVERY
+            _LOGGER.warning(
+                "Importing Nanoleaf %s from the discovery integration", name
+            )
+            return await self.async_setup_finish()
+
+        self.context["title_placeholders"] = {"name": name}
+        return self.async_show_form(step_id="link")
+
+    async def async_step_link(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle Nanoleaf link step."""
+        if user_input is None:
+            return self.async_show_form(step_id="link")
+
+        try:
+            await self.hass.async_add_executor_job(self.nanoleaf.authorize)
+        except NotAuthorizingNewTokens:
+            _LOGGER.warning("Nanoleaf is not allowing new tokens")
+            return self.async_show_form(
+                step_id="link", errors={"base": "not_allowing_new_tokens"}
+            )
+        except Unavailable:
+            _LOGGER.error("Nanoleaf is not available at %s", self.nanoleaf.host)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.user_data_schema,
+                errors={"base": "cannot_connect"},
+                last_step=False,
+            )
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception("Unknown error authorizing Nanoleaf")
+            return self.async_show_form(step_id="link", errors={"base": "unknown"})
+        return await self.async_setup_finish()
+
+    async def async_step_manual(self, user_input: dict[str, Any]) -> FlowResult:
+        """Handle Nanoleaf manual step."""
+        self.nanoleaf.token = user_input[CONF_TOKEN]
+        return await self.async_setup_finish()
+
+    async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
+        """Handle Nanoleaf configuration import."""
+        self._async_abort_entries_match({CONF_HOST: config[CONF_HOST]})
+        _LOGGER.warning(
+            "Importing Nanoleaf on %s from your configuration.yaml", config[CONF_HOST]
+        )
+        self.nanoleaf = Nanoleaf(config[CONF_HOST])
+        self.nanoleaf.token = config[CONF_TOKEN]
+        return await self.async_setup_finish()
+
+    async def async_setup_finish(self) -> FlowResult:
+        """Finish Nanoleaf config flow."""
+        try:
+            info = await self.hass.async_add_executor_job(
+                pynanoleaf_get_info, self.nanoleaf
+            )
+        except Unavailable:
+            _LOGGER.error("Nanoleaf is not available at %s", self.nanoleaf.host)
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.user_data_schema,
+                errors={"base": "cannot_connect"},
+                last_step=False,
+            )
+        except InvalidToken:
+            _LOGGER.error("Nanoleaf token %s is invalid", self.nanoleaf.token)
+            return self.async_show_form(
+                step_id="manual",
+                data_schema=MANUAL_SCHEMA,
+                errors={"base": "invalid_token"},
+            )
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.exception(
+                "Unknown error connecting with Nanoleaf at %s with token %s",
+                self.nanoleaf.host,
+                self.nanoleaf.token,
+            )
+            return self.async_show_form(
+                step_id="user",
+                data_schema=self.user_data_schema,
+                errors={"base": "unknown"},
+                last_step=False,
+            )
+        name = info["name"]
+
+        await self.async_set_unique_id(name)
+        self._abort_if_unique_id_configured({CONF_HOST: self.nanoleaf.host})
+
+        # Log successfully imported instructions and optionally update the Nanoleaf config file
+        if self.context["source"] == config_entries.SOURCE_IMPORT:
+            _LOGGER.warning(
+                (
+                    "Successfully imported Nanoleaf %s on %s.",
+                    "You can remove the light from your configuration.yaml",
+                ),
+                name,
+                self.nanoleaf.host,
+            )
+        elif self.context["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY:
+            if self.nanoleaf.host in self.discovery_conf:
+                self.discovery_conf.pop(self.nanoleaf.host)
+            if self.device_id in self.discovery_conf:
+                self.discovery_conf.pop(self.device_id)
+            _LOGGER.warning(
+                "Successfully imported Nanoleaf %s from the discovery integration",
+                name,
+            )
+            if self.discovery_conf:
+                save_json(self.hass.config.path(CONFIG_FILE), self.discovery_conf)
+            else:
+                save_json(
+                    self.hass.config.path(CONFIG_FILE),
+                    {
+                        0: "The Nanoleaf configuration has been imported into a config flow.",
+                        1: "This file is no longer used. YOU CAN DELETE THIS FILE.",
+                        2: "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml",
+                    },
+                )
+                _LOGGER.warning(
+                    (
+                        "All Nanoleaf devices from the discovery integration are imported. "
+                        "You can remove the '%s' file from your config folder. (This file may be hidden.) "
+                        "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml."
+                    ),
+                    CONFIG_FILE,
+                )
+
+        return self.async_create_entry(
+            title=name,
+            data={
+                CONF_HOST: self.nanoleaf.host,
+                CONF_TOKEN: self.nanoleaf.token,
+            },
+        )

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -97,7 +97,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Import from discovery integration
         self.device_id = discovery_info["properties"]["id"]
-        self.discovery_conf = dict(load_json(self.hass.config.path(CONFIG_FILE)))
+        self.discovery_conf = dict(
+            await self.hass.async_add_executor_job(
+                load_json, self.hass.config.path(CONFIG_FILE)
+            )
+        )
         self.nanoleaf.token = self.discovery_conf.get(host, {}).get("token")  # < 2021.4
         self.nanoleaf.token = self.discovery_conf.get(self.device_id, {}).get(
             "token", self.nanoleaf.token
@@ -201,9 +205,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 name,
             )
             if self.discovery_conf:
-                save_json(self.hass.config.path(CONFIG_FILE), self.discovery_conf)
+                await self.hass.async_add_executor_job(
+                    save_json, self.hass.config.path(CONFIG_FILE), self.discovery_conf
+                )
             else:
-                save_json(
+                await self.hass.async_add_executor_job(
+                    save_json,
                     self.hass.config.path(CONFIG_FILE),
                     {
                         0: "The Nanoleaf configuration has been imported into a config flow.",

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Final
 
 from pynanoleaf import InvalidToken, Nanoleaf, NotAuthorizingNewTokens, Unavailable
@@ -210,21 +211,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
             else:
                 await self.hass.async_add_executor_job(
-                    save_json,
-                    self.hass.config.path(CONFIG_FILE),
-                    {
-                        0: "The Nanoleaf configuration has been imported into a config flow.",
-                        1: "This file is no longer used. YOU CAN DELETE THIS FILE.",
-                        2: "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml",
-                    },
+                    os.remove, self.hass.config.path(CONFIG_FILE)
                 )
                 _LOGGER.warning(
-                    (
-                        "All Nanoleaf devices from the discovery integration are imported. "
-                        "You can remove the '%s' file from your config folder. (This file may be hidden.) "
-                        "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml"
-                    ),
-                    CONFIG_FILE,
+                    "All Nanoleaf devices from the discovery integration are imported. "
+                    "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml"
                 )
 
         return self.async_create_entry(

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -167,12 +167,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.nanoleaf.host,
                 self.nanoleaf.token,
             )
-            return self.async_show_form(
-                step_id="user",
-                data_schema=USER_SCHEMA,
-                errors={"base": "unknown"},
-                last_step=False,
-            )
+            return self.async_abort(reason="unknown")
         name = info["name"]
 
         await self.async_set_unique_id(name)

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -158,9 +158,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         except Unavailable:
             return self.async_abort(reason="cannot_connect")
         except InvalidToken:
-            return self.async_show_form(
-                step_id="link", errors={"base": "invalid_token"}
-            )
+            return self.async_abort(reason="invalid_token")
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception(
                 "Unknown error connecting with Nanoleaf at %s with token %s",

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -55,7 +55,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await self.hass.async_add_executor_job(self.nanoleaf.authorize)
         except Unavailable:
-            _LOGGER.warning("Nanoleaf is not available at %s", self.nanoleaf.host)
             return self.async_show_form(
                 step_id="user",
                 data_schema=USER_SCHEMA,
@@ -123,12 +122,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         try:
             await self.hass.async_add_executor_job(self.nanoleaf.authorize)
         except NotAuthorizingNewTokens:
-            _LOGGER.warning("Nanoleaf is not allowing new tokens")
             return self.async_show_form(
                 step_id="link", errors={"base": "not_allowing_new_tokens"}
             )
         except Unavailable:
-            _LOGGER.error("Nanoleaf is not available at %s", self.nanoleaf.host)
             return self.async_show_form(
                 step_id="user",
                 data_schema=USER_SCHEMA,
@@ -157,7 +154,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 pynanoleaf_get_info, self.nanoleaf
             )
         except Unavailable:
-            _LOGGER.error("Nanoleaf is not available at %s", self.nanoleaf.host)
             return self.async_show_form(
                 step_id="user",
                 data_schema=USER_SCHEMA,
@@ -165,7 +161,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 last_step=False,
             )
         except InvalidToken:
-            _LOGGER.error("Nanoleaf token %s is invalid", self.nanoleaf.token)
             return self.async_show_form(
                 step_id="link", errors={"base": "invalid_token"}
             )

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -110,11 +110,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.discovery_conf.get(host, {}).get("token"),  # < 2021.4
         )
         if self.nanoleaf.token is not None:
-            self.context["source"] = config_entries.SOURCE_INTEGRATION_DISCOVERY
             _LOGGER.warning(
                 "Importing Nanoleaf %s from the discovery integration", name
             )
-            return await self.async_setup_finish()
+            return await self.async_setup_finish(discovery_integration_import=True)
 
         self.context["title_placeholders"] = {"name": name}
         return await self.async_step_link()
@@ -149,7 +148,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.nanoleaf.token = config[CONF_TOKEN]
         return await self.async_setup_finish()
 
-    async def async_setup_finish(self) -> FlowResult:
+    async def async_setup_finish(
+        self, discovery_integration_import: bool = False
+    ) -> FlowResult:
         """Finish Nanoleaf config flow."""
         try:
             info = await self.hass.async_add_executor_job(
@@ -171,7 +172,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(name)
         self._abort_if_unique_id_configured({CONF_HOST: self.nanoleaf.host})
 
-        if self.context["source"] == config_entries.SOURCE_INTEGRATION_DISCOVERY:
+        if discovery_integration_import:
             if self.nanoleaf.host in self.discovery_conf:
                 self.discovery_conf.pop(self.nanoleaf.host)
             if self.device_id in self.discovery_conf:

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -179,7 +179,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     async def async_step_import(self, config: dict[str, Any]) -> FlowResult:
         """Handle Nanoleaf configuration import."""
         self._async_abort_entries_match({CONF_HOST: config[CONF_HOST]})
-        _LOGGER.warning(
+        _LOGGER.debug(
             "Importing Nanoleaf on %s from your configuration.yaml", config[CONF_HOST]
         )
         self.nanoleaf = Nanoleaf(config[CONF_HOST])

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -1,4 +1,4 @@
-"""Config flow to configure the Nuki integration."""
+"""Config flow for Nanoleaf integration."""
 from __future__ import annotations
 
 import logging

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from pynanoleaf import InvalidToken, Nanoleaf, NotAuthorizingNewTokens, Unavailable
 import voluptuous as vol
@@ -99,10 +99,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Import from discovery integration
         self.device_id = discovery_info["properties"]["id"]
-        self.discovery_conf = dict(
+        self.discovery_conf = cast(
+            dict,
             await self.hass.async_add_executor_job(
                 load_json, self.hass.config.path(CONFIG_FILE)
-            )
+            ),
         )
         self.nanoleaf.token = self.discovery_conf.get(host, {}).get("token")  # < 2021.4
         self.nanoleaf.token = self.discovery_conf.get(self.device_id, {}).get(

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -258,7 +258,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     (
                         "All Nanoleaf devices from the discovery integration are imported. "
                         "You can remove the '%s' file from your config folder. (This file may be hidden.) "
-                        "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml."
+                        "If you used the discovery integration only for Nanoleaf you can remove it from your configuration.yaml"
                     ),
                     CONFIG_FILE,
                 )

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -119,17 +119,6 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = {"name": name}
         return await self.async_step_link()
 
-    async def async_handle_unavailable(self):
-        """Handle unavailable device."""
-        if self.context["source"] == config_entries.SOURCE_USER:
-            return self.async_show_form(
-                step_id="user",
-                data_schema=USER_SCHEMA,
-                errors={"base": "cannot_connect"},
-                last_step=False,
-            )
-        return self.async_abort(reason="cannot_connect")
-
     async def async_step_link(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
@@ -144,7 +133,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 step_id="link", errors={"base": "not_allowing_new_tokens"}
             )
         except Unavailable:
-            return await self.async_handle_unavailable()
+            return self.async_abort(reason="cannot_connect")
         except Exception:  # pylint: disable=broad-except
             _LOGGER.exception("Unknown error authorizing Nanoleaf")
             return self.async_show_form(step_id="link", errors={"base": "unknown"})
@@ -167,7 +156,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 pynanoleaf_get_info, self.nanoleaf
             )
         except Unavailable:
-            return await self.async_handle_unavailable()
+            return self.async_abort(reason="cannot_connect")
         except InvalidToken:
             return self.async_show_form(
                 step_id="link", errors={"base": "invalid_token"}

--- a/homeassistant/components/nanoleaf/config_flow.py
+++ b/homeassistant/components/nanoleaf/config_flow.py
@@ -35,14 +35,13 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    nanoleaf: Nanoleaf
-
-    # For discovery integration import
-    discovery_conf: dict
-    device_id: str
-
     def __init__(self) -> None:
         """Initialize a Nanoleaf flow."""
+        self.nanoleaf: Nanoleaf
+
+        # For discovery integration import
+        self.discovery_conf: dict
+        self.device_id: str
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/nanoleaf/const.py
+++ b/homeassistant/components/nanoleaf/const.py
@@ -1,0 +1,3 @@
+"""Constants for Nanoleaf integration."""
+
+DOMAIN = "nanoleaf"

--- a/homeassistant/components/nanoleaf/const.py
+++ b/homeassistant/components/nanoleaf/const.py
@@ -1,3 +1,7 @@
 """Constants for Nanoleaf integration."""
 
 DOMAIN = "nanoleaf"
+
+DEVICE = "device"
+SERIAL_NO = "serial_no"
+NAME = "name"

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -57,19 +57,18 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(
+async def async_setup_platform(
     hass: HomeAssistant,
     config: ConfigType,
     add_entities: AddEntitiesCallback,
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Import Nanoleaf light platform."""
-    hass.async_create_task(
-        hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": SOURCE_IMPORT},
-            data={CONF_HOST: config[CONF_HOST], CONF_TOKEN: config[CONF_TOKEN]},
-        )
+    await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data={CONF_HOST: config[CONF_HOST], CONF_TOKEN: config[CONF_TOKEN]},
+
     )
 
 

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -1,4 +1,6 @@
 """Support for Nanoleaf Lights."""
+from __future__ import annotations
+
 import logging
 
 from pynanoleaf import Nanoleaf, Unavailable
@@ -18,21 +20,23 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     LightEntity,
 )
+from homeassistant.components.nanoleaf.util import pynanoleaf_get_info
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
+from homeassistant.core import HomeAssistant
 import homeassistant.helpers.config_validation as cv
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import color as color_util
 from homeassistant.util.color import (
     color_temperature_mired_to_kelvin as mired_to_kelvin,
 )
-from homeassistant.util.json import load_json, save_json
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_NAME = "Nanoleaf"
-
-DATA_NANOLEAF = "nanoleaf"
-
-CONFIG_FILE = ".nanoleaf.conf"
 
 ICON = "mdi:triangle-outline"
 
@@ -53,69 +57,40 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 )
 
 
-def setup_platform(hass, config, add_entities, discovery_info=None):
+def setup_platform(
+    hass: HomeAssistant,
+    config: ConfigType,
+    add_entities: AddEntitiesCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> None:
+    """Import Nanoleaf light platform."""
+    hass.async_create_task(
+        hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": SOURCE_IMPORT},
+            data={CONF_HOST: config[CONF_HOST], CONF_TOKEN: config[CONF_TOKEN]},
+        )
+    )
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, add_entities: AddEntitiesCallback
+) -> None:
     """Set up the Nanoleaf light."""
-
-    if DATA_NANOLEAF not in hass.data:
-        hass.data[DATA_NANOLEAF] = {}
-
-    token = ""
-    if discovery_info is not None:
-        host = discovery_info["host"]
-        name = None
-        device_id = discovery_info["properties"]["id"]
-
-        # if device already exists via config, skip discovery setup
-        if host in hass.data[DATA_NANOLEAF]:
-            return
-        _LOGGER.info("Discovered a new Nanoleaf: %s", discovery_info)
-        conf = load_json(hass.config.path(CONFIG_FILE))
-        if host in conf and device_id not in conf:
-            conf[device_id] = conf.pop(host)
-            save_json(hass.config.path(CONFIG_FILE), conf)
-        token = conf.get(device_id, {}).get("token", "")
-    else:
-        host = config[CONF_HOST]
-        name = config[CONF_NAME]
-        token = config[CONF_TOKEN]
-
-    nanoleaf_light = Nanoleaf(host)
-
-    if not token:
-        token = nanoleaf_light.request_token()
-        if not token:
-            _LOGGER.error(
-                "Could not generate the auth token, did you press "
-                "and hold the power button on %s"
-                "for 5-7 seconds?",
-                name,
-            )
-            return
-        conf = load_json(hass.config.path(CONFIG_FILE))
-        conf[host] = {"token": token}
-        save_json(hass.config.path(CONFIG_FILE), conf)
-
-    nanoleaf_light.token = token
-
-    try:
-        info = nanoleaf_light.info
-    except Unavailable:
-        _LOGGER.error("Could not connect to Nanoleaf Light: %s on %s", name, host)
-        return
-
-    if name is None:
-        name = info.name
-
-    hass.data[DATA_NANOLEAF][host] = nanoleaf_light
-    add_entities([NanoleafLight(nanoleaf_light, name)], True)
+    nanoleaf = Nanoleaf(entry.data[CONF_HOST])
+    nanoleaf.token = entry.data[CONF_TOKEN]
+    info = await hass.async_add_executor_job(pynanoleaf_get_info, nanoleaf)
+    name = info["name"]
+    serial_no = info["serialNo"]
+    add_entities([NanoleafLight(nanoleaf, name, serial_no)], True)
 
 
 class NanoleafLight(LightEntity):
     """Representation of a Nanoleaf Light."""
 
-    def __init__(self, light, name):
+    def __init__(self, light, name, unique_id):
         """Initialize an Nanoleaf light."""
-        self._unique_id = light.serialNo
+        self._unique_id = unique_id
         self._available = True
         self._brightness = None
         self._color_temp = None
@@ -239,7 +214,6 @@ class NanoleafLight(LightEntity):
 
     def update(self):
         """Fetch new state data for this light."""
-
         try:
             self._available = self._light.available
             self._brightness = self._light.brightness

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -68,7 +68,6 @@ async def async_setup_platform(
         DOMAIN,
         context={"source": SOURCE_IMPORT},
         data={CONF_HOST: config[CONF_HOST], CONF_TOKEN: config[CONF_TOKEN]},
-
     )
 
 

--- a/homeassistant/components/nanoleaf/light.py
+++ b/homeassistant/components/nanoleaf/light.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 
-from pynanoleaf import Nanoleaf, Unavailable
+from pynanoleaf import Unavailable
 import voluptuous as vol
 
 from homeassistant.components.light import (
@@ -20,7 +20,6 @@ from homeassistant.components.light import (
     SUPPORT_TRANSITION,
     LightEntity,
 )
-from homeassistant.components.nanoleaf.util import pynanoleaf_get_info
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_NAME, CONF_TOKEN
 from homeassistant.core import HomeAssistant
@@ -32,7 +31,7 @@ from homeassistant.util.color import (
     color_temperature_mired_to_kelvin as mired_to_kelvin,
 )
 
-from .const import DOMAIN
+from .const import DEVICE, DOMAIN, NAME, SERIAL_NO
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -75,12 +74,8 @@ async def async_setup_entry(
     hass: HomeAssistant, entry: ConfigEntry, add_entities: AddEntitiesCallback
 ) -> None:
     """Set up the Nanoleaf light."""
-    nanoleaf = Nanoleaf(entry.data[CONF_HOST])
-    nanoleaf.token = entry.data[CONF_TOKEN]
-    info = await hass.async_add_executor_job(pynanoleaf_get_info, nanoleaf)
-    name = info["name"]
-    serial_no = info["serialNo"]
-    add_entities([NanoleafLight(nanoleaf, name, serial_no)], True)
+    data = hass.data[DOMAIN][entry.entry_id]
+    add_entities([NanoleafLight(data[DEVICE], data[NAME], data[SERIAL_NO])], True)
 
 
 class NanoleafLight(LightEntity):

--- a/homeassistant/components/nanoleaf/manifest.json
+++ b/homeassistant/components/nanoleaf/manifest.json
@@ -1,8 +1,15 @@
 {
   "domain": "nanoleaf",
   "name": "Nanoleaf",
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/nanoleaf",
   "requirements": ["pynanoleaf==0.1.0"],
-  "codeowners": [],
+  "zeroconf": ["_nanoleafms._tcp.local.", "_nanoleafapi._tcp.local."],
+  "homekit" : {
+    "models": [
+      "NL"
+    ]
+  },
+  "codeowners": ["@milanmeu"],
   "iot_class": "local_polling"
 }

--- a/homeassistant/components/nanoleaf/manifest.json
+++ b/homeassistant/components/nanoleaf/manifest.json
@@ -7,7 +7,7 @@
   "zeroconf": ["_nanoleafms._tcp.local.", "_nanoleafapi._tcp.local."],
   "homekit" : {
     "models": [
-      "NL"
+      "NL*"
     ]
   },
   "codeowners": ["@milanmeu"],

--- a/homeassistant/components/nanoleaf/strings.json
+++ b/homeassistant/components/nanoleaf/strings.json
@@ -10,13 +10,6 @@
       "link": {
         "title": "Link Nanoleaf",
         "description": "Press and hold the power button on your Nanoleaf for 5 seconds until the button LEDs start flashing, then click **SUBMIT** within 30 seconds."
-      },
-      "manual": {
-        "title": "Provide your token",
-        "description": "Information on how to get a token is available on https://www.home-assistant.io/integrations/nanoleaf/#getting-the-auth-token",
-        "data": {
-          "token": "Token"
-        }
       }
     },
     "error": {

--- a/homeassistant/components/nanoleaf/strings.json
+++ b/homeassistant/components/nanoleaf/strings.json
@@ -14,13 +14,13 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_token": "[%key:common::config_flow::error::invalid_access_token%]",
-      "unknown": "[%key:common::config_flow::error::unknown%]",
-      "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above."
+      "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_token": "[%key:common::config_flow::error::invalid_access_token%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }

--- a/homeassistant/components/nanoleaf/strings.json
+++ b/homeassistant/components/nanoleaf/strings.json
@@ -1,0 +1,32 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        }
+      },
+      "link": {
+        "title": "Link Nanoleaf",
+        "description": "Press and hold the power button on your Nanoleaf for 5 seconds until the button LEDs start flashing, then click **SUBMIT** within 30 seconds."
+      },
+      "manual": {
+        "title": "Provide your token",
+        "description": "Information on how to get a token is available on https://www.home-assistant.io/integrations/nanoleaf/#getting-the-auth-token",
+        "data": {
+          "token": "Token"
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_token": "Invalid token",
+      "unknown": "[%key:common::config_flow::error::unknown%]",
+      "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above."
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  }
+}

--- a/homeassistant/components/nanoleaf/strings.json
+++ b/homeassistant/components/nanoleaf/strings.json
@@ -14,13 +14,14 @@
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-      "invalid_token": "Invalid token",
+      "invalid_token": "[%key:common::config_flow::error::invalid_access_token%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above."
     },
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
     }
   }
 }

--- a/homeassistant/components/nanoleaf/strings.json
+++ b/homeassistant/components/nanoleaf/strings.json
@@ -19,7 +19,8 @@
       "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above."
     },
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
     }
   }
 }

--- a/homeassistant/components/nanoleaf/translations/en.json
+++ b/homeassistant/components/nanoleaf/translations/en.json
@@ -1,7 +1,8 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device is already configured"
+            "already_configured": "Device is already configured",
+            "cannot_connect": "Failed to connect"
         },
         "error": {
             "cannot_connect": "Failed to connect",

--- a/homeassistant/components/nanoleaf/translations/en.json
+++ b/homeassistant/components/nanoleaf/translations/en.json
@@ -2,11 +2,12 @@
     "config": {
         "abort": {
             "already_configured": "Device is already configured",
-            "cannot_connect": "Failed to connect"
+            "cannot_connect": "Failed to connect",
+            "invalid_token": "Invalid access token",
+            "unknown": "Unexpected error"
         },
         "error": {
             "cannot_connect": "Failed to connect",
-            "invalid_token": "Invalid token",
             "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above.",
             "unknown": "Unexpected error"
         },

--- a/homeassistant/components/nanoleaf/translations/en.json
+++ b/homeassistant/components/nanoleaf/translations/en.json
@@ -1,0 +1,32 @@
+{
+    "config": {
+        "abort": {
+            "already_configured": "Device is already configured"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_token": "Invalid token",
+            "not_allowing_new_tokens": "Nanoleaf is not allowing new tokens, follow the instructions above.",
+            "unknown": "Unexpected error"
+        },
+        "flow_title": "{name}",
+        "step": {
+            "link": {
+                "description": "Press and hold the power button on your Nanoleaf for 5 seconds until the button LEDs start flashing, then click **SUBMIT** within 30 seconds.",
+                "title": "Link Nanoleaf"
+            },
+            "manual": {
+                "data": {
+                    "token": "Token"
+                },
+                "description": "Information on how to get a token is available on https://www.home-assistant.io/integrations/nanoleaf/#getting-the-auth-token",
+                "title": "Provide your token"
+            },
+            "user": {
+                "data": {
+                    "host": "Host"
+                }
+            }
+        }
+    }
+}

--- a/homeassistant/components/nanoleaf/translations/en.json
+++ b/homeassistant/components/nanoleaf/translations/en.json
@@ -15,13 +15,6 @@
                 "description": "Press and hold the power button on your Nanoleaf for 5 seconds until the button LEDs start flashing, then click **SUBMIT** within 30 seconds.",
                 "title": "Link Nanoleaf"
             },
-            "manual": {
-                "data": {
-                    "token": "Token"
-                },
-                "description": "Information on how to get a token is available on https://www.home-assistant.io/integrations/nanoleaf/#getting-the-auth-token",
-                "title": "Provide your token"
-            },
             "user": {
                 "data": {
                     "host": "Host"

--- a/homeassistant/components/nanoleaf/util.py
+++ b/homeassistant/components/nanoleaf/util.py
@@ -1,0 +1,7 @@
+"""Nanoleaf integration util."""
+from pynanoleaf.pynanoleaf import Nanoleaf
+
+
+def pynanoleaf_get_info(nanoleaf_light: Nanoleaf) -> dict:
+    """Get Nanoleaf light info."""
+    return nanoleaf_light.info

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -176,6 +176,7 @@ FLOWS = [
     "myq",
     "mysensors",
     "nam",
+    "nanoleaf",
     "neato",
     "nest",
     "netatmo",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -261,7 +261,7 @@ HOMEKIT = {
     "Iota": "abode",
     "LIFX": "lifx",
     "MYQ": "myq",
-    "NL": "nanoleaf",
+    "NL*": "nanoleaf",
     "Netatmo Relay": "netatmo",
     "PowerView": "hunterdouglas_powerview",
     "Presence": "netatmo",

--- a/homeassistant/generated/zeroconf.py
+++ b/homeassistant/generated/zeroconf.py
@@ -165,6 +165,16 @@ ZEROCONF = {
             "domain": "xiaomi_miio"
         }
     ],
+    "_nanoleafapi._tcp.local.": [
+        {
+            "domain": "nanoleaf"
+        }
+    ],
+    "_nanoleafms._tcp.local.": [
+        {
+            "domain": "nanoleaf"
+        }
+    ],
     "_nut._tcp.local.": [
         {
             "domain": "nut"
@@ -251,6 +261,7 @@ HOMEKIT = {
     "Iota": "abode",
     "LIFX": "lifx",
     "MYQ": "myq",
+    "NL": "nanoleaf",
     "Netatmo Relay": "netatmo",
     "PowerView": "hunterdouglas_powerview",
     "Presence": "netatmo",

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -941,6 +941,9 @@ pymyq==3.1.3
 # homeassistant.components.mysensors
 pymysensors==0.21.0
 
+# homeassistant.components.nanoleaf
+pynanoleaf==0.1.0
+
 # homeassistant.components.nuki
 pynuki==1.4.1
 

--- a/tests/components/nanoleaf/__init__.py
+++ b/tests/components/nanoleaf/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Nanoleaf integration."""

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -257,7 +257,7 @@ async def test_import_config_invalid_token(hass: HomeAssistant) -> None:
         )
 
     assert result["type"] == "form"
-    assert result["step_id"] == "manual"
+    assert result["step_id"] == "link"
     assert result["errors"] == {"base": "invalid_token"}
 
 

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -326,7 +326,7 @@ async def test_import_last_discovery_integration_host_zeroconf(
     ), patch(
         "homeassistant.components.nanoleaf.config_flow.os.remove",
         return_value=None,
-    ), patch(
+    ) as mock_remove, patch(
         "homeassistant.components.nanoleaf.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -347,6 +347,7 @@ async def test_import_last_discovery_integration_host_zeroconf(
         CONF_HOST: TEST_HOST,
         CONF_TOKEN: TEST_TOKEN,
     }
+    mock_remove.assert_called_once()
     await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -372,7 +373,7 @@ async def test_import_not_last_discovery_integration_device_id_homekit(
     ), patch(
         "homeassistant.components.nanoleaf.config_flow.save_json",
         return_value=None,
-    ), patch(
+    ) as mock_save_json, patch(
         "homeassistant.components.nanoleaf.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
@@ -393,5 +394,6 @@ async def test_import_not_last_discovery_integration_device_id_homekit(
         CONF_HOST: TEST_HOST,
         CONF_TOKEN: TEST_TOKEN,
     }
+    mock_save_json.assert_called_once()
     await hass.async_block_till_done()
     assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -283,7 +283,6 @@ async def test_import_config(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_HOST: TEST_HOST, CONF_TOKEN: TEST_TOKEN},
         )
-
     assert result["type"] == "create_entry"
     assert result["title"] == TEST_NAME
     assert result["data"] == {
@@ -305,10 +304,8 @@ async def test_import_config_invalid_token(hass: HomeAssistant) -> None:
             context={"source": config_entries.SOURCE_IMPORT},
             data={CONF_HOST: TEST_HOST, CONF_TOKEN: TEST_TOKEN},
         )
-
-    assert result["type"] == "form"
-    assert result["step_id"] == "link"
-    assert result["errors"] == {"base": "invalid_token"}
+    assert result["type"] == "abort"
+    assert result["reason"] == "invalid_token"
 
 
 async def test_import_last_discovery_integration_host_zeroconf(

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -277,7 +277,7 @@ async def test_import_last_discovery_integration_host_zeroconf(
         "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
         return_value={"name": TEST_NAME},
     ), patch(
-        "homeassistant.components.nanoleaf.config_flow.save_json",
+        "homeassistant.components.nanoleaf.config_flow.os.remove",
         return_value=None,
     ), patch(
         "homeassistant.components.nanoleaf.async_setup_entry",

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -1,0 +1,376 @@
+"""Test the Nanoleaf config flow."""
+from unittest.mock import patch
+
+from pynanoleaf import InvalidToken, NotAuthorizingNewTokens, Unavailable
+
+from homeassistant import config_entries
+from homeassistant.components.nanoleaf.config_flow import (
+    ADVANCED_USER_SCHEMA,
+    CONF_MANUAL,
+    CONF_MODE,
+)
+from homeassistant.components.nanoleaf.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_TOKEN
+from homeassistant.core import HomeAssistant
+
+TEST_NAME = "Canvas ADF9"
+TEST_HOST = "192.168.0.100"
+TEST_TOKEN = "R34F1c92FNv3pcZs4di17RxGqiLSwHM"
+TEST_OTHER_TOKEN = "Qs4dxGcHR34l29RF1c92FgiLQBt3pcM"
+TEST_DEVICE_ID = "5E:2E:EA:XX:XX:XX"
+TEST_OTHER_DEVICE_ID = "5E:2E:EA:YY:YY:YY"
+
+
+async def test_user_unavailable(hass: HomeAssistant) -> None:
+    """Test we handle Unavailable errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        side_effect=Unavailable("message"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "cannot_connect"}
+    assert not result2["last_step"]
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        return_value=None,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+    assert result3["step_id"] == "link"
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        side_effect=Unavailable("message"),
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+    assert result4["type"] == "form"
+    assert result4["step_id"] == "user"
+    assert result4["errors"] == {"base": "cannot_connect"}
+    assert not result4["last_step"]
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        return_value=None,
+    ):
+        result5 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+    assert result5["step_id"] == "link"
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        side_effect=Unavailable("message"),
+    ):
+        result6 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+    assert result6["type"] == "form"
+    assert result6["step_id"] == "user"
+    assert result6["errors"] == {"base": "cannot_connect"}
+    assert not result6["last_step"]
+
+
+async def test_user_not_authorizing_new_tokens(hass: HomeAssistant) -> None:
+    """Test we handle NotAuthorizingNewTokens errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] == "form"
+    assert result["errors"] is None
+    assert not result["last_step"]
+    assert result["step_id"] == "user"
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        side_effect=NotAuthorizingNewTokens("message"),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+    assert result2["type"] == "form"
+    assert result2["errors"] is None
+    assert result2["step_id"] == "link"
+
+    result3 = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+    )
+    assert result3["type"] == "form"
+    assert result3["errors"] is None
+    assert result3["step_id"] == "link"
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        side_effect=NotAuthorizingNewTokens("message"),
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+    assert result4["type"] == "form"
+    assert result4["step_id"] == "link"
+    assert result4["errors"] == {"base": "not_allowing_new_tokens"}
+
+
+async def test_user_manual_invalid_token(hass: HomeAssistant) -> None:
+    """Test we handle InvalidToken errors in manual flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER, "show_advanced_options": True},
+    )
+    assert result["data_schema"] == ADVANCED_USER_SCHEMA
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        return_value=None,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+                CONF_MODE: CONF_MANUAL,
+            },
+        )
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "manual"
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        side_effect=InvalidToken("message"),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_TOKEN: TEST_TOKEN,
+            },
+        )
+
+    assert result3["step_id"] == "manual"
+    assert result3["errors"] == {"base": "invalid_token"}
+    assert result3["type"] == "form"
+
+
+async def test_user_exception(hass: HomeAssistant) -> None:
+    """Test we handle Exception errors."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        side_effect=Exception,
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+    assert result2["type"] == "form"
+    assert result2["step_id"] == "user"
+    assert result2["errors"] == {"base": "unknown"}
+    assert not result2["last_step"]
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        return_value=None,
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: TEST_HOST,
+            },
+        )
+    assert result3["step_id"] == "link"
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        side_effect=Exception,
+    ):
+        result4 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+    assert result4["type"] == "form"
+    assert result4["step_id"] == "link"
+    assert result4["errors"] == {"base": "unknown"}
+
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.Nanoleaf.authorize",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        side_effect=Exception,
+    ):
+        result5 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+    assert result5["type"] == "form"
+    assert result5["step_id"] == "user"
+    assert result5["errors"] == {"base": "unknown"}
+    assert not result5["last_step"]
+
+
+async def test_zeroconf_discovery(hass: HomeAssistant) -> None:
+    """Test zeroconfig discovery flow init."""
+    zeroconf = "_nanoleafms._tcp.local"
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        return_value={"name": TEST_NAME},
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.load_json",
+        return_value={},
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data={
+                "host": TEST_HOST,
+                "name": f"{TEST_NAME}.{zeroconf}",
+                "type": zeroconf,
+                "properties": {"id": TEST_DEVICE_ID},
+            },
+        )
+    assert result["type"] == "form"
+    assert result["step_id"] == "link"
+
+
+async def test_import_config(hass: HomeAssistant) -> None:
+    """Test configuration import."""
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        return_value={"name": TEST_NAME},
+    ), patch(
+        "homeassistant.components.nanoleaf.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_IMPORT},
+            data={CONF_HOST: TEST_HOST, CONF_TOKEN: TEST_TOKEN},
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == TEST_NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST,
+        CONF_TOKEN: TEST_TOKEN,
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import_last_discovery_integration_host_zeroconf(
+    hass: HomeAssistant,
+) -> None:
+    """
+    Test discovery integration import from < 2021.4 (host) with zeroconf.
+
+    Device is last in Nanoleaf config file.
+    """
+    zeroconf = "_nanoleafapi._tcp.local"
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.load_json",
+        return_value={TEST_HOST: {"token": TEST_TOKEN}},
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        return_value={"name": TEST_NAME},
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.save_json",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.nanoleaf.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_ZEROCONF},
+            data={
+                "host": TEST_HOST,
+                "name": f"{TEST_NAME}.{zeroconf}",
+                "type": zeroconf,
+                "properties": {"id": TEST_DEVICE_ID},
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == TEST_NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST,
+        CONF_TOKEN: TEST_TOKEN,
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup_entry.mock_calls) == 1
+
+
+async def test_import_not_last_discovery_integration_device_id_homekit(
+    hass: HomeAssistant,
+) -> None:
+    """
+    Test discovery integration import from >= 2021.4 (device_id) with homekit.
+
+    Device is not the only one in the Nanoleaf config file.
+    """
+    homekit = "_hap._tcp.local"
+    with patch(
+        "homeassistant.components.nanoleaf.config_flow.load_json",
+        return_value={
+            TEST_DEVICE_ID: {"token": TEST_TOKEN},
+            TEST_OTHER_DEVICE_ID: {"token": TEST_OTHER_TOKEN},
+        },
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.pynanoleaf_get_info",
+        return_value={"name": TEST_NAME},
+    ), patch(
+        "homeassistant.components.nanoleaf.config_flow.save_json",
+        return_value=None,
+    ), patch(
+        "homeassistant.components.nanoleaf.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_HOMEKIT},
+            data={
+                "host": TEST_HOST,
+                "name": f"{TEST_NAME}.{homekit}",
+                "type": homekit,
+                "properties": {"id": TEST_DEVICE_ID},
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["title"] == TEST_NAME
+    assert result["data"] == {
+        CONF_HOST: TEST_HOST,
+        CONF_TOKEN: TEST_TOKEN,
+    }
+    await hass.async_block_till_done()
+    assert len(mock_setup_entry.mock_calls) == 1

--- a/tests/components/nanoleaf/test_config_flow.py
+++ b/tests/components/nanoleaf/test_config_flow.py
@@ -199,10 +199,8 @@ async def test_user_exception(hass: HomeAssistant) -> None:
             result["flow_id"],
             {},
         )
-    assert result5["type"] == "form"
-    assert result5["step_id"] == "user"
-    assert result5["errors"] == {"base": "unknown"}
-    assert not result5["last_step"]
+    assert result5["type"] == "abort"
+    assert result5["reason"] == "unknown"
 
 
 async def test_zeroconf_discovery(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change
The Nanoleaf integration migrated to configuration via the UI. Configuring Nanoleaf via YAML configuration has been deprecated and will be removed in a future Home Assistant release. Configuring Nanoleaf via the discovery integration is removed.

Your existing YAML configuration is automatically imported on upgrade to this release; and thus can be safely removed from your YAML configuration after upgrading.

You can remove `discovery:` from your configuration.yaml if you only used it for Nanoleaf.
The `.nanoleaf.conf` file in your config folder will be automatically removed once all devices have been imported.

## Proposed change
- Add config flow
- Discover devices with zeroconf and homekit
- Import configuration.yaml
- Import discovery integration:
  - Mark `nanoleaf_aurora` (old domain) in the discovery integration as converted to config flow
  - Import and edit `.nanoleaf.conf` file
- Set me (@milanmeu) as codeowner


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18349

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
