### PR TITLE
ESPHome delete store data when unloading entry

### DIFF
--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -627,6 +627,7 @@ async def _cleanup_instance(
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload an esphome config entry."""
     entry_data = await _cleanup_instance(hass, entry)
+    await entry_data.async_remove_store()
     return await hass.config_entries.async_unload_platforms(
         entry, entry_data.loaded_platforms
     )

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass, field
 import functools
 import logging
 import math
@@ -18,7 +19,6 @@ from aioesphomeapi import (
     UserService,
     UserServiceArgType,
 )
-import attr
 import voluptuous as vol
 from zeroconf import DNSPointer, DNSRecord, RecordUpdateListener, Zeroconf
 
@@ -55,12 +55,12 @@ _T = TypeVar("_T")
 STORAGE_VERSION = 1
 
 
-@attr.s
+@dataclass
 class DomainData:
     """Define a class that stores global esphome data in hass.data[DOMAIN]."""
 
-    _entry_datas: dict[str, RuntimeEntryData] = attr.ib(factory=dict)
-    _stores: dict[str, Store] = attr.ib(factory=dict)
+    _entry_datas: dict[str, RuntimeEntryData] = field(default_factory=dict)
+    _stores: dict[str, Store] = field(default_factory=dict)
 
     def get_entry_data(self, entry: ConfigEntry) -> RuntimeEntryData:
         """Return the runtime entry data associated with this config entry.

--- a/homeassistant/components/esphome/__init__.py
+++ b/homeassistant/components/esphome/__init__.py
@@ -18,6 +18,7 @@ from aioesphomeapi import (
     UserService,
     UserServiceArgType,
 )
+import attr
 import voluptuous as vol
 from zeroconf import DNSPointer, DNSRecord, RecordUpdateListener, Zeroconf
 
@@ -48,18 +49,61 @@ from homeassistant.helpers.template import Template
 from .entry_data import RuntimeEntryData
 
 DOMAIN = "esphome"
-# hass.data key under which to store `Store` instances for unloaded entries.
-KEY_UNLOADED_STORES = "esphome.unloaded_stores"
 _LOGGER = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 STORAGE_VERSION = 1
 
 
+@attr.s
+class DomainData:
+    """Define a class that stores global esphome data in hass.data[DOMAIN]."""
+
+    _entry_datas: dict[str, RuntimeEntryData] = attr.ib(factory=dict)
+    _stores: dict[str, Store] = attr.ib(factory=dict)
+
+    def get_entry_data(self, entry: ConfigEntry) -> RuntimeEntryData:
+        """Return the runtime entry data associated with this config entry.
+
+        Raises KeyError if the entry isn't loaded yet.
+        """
+        return self._entry_datas[entry.entry_id]
+
+    def set_entry_data(self, entry: ConfigEntry, entry_data: RuntimeEntryData) -> None:
+        """Set the runtime entry data associated with this config entry."""
+        if entry.entry_id in self._entry_datas:
+            raise ValueError("Entry data for this entry is already set")
+        self._entry_datas[entry.entry_id] = entry_data
+
+    def pop_entry_data(self, entry: ConfigEntry) -> RuntimeEntryData:
+        """Pop the runtime entry data instance associated with this config entry."""
+        return self._entry_datas.pop(entry.entry_id)
+
+    def is_entry_loaded(self, entry: ConfigEntry) -> bool:
+        """Check whether the given entry is loaded."""
+        return entry.entry_id in self._entry_datas
+
+    def get_or_create_store(self, hass: HomeAssistant, entry: ConfigEntry) -> Store:
+        """Get or create a Store instance for the given config entry."""
+        return self._stores.setdefault(
+            entry.entry_id,
+            Store(
+                hass, STORAGE_VERSION, f"esphome.{entry.entry_id}", encoder=JSONEncoder
+            ),
+        )
+
+    @classmethod
+    def get(cls: type[_T], hass: HomeAssistant) -> _T:
+        """Get the global DomainData instance stored in hass.data."""
+        # Don't use setdefault - this is a hot code path
+        if DOMAIN in hass.data:
+            return hass.data[DOMAIN]
+        ret = hass.data[DOMAIN] = cls()
+        return ret
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up the esphome component."""
-    hass.data.setdefault(DOMAIN, {})
-
     host = entry.data[CONF_HOST]
     port = entry.data[CONF_PORT]
     password = entry.data[CONF_PASSWORD]
@@ -76,11 +120,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         zeroconf_instance=zeroconf_instance,
     )
 
-    # Store client in per-config-entry hass.data
-    store = _get_store(hass, entry)
-    entry_data = hass.data[DOMAIN][entry.entry_id] = RuntimeEntryData(
-        client=cli, entry_id=entry.entry_id, store=store
+    domain_data = DomainData.get(hass)
+    entry_data = RuntimeEntryData(
+        client=cli,
+        entry_id=entry.entry_id,
+        store=domain_data.get_or_create_store(hass, entry),
     )
+    domain_data.set_entry_data(entry, entry_data)
 
     async def on_stop(event: Event) -> None:
         """Cleanup the socket client on HA stop."""
@@ -286,7 +332,11 @@ class ReconnectLogic(RecordUpdateListener):
 
     @property
     def _entry_data(self) -> RuntimeEntryData | None:
-        return self._hass.data[DOMAIN].get(self._entry.entry_id)
+        domain_data = DomainData.get(self._hass)
+        try:
+            return domain_data.get_entry_data(self._entry)
+        except KeyError:
+            return None
 
     async def _on_disconnect(self):
         """Log and issue callbacks when disconnecting."""
@@ -382,7 +432,7 @@ class ReconnectLogic(RecordUpdateListener):
                 return False
 
         # Check if the entry got removed or disabled, in which case we shouldn't reconnect
-        if self._entry.entry_id not in self._hass.data[DOMAIN]:
+        if not DomainData.get(self._hass).is_entry_loaded(self._entry):
             # When removing/disconnecting manually
             return
 
@@ -615,7 +665,8 @@ async def _cleanup_instance(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> RuntimeEntryData:
     """Cleanup the esphome client if it exists."""
-    data: RuntimeEntryData = hass.data[DOMAIN].pop(entry.entry_id)
+    domain_data = DomainData.get(hass)
+    data = domain_data.pop_entry_data(entry)
     for disconnect_cb in data.disconnect_callbacks:
         disconnect_cb()
     for cleanup_callback in data.cleanup_callbacks:
@@ -627,12 +678,6 @@ async def _cleanup_instance(
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload an esphome config entry."""
     entry_data = await _cleanup_instance(hass, entry)
-
-    # Persist store instance so that it's re-used when removing or loading again
-    # Otherwise race conditions could occur with two separate stores pointing to the same path
-    unloaded_stores: dict[str, Store] = hass.data.setdefault(KEY_UNLOADED_STORES, {})
-    unloaded_stores[entry.entry_id] = entry_data.store
-
     return await hass.config_entries.async_unload_platforms(
         entry, entry_data.loaded_platforms
     )
@@ -640,14 +685,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Remove an esphome config entry."""
-    await _get_store(hass, entry).async_remove()
-
-
-def _get_store(hass: HomeAssistant, entry: ConfigEntry) -> Store:
-    return hass.data.get(KEY_UNLOADED_STORES, {}).get(
-        entry.entry_id,
-        Store(hass, STORAGE_VERSION, f"esphome.{entry.entry_id}", encoder=JSONEncoder),
-    )
+    await DomainData.get(hass).get_or_create_store(hass, entry).async_remove()
 
 
 async def platform_async_setup_entry(
@@ -665,7 +703,7 @@ async def platform_async_setup_entry(
     This method is in charge of receiving, distributing and storing
     info and state updates.
     """
-    entry_data: RuntimeEntryData = hass.data[DOMAIN][entry.entry_id]
+    entry_data: RuntimeEntryData = DomainData.get(hass).get_entry_data(entry)
     entry_data.info[component_key] = {}
     entry_data.old_info[component_key] = {}
     entry_data.state[component_key] = {}
@@ -686,7 +724,7 @@ async def platform_async_setup_entry(
                 old_infos.pop(info.key)
             else:
                 # Create new entity
-                entity = entity_type(entry.entry_id, component_key, info.key)
+                entity = entity_type(entry_data, component_key, info.key)
                 add_entities.append(entity)
             new_infos[info.key] = info
 
@@ -764,9 +802,11 @@ class EsphomeEnumMapper(Generic[_T]):
 class EsphomeBaseEntity(Entity):
     """Define a base esphome entity."""
 
-    def __init__(self, entry_id: str, component_key: str, key: int) -> None:
+    def __init__(
+        self, entry_data: RuntimeEntryData, component_key: str, key: int
+    ) -> None:
         """Initialize."""
-        self._entry_id = entry_id
+        self._entry_data = entry_data
         self._component_key = component_key
         self._key = key
 
@@ -802,8 +842,8 @@ class EsphomeBaseEntity(Entity):
         self.async_write_ha_state()
 
     @property
-    def _entry_data(self) -> RuntimeEntryData:
-        return self.hass.data[DOMAIN][self._entry_id]
+    def _entry_id(self) -> str:
+        return self._entry_data.entry_id
 
     @property
     def _api_version(self) -> APIVersion:

--- a/homeassistant/components/esphome/camera.py
+++ b/homeassistant/components/esphome/camera.py
@@ -32,10 +32,10 @@ async def async_setup_entry(
 class EsphomeCamera(Camera, EsphomeBaseEntity):
     """A camera implementation for ESPHome."""
 
-    def __init__(self, entry_id: str, component_key: str, key: int) -> None:
+    def __init__(self, *args, **kwargs) -> None:
         """Initialize."""
         Camera.__init__(self)
-        EsphomeBaseEntity.__init__(self, entry_id, component_key, key)
+        EsphomeBaseEntity.__init__(self, *args, **kwargs)
         self._image_cond = asyncio.Condition()
 
     @property

--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -12,8 +12,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import DOMAIN
-from .entry_data import RuntimeEntryData
+from . import DOMAIN, DomainData
 
 
 class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -104,9 +103,9 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             ]:
                 # Is this address or IP address already configured?
                 already_configured = True
-            elif entry.entry_id in self.hass.data.get(DOMAIN, {}):
+            elif DomainData.get(self.hass).is_entry_loaded(entry):
                 # Does a config entry with this name already exist?
-                data: RuntimeEntryData = self.hass.data[DOMAIN][entry.entry_id]
+                data = DomainData.get(self.hass).get_entry_data(entry)
 
                 # Node names are unique in the network
                 if data.device_info is not None:

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -181,10 +181,6 @@ class RuntimeEntryData:
 
         self.store.async_delay_save(_memorized_storage, SAVE_DELAY)
 
-    async def async_remove_store(self) -> None:
-        """Permanently delete the store data from the filesystem."""
-        await self.store.async_remove()
-
 
 def _attr_obj_from_dict(cls, **kwargs):
     return cls(**{key: kwargs[key] for key in attr.fields_dict(cls) if key in kwargs})

--- a/homeassistant/components/esphome/entry_data.py
+++ b/homeassistant/components/esphome/entry_data.py
@@ -181,6 +181,10 @@ class RuntimeEntryData:
 
         self.store.async_delay_save(_memorized_storage, SAVE_DELAY)
 
+    async def async_remove_store(self) -> None:
+        """Permanently delete the store data from the filesystem."""
+        await self.store.async_remove()
+
 
 def _attr_obj_from_dict(cls, **kwargs):
     return cls(**{key: kwargs[key] for key in attr.fields_dict(cls) if key in kwargs})

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.esphome import DOMAIN
+from homeassistant.components.esphome import DOMAIN, DomainData
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.data_entry_flow import (
     RESULT_TYPE_ABORT,
@@ -265,7 +265,8 @@ async def test_discovery_already_configured_name(hass, mock_client):
 
     mock_entry_data = MagicMock()
     mock_entry_data.device_info.name = "test8266"
-    hass.data[DOMAIN] = {entry.entry_id: mock_entry_data}
+    domain_data = DomainData.get(hass)
+    domain_data.set_entry_data(entry, mock_entry_data)
 
     service_info = {
         "host": "192.168.43.184",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

ESPHome stores internal data in `.storage/esphome.{entry_id}` - this data is only for recreating entities on HA startup.

When removing an entry, previously that file was just left around (which isn't a real problem because it will never be touched again). This PR explicitly deletes that file on config entry removal.

Additionally, the stores are persisted in a new hass.data entry. (otherwise in _theory_ there could have been minor issues when a config entry was unloaded then re-loaded in short succession; then two `Store` s would point to the same path, each with their own listeners)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: https://github.com/esphome/issues/issues/1637#issuecomment-870348077
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
