### PR TITLE
Add precision and time unit to History Stats integration

### DIFF
--- a/homeassistant/components/history_stats/sensor.py
+++ b/homeassistant/components/history_stats/sensor.py
@@ -151,8 +151,9 @@ class HistoryStatsSensor(SensorEntity):
         self._name = name
         self._precision = precision
         self._time_unit = time_unit
+        # use UNITS dict for all but 'time' sensors, which use the config variable time_unit
         self._unit_of_measurement = (
-            UNITS[sensor_type] if not sensor_type == CONF_TYPE_TIME else time_unit
+            UNITS[sensor_type] if sensor_type != CONF_TYPE_TIME else time_unit
         )
 
         self._period = (datetime.datetime.now(), datetime.datetime.now())

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -89,10 +89,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
             duration = timedelta(hours=2, minutes=1)
 
             sensor1 = HistoryStatsSensor(
-                self.hass, "test", "on", today, None, duration, "time", "test", 2
+                self.hass, "test", "on", today, None, duration, "time", "test", 2, "h"
             )
             sensor2 = HistoryStatsSensor(
-                self.hass, "test", "on", None, today, duration, "time", "test", 2
+                self.hass, "test", "on", None, today, duration, "time", "test", 2, "h"
             )
 
             sensor1.update_period()
@@ -126,10 +126,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
         bad = Template("{{ TEST }}", self.hass)
 
         sensor1 = HistoryStatsSensor(
-            self.hass, "test", "on", good, bad, None, "time", "Test", 2
+            self.hass, "test", "on", good, bad, None, "time", "Test", 2, "h"
         )
         sensor2 = HistoryStatsSensor(
-            self.hass, "test", "on", bad, good, None, "time", "Test", 2
+            self.hass, "test", "on", bad, good, None, "time", "Test", 2, "h"
         )
 
         before_update1 = sensor1._period
@@ -167,10 +167,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
         duration = "01:00"
 
         sensor1 = HistoryStatsSensor(
-            self.hass, "test", "on", bad, None, duration, "time", "Test", 2
+            self.hass, "test", "on", bad, None, duration, "time", "Test", 2, "h"
         )
         sensor2 = HistoryStatsSensor(
-            self.hass, "test", "on", None, bad, duration, "time", "Test", 2
+            self.hass, "test", "on", None, bad, duration, "time", "Test", 2, "h"
         )
 
         before_update1 = sensor1._period
@@ -246,6 +246,7 @@ async def test_reload(hass):
                 "start": "{{ as_timestamp(now()) - 3600 }}",
                 "duration": "01:00",
                 "precision": 2,
+                "time_unit": "h",
             },
         },
     )
@@ -311,6 +312,7 @@ async def test_measure_multiple(hass):
                     "end": "{{ now() }}",
                     "type": "time",
                     "precision": 2,
+                    "time_unit": "h",
                 },
                 {
                     "platform": "history_stats",
@@ -321,6 +323,7 @@ async def test_measure_multiple(hass):
                     "end": "{{ now() }}",
                     "type": "time",
                     "precision": 2,
+                    "time_unit": "h",
                 },
                 {
                     "platform": "history_stats",
@@ -341,6 +344,17 @@ async def test_measure_multiple(hass):
                     "type": "ratio",
                     "precision": 1,
                 },
+                {
+                    "platform": "history_stats",
+                    "entity_id": "input_select.test_id",
+                    "name": "sensor5",
+                    "state": ["orange", "blue"],
+                    "start": "{{ as_timestamp(now()) - 3600 }}",
+                    "end": "{{ now() }}",
+                    "type": "time",
+                    "precision": 1,
+                    "time_unit": "min",
+                },
             ]
         },
     )
@@ -357,6 +371,7 @@ async def test_measure_multiple(hass):
     assert hass.states.get("sensor.sensor2").state == STATE_UNKNOWN
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "50.0"
+    assert hass.states.get("sensor.sensor5").state == "30.0"
 
 
 async def async_test_measure(hass):
@@ -421,6 +436,17 @@ async def async_test_measure(hass):
                     "type": "ratio",
                     "precision": 1,
                 },
+                {
+                    "platform": "history_stats",
+                    "entity_id": "binary_sensor.test_id",
+                    "name": "sensor5",
+                    "state": "on",
+                    "start": "{{ as_timestamp(now()) - 3600 }}",
+                    "end": "{{ now() }}",
+                    "type": "time",
+                    "precision": 1,
+                    "time_unit": "min",
+                },
             ]
         },
     )
@@ -437,6 +463,7 @@ async def async_test_measure(hass):
     assert hass.states.get("sensor.sensor2").state == STATE_UNKNOWN
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "50.0"
+    assert hass.states.get("sensor.sensor5").state == "30.0"
 
 
 def _get_fixtures_base_path():

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -352,8 +352,8 @@ async def test_measure_multiple(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "time",
-                    "precision": 1,
-                    "time_unit": "min",
+                    "precision": 3,
+                    "time_unit": "d",
                 },
             ]
         },
@@ -371,7 +371,7 @@ async def test_measure_multiple(hass):
     assert hass.states.get("sensor.sensor2").state == STATE_UNKNOWN
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "50.0"
-    assert hass.states.get("sensor.sensor5").state == "30.0"
+    assert hass.states.get("sensor.sensor5").state == "0.021"
 
 
 async def async_test_measure(hass):
@@ -444,8 +444,8 @@ async def async_test_measure(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "time",
-                    "precision": 1,
-                    "time_unit": "min",
+                    "precision": 3,
+                    "time_unit": "d",
                 },
             ]
         },
@@ -463,7 +463,7 @@ async def async_test_measure(hass):
     assert hass.states.get("sensor.sensor2").state == STATE_UNKNOWN
     assert hass.states.get("sensor.sensor3").state == "2"
     assert hass.states.get("sensor.sensor4").state == "50.0"
-    assert hass.states.get("sensor.sensor5").state == "30.0"
+    assert hass.states.get("sensor.sensor5").state == "0.021"
 
 
 def _get_fixtures_base_path():

--- a/tests/components/history_stats/test_sensor.py
+++ b/tests/components/history_stats/test_sensor.py
@@ -64,6 +64,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
                 ".replace(minute=0).replace(second=0) }}",
                 "duration": "02:00",
                 "name": "Test",
+                "precision": 2,
             },
         }
 
@@ -88,10 +89,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
             duration = timedelta(hours=2, minutes=1)
 
             sensor1 = HistoryStatsSensor(
-                self.hass, "test", "on", today, None, duration, "time", "test"
+                self.hass, "test", "on", today, None, duration, "time", "test", 2
             )
             sensor2 = HistoryStatsSensor(
-                self.hass, "test", "on", None, today, duration, "time", "test"
+                self.hass, "test", "on", None, today, duration, "time", "test", 2
             )
 
             sensor1.update_period()
@@ -125,10 +126,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
         bad = Template("{{ TEST }}", self.hass)
 
         sensor1 = HistoryStatsSensor(
-            self.hass, "test", "on", good, bad, None, "time", "Test"
+            self.hass, "test", "on", good, bad, None, "time", "Test", 2
         )
         sensor2 = HistoryStatsSensor(
-            self.hass, "test", "on", bad, good, None, "time", "Test"
+            self.hass, "test", "on", bad, good, None, "time", "Test", 2
         )
 
         before_update1 = sensor1._period
@@ -151,6 +152,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
                 "state": "on",
                 "start": "{{ now() }}",
                 "duration": "TEST",
+                "precision": 2,
             },
         }
 
@@ -165,10 +167,10 @@ class TestHistoryStatsSensor(unittest.TestCase):
         duration = "01:00"
 
         sensor1 = HistoryStatsSensor(
-            self.hass, "test", "on", bad, None, duration, "time", "Test"
+            self.hass, "test", "on", bad, None, duration, "time", "Test", 2
         )
         sensor2 = HistoryStatsSensor(
-            self.hass, "test", "on", None, bad, duration, "time", "Test"
+            self.hass, "test", "on", None, bad, duration, "time", "Test", 2
         )
 
         before_update1 = sensor1._period
@@ -210,6 +212,7 @@ class TestHistoryStatsSensor(unittest.TestCase):
                 "start": "{{ as_timestamp(now()) - 3600 }}",
                 "end": "{{ now() }}",
                 "duration": "01:00",
+                "precision": 2,
             },
         }
 
@@ -242,6 +245,7 @@ async def test_reload(hass):
                 "state": "on",
                 "start": "{{ as_timestamp(now()) - 3600 }}",
                 "duration": "01:00",
+                "precision": 2,
             },
         },
     )
@@ -306,6 +310,7 @@ async def test_measure_multiple(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "time",
+                    "precision": 2,
                 },
                 {
                     "platform": "history_stats",
@@ -315,6 +320,7 @@ async def test_measure_multiple(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "time",
+                    "precision": 2,
                 },
                 {
                     "platform": "history_stats",
@@ -333,6 +339,7 @@ async def test_measure_multiple(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "ratio",
+                    "precision": 1,
                 },
             ]
         },
@@ -383,6 +390,7 @@ async def async_test_measure(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "time",
+                    "precision": 2,
                 },
                 {
                     "platform": "history_stats",
@@ -392,6 +400,7 @@ async def async_test_measure(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "time",
+                    "precision": 2,
                 },
                 {
                     "platform": "history_stats",
@@ -410,6 +419,7 @@ async def async_test_measure(hass):
                     "start": "{{ as_timestamp(now()) - 3600 }}",
                     "end": "{{ now() }}",
                     "type": "ratio",
+                    "precision": 1,
                 },
             ]
         },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add precision (`precision:`) and time unit (`time_unit:`) configuration variables to control how the state value of a `history_stats` sensor is displayed:

- `precision` indicates the number of decimals to be used in the `round()` operation prior to displaying the state value.  It affects both `type: time` and `type: ratio` sensors. The default value is `2`.
- `time_unit` indicates the unit of time (`d`, `h`, `min`, `s`) to be used for the state value of a `type: time` sensor.  Valid units are taken from the HASS [const.py](https://github.com/home-assistant/core/blob/dev/homeassistant/const.py).

The addition of the two configuration variables is motivated by [issue#52251](https://github.com/home-assistant/core/issues/52251).  More specifically:

1. Use of `hours` as time unit for the `state` value is arbitrary;
2. In the user's example, the `value` attribute shows `9m` but the `state` (`0.17` hours) suggests it should be `10m` instead (`0.17 * 60` = `10` minutes and `12` seconds). This is related to `divmod()` usage in the `pretty_duration()` static method. Specifically, if `hours < 0`, `pretty_duration()` returns only the *integer* `minutes`, which is lower than or equal to `hours*60`. However, the `state` of the entity is shown as a *rounded* (`2` decimals) *floating number* in `hours` units. Therefore, if `hours` was `.166` prior to rounding, for example, `pretty_duration()` would return `9m` because `divmod(int(0.166*3600), 60) = (9, 57)` and `minutes` is defined as `a // b` (floor division) of `divmod(a, b)` but the `state` of the entity would be `0.17` due to `round(0.166, 2)`. 

This PR fixes both issues via the inclusion of user-specified decimals (`precision`) and unit of time (`time_unit`) while maintaining backward compatibility--that is, existing configurations that make use of the History Stats integration will not be affected by these changes, owing to the default values being the same as in the current implementation of the History Stats integration.

Other noteworthy observations:

- Tests for the History Stats sensor ([`tests/components/history_stats/test_sensor.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/history_stats/sensor.py)) were updated to include reference to the two new configuration variables. In addition, a new test sensor was created for two test methods that make use of a non-default `time_unit` (`"min"`).  New tests that specifically test `precision` and `time_unit` were not included.

- Merging this PR requires editing the docs for the History Stats integration to reference the new configuration variables.  *Edited*: Added reference to the doc PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #52251
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18380

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
