### PR TITLE
Fix Sensibo timeout exceptions

### DIFF
--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -399,9 +399,9 @@ class SensiboClimate(ClimateEntity):
             aiohttp.client_exceptions.ClientError,
             asyncio.TimeoutError,
             pysensibo.SensiboError,
-        ):
-            _LOGGER.error(
-                "Failed to set AC state for device '%s' to Sensibo servers", self.name
-            )
+        ) as err:
             self._available = False
             self.async_write_ha_state()
+            raise Exception(
+                f"Failed to set AC state for device {self.name} to Sensibo servers"
+            ) from err

--- a/homeassistant/components/sensibo/climate.py
+++ b/homeassistant/components/sensibo/climate.py
@@ -40,7 +40,7 @@ from .const import DOMAIN as SENSIBO_DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 ALL = ["all"]
-TIMEOUT = 10
+TIMEOUT = 8
 
 SERVICE_ASSUME_STATE = "assume_state"
 
@@ -91,17 +91,18 @@ async def async_setup_platform(hass, config, async_add_entities, discovery_info=
     )
     devices = []
     try:
-        for dev in await client.async_get_devices(_INITIAL_FETCH_FIELDS):
-            if config[CONF_ID] == ALL or dev["id"] in config[CONF_ID]:
-                devices.append(
-                    SensiboClimate(client, dev, hass.config.units.temperature_unit)
-                )
+        with async_timeout.timeout(TIMEOUT):
+            for dev in await client.async_get_devices(_INITIAL_FETCH_FIELDS):
+                if config[CONF_ID] == ALL or dev["id"] in config[CONF_ID]:
+                    devices.append(
+                        SensiboClimate(client, dev, hass.config.units.temperature_unit)
+                    )
     except (
         aiohttp.client_exceptions.ClientConnectorError,
         asyncio.TimeoutError,
         pysensibo.SensiboError,
     ) as err:
-        _LOGGER.exception("Failed to connect to Sensibo servers")
+        _LOGGER.error("Failed to get devices from Sensibo servers")
         raise PlatformNotReady from err
 
     if not devices:
@@ -150,6 +151,7 @@ class SensiboClimate(ClimateEntity):
         self._units = units
         self._available = False
         self._do_update(data)
+        self._failed_update = False
 
     @property
     def supported_features(self):
@@ -316,59 +318,35 @@ class SensiboClimate(ClimateEntity):
             else:
                 return
 
-        with async_timeout.timeout(TIMEOUT):
-            await self._client.async_set_ac_state_property(
-                self._id, "targetTemperature", temperature, self._ac_states
-            )
+        await self._async_set_ac_state_property("targetTemperature", temperature)
 
     async def async_set_fan_mode(self, fan_mode):
         """Set new target fan mode."""
-        with async_timeout.timeout(TIMEOUT):
-            await self._client.async_set_ac_state_property(
-                self._id, "fanLevel", fan_mode, self._ac_states
-            )
+        await self._async_set_ac_state_property("fanLevel", fan_mode)
 
     async def async_set_hvac_mode(self, hvac_mode):
         """Set new target operation mode."""
         if hvac_mode == HVAC_MODE_OFF:
-            with async_timeout.timeout(TIMEOUT):
-                await self._client.async_set_ac_state_property(
-                    self._id, "on", False, self._ac_states
-                )
+            await self._async_set_ac_state_property("on", False)
             return
 
         # Turn on if not currently on.
         if not self._ac_states["on"]:
-            with async_timeout.timeout(TIMEOUT):
-                await self._client.async_set_ac_state_property(
-                    self._id, "on", True, self._ac_states
-                )
+            await self._async_set_ac_state_property("on", True)
 
-        with async_timeout.timeout(TIMEOUT):
-            await self._client.async_set_ac_state_property(
-                self._id, "mode", HA_TO_SENSIBO[hvac_mode], self._ac_states
-            )
+        await self._async_set_ac_state_property("mode", HA_TO_SENSIBO[hvac_mode])
 
     async def async_set_swing_mode(self, swing_mode):
         """Set new target swing operation."""
-        with async_timeout.timeout(TIMEOUT):
-            await self._client.async_set_ac_state_property(
-                self._id, "swing", swing_mode, self._ac_states
-            )
+        await self._async_set_ac_state_property("swing", swing_mode)
 
     async def async_turn_on(self):
         """Turn Sensibo unit on."""
-        with async_timeout.timeout(TIMEOUT):
-            await self._client.async_set_ac_state_property(
-                self._id, "on", True, self._ac_states
-            )
+        await self._async_set_ac_state_property("on", True)
 
     async def async_turn_off(self):
         """Turn Sensibo unit on."""
-        with async_timeout.timeout(TIMEOUT):
-            await self._client.async_set_ac_state_property(
-                self._id, "on", False, self._ac_states
-            )
+        await self._async_set_ac_state_property("on", False)
 
     async def async_assume_state(self, state):
         """Set external state."""
@@ -377,14 +355,7 @@ class SensiboClimate(ClimateEntity):
         )
 
         if change_needed:
-            with async_timeout.timeout(TIMEOUT):
-                await self._client.async_set_ac_state_property(
-                    self._id,
-                    "on",
-                    state != HVAC_MODE_OFF,  # value
-                    self._ac_states,
-                    True,  # assumed_state
-                )
+            await self._async_set_ac_state_property("on", state != HVAC_MODE_OFF, True)
 
         if state in [STATE_ON, HVAC_MODE_OFF]:
             self._external_state = None
@@ -396,7 +367,41 @@ class SensiboClimate(ClimateEntity):
         try:
             with async_timeout.timeout(TIMEOUT):
                 data = await self._client.async_get_device(self._id, _FETCH_FIELDS)
-                self._do_update(data)
-        except (aiohttp.client_exceptions.ClientError, pysensibo.SensiboError):
-            _LOGGER.warning("Failed to connect to Sensibo servers")
+        except (
+            aiohttp.client_exceptions.ClientError,
+            asyncio.TimeoutError,
+            pysensibo.SensiboError,
+        ):
+            if self._failed_update:
+                _LOGGER.warning(
+                    "Failed to update data for device '%s' from Sensibo servers",
+                    self.name,
+                )
+                self._available = False
+                self.async_write_ha_state()
+                return
+
+            _LOGGER.debug("First failed update data for device '%s'", self.name)
+            self._failed_update = True
+            return
+
+        self._failed_update = False
+        self._do_update(data)
+
+    async def _async_set_ac_state_property(self, name, value, assumed_state=False):
+        """Set AC state."""
+        try:
+            with async_timeout.timeout(TIMEOUT):
+                await self._client.async_set_ac_state_property(
+                    self._id, name, value, self._ac_states, assumed_state
+                )
+        except (
+            aiohttp.client_exceptions.ClientError,
+            asyncio.TimeoutError,
+            pysensibo.SensiboError,
+        ):
+            _LOGGER.error(
+                "Failed to set AC state for device '%s' to Sensibo servers", self.name
+            )
             self._available = False
+            self.async_write_ha_state()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix for the following bugs:
- Wrap initial get devices with timeout so that in case of no connection to the cloud at startup it will correctly raise `PlatformNotReady`.
- Catch timeout exception on periodic updates so that instead of an uncaught exception it will be handled properly and the device will be marked unavailable.
- Use single common function for all API calls to properly catch timeout errors and raise detailed exception.

Other fixes:
- Reduce timeout from 10 seconds to 8 seconds, average time to fetch data from the cloud is 0.5 seconds so there is no need to wait 10 seconds which will add additional warning of an update which takes too long.
- Since the bugfix above which catch the exception of periodic updates can now mark the device unavailable, allow single failed update without marking the device unavailable, upon two failed updates the device will be marked unavailable (Sensibo cloud may sometime not respond to an update request).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
