### PR TITLE
Bump eight sleep dependency to fix bug

### DIFF
--- a/homeassistant/components/eight_sleep/__init__.py
+++ b/homeassistant/components/eight_sleep/__init__.py
@@ -85,12 +85,15 @@ SERVICE_EIGHT_SCHEMA = vol.Schema(
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        DOMAIN: vol.Schema(
-            {
-                vol.Required(CONF_USERNAME): cv.string,
-                vol.Required(CONF_PASSWORD): cv.string,
-                cv.deprecated(CONF_PARTNER): cv.boolean,
-            }
+        DOMAIN: vol.All(
+            cv.deprecated(CONF_PARTNER),
+            vol.Schema(
+                {
+                    vol.Required(CONF_USERNAME): cv.string,
+                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Optional(CONF_PARTNER): cv.boolean,
+                }
+            ),
         )
     },
     extra=vol.ALLOW_EXTRA,

--- a/homeassistant/components/eight_sleep/binary_sensor.py
+++ b/homeassistant/components/eight_sleep/binary_sensor.py
@@ -35,8 +35,6 @@ class EightHeatSensor(EightSleepHeatEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(eight)
 
-        self._attr_name = f"{name} {self._mapped_name}"
-        self._attr_device_class = DEVICE_CLASS_OCCUPANCY
         self._sensor = sensor
         self._mapped_name = NAME_MAP.get(self._sensor, self._sensor)
         self._state = None
@@ -44,6 +42,9 @@ class EightHeatSensor(EightSleepHeatEntity, BinarySensorEntity):
         self._side = self._sensor.split("_")[0]
         self._userid = self._eight.fetch_userid(self._side)
         self._usrobj = self._eight.users[self._userid]
+
+        self._attr_name = f"{name} {self._mapped_name}"
+        self._attr_device_class = DEVICE_CLASS_OCCUPANCY
 
         _LOGGER.debug(
             "Presence Sensor: %s, Side: %s, User: %s",

--- a/homeassistant/components/eight_sleep/binary_sensor.py
+++ b/homeassistant/components/eight_sleep/binary_sensor.py
@@ -1,7 +1,10 @@
 """Support for Eight Sleep binary sensors."""
 import logging
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import (
+    DEVICE_CLASS_OCCUPANCY,
+    BinarySensorEntity,
+)
 
 from . import CONF_BINARY_SENSORS, DATA_EIGHT, NAME_MAP, EightSleepHeatEntity
 
@@ -32,9 +35,10 @@ class EightHeatSensor(EightSleepHeatEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(eight)
 
+        self._attr_name = f"{name} {self._mapped_name}"
+        self._attr_device_class = DEVICE_CLASS_OCCUPANCY
         self._sensor = sensor
         self._mapped_name = NAME_MAP.get(self._sensor, self._sensor)
-        self._name = f"{name} {self._mapped_name}"
         self._state = None
 
         self._side = self._sensor.split("_")[0]
@@ -47,11 +51,6 @@ class EightHeatSensor(EightSleepHeatEntity, BinarySensorEntity):
             self._side,
             self._userid,
         )
-
-    @property
-    def name(self):
-        """Return the name of the sensor, if any."""
-        return self._name
 
     @property
     def is_on(self):

--- a/homeassistant/components/eight_sleep/manifest.json
+++ b/homeassistant/components/eight_sleep/manifest.json
@@ -2,7 +2,7 @@
   "domain": "eight_sleep",
   "name": "Eight Sleep",
   "documentation": "https://www.home-assistant.io/integrations/eight_sleep",
-  "requirements": ["pyeight==0.1.7"],
+  "requirements": ["pyeight==0.1.8"],
   "codeowners": ["@mezz64"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/eight_sleep/manifest.json
+++ b/homeassistant/components/eight_sleep/manifest.json
@@ -2,7 +2,7 @@
   "domain": "eight_sleep",
   "name": "Eight Sleep",
   "documentation": "https://www.home-assistant.io/integrations/eight_sleep",
-  "requirements": ["pyeight==0.1.5"],
+  "requirements": ["pyeight==0.1.7"],
   "codeowners": ["@mezz64"],
   "iot_class": "cloud_polling"
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1396,7 +1396,7 @@ pyeconet==0.1.14
 pyedimax==0.2.1
 
 # homeassistant.components.eight_sleep
-pyeight==0.1.5
+pyeight==0.1.7
 
 # homeassistant.components.emby
 pyemby==1.7

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1396,7 +1396,7 @@ pyeconet==0.1.14
 pyedimax==0.2.1
 
 # homeassistant.components.eight_sleep
-pyeight==0.1.7
+pyeight==0.1.8
 
 # homeassistant.components.emby
 pyemby==1.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
The `partner` configuration option has been deprecated and will be removed in a future Home Assistant release


## Proposed change
The current version of `pyEight` has several bugs:
1. Username and password weren't URL encoded before being passed to the Eight Sleep API so some passwords would cause the authentication step to fail (fixed here: https://github.com/mezz64/pyEight/pull/17)
2. There was a bug if you were a solo sleeper configured in the app to be on a certain side of the bed that would cause the code to raise an exception (that was fixed here, along with some other cleanup, like allowing HA to pass in the client session to the library: https://github.com/mezz64/pyEight/pull/18)
3. The appropriate headers were not passed to the clientsession provided by HA which caused API failures to happen (this was newly introduced by some of my changes but is fixed in https://github.com/mezz64/pyEight/pull/19)
4. Sometimes we tried to access an Index that didn't exist and it wasn't caught (also fixed in https://github.com/mezz64/pyEight/pull/19)

As a result of the changes in 2, users no longer need to tell the library if there are two people using the bed, the library will figure it out on its own


https://github.com/mezz64/pyEight/compare/0.1.5...0.1.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
