### PR TITLE
Fix MusicCast subwoofers

### DIFF
--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": [
-    "aiomusiccast==0.6"
+    "aiomusiccast==0.7.1"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": [
-    "aiomusiccast==0.7.1"
+    "aiomusiccast==0.8.0a0"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": [
-    "aiomusiccast==0.8.0a0"
+    "aiomusiccast==0.8.0"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -205,13 +205,17 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
     @property
     def volume_level(self):
         """Return the volume level of the media player (0..1)."""
-        volume = self.coordinator.data.zones[self._zone_id].current_volume
-        return (volume - self._volume_min) / (self._volume_max - self._volume_min)
+        if ZoneFeature.VOLUME in self.coordinator.data.zones[self._zone_id].features:
+            volume = self.coordinator.data.zones[self._zone_id].current_volume
+            return (volume - self._volume_min) / (self._volume_max - self._volume_min)
+        return None
 
     @property
     def is_volume_muted(self):
         """Return boolean if volume is currently muted."""
-        return self.coordinator.data.zones[self._zone_id].mute
+        if ZoneFeature.VOLUME in self.coordinator.data.zones[self._zone_id].features:
+            return self.coordinator.data.zones[self._zone_id].mute
+        return None
 
     @property
     def shuffle(self):

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -383,12 +383,6 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
                 "Service next track is not supported for non NetUSB or Tuner sources."
             )
 
-    def clear_playlist(self):
-        """Clear players playlist."""
-        self._cur_track = 0
-        self._player_state = STATE_OFF
-        self.async_write_ha_state()
-
     async def async_set_repeat(self, repeat):
         """Enable/disable repeat mode."""
         if self._is_netusb:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.7.1
+aiomusiccast==0.8.0a0
 
 # homeassistant.components.keyboard_remote
 aionotify==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.6
+aiomusiccast==0.7.1
 
 # homeassistant.components.keyboard_remote
 aionotify==0.2.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.8.0a0
+aiomusiccast==0.8.0
 
 # homeassistant.components.keyboard_remote
 aionotify==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.7.1
+aiomusiccast==0.8.0a0
 
 # homeassistant.components.notion
 aionotion==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.6
+aiomusiccast==0.7.1
 
 # homeassistant.components.notion
 aionotion==1.1.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.8.0a0
+aiomusiccast==0.8.0
 
 # homeassistant.components.notion
 aionotion==1.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A user on discord found a bug when using their Musiccast-enabled subwoofer with the new Musiccast integration. Because the Subwoofer doesn't have dedicated volume support, the setup failed.

This PR adds a feature check and sets the supported features on the media_player correctly.

To do this, the library got updated: https://github.com/vigonotion/aiomusiccast/compare/0.7.1...0.8.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: _Bug got reported via Discord to me_
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
