### PR TITLE
Refactor decompression timestamp validation logic in stream component

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from collections import deque
 from collections.abc import Iterator, Mapping
 from io import BytesIO
+import itertools
 import logging
 from threading import Event
 from typing import Any, Callable, cast
@@ -201,7 +202,41 @@ class SegmentBuffer:
         self._memory_file.close()
 
 
-def stream_worker(  # noqa: C901
+class TimestampValidator:
+    """Validate orering of timestamps for packets in a stream."""
+
+    def __init__(self) -> None:
+        """Initialize the TimestampValidator."""
+        # Decompression timestamp of last packet in each stream
+        self._last_dts: dict[av.stream.Stream, float] = {}
+        # Number of consecutive missing decompression timestamps
+        self._missing_dts = 0
+
+    def is_valid(self, packet: av.Packet) -> float:
+        """Validate the packet timestamp based on ordering within the stream."""
+        # Discard packets missing DTS. Terminate if too many are missing.
+        if packet.dts is None:
+            if self._missing_dts >= MAX_MISSING_DTS:
+                raise StopIteration(
+                    f"No dts in {MAX_MISSING_DTS+1} consecutive packets"
+                )
+            self._missing_dts += 1
+            return False
+        self._missing_dts = 0
+        # Discard when dts is not monotonic. Terminate if gap is too wide.
+        prev_dts = self._last_dts.get(packet.stream, float("-inf"))
+        if packet.dts <= prev_dts:
+            gap = packet.time_base * (prev_dts - packet.dts)
+            if gap > MAX_TIMESTAMP_GAP:
+                raise StopIteration(
+                    f"Timestamp overflow detected: last dts = {prev_dts}, dts = {packet.dts}"
+                )
+            return False
+        self._last_dts[packet.stream] = packet.dts
+        return True
+
+
+def stream_worker(
     source: str,
     options: dict[str, str],
     segment_buffer: SegmentBuffer,
@@ -234,10 +269,8 @@ def stream_worker(  # noqa: C901
 
     # Iterator for demuxing
     container_packets: Iterator[av.Packet]
-    # The decoder timestamps of the latest packet in each stream we processed
-    last_dts = {video_stream: float("-inf"), audio_stream: float("-inf")}
-    # Keep track of consecutive packets without a dts to detect end of stream.
-    missing_dts = 0
+    # Ensure packets are ordered correctly
+    dts_validator = TimestampValidator()
     # The video dts at the beginning of the segment
     segment_start_dts: int | None = None
     # Because of problems 1 and 2 below, we need to store the first few packets and replay them
@@ -246,7 +279,6 @@ def stream_worker(  # noqa: C901
     # Have to work around two problems with RTSP feeds in ffmpeg
     # 1 - first frame has bad pts/dts https://trac.ffmpeg.org/ticket/5018
     # 2 - seeking can be problematic https://trac.ffmpeg.org/ticket/7815
-
     def peek_first_dts() -> bool:
         """Initialize by peeking into the first few packets of the stream.
 
@@ -254,23 +286,15 @@ def stream_worker(  # noqa: C901
         Also load the first video keyframe dts into segment_start_dts and check if the audio stream really exists.
         """
         nonlocal segment_start_dts, audio_stream, container_packets
-        missing_dts = 0
         found_audio = False
         try:
-            container_packets = container.demux((video_stream, audio_stream))
+            container_packets = filter(
+                dts_validator.is_valid, container.demux((video_stream, audio_stream))
+            )
             first_packet: av.Packet | None = None
             # Get to first video keyframe
             while first_packet is None:
                 packet = next(container_packets)
-                if (
-                    packet.dts is None
-                ):  # Allow MAX_MISSING_DTS packets with no dts, raise error on the next one
-                    if missing_dts >= MAX_MISSING_DTS:
-                        raise StopIteration(
-                            f"Invalid data - got {MAX_MISSING_DTS+1} packets with missing DTS while initializing"
-                        )
-                    missing_dts += 1
-                    continue
                 if packet.stream == audio_stream:
                     found_audio = True
                 elif packet.is_keyframe:  # video_keyframe
@@ -283,15 +307,6 @@ def stream_worker(  # noqa: C901
                 and len(initial_packets) < PACKETS_TO_WAIT_FOR_AUDIO
             ):
                 packet = next(container_packets)
-                if (
-                    packet.dts is None
-                ):  # Allow MAX_MISSING_DTS packet with no dts, raise error on the next one
-                    if missing_dts >= MAX_MISSING_DTS:
-                        raise StopIteration(
-                            f"Invalid data - got {MAX_MISSING_DTS+1} packets with missing DTS while initializing"
-                        )
-                    missing_dts += 1
-                    continue
                 if packet.stream == audio_stream:
                     # detect ADTS AAC and disable audio
                     if audio_stream.codec.name == "aac" and packet.size > 2:
@@ -300,7 +315,10 @@ def stream_worker(  # noqa: C901
                                 _LOGGER.warning(
                                     "ADTS AAC detected - disabling audio stream"
                                 )
-                                container_packets = container.demux(video_stream)
+                                container_packets = filter(
+                                    dts_validator.is_valid,
+                                    container.demux(video_stream),
+                                )
                                 audio_stream = None
                                 continue
                     found_audio = True
@@ -330,41 +348,15 @@ def stream_worker(  # noqa: C901
     assert isinstance(segment_start_dts, int)
     segment_buffer.reset(segment_start_dts)
 
+    # Rewind the stream and iterate over the initial set of packets again
+    # filtering out any packets with timestamp ordering issues.
+    packets = itertools.chain(initial_packets, container_packets)
     while not quit_event.is_set():
         try:
-            if len(initial_packets) > 0:
-                packet = initial_packets.popleft()
-            else:
-                packet = next(container_packets)
-            if packet.dts is None:
-                # Allow MAX_MISSING_DTS consecutive packets without dts. Terminate the stream on the next one.
-                if missing_dts >= MAX_MISSING_DTS:
-                    raise StopIteration(
-                        f"No dts in {MAX_MISSING_DTS+1} consecutive packets"
-                    )
-                missing_dts += 1
-                continue
-            missing_dts = 0
+            packet = next(packets)
         except (av.AVError, StopIteration) as ex:
             _LOGGER.error("Error demuxing stream: %s", str(ex))
             break
-
-        # Discard packet if dts is not monotonic
-        if packet.dts <= last_dts[packet.stream]:
-            if (
-                packet.time_base * (last_dts[packet.stream] - packet.dts)
-                > MAX_TIMESTAMP_GAP
-            ):
-                _LOGGER.warning(
-                    "Timestamp overflow detected: last dts %s, dts = %s, resetting stream",
-                    last_dts[packet.stream],
-                    packet.dts,
-                )
-                break
-            continue
-
-        # Update last_dts processed
-        last_dts[packet.stream] = packet.dts
 
         # Mux packets, and possibly write a segment to the output stream.
         # This mutates packet timestamps and stream

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -316,7 +316,6 @@ def stream_worker(
                                 _LOGGER.warning(
                                     "ADTS AAC detected - disabling audio stream"
                                 )
-                                dts_validator = TimestampValidator()
                                 container_packets = filter(
                                     dts_validator.is_valid,
                                     container.demux(video_stream),

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -203,7 +203,7 @@ class SegmentBuffer:
 
 
 class TimestampValidator:
-    """Validate orering of timestamps for packets in a stream."""
+    """Validate ordering of timestamps for packets in a stream."""
 
     def __init__(self) -> None:
         """Initialize the TimestampValidator."""
@@ -277,6 +277,7 @@ def stream_worker(
     # Have to work around two problems with RTSP feeds in ffmpeg
     # 1 - first frame has bad pts/dts https://trac.ffmpeg.org/ticket/5018
     # 2 - seeking can be problematic https://trac.ffmpeg.org/ticket/7815
+
     def peek_first_dts() -> bool:
         """Initialize by peeking into the first few packets of the stream.
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -269,8 +269,6 @@ def stream_worker(
 
     # Iterator for demuxing
     container_packets: Iterator[av.Packet]
-    # Ensure packets are ordered correctly
-    dts_validator = TimestampValidator()
     # The video dts at the beginning of the segment
     segment_start_dts: int | None = None
     # Because of problems 1 and 2 below, we need to store the first few packets and replay them
@@ -288,6 +286,8 @@ def stream_worker(
         nonlocal segment_start_dts, audio_stream, container_packets
         found_audio = False
         try:
+            # Ensure packets are ordered correctly
+            dts_validator = TimestampValidator()
             container_packets = filter(
                 dts_validator.is_valid, container.demux((video_stream, audio_stream))
             )
@@ -315,6 +315,7 @@ def stream_worker(
                                 _LOGGER.warning(
                                     "ADTS AAC detected - disabling audio stream"
                                 )
+                                dts_validator = TimestampValidator()
                                 container_packets = filter(
                                     dts_validator.is_valid,
                                     container.demux(video_stream),


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Refactor decompression timestamp validation logic into a separate class and apply it as a filter on the packet iterator. Also simplify the logic for rewinding the start of the stream into a single iterator. Removes the lint error related to a complex function by reducing total lines of code in that function.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
