### PR TITLE
Musiccast grouping fixes

### DIFF
--- a/homeassistant/components/yamaha_musiccast/manifest.json
+++ b/homeassistant/components/yamaha_musiccast/manifest.json
@@ -4,7 +4,7 @@
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/yamaha_musiccast",
   "requirements": [
-    "aiomusiccast==0.8.0"
+    "aiomusiccast==0.8.2"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -587,7 +587,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
         Creates a new group if necessary. Used for join service.
         """
-        _LOGGER.info(
+        _LOGGER.debug(
             "%s wants to add the following entities %s",
             self.entity_id,
             str(group_members),
@@ -636,7 +636,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         _LOGGER.debug(
             "%s added the following entities %s", self.entity_id, str(entities)
         )
-        _LOGGER.info(
+        _LOGGER.debug(
             "%s has now the following musiccast group %s",
             self.entity_id,
             str(self.musiccast_group),
@@ -681,7 +681,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
         if self.musiccast_zone_entity.is_server:
             # If one of the zones of the device is a server, we need to unjoin first.
-            _LOGGER.info(
+            _LOGGER.debug(
                 "%s is a server of a group and has to stop distribution "
                 "to use MusicCast for %s",
                 self.musiccast_zone_entity.entity_id,
@@ -694,7 +694,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
                 _LOGGER.warning("%s is already part of the group", self.entity_id)
                 return
 
-            _LOGGER.info(
+            _LOGGER.debug(
                 "%s is client in a different group, will unjoin first",
                 self.entity_id,
             )
@@ -764,7 +764,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
         Should only be called for servers.
         """
-        _LOGGER.info("%s closes his group", self.entity_id)
+        _LOGGER.debug("%s closes his group", self.entity_id)
         for client in self.musiccast_group:
             if client != self:
                 await client.async_client_leave_group()
@@ -782,7 +782,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
                 client_ips_for_removal.append(expected_client_ip)
 
         if len(client_ips_for_removal) > 0:
-            _LOGGER.info(
+            _LOGGER.debug(
                 "%s says good bye to the following members %s",
                 self.entity_id,
                 str(client_ips_for_removal),

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -148,22 +148,28 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
         self._cur_track = 0
         self._repeat = REPEAT_MODE_OFF
-        self.coordinator.entities.append(self)
 
     async def async_added_to_hass(self):
         """Run when this Entity has been added to HA."""
         await super().async_added_to_hass()
+        self.coordinator.entities.append(self)
         # Sensors should also register callbacks to HA when their state changes
         self.coordinator.musiccast.register_callback(self.async_write_ha_state)
         self.coordinator.musiccast.register_group_update_callback(
             self.update_all_mc_entities
         )
+        self.coordinator.async_add_listener(self.check_client_list)
 
     async def async_will_remove_from_hass(self):
         """Entity being removed from hass."""
         await super().async_will_remove_from_hass()
+        self.coordinator.entities.remove(self)
         # The opposite of async_added_to_hass. Remove any registered call backs here.
         self.coordinator.musiccast.remove_callback(self.async_write_ha_state)
+        self.coordinator.musiccast.remove_group_update_callback(
+            self.update_all_mc_entities
+        )
+        self.coordinator.async_remove_listener(self.check_client_list)
 
     @property
     def should_poll(self):
@@ -573,12 +579,18 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
         return self
 
-    async def update_all_mc_entities(self):
+    async def update_all_mc_entities(self, check_clients=False):
         """Update the whole musiccast system when group data change."""
-        for entity in self.get_all_mc_entities():
-            if entity.is_server:
+        # First update all servers as they provide the group information for their clients
+        for entity in self.get_all_server_entities():
+            if check_clients or self.coordinator.musiccast.group_reduce_by_source:
                 await entity.async_check_client_list()
-            entity.async_write_ha_state()
+            else:
+                entity.async_write_ha_state()
+        # Then update all other entities
+        for entity in self.get_all_mc_entities():
+            if not entity.is_server:
+                entity.async_write_ha_state()
 
     # Services
 
@@ -599,6 +611,9 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             if entity.entity_id in group_members
         ]
 
+        if self.state == STATE_OFF:
+            await self.async_turn_on()
+
         if not self.is_server and self.musiccast_zone_entity.is_server:
             # The MusicCast Distribution Module of this device is already in use. To use it as a server, we first
             # have to unjoin and wait until the servers are updated.
@@ -611,28 +626,29 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             if self.is_server
             else uuid.random_uuid_hex().upper()
         )
+
+        ip_addresses = set()
         # First let the clients join
         for client in entities:
             if client != self:
                 try:
-                    await client.async_client_join(group, self)
+                    if await client.async_client_join(group, self):
+                        ip_addresses.add(client.ip_address)
                 except MusicCastGroupException:
                     _LOGGER.warning(
                         "%s is struggling to update its group data. Will retry perform the update",
                         client.entity_id,
                     )
-                    await client.async_client_join(group, self)
+                    if await client.async_client_join(group, self):
+                        ip_addresses.add(client.ip_address)
 
-        await self.coordinator.musiccast.mc_server_group_extend(
-            self._zone_id,
-            [
-                entity.ip_address
-                for entity in entities
-                if entity.ip_address != self.ip_address
-            ],
-            group,
-            self.get_distribution_num(),
-        )
+        if ip_addresses:
+            await self.coordinator.musiccast.mc_server_group_extend(
+                self._zone_id,
+                list(ip_addresses),
+                group,
+                self.get_distribution_num(),
+            )
         _LOGGER.debug(
             "%s added the following entities %s", self.entity_id, str(entities)
         )
@@ -642,7 +658,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             str(self.musiccast_group),
         )
 
-        await self.update_all_mc_entities()
+        await self.update_all_mc_entities(True)
 
     async def async_unjoin_player(self):
         """Leave the group.
@@ -656,15 +672,15 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         else:
             await self.async_client_leave_group()
 
-        await self.update_all_mc_entities()
+        await self.update_all_mc_entities(True)
 
     # Internal client functions
 
-    async def async_client_join(self, group_id, server):
+    async def async_client_join(self, group_id, server) -> bool:
         """Let the client join a group.
 
         If this client is a server, the server will stop distributing. If the client is part of a different group,
-        it will leave that group first.
+        it will leave that group first. Returns True, if the server has to add the client on his side.
         """
         # If we should join the group, which is served by the main zone, we can simply select main_sync as input.
         _LOGGER.debug("%s called service client join", self.entity_id)
@@ -674,7 +690,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             if server.zone == DEFAULT_ZONE:
                 await self.async_select_source(ATTR_MAIN_SYNC)
                 server.async_write_ha_state()
-                return
+                return False
 
             # It is not possible to join a group hosted by zone2 from main zone.
             raise HomeAssistantError(
@@ -692,9 +708,9 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             await self.musiccast_zone_entity.async_server_close_group()
 
         elif self.is_client:
-            if self.coordinator.data.group_id == server.coordinator.data.group_id:
+            if self.is_part_of_group(server):
                 _LOGGER.warning("%s is already part of the group", self.entity_id)
-                return
+                return False
 
             _LOGGER.debug(
                 "%s is client in a different group, will unjoin first",
@@ -709,20 +725,14 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         ):
             # The device is already part of this group (e.g. main zone is also a client of this group).
             # Just select mc_link as source
-            await self.async_select_source(ATTR_MC_LINK)
-            # As the musiccast group has changed, we need to trigger the servers ha state.
-            # In other cases this happens due to the callback after the dist updated message.
-            server.async_write_ha_state()
-            return
+            await self.coordinator.musiccast.zone_join(self._zone_id)
+            return False
 
         _LOGGER.debug("%s will now join as a client", self.entity_id)
         await self.coordinator.musiccast.mc_client_join(
             server.ip_address, group_id, self._zone_id
         )
-
-        # Ensure that mc link is selected. If main sync was selected previously, it's possible that this does not
-        # happen automatically
-        await self.async_select_source(ATTR_MC_LINK)
+        return True
 
     async def async_client_leave_group(self, force=False):
         """Make self leave the group.
@@ -734,13 +744,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
             self.source == ATTR_MAIN_SYNC
             or [entity for entity in self.other_zones if entity.source == ATTR_MC_LINK]
         ):
-            # If we are only syncing to main or another zone is also using the musiccast module as client, don't
-            # kill the client session, just select a dummy source.
-            save_inputs = self.coordinator.musiccast.get_save_inputs(self._zone_id)
-            if save_inputs:
-                await self.async_select_source(save_inputs[0])
-            # Then turn off the zone
-            await self.async_turn_off()
+            await self.coordinator.musiccast.zone_unjoin(self._zone_id)
         else:
             servers = [
                 server
@@ -752,9 +756,6 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
                 await servers[0].coordinator.musiccast.mc_server_group_reduce(
                     servers[0].zone_id, [self.ip_address], self.get_distribution_num()
                 )
-
-        for server in self.get_all_server_entities():
-            await server.async_check_client_list()
 
     # Internal server functions
 
@@ -771,26 +772,31 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
     async def async_check_client_list(self):
         """Let the server check if all its clients are still part of his group."""
-        _LOGGER.debug("%s updates his group members", self.entity_id)
-        client_ips_for_removal = []
-        for expected_client_ip in self.coordinator.data.group_client_list:
-            if expected_client_ip not in [
-                entity.ip_address for entity in self.musiccast_group
-            ]:
-                # The client is no longer part of the group. Prepare removal.
-                client_ips_for_removal.append(expected_client_ip)
+        if self.is_server and not self.coordinator.data.group_update_lock.locked():
+            _LOGGER.debug("%s updates his group members", self.entity_id)
+            client_ips_for_removal = []
+            for expected_client_ip in self.coordinator.data.group_client_list:
+                if expected_client_ip not in [
+                    entity.ip_address for entity in self.musiccast_group
+                ]:
+                    # The client is no longer part of the group. Prepare removal.
+                    client_ips_for_removal.append(expected_client_ip)
 
-        if client_ips_for_removal:
-            _LOGGER.debug(
-                "%s says good bye to the following members %s",
-                self.entity_id,
-                str(client_ips_for_removal),
-            )
-            await self.coordinator.musiccast.mc_server_group_reduce(
-                self._zone_id, client_ips_for_removal, self.get_distribution_num()
-            )
-        if len(self.musiccast_group) < 2:
-            # The group is empty, stop distribution.
-            await self.async_server_close_group()
+            if client_ips_for_removal:
+                _LOGGER.debug(
+                    "%s says good bye to the following members %s",
+                    self.entity_id,
+                    str(client_ips_for_removal),
+                )
+                await self.coordinator.musiccast.mc_server_group_reduce(
+                    self._zone_id, client_ips_for_removal, self.get_distribution_num()
+                )
+            if len(self.musiccast_group) < 2:
+                # The group is empty, stop distribution.
+                await self.async_server_close_group()
 
-        self.async_write_ha_state()
+            self.async_write_ha_state()
+
+    def check_client_list(self):
+        """Call async_check_client_list from a sync context."""
+        self.hass.create_task(self.async_check_client_list())

--- a/homeassistant/components/yamaha_musiccast/media_player.py
+++ b/homeassistant/components/yamaha_musiccast/media_player.py
@@ -158,7 +158,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         self.coordinator.musiccast.register_group_update_callback(
             self.update_all_mc_entities
         )
-        self.coordinator.async_add_listener(self.check_client_list)
+        self.coordinator.async_add_listener(self.async_schedule_check_client_list)
 
     async def async_will_remove_from_hass(self):
         """Entity being removed from hass."""
@@ -169,7 +169,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
         self.coordinator.musiccast.remove_group_update_callback(
             self.update_all_mc_entities
         )
-        self.coordinator.async_remove_listener(self.check_client_list)
+        self.coordinator.async_remove_listener(self.async_schedule_check_client_list)
 
     @property
     def should_poll(self):
@@ -797,6 +797,7 @@ class MusicCastMediaPlayer(MusicCastDeviceEntity, MediaPlayerEntity):
 
             self.async_write_ha_state()
 
-    def check_client_list(self):
-        """Call async_check_client_list from a sync context."""
+    @callback
+    def async_schedule_check_client_list(self):
+        """Schedule async_check_client_list."""
         self.hass.create_task(self.async_check_client_list())

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -209,7 +209,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.8.0
+aiomusiccast==0.8.2
 
 # homeassistant.components.keyboard_remote
 aionotify==0.2.0

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -134,7 +134,7 @@ aiolyric==1.0.7
 aiomodernforms==0.1.8
 
 # homeassistant.components.yamaha_musiccast
-aiomusiccast==0.8.0
+aiomusiccast==0.8.2
 
 # homeassistant.components.notion
 aionotion==1.1.0


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
This PR implements the changes @MartinHjelmare requested after PR #51952 was merged into dev. There two exceptions from this due to mypy validation errors:
1. In `get_all_mc_entities` we have to check, if the entity is a MusicCastMediaPlayer, otherwise the returned list is of type MusicCastDeviceEntity. Of course we could remove or change the return type from that method, but this would lower the maintainability in my opinion. mypy error:
    `List comprehension has incompatible type List[MusicCastDeviceEntity]; expected List[MusicCastMediaPlayer]`
2. In `is_server` we have to use the len(xxx)>0 pattern because we build a boolean value from this. mypy error:
    `Incompatible return value type (got "Union[bool, Any, List[Any]]", expected "bool")`

In addition, some refactoring for multi_zone devices in groups was done. Therefore the aiomusiccast library was updated. 

This also fixes an issue, which can occur, when using the official musiccast app to create or update groups. Until now it was possible that our integration was that fast in performing checks for the integrity of the groups that the musiccast App did not finish the grouping procedure before this integration restored the old, working group configuration.

Meanwhile @WizBangCrash opened #53406, which is fixed by this PR as he confirmed in the issue.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #53406
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
