### PR TITLE
Clean up Surepetcare sensor

### DIFF
--- a/homeassistant/components/surepetcare/sensor.py
+++ b/homeassistant/components/surepetcare/sensor.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from surepy.entities import SurepyEntity
 from surepy.enums import EntityType
@@ -57,27 +56,41 @@ class SureBattery(SensorEntity):
         self._id = _id
         self._spc: SurePetcareAPI = spc
 
-        self._surepy_entity: SurepyEntity = self._spc.states[_id]
-        self._state: dict[str, Any] = {}
+        surepy_entity: SurepyEntity = self._spc.states[_id]
 
         self._attr_device_class = DEVICE_CLASS_BATTERY
-        self._attr_name = f"{self._surepy_entity.type.name.capitalize()} {self._surepy_entity.name.capitalize()} Battery Level"
+        self._attr_name = f"{surepy_entity.type.name.capitalize()} {surepy_entity.name.capitalize()} Battery Level"
         self._attr_unit_of_measurement = PERCENTAGE
         self._attr_unique_id = (
-            f"{self._surepy_entity.household_id}-{self._surepy_entity.id}-battery"
+            f"{surepy_entity.household_id}-{surepy_entity.id}-battery"
         )
-
-    @property
-    def available(self) -> bool:
-        """Return true if entity is available."""
-        return bool(self._state)
 
     @callback
     def _async_update(self) -> None:
         """Get the latest data and update the state."""
-        self._surepy_entity = self._spc.states[self._id]
-        self._state = self._surepy_entity.raw_data()["status"]
-        _LOGGER.debug("%s -> self._state: %s", self.name, self._state)
+        surepy_entity = self._spc.states[self._id]
+        state = surepy_entity.raw_data()["status"]
+
+        self._attr_available = bool(state)
+        try:
+            per_battery_voltage = state["battery"] / 4
+            voltage_diff = per_battery_voltage - SURE_BATT_VOLTAGE_LOW
+            self._attr_state = min(
+                int(voltage_diff / SURE_BATT_VOLTAGE_DIFF * 100), 100
+            )
+        except (KeyError, TypeError):
+            self._attr_state = None
+
+        if state:
+            voltage_per_battery = float(state["battery"]) / 4
+            self._attr_extra_state_attributes = {
+                ATTR_VOLTAGE: f"{float(state['battery']):.2f}",
+                f"{ATTR_VOLTAGE}_per_battery": f"{voltage_per_battery:.2f}",
+            }
+        else:
+            self._attr_extra_state_attributes = None
+        self.async_write_ha_state()
+        _LOGGER.debug("%s -> state: %s", self.name, state)
 
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
@@ -85,26 +98,3 @@ class SureBattery(SensorEntity):
             async_dispatcher_connect(self.hass, TOPIC_UPDATE, self._async_update)
         )
         self._async_update()
-
-    @property
-    def state(self) -> int | None:
-        """Return battery level in percent."""
-        try:
-            per_battery_voltage = self._state["battery"] / 4
-            voltage_diff = per_battery_voltage - SURE_BATT_VOLTAGE_LOW
-            return min(int(voltage_diff / SURE_BATT_VOLTAGE_DIFF * 100), 100)
-        except (KeyError, TypeError):
-            return None
-
-    @property
-    def extra_state_attributes(self) -> dict[str, Any] | None:
-        """Return state attributes."""
-        attributes = None
-        if self._state:
-            voltage_per_battery = float(self._state["battery"]) / 4
-            attributes = {
-                ATTR_VOLTAGE: f"{float(self._state['battery']):.2f}",
-                f"{ATTR_VOLTAGE}_per_battery": f"{voltage_per_battery:.2f}",
-            }
-
-        return attributes


### PR DESCRIPTION
Signed-off-by: Daniel Hjelseth Høyer <github@dahoiv.net>

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Surepetcare, cleanup sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
