### PR TITLE
Handle FailedCommand exceptions in zwave_js WS API

### DIFF
--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -1183,7 +1183,6 @@ async def websocket_update_log_config(
     },
 )
 @websocket_api.async_response
-@async_catch_zwave_errors
 @async_get_entry
 async def websocket_get_log_config(
     hass: HomeAssistant,

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -148,10 +148,11 @@ def async_catch_zwave_errors(orig_func: Callable) -> Callable:
         connection: ActiveConnection,
         msg: dict,
         *args: list,
+        **kwargs: dict,
     ) -> None:
         """Catch FailedZWaveCommand within function and send relevant error."""
         try:
-            await orig_func(hass, connection, msg, *args)
+            await orig_func(hass, connection, msg, *args, **kwargs)
         except FailedZWaveCommand as err:
             error_msg = f"{err.zwave_error_code}: {err.zwave_error_message}"
             # Unsubscribe to callbacks

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -144,7 +144,7 @@ def async_handle_failed_command(orig_func: Callable) -> Callable:
         hass: HomeAssistant,
         connection: ActiveConnection,
         msg: dict,
-        *args: list,
+        *args: Any,
         **kwargs: dict,
     ) -> None:
         """Handle FailedCommand within function and send relevant error."""

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -83,9 +83,6 @@ STATUS = "status"
 ENABLED = "enabled"
 OPTED_IN = "opted_in"
 
-# Error codes
-ERR_ZWAVE_ERROR = "zwave_error"
-
 
 def async_get_entry(orig_func: Callable) -> Callable:
     """Decorate async function to get entry."""

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -145,7 +145,7 @@ def async_handle_failed_command(orig_func: Callable) -> Callable:
         connection: ActiveConnection,
         msg: dict,
         *args: Any,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         """Handle FailedCommand within function and send relevant error."""
         try:

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -154,12 +154,11 @@ def async_catch_zwave_errors(orig_func: Callable) -> Callable:
         try:
             await orig_func(hass, connection, msg, *args, **kwargs)
         except FailedZWaveCommand as err:
-            error_msg = f"{err.zwave_error_code}: {err.zwave_error_message}"
             # Unsubscribe to callbacks
             if unsubs := msg.get(DATA_UNSUBSCRIBE):
                 for unsub in unsubs:
                     unsub()
-            connection.send_error(msg[ID], ERR_ZWAVE_ERROR, error_msg)
+            connection.send_error(msg[ID], ERR_ZWAVE_ERROR, err.args[0])
 
     return async_catch_zwave_errors_func
 

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import dataclasses
 from functools import partial, wraps
 import json
-from typing import Callable
+from typing import Any, Callable
 
 from aiohttp import hdrs, web, web_exceptions, web_request
 import voluptuous as vol

--- a/homeassistant/components/zwave_js/api.py
+++ b/homeassistant/components/zwave_js/api.py
@@ -151,7 +151,7 @@ def async_catch_zwave_errors(orig_func: Callable) -> Callable:
     ) -> None:
         """Catch FailedZWaveCommand within function and send relevant error."""
         try:
-            orig_func(hass, connection, msg, *args)
+            await orig_func(hass, connection, msg, *args)
         except FailedZWaveCommand as err:
             error_msg = f"{err.zwave_error_code}: {err.zwave_error_message}"
             # Unsubscribe to callbacks

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -285,7 +285,7 @@ async def test_ping_node(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.node.Node.async_ping",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -299,7 +299,7 @@ async def test_ping_node(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -409,7 +409,7 @@ async def test_add_node(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_begin_inclusion",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -422,7 +422,7 @@ async def test_add_node(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -461,7 +461,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_stop_inclusion",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -474,12 +474,12 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_stop_exclusion",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -492,7 +492,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -572,7 +572,7 @@ async def test_remove_node(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_begin_exclusion",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -585,7 +585,7 @@ async def test_remove_node(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -737,7 +737,7 @@ async def test_replace_failed_node(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_replace_failed_node",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -751,7 +751,7 @@ async def test_replace_failed_node(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -820,7 +820,7 @@ async def test_remove_failed_node(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_remove_failed_node",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -834,7 +834,7 @@ async def test_remove_failed_node(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -881,7 +881,7 @@ async def test_begin_healing_network(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_begin_healing_network",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -894,7 +894,7 @@ async def test_begin_healing_network(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -989,7 +989,7 @@ async def test_stop_healing_network(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_stop_healing_network",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1002,7 +1002,7 @@ async def test_stop_healing_network(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1049,7 +1049,7 @@ async def test_heal_node(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.controller.Controller.async_heal_node",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1063,7 +1063,7 @@ async def test_heal_node(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1167,7 +1167,7 @@ async def test_refresh_node_info(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.node.Node.async_refresh_info",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1181,7 +1181,7 @@ async def test_refresh_node_info(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1256,7 +1256,7 @@ async def test_refresh_node_values(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.node.Node.async_refresh_values",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1270,7 +1270,7 @@ async def test_refresh_node_values(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1349,7 +1349,7 @@ async def test_refresh_node_cc_values(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.node.Node.async_refresh_cc_values",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1364,7 +1364,7 @@ async def test_refresh_node_cc_values(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1571,7 +1571,7 @@ async def test_set_config_parameter(
     # Test FailedZWaveCommand is caught
     with patch(
         "homeassistant.components.zwave_js.api.async_set_config_parameter",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1588,7 +1588,7 @@ async def test_set_config_parameter(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -1911,7 +1911,7 @@ async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.driver.Driver.async_start_listening_logs",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -1924,7 +1924,7 @@ async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2061,7 +2061,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.driver.Driver.async_update_log_config",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -2075,7 +2075,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2207,7 +2207,7 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.driver.Driver.async_is_statistics_enabled",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -2220,12 +2220,12 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.driver.Driver.async_enable_statistics",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -2239,7 +2239,7 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2298,7 +2298,7 @@ async def test_abort_firmware_update(
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.node.Node.async_abort_firmware_update",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -2312,7 +2312,7 @@ async def test_abort_firmware_update(
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2524,7 +2524,7 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.driver.Driver.async_check_for_config_updates",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -2537,7 +2537,7 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
@@ -2589,7 +2589,7 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
     # Test FailedZWaveCommand is caught
     with patch(
         "zwave_js_server.model.driver.Driver.async_install_config_update",
-        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+        side_effect=FailedZWaveCommand("failed_command", 1, "error message"),
     ):
         await ws_client.send_json(
             {
@@ -2602,7 +2602,7 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
 
         assert not msg["success"]
         assert msg["error"]["code"] == ERR_ZWAVE_ERROR
-        assert msg["error"]["message"] == "1: a"
+        assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -20,7 +20,6 @@ from homeassistant.components.zwave_js.api import (
     ENABLED,
     ENTRY_ID,
     ERR_NOT_LOADED,
-    ERR_ZWAVE_ERROR,
     FILENAME,
     FORCE_CONSOLE,
     ID,
@@ -298,7 +297,7 @@ async def test_ping_node(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -421,7 +420,7 @@ async def test_add_node(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -473,7 +472,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test FailedZWaveCommand is caught
@@ -491,7 +490,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -584,7 +583,7 @@ async def test_remove_node(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -750,7 +749,7 @@ async def test_replace_failed_node(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -833,7 +832,7 @@ async def test_remove_failed_node(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -893,7 +892,7 @@ async def test_begin_healing_network(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1001,7 +1000,7 @@ async def test_stop_healing_network(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1062,7 +1061,7 @@ async def test_heal_node(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1180,7 +1179,7 @@ async def test_refresh_node_info(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1269,7 +1268,7 @@ async def test_refresh_node_values(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1363,7 +1362,7 @@ async def test_refresh_node_cc_values(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1587,7 +1586,7 @@ async def test_set_config_parameter(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -1923,7 +1922,7 @@ async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -2074,7 +2073,7 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -2219,7 +2218,7 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test FailedZWaveCommand is caught
@@ -2238,7 +2237,7 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -2311,7 +2310,7 @@ async def test_abort_firmware_update(
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -2536,7 +2535,7 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails
@@ -2601,7 +2600,7 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
         msg = await ws_client.receive_json()
 
         assert not msg["success"]
-        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["code"] == "zwave_error"
         assert msg["error"]["message"] == "Z-Wave error 1: error message"
 
     # Test sending command with not loaded entry fails

--- a/tests/components/zwave_js/test_api.py
+++ b/tests/components/zwave_js/test_api.py
@@ -7,6 +7,7 @@ from zwave_js_server.const import LogLevel
 from zwave_js_server.event import Event
 from zwave_js_server.exceptions import (
     FailedCommand,
+    FailedZWaveCommand,
     InvalidNewValue,
     NotFoundError,
     SetValueFailed,
@@ -19,6 +20,7 @@ from homeassistant.components.zwave_js.api import (
     ENABLED,
     ENTRY_ID,
     ERR_NOT_LOADED,
+    ERR_ZWAVE_ERROR,
     FILENAME,
     FORCE_CONSOLE,
     ID,
@@ -280,13 +282,32 @@ async def test_ping_node(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.node.Node.async_ping",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 5,
+                TYPE: "zwave_js/ping_node",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: node.node_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 5,
+            ID: 6,
             TYPE: "zwave_js/ping_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: node.node_id,
@@ -385,12 +406,30 @@ async def test_add_node(
     msg = await ws_client.receive_json()
     assert msg["event"]["event"] == "interview failed"
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_begin_inclusion",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/add_node",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 4, TYPE: "zwave_js/add_node", ENTRY_ID: entry.entry_id}
+        {ID: 5, TYPE: "zwave_js/add_node", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 
@@ -419,12 +458,48 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
     msg = await ws_client.receive_json()
     assert msg["success"]
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_stop_inclusion",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 6,
+                TYPE: "zwave_js/stop_inclusion",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_stop_exclusion",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 7,
+                TYPE: "zwave_js/stop_exclusion",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 6, TYPE: "zwave_js/stop_inclusion", ENTRY_ID: entry.entry_id}
+        {ID: 8, TYPE: "zwave_js/stop_inclusion", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 
@@ -432,7 +507,7 @@ async def test_cancel_inclusion_exclusion(hass, integration, client, hass_ws_cli
     assert msg["error"]["code"] == ERR_NOT_LOADED
 
     await ws_client.send_json(
-        {ID: 7, TYPE: "zwave_js/stop_exclusion", ENTRY_ID: entry.entry_id}
+        {ID: 9, TYPE: "zwave_js/stop_exclusion", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 
@@ -494,12 +569,30 @@ async def test_remove_node(
     )
     assert device is None
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_begin_exclusion",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/remove_node",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 4, TYPE: "zwave_js/remove_node", ENTRY_ID: entry.entry_id}
+        {ID: 5, TYPE: "zwave_js/remove_node", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 
@@ -641,13 +734,32 @@ async def test_replace_failed_node(
     msg = await ws_client.receive_json()
     assert msg["event"]["event"] == "interview failed"
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_replace_failed_node",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/replace_failed_node",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 67,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 5,
             TYPE: "zwave_js/replace_failed_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
@@ -705,13 +817,32 @@ async def test_remove_failed_node(
     )
     assert device is None
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_remove_failed_node",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/remove_failed_node",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 67,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 5,
             TYPE: "zwave_js/remove_failed_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
@@ -747,13 +878,31 @@ async def test_begin_healing_network(
     assert msg["success"]
     assert msg["result"]
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_begin_healing_network",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/begin_healing_network",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 5,
             TYPE: "zwave_js/begin_healing_network",
             ENTRY_ID: entry.entry_id,
         }
@@ -837,13 +986,31 @@ async def test_stop_healing_network(
     assert msg["success"]
     assert msg["result"]
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_stop_healing_network",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/stop_healing_network",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 5,
             TYPE: "zwave_js/stop_healing_network",
             ENTRY_ID: entry.entry_id,
         }
@@ -879,13 +1046,32 @@ async def test_heal_node(
     assert msg["success"]
     assert msg["result"]
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.controller.Controller.async_heal_node",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/heal_node",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 67,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 5,
             TYPE: "zwave_js/heal_node",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 67,
@@ -978,13 +1164,32 @@ async def test_refresh_node_info(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.node.Node.async_refresh_info",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 3,
+                TYPE: "zwave_js/refresh_node_info",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 52,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 3,
+            ID: 4,
             TYPE: "zwave_js/refresh_node_info",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 52,
@@ -1048,6 +1253,42 @@ async def test_refresh_node_values(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.node.Node.async_refresh_values",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/refresh_node_values",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 52,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 5,
+            TYPE: "zwave_js/refresh_node_values",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: 52,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
+
 
 async def test_refresh_node_cc_values(
     hass, client, multisensor_6, integration, hass_ws_client
@@ -1105,13 +1346,33 @@ async def test_refresh_node_cc_values(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.node.Node.async_refresh_cc_values",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/refresh_node_cc_values",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 52,
+                COMMAND_CLASS_ID: 112,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 5,
             TYPE: "zwave_js/refresh_node_cc_values",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 52,
@@ -1307,13 +1568,35 @@ async def test_set_config_parameter(
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "homeassistant.components.zwave_js.api.async_set_config_parameter",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 7,
+                TYPE: "zwave_js/set_config_parameter",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: 52,
+                PROPERTY: 102,
+                PROPERTY_KEY: 1,
+                VALUE: 1,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 7,
+            ID: 8,
             TYPE: "zwave_js/set_config_parameter",
             ENTRY_ID: entry.entry_id,
             NODE_ID: 52,
@@ -1625,12 +1908,30 @@ async def test_subscribe_log_updates(hass, integration, client, hass_ws_client):
         },
     }
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_start_listening_logs",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 2,
+                TYPE: "zwave_js/subscribe_log_updates",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
-        {ID: 2, TYPE: "zwave_js/subscribe_log_updates", ENTRY_ID: entry.entry_id}
+        {ID: 3, TYPE: "zwave_js/subscribe_log_updates", ENTRY_ID: entry.entry_id}
     )
     msg = await ws_client.receive_json()
 
@@ -1757,13 +2058,32 @@ async def test_update_log_config(hass, client, integration, hass_ws_client):
         and "must be provided if logging to file" in msg["error"]["message"]
     )
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_update_log_config",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 7,
+                TYPE: "zwave_js/update_log_config",
+                ENTRY_ID: entry.entry_id,
+                CONFIG: {LEVEL: "Error"},
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 7,
+            ID: 8,
             TYPE: "zwave_js/update_log_config",
             ENTRY_ID: entry.entry_id,
             CONFIG: {LEVEL: "Error"},
@@ -1884,13 +2204,50 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
 
     client.async_send_command.reset_mock()
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_is_statistics_enabled",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 4,
+                TYPE: "zwave_js/data_collection_status",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_enable_statistics",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 5,
+                TYPE: "zwave_js/update_data_collection_preference",
+                ENTRY_ID: entry.entry_id,
+                OPTED_IN: True,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 4,
+            ID: 6,
             TYPE: "zwave_js/data_collection_status",
             ENTRY_ID: entry.entry_id,
         }
@@ -1902,7 +2259,7 @@ async def test_data_collection(hass, client, integration, hass_ws_client):
 
     await ws_client.send_json(
         {
-            ID: 5,
+            ID: 7,
             TYPE: "zwave_js/update_data_collection_preference",
             ENTRY_ID: entry.entry_id,
             OPTED_IN: True,
@@ -1937,6 +2294,42 @@ async def test_abort_firmware_update(
     args = client.async_send_command_no_wait.call_args[0][0]
     assert args["command"] == "node.abort_firmware_update"
     assert args["nodeId"] == multisensor_6.node_id
+
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.node.Node.async_abort_firmware_update",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 2,
+                TYPE: "zwave_js/abort_firmware_update",
+                ENTRY_ID: entry.entry_id,
+                NODE_ID: multisensor_6.node_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
+    # Test sending command with not loaded entry fails
+    await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    await ws_client.send_json(
+        {
+            ID: 3,
+            TYPE: "zwave_js/abort_firmware_update",
+            ENTRY_ID: entry.entry_id,
+            NODE_ID: multisensor_6.node_id,
+        }
+    )
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_NOT_LOADED
 
 
 async def test_abort_firmware_update_failures(
@@ -2128,13 +2521,31 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
     assert config_update["update_available"]
     assert config_update["new_version"] == "test"
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_check_for_config_updates",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 2,
+                TYPE: "zwave_js/check_for_config_updates",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 2,
+            ID: 3,
             TYPE: "zwave_js/check_for_config_updates",
             ENTRY_ID: entry.entry_id,
         }
@@ -2146,7 +2557,7 @@ async def test_check_for_config_updates(hass, client, integration, hass_ws_clien
 
     await ws_client.send_json(
         {
-            ID: 3,
+            ID: 4,
             TYPE: "zwave_js/check_for_config_updates",
             ENTRY_ID: "INVALID",
         }
@@ -2175,13 +2586,31 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
     assert msg["result"]
     assert msg["success"]
 
+    # Test FailedZWaveCommand is caught
+    with patch(
+        "zwave_js_server.model.driver.Driver.async_install_config_update",
+        side_effect=FailedZWaveCommand("failed_command", 1, "a"),
+    ):
+        await ws_client.send_json(
+            {
+                ID: 2,
+                TYPE: "zwave_js/install_config_update",
+                ENTRY_ID: entry.entry_id,
+            }
+        )
+        msg = await ws_client.receive_json()
+
+        assert not msg["success"]
+        assert msg["error"]["code"] == ERR_ZWAVE_ERROR
+        assert msg["error"]["message"] == "1: a"
+
     # Test sending command with not loaded entry fails
     await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
 
     await ws_client.send_json(
         {
-            ID: 2,
+            ID: 3,
             TYPE: "zwave_js/install_config_update",
             ENTRY_ID: entry.entry_id,
         }
@@ -2193,7 +2622,7 @@ async def test_install_config_update(hass, client, integration, hass_ws_client):
 
     await ws_client.send_json(
         {
-            ID: 3,
+            ID: 4,
             TYPE: "zwave_js/install_config_update",
             ENTRY_ID: "INVALID",
         }


### PR DESCRIPTION
## Proposed change
We currently don't handle `FailedCommand` exceptions when handling websocket API requests. I've added a decorator and decorated every function that issues a command to catch these types of errors and to return friendly errors so that they can be handled in the UI.

Important note: I was worried about not unsubscribing callbacks in case of an error, so I came up with an approach to address it. I think it's safe, but want to point it out because it should be reviewed.

This is a good hotfix candidate since it only makes things better


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
