### PR TITLE
Validate Number value before calling entity method

### DIFF
--- a/homeassistant/components/demo/number.py
+++ b/homeassistant/components/demo/number.py
@@ -1,8 +1,6 @@
 """Demo platform that offers a fake Number entity."""
 from __future__ import annotations
 
-import voluptuous as vol
-
 from homeassistant.components.number import NumberEntity
 from homeassistant.const import DEVICE_DEFAULT_NAME
 
@@ -82,12 +80,5 @@ class DemoNumber(NumberEntity):
 
     async def async_set_value(self, value):
         """Update the current value."""
-        num_value = float(value)
-
-        if num_value < self.min_value or num_value > self.max_value:
-            raise vol.Invalid(
-                f"Invalid value for {self.entity_id}: {value} (range {self.min_value} - {self.max_value})"
-            )
-
-        self._attr_value = num_value
+        self._attr_value = value
         self.async_write_ha_state()

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -73,8 +73,5 @@ class DemoSelect(SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
-        if option not in self.options:
-            raise ValueError(f"Invalid option for {self.entity_id}: {option}")
-
         self._attr_current_option = option
         self.async_write_ha_state()

--- a/homeassistant/components/demo/select.py
+++ b/homeassistant/components/demo/select.py
@@ -73,5 +73,8 @@ class DemoSelect(SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Update the current selected option."""
+        if option not in self.options:
+            raise ValueError(f"Invalid option for {self.entity_id}: {option}")
+
         self._attr_current_option = option
         self.async_write_ha_state()

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -61,7 +61,7 @@ async def async_set_value(entry: NumberEntity, async_service_call: Callable) -> 
         raise ValueError(
             f"Value {value} not a valid {entry.name} within the range {entry.min_value} - {entry.max_value}"
         )
-    return await entry.async_set_value(value)
+    await entry.async_set_value(value)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -54,14 +54,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_set_value(entry: NumberEntity, service_call: ServiceCall) -> None:
+async def async_set_value(entity: NumberEntity, service_call: ServiceCall) -> None:
     """Service call wrapper to set a new value."""
     value = service_call.data["value"]
-    if value < entry.min_value or value > entry.max_value:
+    if value < entity.min_value or value > entity.max_value:
         raise ValueError(
-            f"Value {value} not a valid for {entry.name} within the range {entry.min_value} - {entry.max_value}"
+            f"Value {value} not a valid for {entity.name} within the range {entity.min_value} - {entity.max_value}"
         )
-    await entry.async_set_value(value)
+    await entity.async_set_value(value)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -8,7 +8,7 @@ from typing import Any, final
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.config_validation import (  # noqa: F401
     PLATFORM_SCHEMA,
     PLATFORM_SCHEMA_BASE,

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -56,7 +56,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
 async def async_set_value(entry: NumberEntity, service_call: ServiceCall) -> None:
     """Service call wrapper to set a new value."""
-    value = getattr(async_service_call, "data")["value"]
+    value = service_call.data["value"]
     if value < entry.min_value or value > entry.max_value:
         raise ValueError(
             f"Value {value} not a valid for {entry.name} within the range {entry.min_value} - {entry.max_value}"

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -54,7 +54,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     return True
 
 
-async def async_set_value(entry: NumberEntity, async_service_call: Callable) -> None:
+async def async_set_value(entry: NumberEntity, service_call: ServiceCall) -> None:
     """Service call wrapper to set a new value."""
     value = getattr(async_service_call, "data")["value"]
     if value < entry.min_value or value > entry.max_value:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -59,7 +59,7 @@ async def async_set_value(entry: NumberEntity, async_service_call: Callable) -> 
     value = getattr(async_service_call, "data")["value"]
     if value < entry.min_value or value > entry.max_value:
         raise ValueError(
-            f"Value {value} not a valid {entry.name} within the range {entry.min_value} - {entry.max_value}"
+            f"Value {value} not a valid for {entry.name} within the range {entry.min_value} - {entry.max_value}"
         )
     await entry.async_set_value(value)
 

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any, final
+from typing import Any, Callable, final
 
 import voluptuous as vol
 
@@ -48,10 +48,20 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(
         SERVICE_SET_VALUE,
         {vol.Required(ATTR_VALUE): vol.Coerce(float)},
-        "async_set_value",
+        async_set_value,
     )
 
     return True
+
+
+async def async_set_value(entry: NumberEntity, async_service_call: Callable) -> None:
+    """Service call wrapper to set a new value."""
+    value = getattr(async_service_call, "data")["value"]
+    if value < entry.min_value or value > entry.max_value:
+        raise ValueError(
+            f"Value {value} not a valid {entry.name} within the range {entry.min_value} - {entry.max_value}"
+        )
+    return await entry.async_set_value(value)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
-from typing import Any, Callable, final
+from typing import Any, final
 
 import voluptuous as vol
 

--- a/homeassistant/components/number/__init__.py
+++ b/homeassistant/components/number/__init__.py
@@ -59,7 +59,7 @@ async def async_set_value(entity: NumberEntity, service_call: ServiceCall) -> No
     value = service_call.data["value"]
     if value < entity.min_value or value > entity.max_value:
         raise ValueError(
-            f"Value {value} not a valid for {entity.name} within the range {entity.min_value} - {entity.max_value}"
+            f"Value {value} for {entity.name} is outside valid range {entity.min_value} - {entity.max_value}"
         )
     await entity.async_set_value(value)
 

--- a/tests/components/demo/test_number.py
+++ b/tests/components/demo/test_number.py
@@ -67,7 +67,7 @@ async def test_set_value_bad_range(hass):
     state = hass.states.get(ENTITY_VOLUME)
     assert state.state == "42.0"
 
-    with pytest.raises(vol.Invalid):
+    with pytest.raises(ValueError):
         await hass.services.async_call(
             DOMAIN,
             SERVICE_SET_VALUE,

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from homeassistant.components.number import DOMAIN, NumberEntity
+from homeassistant.components.number import ATTR_STEP, DOMAIN, NumberEntity
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
@@ -82,7 +82,9 @@ async def test_custom_integration_and_validation(
     assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
     await hass.async_block_till_done()
 
-    assert hass.states.get(reg_entry_1.entity_id).state == "50.0"
+    state = hass.states.get(reg_entry_1.entity_id)
+    assert state.attributes.get(ATTR_VALUE) is None
+    assert state.attributes.get(ATTR_STEP) == 1.0
 
     await hass.services.async_call(
         DOMAIN,
@@ -93,7 +95,8 @@ async def test_custom_integration_and_validation(
 
     hass.states.async_set(reg_entry_1.entity_id, 60.0)
     await hass.async_block_till_done()
-    assert hass.states.get(reg_entry_1.entity_id).state == "60.0"
+    state = hass.states.get(reg_entry_1.entity_id)
+    assert state.state == "60.0"
 
     # test ValueError trigger
     with pytest.raises(ValueError):
@@ -103,5 +106,7 @@ async def test_custom_integration_and_validation(
             {ATTR_VALUE: 110.0, ATTR_ENTITY_ID: reg_entry_1.entity_id},
             blocking=True,
         )
+
     await hass.async_block_till_done()
-    assert hass.states.get(reg_entry_1.entity_id).state == "60.0"
+    state = hass.states.get(reg_entry_1.entity_id)
+    assert state.state == "60.0"

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -3,7 +3,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from homeassistant.components.number import ATTR_STEP, DOMAIN, NumberEntity
+from homeassistant.components.number import (
+    ATTR_STEP,
+    ATTR_VALUE,
+    DOMAIN,
+    SERVICE_SET_VALUE,
+    NumberEntity,
+)
 from homeassistant.const import ATTR_ENTITY_ID, CONF_PLATFORM
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry
@@ -11,9 +17,6 @@ from homeassistant.setup import async_setup_component
 
 from tests.common import mock_registry
 from tests.testing_config.custom_components.test.number import UNIQUE_NUMBER
-
-ATTR_VALUE = "value"
-SERVICE_SET_VALUE = "set_value"
 
 
 class MockDefaultNumberEntity(NumberEntity):

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -70,7 +70,7 @@ async def test_custom_integration_and_validation(
     await hass.async_block_till_done()
 
     state = hass.states.get("number.test")
-    assert state.attributes.get(ATTR_VALUE) is None
+    assert state.state == "50.0"
     assert state.attributes.get(ATTR_STEP) == 1.0
 
     await hass.services.async_call(

--- a/tests/components/number/test_init.py
+++ b/tests/components/number/test_init.py
@@ -38,7 +38,7 @@ class MockNumberEntity(NumberEntity):
         return 0.5
 
 
-async def test_step(hass: HomeAssistant):
+async def test_step(hass: HomeAssistant) -> None:
     """Test the step calculation."""
     number = MockDefaultNumberEntity()
     assert number.step == 1.0
@@ -47,7 +47,7 @@ async def test_step(hass: HomeAssistant):
     assert number_2.step == 0.1
 
 
-async def test_sync_set_value(hass: HomeAssistant):
+async def test_sync_set_value(hass: HomeAssistant) -> None:
     """Test if async set_value calls sync set_value."""
     number = MockDefaultNumberEntity()
     number.hass = hass
@@ -60,8 +60,8 @@ async def test_sync_set_value(hass: HomeAssistant):
 
 
 async def test_custom_integration_and_validation(
-    hass: HomeAssistant, enable_custom_integrations
-):
+    hass: HomeAssistant, enable_custom_integrations: None
+) -> None:
     """Test we can only set valid values."""
     platform = getattr(hass.components, f"test.{DOMAIN}")
     platform.init()

--- a/tests/testing_config/custom_components/test/number.py
+++ b/tests/testing_config/custom_components/test/number.py
@@ -1,0 +1,73 @@
+"""
+Provide a mock number platform.
+
+Call init before using it in your tests to ensure clean test data.
+"""
+from homeassistant.components.number import NumberEntity
+
+from tests.common import MockEntity
+
+UNIQUE_SELECT_1 = "unique_number_1"
+UNIQUE_SELECT_2 = "unique_number_2"
+
+ENTITIES = []
+
+
+class MockSelectEntity(MockEntity, NumberEntity):
+    """Mock Select class."""
+
+    _attr_value = None
+
+    @property
+    def max(self) -> list:
+        """Return the maximum accepted value (inclusive)."""
+        return self._handle("max")
+
+    @property
+    def min(self) -> list:
+        """Return the minimum accepted value (inclusive)."""
+        return self._handle("min")
+
+    @property
+    def value(self):
+        """Return the current value."""
+        return self._handle("value")
+
+
+def set_value(self, value: float) -> None:
+    """Change the selected option."""
+    self._attr_value = value
+
+
+def init(empty=False):
+    """Initialize the platform with entities."""
+    global ENTITIES
+
+    ENTITIES = (
+        []
+        if empty
+        else [
+            MockSelectEntity(
+                name="number 1",
+                unique_id="unique_number_1",
+                min=0.0,
+                max=100.0,
+                value=50.0,
+            ),
+            MockSelectEntity(
+                name="number 2",
+                unique_id="unique_number_2",
+                min=0.0,
+                max=1.0,
+                value=0.5,
+                step=0.1,
+            ),
+        ]
+    )
+
+
+async def async_setup_platform(
+    hass, config, async_add_entities_callback, discovery_info=None
+):
+    """Return mock entities."""
+    async_add_entities_callback(ENTITIES)

--- a/tests/testing_config/custom_components/test/number.py
+++ b/tests/testing_config/custom_components/test/number.py
@@ -7,13 +7,12 @@ from homeassistant.components.number import NumberEntity
 
 from tests.common import MockEntity
 
-UNIQUE_SELECT_1 = "unique_number_1"
-UNIQUE_SELECT_2 = "unique_number_2"
+UNIQUE_NUMBER = "unique_number"
 
 ENTITIES = []
 
 
-class MockSelectEntity(MockEntity, NumberEntity):
+class MockNumberEntity(MockEntity, NumberEntity):
     """Mock Select class."""
 
     _attr_value = None
@@ -33,10 +32,9 @@ class MockSelectEntity(MockEntity, NumberEntity):
         """Return the current value."""
         return self._handle("value")
 
-
-def set_value(self, value: float) -> None:
-    """Change the selected option."""
-    self._attr_value = value
+    def set_value(self, value: float) -> None:
+        """Change the selected option."""
+        self._attr_value = value
 
 
 def init(empty=False):
@@ -47,20 +45,12 @@ def init(empty=False):
         []
         if empty
         else [
-            MockSelectEntity(
+            MockNumberEntity(
                 name="number 1",
-                unique_id="unique_number_1",
+                unique_id=UNIQUE_NUMBER,
                 min=0.0,
                 max=100.0,
                 value=50.0,
-            ),
-            MockSelectEntity(
-                name="number 2",
-                unique_id="unique_number_2",
-                min=0.0,
-                max=1.0,
-                value=0.5,
-                step=0.1,
             ),
         ]
     )

--- a/tests/testing_config/custom_components/test/number.py
+++ b/tests/testing_config/custom_components/test/number.py
@@ -15,17 +15,8 @@ ENTITIES = []
 class MockNumberEntity(MockEntity, NumberEntity):
     """Mock Select class."""
 
-    _attr_value = None
-
-    @property
-    def max(self) -> list:
-        """Return the maximum accepted value (inclusive)."""
-        return self._handle("max")
-
-    @property
-    def min(self) -> list:
-        """Return the minimum accepted value (inclusive)."""
-        return self._handle("min")
+    _attr_value = 50.0
+    _attr_step = 1.0
 
     @property
     def value(self):
@@ -46,9 +37,8 @@ def init(empty=False):
         if empty
         else [
             MockNumberEntity(
-                name="number 1",
+                name="test",
                 unique_id=UNIQUE_NUMBER,
-                value=50.0,
             ),
         ]
     )

--- a/tests/testing_config/custom_components/test/number.py
+++ b/tests/testing_config/custom_components/test/number.py
@@ -48,8 +48,6 @@ def init(empty=False):
             MockNumberEntity(
                 name="number 1",
                 unique_id=UNIQUE_NUMBER,
-                min=0.0,
-                max=100.0,
                 value=50.0,
             ),
         ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The `number` integration supports the `set_value` method to set the numbers value.
The attributes `min_value` and `max_value` should be checked by the platform before they are passed to the entry method.
If a passed `value` is not between  `min_value` and `max_value`  a `ValueError` should be raised. But this not happening.
This PR add this functionality to the number platform and updates the tests for the `demo` platform.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52342
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
