### PR TITLE
Demo: remove deprecated switch entity properties

### DIFF
--- a/homeassistant/components/demo/sensor.py
+++ b/homeassistant/components/demo/sensor.py
@@ -10,9 +10,13 @@ from homeassistant.const import (
     CONCENTRATION_PARTS_PER_MILLION,
     DEVICE_CLASS_CO,
     DEVICE_CLASS_CO2,
+    DEVICE_CLASS_ENERGY,
     DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
+    POWER_WATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
@@ -66,6 +70,24 @@ async def async_setup_platform(
                 STATE_CLASS_MEASUREMENT,
                 CONCENTRATION_PARTS_PER_MILLION,
                 14,
+            ),
+            DemoSensor(
+                "sensor_5",
+                "Power consumption",
+                100,
+                DEVICE_CLASS_POWER,
+                STATE_CLASS_MEASUREMENT,
+                POWER_WATT,
+                None,
+            ),
+            DemoSensor(
+                "sensor_6",
+                "Today energy",
+                15,
+                DEVICE_CLASS_ENERGY,
+                STATE_CLASS_MEASUREMENT,
+                ENERGY_KILO_WATT_HOUR,
+                None,
             ),
         ]
     )

--- a/homeassistant/components/demo/switch.py
+++ b/homeassistant/components/demo/switch.py
@@ -49,7 +49,6 @@ class DemoSwitch(SwitchEntity):
         self._attr_icon = icon
         self._attr_is_on = state
         self._attr_name = name or DEVICE_DEFAULT_NAME
-        self._attr_today_energy_kwh = 15
         self._attr_unique_id = unique_id
 
     @property
@@ -63,11 +62,9 @@ class DemoSwitch(SwitchEntity):
     def turn_on(self, **kwargs):
         """Turn the switch on."""
         self._attr_is_on = True
-        self._attr_current_power_w = 100
         self.schedule_update_ha_state()
 
     def turn_off(self, **kwargs):
         """Turn the device off."""
         self._attr_is_on = False
-        self._attr_current_power_w = 0
         self.schedule_update_ha_state()

--- a/tests/components/demo/test_switch.py
+++ b/tests/components/demo/test_switch.py
@@ -1,0 +1,88 @@
+"""The tests for the demo switch component."""
+import pytest
+
+from homeassistant.components.demo import DOMAIN
+from homeassistant.components.switch import (
+    DOMAIN as SWITCH_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON
+from homeassistant.setup import async_setup_component
+
+SWITCH_ENTITY_IDS = ["switch.decorative_lights", "switch.ac"]
+
+
+@pytest.fixture(autouse=True)
+async def setup_comp(hass):
+    """Set up demo component."""
+    assert await async_setup_component(
+        hass, SWITCH_DOMAIN, {SWITCH_DOMAIN: {"platform": DOMAIN}}
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
+async def test_turn_on(hass, switch_entity_id):
+    """Test switch turn on method."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: switch_entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(switch_entity_id)
+    assert state.state == STATE_OFF
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: switch_entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(switch_entity_id)
+    assert state.state == STATE_ON
+
+
+@pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
+async def test_turn_off(hass, switch_entity_id):
+    """Test switch turn off method."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: switch_entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(switch_entity_id)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: switch_entity_id},
+        blocking=True,
+    )
+
+    state = hass.states.get(switch_entity_id)
+    assert state.state == STATE_OFF
+
+
+@pytest.mark.parametrize("switch_entity_id", SWITCH_ENTITY_IDS)
+async def test_turn_off_without_entity_id(hass, switch_entity_id):
+    """Test switch turn off all switches."""
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: "all"}, blocking=True
+    )
+
+    state = hass.states.get(switch_entity_id)
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: "all"}, blocking=True
+    )
+
+    state = hass.states.get(switch_entity_id)
+    assert state.state == STATE_OFF

--- a/tests/components/emulated_kasa/test_init.py
+++ b/tests/components/emulated_kasa/test_init.py
@@ -217,6 +217,12 @@ async def test_switch_power(hass):
         SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: ENTITY_SWITCH}, blocking=True
     )
 
+    hass.states.async_set(
+        ENTITY_SWITCH,
+        STATE_ON,
+        attributes={ATTR_CURRENT_POWER_W: 100, ATTR_FRIENDLY_NAME: "AC"},
+    )
+
     switch = hass.states.get(ENTITY_SWITCH)
     assert switch.state == STATE_ON
     power = switch.attributes[ATTR_CURRENT_POWER_W]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
Demo switch entity no longer reports `current_power_w` and `today_energy_kwh`

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed [architecture#579](https://github.com/home-assistant/architecture/discussions/579,) the following properties of the demo platform switch entity removed and migrated to sensors:
- `current_power_w`
- `today_energy_kwh`

Add tests for demo switch platform
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [X] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
