### PR TITLE
Remove Rituals room size number entity

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/number.py
+++ b/homeassistant/components/rituals_perfume_genie/number.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RitualsDataUpdateCoordinator
-from .const import ATTRIBUTES, COORDINATORS, DEVICES, DOMAIN, ROOM, SPEED
+from .const import ATTRIBUTES, COORDINATORS, DEVICES, DOMAIN, SPEED
 from .entity import DiffuserEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,6 @@ MIN_ROOM_SIZE = 1
 MAX_ROOM_SIZE = 4
 
 PERFUME_AMOUNT_SUFFIX = " Perfume Amount"
-ROOM_SIZE_SUFFIX = " Room Size"
 
 
 async def async_setup_entry(
@@ -37,7 +36,6 @@ async def async_setup_entry(
     for hublot, diffuser in diffusers.items():
         coordinator = coordinators[hublot]
         entities.append(DiffuserPerfumeAmount(diffuser, coordinator))
-        entities.append(DiffuserRoomSize(diffuser, coordinator))
 
     async_add_entities(entities)
 
@@ -81,46 +79,4 @@ class DiffuserPerfumeAmount(NumberEntity, DiffuserEntity):
                 value,
                 MIN_PERFUME_AMOUNT,
                 MAX_PERFUME_AMOUNT,
-            )
-
-
-class DiffuserRoomSize(NumberEntity, DiffuserEntity):
-    """Representation of a diffuser room size number."""
-
-    def __init__(
-        self, diffuser: Diffuser, coordinator: RitualsDataUpdateCoordinator
-    ) -> None:
-        """Initialize the diffuser room size number."""
-        super().__init__(diffuser, coordinator, ROOM_SIZE_SUFFIX)
-
-    @property
-    def icon(self) -> str:
-        """Return the icon of the room size entity."""
-        return "mdi:ruler-square"
-
-    @property
-    def value(self) -> int:
-        """Return the current room size."""
-        return self._diffuser.hub_data[ATTRIBUTES][ROOM]
-
-    @property
-    def min_value(self) -> int:
-        """Return the minimum room size."""
-        return MIN_ROOM_SIZE
-
-    @property
-    def max_value(self) -> int:
-        """Return the maximum room size."""
-        return MAX_ROOM_SIZE
-
-    async def async_set_value(self, value: float) -> None:
-        """Set the room size."""
-        if value.is_integer() and MIN_ROOM_SIZE <= value <= MAX_ROOM_SIZE:
-            await self._diffuser.set_room_size(int(value))
-        else:
-            _LOGGER.warning(
-                "Can't set the room size to %s. Room size must be an integer between %s and %s, inclusive",
-                value,
-                MIN_ROOM_SIZE,
-                MAX_ROOM_SIZE,
             )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The switch extra state attribute `fan_speed` will be removed in 2021.9.
As of this release, the attribute is available as a number entity, this makes it possible to set the value in Home Assistant :tada:.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove Rituals Perfume Genie room size number entity.

The entity was added in #49723 as a number entity. (Not in a release yet)
A select entity would be better but was not available at the time. https://github.com/home-assistant/core/pull/49723#discussion_r633007060
There is a PR open to change the Number entity to a Select entity https://github.com/home-assistant/core/pull/51993. 
Because this PR may not be merged before the next release, the number entity should be removed so that it is not included in the release.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
