### PR TITLE
Update the ip/port in the homekit_controller config entry when it changes

### DIFF
--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -236,13 +236,6 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
             config_num = None
 
-        # Device isn't paired with us or anyone else.
-        # But we have a 'complete' config entry for it - that is probably
-        # invalid. Remove it automatically.
-        existing = find_existing_host(self.hass, hkid)
-        if not paired and existing:
-            await self.hass.config_entries.async_remove(existing.entry_id)
-
         # If the device is already paired and known to us we should monitor c#
         # (config_num) for changes. If it changes, we check for new entities
         if paired and hkid in self.hass.data.get(KNOWN_DEVICES, {}):
@@ -260,6 +253,14 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_configured")
 
         _LOGGER.debug("Discovered device %s (%s - %s)", name, model, hkid)
+
+        # Device isn't paired with us or anyone else.
+        # But we have a 'complete' config entry for it - that is probably
+        # invalid. Remove it automatically.
+        existing = find_existing_host(self.hass, hkid)
+        if not paired and existing:
+            await self.hass.config_entries.async_remove(existing.entry_id)
+
         # Set unique-id and error out if it's already configured
         await self.async_set_unique_id(normalize_hkid(hkid))
         self._abort_if_unique_id_configured(

--- a/homeassistant/components/homekit_controller/config_flow.py
+++ b/homeassistant/components/homekit_controller/config_flow.py
@@ -236,9 +236,20 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             )
             config_num = None
 
+        # Set unique-id and error out if it's already configured
+        existing_entry = await self.async_set_unique_id(normalize_hkid(hkid))
+        updated_ip_port = {
+            "AccessoryIP": discovery_info["host"],
+            "AccessoryPort": discovery_info["port"],
+        }
+
         # If the device is already paired and known to us we should monitor c#
         # (config_num) for changes. If it changes, we check for new entities
         if paired and hkid in self.hass.data.get(KNOWN_DEVICES, {}):
+            if existing_entry:
+                self.hass.config_entries.async_update_entry(
+                    existing_entry, data={**existing_entry.data, **updated_ip_port}
+                )
             conn = self.hass.data[KNOWN_DEVICES][hkid]
             # When we rediscover the device, let aiohomekit know
             # that the device is available and we should not wait
@@ -262,13 +273,7 @@ class HomekitControllerFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             await self.hass.config_entries.async_remove(existing.entry_id)
 
         # Set unique-id and error out if it's already configured
-        await self.async_set_unique_id(normalize_hkid(hkid))
-        self._abort_if_unique_id_configured(
-            updates={
-                "AccessoryIP": discovery_info["host"],
-                "AccessoryPort": discovery_info["port"],
-            }
-        )
+        self._abort_if_unique_id_configured(updates=updated_ip_port)
 
         self.context["hkid"] = hkid
 

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for homekit_controller config flow."""
 from unittest import mock
 import unittest.mock
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import aiohomekit
 from aiohomekit.model import Accessories, Accessory
@@ -11,6 +11,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.homekit_controller import config_flow
+from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.helpers import device_registry
 
 from tests.common import MockConfigEntry, mock_device_registry
@@ -410,6 +411,47 @@ async def test_discovery_already_configured(hass, controller):
     assert result["reason"] == "already_configured"
     assert entry.data["AccessoryIP"] == discovery_info["host"]
     assert entry.data["AccessoryPort"] == discovery_info["port"]
+
+
+async def test_discovery_already_configured_update_csharp(hass, controller):
+    """Already configured and csharp changes."""
+    entry = MockConfigEntry(
+        domain="homekit_controller",
+        data={
+            "AccessoryIP": "4.4.4.4",
+            "AccessoryPort": 66,
+            "AccessoryPairingID": "AA:BB:CC:DD:EE:FF",
+        },
+        unique_id="aa:bb:cc:dd:ee:ff",
+    )
+    entry.add_to_hass(hass)
+
+    connection_mock = AsyncMock()
+    connection_mock.pairing.connect.reconnect_soon = AsyncMock()
+    connection_mock.async_refresh_entity_map = AsyncMock()
+    hass.data[KNOWN_DEVICES] = {"AA:BB:CC:DD:EE:FF": connection_mock}
+
+    device = setup_mock_accessory(controller)
+    discovery_info = get_device_discovery_info(device)
+
+    # Set device as already paired
+    discovery_info["properties"]["sf"] = 0x00
+    discovery_info["properties"]["c#"] = 99999
+    discovery_info["properties"]["id"] = "AA:BB:CC:DD:EE:FF"
+
+    # Device is discovered
+    result = await hass.config_entries.flow.async_init(
+        "homekit_controller",
+        context={"source": config_entries.SOURCE_ZEROCONF},
+        data=discovery_info,
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+    await hass.async_block_till_done()
+
+    assert entry.data["AccessoryIP"] == discovery_info["host"]
+    assert entry.data["AccessoryPort"] == discovery_info["port"]
+    assert connection_mock.async_refresh_entity_map.await_count == 1
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_START_ABORT_ERRORS)

--- a/tests/components/homekit_controller/test_config_flow.py
+++ b/tests/components/homekit_controller/test_config_flow.py
@@ -383,11 +383,16 @@ async def test_discovery_invalid_config_entry(hass, controller):
 
 async def test_discovery_already_configured(hass, controller):
     """Already configured."""
-    MockConfigEntry(
+    entry = MockConfigEntry(
         domain="homekit_controller",
-        data={"AccessoryPairingID": "00:00:00:00:00:00"},
+        data={
+            "AccessoryIP": "4.4.4.4",
+            "AccessoryPort": 66,
+            "AccessoryPairingID": "00:00:00:00:00:00",
+        },
         unique_id="00:00:00:00:00:00",
-    ).add_to_hass(hass)
+    )
+    entry.add_to_hass(hass)
 
     device = setup_mock_accessory(controller)
     discovery_info = get_device_discovery_info(device)
@@ -403,6 +408,8 @@ async def test_discovery_already_configured(hass, controller):
     )
     assert result["type"] == "abort"
     assert result["reason"] == "already_configured"
+    assert entry.data["AccessoryIP"] == discovery_info["host"]
+    assert entry.data["AccessoryPort"] == discovery_info["port"]
 
 
 @pytest.mark.parametrize("exception,expected", PAIRING_START_ABORT_ERRORS)


### PR DESCRIPTION



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

- When we get a new IP from zeroconf we did not update the
  config entry. By updating the config entry we avoid the
  mdns lookup on the next restart

Noticed this when fixing #52548

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
