### PR TITLE
Speed up lookup of AirVisual pollutant labels, levels, and units

### DIFF
--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -56,57 +56,32 @@ NODE_PRO_SENSORS = [
     (SENSOR_KIND_TEMPERATURE, "Temperature", DEVICE_CLASS_TEMPERATURE, TEMP_CELSIUS),
 ]
 
+POLLUTANT_LABELS = {
+    "co": "Carbon Monoxide",
+    "n2": "Nitrogen Dioxide",
+    "o3": "Ozone",
+    "p1": "PM10",
+    "p2": "PM2.5",
+    "s2": "Sulfur Dioxide",
+}
 
-@callback
-def async_get_pollutant_label(symbol):
-    """Get a pollutant's label based on its symbol."""
-    if symbol == "co":
-        return "Carbon Monoxide"
-    if symbol == "n2":
-        return "Nitrogen Dioxide"
-    if symbol == "o3":
-        return "Ozone"
-    if symbol == "p1":
-        return "PM10"
-    if symbol == "p2":
-        return "PM2.5"
-    if symbol == "s2":
-        return "Sulfur Dioxide"
-    return symbol
+POLLUTANT_LEVELS = {
+    (0, 50): ("Good", "mid:emoticon-excited"),
+    (51, 100): ("Moderate", "mid:emoticon-happy"),
+    (101, 150): ("Unhealthy for sensitive groups", "mid:emoticon-neutral"),
+    (151, 200): ("Unhealthy", "mid:emoticon-sad"),
+    (201, 300): ("Very unhealthy", "mid:emoticon-dead"),
+    (301, 1000): ("Hazardous", "mid:biohazard"),
+}
 
-
-@callback
-def async_get_pollutant_level_info(value):
-    """Return a verbal pollutant level (and associated icon) for a numeric value."""
-    if 0 <= value <= 50:
-        return ("Good", "mdi:emoticon-excited")
-    if 51 <= value <= 100:
-        return ("Moderate", "mdi:emoticon-happy")
-    if 101 <= value <= 150:
-        return ("Unhealthy for sensitive groups", "mdi:emoticon-neutral")
-    if 151 <= value <= 200:
-        return ("Unhealthy", "mdi:emoticon-sad")
-    if 201 <= value <= 300:
-        return ("Very Unhealthy", "mdi:emoticon-dead")
-    return ("Hazardous", "mdi:biohazard")
-
-
-@callback
-def async_get_pollutant_unit(symbol):
-    """Get a pollutant's unit based on its symbol."""
-    if symbol == "co":
-        return CONCENTRATION_PARTS_PER_MILLION
-    if symbol == "n2":
-        return CONCENTRATION_PARTS_PER_BILLION
-    if symbol == "o3":
-        return CONCENTRATION_PARTS_PER_BILLION
-    if symbol == "p1":
-        return CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    if symbol == "p2":
-        return CONCENTRATION_MICROGRAMS_PER_CUBIC_METER
-    if symbol == "s2":
-        return CONCENTRATION_PARTS_PER_BILLION
-    return None
+POLLUTANT_UNITS = {
+    "co": CONCENTRATION_PARTS_PER_MILLION,
+    "n2": CONCENTRATION_PARTS_PER_BILLION,
+    "o3": CONCENTRATION_PARTS_PER_BILLION,
+    "p1": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "p2": CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
+    "s2": CONCENTRATION_PARTS_PER_BILLION,
+}
 
 
 async def async_setup_entry(hass, config_entry, async_add_entities):
@@ -197,16 +172,20 @@ class AirVisualGeographySensor(AirVisualEntity, SensorEntity):
 
         if self._kind == SENSOR_KIND_LEVEL:
             aqi = data[f"aqi{self._locale}"]
-            self._state, self._attr_icon = async_get_pollutant_level_info(aqi)
+            [(self._state, self._attr_icon)] = [
+                (name, icon)
+                for (floor, ceiling), (name, icon) in POLLUTANT_LEVELS.items()
+                if floor <= aqi <= ceiling
+            ]
         elif self._kind == SENSOR_KIND_AQI:
             self._state = data[f"aqi{self._locale}"]
         elif self._kind == SENSOR_KIND_POLLUTANT:
             symbol = data[f"main{self._locale}"]
-            self._state = async_get_pollutant_label(symbol)
+            self._state = POLLUTANT_LABELS[symbol]
             self._attrs.update(
                 {
                     ATTR_POLLUTANT_SYMBOL: symbol,
-                    ATTR_POLLUTANT_UNIT: async_get_pollutant_unit(symbol),
+                    ATTR_POLLUTANT_UNIT: POLLUTANT_UNITS[symbol],
                 }
             )
 

--- a/homeassistant/components/airvisual/sensor.py
+++ b/homeassistant/components/airvisual/sensor.py
@@ -66,12 +66,12 @@ POLLUTANT_LABELS = {
 }
 
 POLLUTANT_LEVELS = {
-    (0, 50): ("Good", "mid:emoticon-excited"),
-    (51, 100): ("Moderate", "mid:emoticon-happy"),
-    (101, 150): ("Unhealthy for sensitive groups", "mid:emoticon-neutral"),
-    (151, 200): ("Unhealthy", "mid:emoticon-sad"),
-    (201, 300): ("Very unhealthy", "mid:emoticon-dead"),
-    (301, 1000): ("Hazardous", "mid:biohazard"),
+    (0, 50): ("Good", "mdi:emoticon-excited"),
+    (51, 100): ("Moderate", "mdi:emoticon-happy"),
+    (101, 150): ("Unhealthy for sensitive groups", "mdi:emoticon-neutral"),
+    (151, 200): ("Unhealthy", "mdi:emoticon-sad"),
+    (201, 300): ("Very unhealthy", "mdi:emoticon-dead"),
+    (301, 1000): ("Hazardous", "mdi:biohazard"),
 }
 
 POLLUTANT_UNITS = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
I somehow missed [a suggestion from @MartinHjelmare](https://github.com/home-assistant/core/pull/44903#discussion_r566523534) on how to speed up the lookup of AirVisual pollutant labels, levels, and units – chalk it up to 2020 brain. Now that it's fully into 2021, this PR fixes the issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
