### PR TITLE
Create temporary files in tmp directory choosen from platform-dependent folder instead of .storage folder

### DIFF
--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -5,6 +5,7 @@ from collections import deque
 import json
 import logging
 import os
+import shutil
 import tempfile
 from typing import Any, Callable
 
@@ -61,17 +62,16 @@ def save_json(
         raise SerializationError(msg) from error
 
     tmp_filename = ""
-    tmp_path = os.path.split(filename)[0]
     try:
         # Modern versions of Python tempfile create this file with mode 0o600
         with tempfile.NamedTemporaryFile(
-            mode="w", encoding="utf-8", dir=tmp_path, delete=False
+            mode="w", encoding="utf-8", delete=False
         ) as fdesc:
             fdesc.write(json_data)
             tmp_filename = fdesc.name
         if not private:
             os.chmod(tmp_filename, 0o644)
-        os.replace(tmp_filename, filename)
+        shutil.move(tmp_filename, filename)
     except OSError as error:
         _LOGGER.exception("Saving JSON file failed: %s", filename)
         raise WriteError(error) from error

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -5,7 +5,6 @@ from collections import deque
 import json
 import logging
 import os
-import shutil
 import tempfile
 from typing import Any, Callable
 
@@ -62,16 +61,17 @@ def save_json(
         raise SerializationError(msg) from error
 
     tmp_filename = ""
+    tmp_path = os.path.split(filename)[0]
     try:
         # Modern versions of Python tempfile create this file with mode 0o600
         with tempfile.NamedTemporaryFile(
-            mode="w", encoding="utf-8", delete=False
+            mode="w", encoding="utf-8", dir=tmp_path, delete=False
         ) as fdesc:
             fdesc.write(json_data)
             tmp_filename = fdesc.name
         if not private:
             os.chmod(tmp_filename, 0o644)
-        shutil.move(tmp_filename, filename)
+        os.replace(tmp_filename, filename)
     except OSError as error:
         _LOGGER.exception("Saving JSON file failed: %s", filename)
         raise WriteError(error) from error

--- a/homeassistant/util/json.py
+++ b/homeassistant/util/json.py
@@ -61,7 +61,16 @@ def save_json(
         raise SerializationError(msg) from error
 
     tmp_filename = ""
-    tmp_path = os.path.split(filename)[0]
+    storege_temp_dir = os.environ.get("STORAGE_TEMP")
+    if (
+        storege_temp_dir is not None
+        and os.path.exists(storege_temp_dir)
+        and os.access(storege_temp_dir, os.W_OK)
+    ):
+        tmp_path = storege_temp_dir
+    else:
+        tmp_path = os.path.split(filename)[0]
+
     try:
         # Modern versions of Python tempfile create this file with mode 0o600
         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
I am running HA in Docker Swarm with config folder (except recorder db) in S3 bucket in order to have it available on all nodes and to keep files persistent. In current code .storage writes uses named temporry file created inside .storage folder, which leads to many requests to S3 bucket. In order to decrease number or requests/writes I would like to propose to move creation of temporary files to platform-dependend tmp folder which can be in e.g. tmpfs or any similiar concept. According to python documentation platform-dependend may be easily owerwriten by setting TMPDIR, TEMP or TMP environment variables, so it is possible to do some fine-grain easily.

Maybe not many users keeps data on S3 bucket, but this change generally will reduce number of writes to .storage folder, which might be important when keeping data on SD card etc.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
shutils.move is used otherwise "OSError: [Errno 18] Invalid cross-device link" may be reported when using os.replace.

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
