### PR TITLE
Allow combining value_template and position_template for template cover

### DIFF
--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -267,7 +267,8 @@ class CoverTemplate(TemplateEntity, CoverEntity):
                 state,
                 ", ".join(_VALID_STATES),
             )
-            self._position = None
+            if not self._position_template:
+                self._position = None
 
     @callback
     def _update_position(self, result):

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -62,8 +62,7 @@ POSITION_ACTION = "set_cover_position"
 TILT_ACTION = "set_cover_tilt_position"
 CONF_TILT_OPTIMISTIC = "tilt_optimistic"
 
-CONF_VALUE_OR_POSITION_TEMPLATE = "value_or_position"
-CONF_OPEN_OR_CLOSE = "open_or_close"
+CONF_OPEN_AND_CLOSE = "open_or_close"
 
 TILT_FEATURES = (
     SUPPORT_OPEN_TILT
@@ -76,8 +75,8 @@ COVER_SCHEMA = vol.All(
     cv.deprecated(CONF_ENTITY_ID),
     vol.Schema(
         {
-            vol.Inclusive(OPEN_ACTION, CONF_OPEN_OR_CLOSE): cv.SCRIPT_SCHEMA,
-            vol.Inclusive(CLOSE_ACTION, CONF_OPEN_OR_CLOSE): cv.SCRIPT_SCHEMA,
+            vol.Inclusive(OPEN_ACTION, CONF_OPEN_AND_CLOSE): cv.SCRIPT_SCHEMA,
+            vol.Inclusive(CLOSE_ACTION, CONF_OPEN_AND_CLOSE): cv.SCRIPT_SCHEMA,
             vol.Optional(STOP_ACTION): cv.SCRIPT_SCHEMA,
             vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,

--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -79,12 +79,7 @@ COVER_SCHEMA = vol.All(
             vol.Inclusive(OPEN_ACTION, CONF_OPEN_OR_CLOSE): cv.SCRIPT_SCHEMA,
             vol.Inclusive(CLOSE_ACTION, CONF_OPEN_OR_CLOSE): cv.SCRIPT_SCHEMA,
             vol.Optional(STOP_ACTION): cv.SCRIPT_SCHEMA,
-            vol.Exclusive(
-                CONF_POSITION_TEMPLATE, CONF_VALUE_OR_POSITION_TEMPLATE
-            ): cv.template,
-            vol.Exclusive(
-                CONF_VALUE_TEMPLATE, CONF_VALUE_OR_POSITION_TEMPLATE
-            ): cv.template,
+            vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
             vol.Optional(CONF_AVAILABILITY_TEMPLATE): cv.template,
             vol.Optional(CONF_POSITION_TEMPLATE): cv.template,
             vol.Optional(CONF_TILT_TEMPLATE): cv.template,
@@ -258,10 +253,11 @@ class CoverTemplate(TemplateEntity, CoverEntity):
         state = str(result).lower()
 
         if state in _VALID_STATES:
-            if state in ("true", STATE_OPEN):
-                self._position = 100
-            else:
-                self._position = 0
+            if not self._position_template:
+                if state in ("true", STATE_OPEN):
+                    self._position = 100
+                else:
+                    self._position = 0
 
             self._is_opening = state == STATE_OPENING
             self._is_closing = state == STATE_CLOSING

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -89,6 +89,79 @@ async def test_template_state_text(hass, calls):
     assert state.state == STATE_CLOSING
 
 
+async def test_template_state_text_combined(hass, calls):
+    """Test the state text of a template which combines position and value templates."""
+    with assert_setup_component(1, "cover"):
+        assert await setup.async_setup_component(
+            hass,
+            "cover",
+            {
+                "cover": {
+                    "platform": "template",
+                    "covers": {
+                        "test_template_cover": {
+                            "position_template": "{{ states.cover.test.attributes.position }}",
+                            "value_template": "{{ states.cover.test_state.state }}",
+                            "open_cover": {
+                                "service": "cover.open_cover",
+                                "entity_id": "cover.test_state",
+                            },
+                            "close_cover": {
+                                "service": "cover.close_cover",
+                                "entity_id": "cover.test_state",
+                            },
+                        }
+                    },
+                }
+            },
+        )
+
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # Test default state
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_OPEN
+
+    # Change to "open" should be ignored
+    state = hass.states.async_set("cover.test_state", STATE_OPEN)
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_OPEN
+
+    # Change to "closed" should be ignored
+    state = hass.states.async_set("cover.test_state", STATE_CLOSED)
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_OPEN
+
+    # Change to "opening" should be accepted
+    state = hass.states.async_set("cover.test_state", STATE_OPENING)
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_OPENING
+
+    # Change to "closing" should be accepted
+    state = hass.states.async_set("cover.test_state", STATE_CLOSING)
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_CLOSING
+
+    # Set position to 0=closed
+    hass.states.async_set("cover.test", STATE_CLOSED, attributes={"position": 0})
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_CLOSING
+    assert state.attributes["current_position"] == 0
+
+    # Clear "closing" state, STATE_OPEN will be ignored and state derived from position
+    state = hass.states.async_set("cover.test_state", STATE_OPEN)
+    await hass.async_block_till_done()
+    state = hass.states.get("cover.test_template_cover")
+    assert state.state == STATE_CLOSED
+
+
 async def test_template_state_boolean(hass, calls):
     """Test the value_template attribute."""
     with assert_setup_component(1, "cover"):
@@ -248,43 +321,6 @@ async def test_template_out_of_bounds(hass, calls):
     state = hass.states.get("cover.test_template_cover")
     assert state.attributes.get("current_tilt_position") is None
     assert state.attributes.get("current_position") is None
-
-
-async def test_template_mutex(hass, calls):
-    """Test that only value or position template can be used."""
-    with assert_setup_component(0, "cover"):
-        assert await setup.async_setup_component(
-            hass,
-            "cover",
-            {
-                "cover": {
-                    "platform": "template",
-                    "covers": {
-                        "test_template_cover": {
-                            "value_template": "{{ 1 == 1 }}",
-                            "position_template": "{{ 42 }}",
-                            "open_cover": {
-                                "service": "cover.open_cover",
-                                "entity_id": "cover.test_state",
-                            },
-                            "close_cover": {
-                                "service": "cover.close_cover",
-                                "entity_id": "cover.test_state",
-                            },
-                            "icon_template": "{% if states.cover.test_state.state %}"
-                            "mdi:check"
-                            "{% endif %}",
-                        }
-                    },
-                }
-            },
-        )
-
-    await hass.async_block_till_done()
-    await hass.async_start()
-    await hass.async_block_till_done()
-
-    assert hass.states.async_all() == []
 
 
 async def test_template_open_or_position(hass, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow combining `value_template` and `position_template` for template cover

Only states `opening` and `closing` are set from the `value_template`, `position` as well as states `closed` and `open` are derived from the `position_template`.

| value_template output | result |
| ------------- |-------------|
| open | state defined by `position_template` |
| close | state defined by `position_template` |
| true | state defined by `position_template` |
| false | state defined by `position_template` |
| opening | state set to `opening` |
| closing | state set to `closing` |

Background in https://github.com/home-assistant/architecture/discussions/582

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/architecture/discussions/582
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18363

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
