### PR TITLE
ecovacs - allow the skipping of certain ecovacs devices

### DIFF
--- a/homeassistant/components/ecovacs/__init__.py
+++ b/homeassistant/components/ecovacs/__init__.py
@@ -16,6 +16,7 @@ DOMAIN = "ecovacs"
 
 CONF_COUNTRY = "country"
 CONF_CONTINENT = "continent"
+CONF_SKIP = "skip_devices"
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -25,6 +26,7 @@ CONFIG_SCHEMA = vol.Schema(
                 vol.Required(CONF_PASSWORD): cv.string,
                 vol.Required(CONF_COUNTRY): vol.All(vol.Lower, cv.string),
                 vol.Required(CONF_CONTINENT): vol.All(vol.Lower, cv.string),
+                vol.Optional(CONF_SKIP, default=[]): cv.ensure_list,
             }
         )
     },
@@ -57,6 +59,12 @@ def setup(hass, config):
     _LOGGER.debug("Ecobot devices: %s", devices)
 
     for device in devices:
+        if device["nick"] in config[DOMAIN].get(CONF_SKIP):
+            _LOGGER.warning(
+                "Skipping Ecovacs device with nickname %s",
+                device["nick"],
+            )
+            continue
         _LOGGER.info(
             "Discovered Ecovacs device on account: %s with nickname %s",
             device["did"],


### PR DESCRIPTION
allows the skipping of devices that this integration doesn't support which in turn fills the logs with errors

## Proposed change
Add a 'skip_devices' option to the ecovacs integration as such:
```
ecovacs:
  username: !secret ecovacs_username
  password: !secret ecovacs_password
  country: uk
  continent: eu
  skip_devices:
    - Rosie
```
There are a number of newer ecovacs devices on the market that don't work with this integration (yet! ever?), This integration still tries to connect to them and fails filling the logs with errors. By excluding (or skipping) these devices at enumeration time we don't add them to home assistant and so create a device and entities that are always offline and filling the logs with errors.


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Link to documentation pull request: 

https://github.com/home-assistant/home-assistant.io/pull/18362

## Checklist
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
 (There are no tests for this integration)

If user exposed functionality or configuration variables are added/changed:

- [X] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
