### PR TITLE
Fix Statistics recorder migration path by dropping in pairs

### DIFF
--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -466,9 +466,8 @@ def _apply_update(engine, session, new_version, old_version):
         # Recreate the statistics and statistics meta tables.
         #
         # Order matters! Statistics has a relation with StatisticsMeta,
-        # so statistics need to be deleted before meta,
-        # and meta needs to be created before statistics.
-        # Recreate the statistics & statistics meta tables.
+        # so statistics need to be deleted before meta (or in pair depending
+        # on the SQL backend); and meta needs to be created before statistics.
         if sqlalchemy.inspect(engine).has_table(
             StatisticsMeta.__tablename__
         ) or sqlalchemy.inspect(engine).has_table(Statistics.__tablename__):

--- a/homeassistant/components/recorder/migration.py
+++ b/homeassistant/components/recorder/migration.py
@@ -347,7 +347,7 @@ def _drop_foreign_key_constraints(connection, engine, table, columns):
             )
 
 
-def _apply_update(engine, session, new_version, old_version):  # noqa: C901
+def _apply_update(engine, session, new_version, old_version):
     """Perform operations to bring schema up to date."""
     connection = session.connection()
     if new_version == 1:
@@ -463,14 +463,20 @@ def _apply_update(engine, session, new_version, old_version):  # noqa: C901
         # This dropped the statistics table, done again in version 18.
         pass
     elif new_version == 18:
-        # Recreate the statisticsmeta tables
-        if sqlalchemy.inspect(engine).has_table(StatisticsMeta.__tablename__):
-            StatisticsMeta.__table__.drop(engine)
-        StatisticsMeta.__table__.create(engine)
+        # Recreate the statistics and statistics meta tables.
+        #
+        # Order matters! Statistics has a relation with StatisticsMeta,
+        # so statistics need to be deleted before meta,
+        # and meta needs to be created before statistics.
+        # Recreate the statistics & statistics meta tables.
+        if sqlalchemy.inspect(engine).has_table(
+            StatisticsMeta.__tablename__
+        ) or sqlalchemy.inspect(engine).has_table(Statistics.__tablename__):
+            Base.metadata.drop_all(
+                bind=engine, tables=[Statistics.__table__, StatisticsMeta.__table__]
+            )
 
-        # Recreate the statistics table
-        if sqlalchemy.inspect(engine).has_table(Statistics.__tablename__):
-            Statistics.__table__.drop(engine)
+        StatisticsMeta.__table__.create(engine)
         Statistics.__table__.create(engine)
     else:
         raise ValueError(f"No schema migration defined for version {new_version}")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Another iteration in resolving the database migration issues, introduced in b0 @ #52331, became problematic in b1 @ #52417 and attempted fix in b2 @ #52449.

This PR cleanup in the right order (whatever the case) and creates in the right order (whatever the case). Also, if the tables were already created including their constraints, it will drop them as a pair to prevent issues with dropping. Cleanup and creation should be in reverse order of each other.

People who have successfully migrated, and thus on schema version 18 already, are not affected. Instances in beta that failed the upgrade should still be on 17 (and older on <17) and this
PR should fix further issues.

There is 1 case that isn't fixable. This only applies to people using MySQL/MariaDB that have been on b0 and b1, these people are missing a statistics table while having an incorrect meta data table. SQLAlchmey will try to create a statistics table against an outdated meta table, before migration even kicks in.

As the latter is a rare case (b1 has been online short) and affects only beta testers using MySQL; this case isn't fixed. Those users should simply drop the `statistics_meta` table and restart Home Assistant (`DROP TABLE statistics_meta;`).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
