### PR TITLE
Reject trusted network access from proxies

### DIFF
--- a/homeassistant/components/http/forwarded.py
+++ b/homeassistant/components/http/forwarded.py
@@ -129,11 +129,9 @@ def async_setup_forwarded(
             overrides["remote"] = str(forwarded_ip)
             break
         else:
-            _LOGGER.warning(
-                "Request originated directly from a trusted proxy included in X-Forwarded-For: %s, this is likely a miss configuration and will be rejected",
-                forwarded_for_headers,
-            )
-            raise HTTPBadRequest()
+            # If all the IP addresses are from trusted networks, take the left-most.
+            forwarded_for_index = -1
+            overrides["remote"] = str(forwarded_for[-1])
 
         # Handle X-Forwarded-Proto
         forwarded_proto_headers: list[str] = request.headers.getall(

--- a/tests/components/http/test_forwarded.py
+++ b/tests/components/http/test_forwarded.py
@@ -43,9 +43,15 @@ async def test_x_forwarded_for_without_trusted_proxy(aiohttp_client, caplog):
 @pytest.mark.parametrize(
     "trusted_proxies,x_forwarded_for,remote",
     [
+        (
+            ["127.0.0.0/24", "1.1.1.1", "10.10.10.0/24"],
+            "10.10.10.10, 1.1.1.1",
+            "10.10.10.10",
+        ),
         (["127.0.0.0/24", "1.1.1.1"], "123.123.123.123, 2.2.2.2, 1.1.1.1", "2.2.2.2"),
         (["127.0.0.0/24", "1.1.1.1"], "123.123.123.123,2.2.2.2,1.1.1.1", "2.2.2.2"),
         (["127.0.0.0/24"], "123.123.123.123, 2.2.2.2, 1.1.1.1", "1.1.1.1"),
+        (["127.0.0.0/24"], "127.0.0.1", "127.0.0.1"),
         (["127.0.0.1", "1.1.1.1"], "123.123.123.123, 1.1.1.1", "123.123.123.123"),
         (["127.0.0.1", "1.1.1.1"], "123.123.123.123, 2.2.2.2, 1.1.1.1", "2.2.2.2"),
         (["127.0.0.1"], "255.255.255.255", "255.255.255.255"),
@@ -75,33 +81,6 @@ async def test_x_forwarded_for_with_trusted_proxy(
     resp = await mock_api_client.get("/", headers={X_FORWARDED_FOR: x_forwarded_for})
 
     assert resp.status == 200
-
-
-@pytest.mark.parametrize(
-    "trusted_proxies,x_forwarded_for",
-    [
-        (
-            ["127.0.0.0/24", "1.1.1.1", "10.10.10.0/24"],
-            "10.10.10.10, 1.1.1.1",
-        ),
-        (["127.0.0.0/24"], "127.0.0.1"),
-    ],
-)
-async def test_x_forwarded_for_from_trusted_proxy_rejected(
-    trusted_proxies, x_forwarded_for, aiohttp_client
-):
-    """Test that we reject forwarded requests from proxy server itself."""
-
-    app = web.Application()
-    app.router.add_get("/", mock_handler)
-    async_setup_forwarded(
-        app, True, [ip_network(trusted_proxy) for trusted_proxy in trusted_proxies]
-    )
-
-    mock_api_client = await aiohttp_client(app)
-    resp = await mock_api_client.get("/", headers={X_FORWARDED_FOR: x_forwarded_for})
-
-    assert resp.status == 400
 
 
 async def test_x_forwarded_for_disabled_with_proxy(aiohttp_client, caplog):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Instead of blocking access from proxy ip. Let's block the trusted network access from any ip/network defined as a proxy. Note, this also blocks trusted network access from proxy ip, even if it did it by direct access.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: #52073 and #52054

closes #52370

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
