### PR TITLE
Upgrade nmap tracker with forked package for compatibility

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
   pull_request: ~
 
 env:
-  CACHE_VERSION: 1
+  CACHE_VERSION: 2
   DEFAULT_PYTHON: 3.8
   PRE_COMMIT_CACHE: ~/.cache/pre-commit
   SQLALCHEMY_WARN_20: 1

--- a/homeassistant/components/nmap_tracker/manifest.json
+++ b/homeassistant/components/nmap_tracker/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nmap Tracker",
   "documentation": "https://www.home-assistant.io/integrations/nmap_tracker",
   "requirements": [
-    "netmap==0.7.0.1",
+    "netmap==0.7.0.2",
     "getmac==0.8.2",
     "ifaddr==0.1.7",
     "mac-vendor-lookup==0.1.11"

--- a/homeassistant/components/nmap_tracker/manifest.json
+++ b/homeassistant/components/nmap_tracker/manifest.json
@@ -3,7 +3,7 @@
   "name": "Nmap Tracker",
   "documentation": "https://www.home-assistant.io/integrations/nmap_tracker",
   "requirements": [
-    "python-nmap==0.6.4",
+    "netmap==0.7.0.1",
     "getmac==0.8.2",
     "ifaddr==0.1.7",
     "mac-vendor-lookup==0.1.11"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1017,6 +1017,9 @@ netdata==0.2.0
 # homeassistant.components.discovery
 netdisco==2.9.0
 
+# homeassistant.components.nmap_tracker
+netmap==0.7.0.1
+
 # homeassistant.components.nam
 nettigo-air-monitor==1.0.0
 
@@ -1862,9 +1865,6 @@ python-mystrom==1.1.2
 
 # homeassistant.components.nest
 python-nest==4.1.0
-
-# homeassistant.components.nmap_tracker
-python-nmap==0.6.4
 
 # homeassistant.components.ozw
 python-openzwave-mqtt[mqtt-client]==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1018,7 +1018,7 @@ netdata==0.2.0
 netdisco==2.9.0
 
 # homeassistant.components.nmap_tracker
-netmap==0.7.0.1
+netmap==0.7.0.2
 
 # homeassistant.components.nam
 nettigo-air-monitor==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -575,7 +575,7 @@ nessclient==0.9.15
 netdisco==2.9.0
 
 # homeassistant.components.nmap_tracker
-netmap==0.7.0.1
+netmap==0.7.0.2
 
 # homeassistant.components.nam
 nettigo-air-monitor==1.0.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -574,6 +574,9 @@ nessclient==0.9.15
 # homeassistant.components.discovery
 netdisco==2.9.0
 
+# homeassistant.components.nmap_tracker
+netmap==0.7.0.1
+
 # homeassistant.components.nam
 nettigo-air-monitor==1.0.0
 
@@ -1035,9 +1038,6 @@ python-miio==0.5.6
 
 # homeassistant.components.nest
 python-nest==4.1.0
-
-# homeassistant.components.nmap_tracker
-python-nmap==0.6.4
 
 # homeassistant.components.ozw
 python-openzwave-mqtt[mqtt-client]==1.4.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace the `python-nmap` package with `netmap` in the NMap Tracker integration.

`python-nmap` has an issue that causes our wheels builds to fail.
An upstream PR is open, but seems stale:
<https://bitbucket.org/xael/python-nmap/pull-requests/1>


In order to keep moving, we've forked the library to our HA libs org and fixed the wheels build.

https://github.com/home-assistant-libs/python-nmap/releases

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
