### PR TITLE
Move Fritzbox power, energy and temperature switch attributes to sensors

### DIFF
--- a/homeassistant/components/fritzbox/const.py
+++ b/homeassistant/components/fritzbox/const.py
@@ -13,9 +13,6 @@ ATTR_STATE_WINDOW_OPEN: Final = "window_open"
 
 ATTR_TEMPERATURE_UNIT: Final = "temperature_unit"
 
-ATTR_TOTAL_CONSUMPTION: Final = "total_consumption"
-ATTR_TOTAL_CONSUMPTION_UNIT: Final = "total_consumption_unit"
-
 CONF_CONNECTIONS: Final = "connections"
 CONF_COORDINATOR: Final = "coordinator"
 

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -13,8 +13,12 @@ from homeassistant.const import (
     ATTR_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
     DEVICE_CLASS_BATTERY,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
+    ENERGY_KILO_WATT_HOUR,
     PERCENTAGE,
+    POWER_WATT,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
@@ -68,16 +72,62 @@ async def async_setup_entry(
                 )
             )
 
+        if device.has_powermeter:
+            entities.append(
+                FritzBoxPowerSensor(
+                    {
+                        ATTR_NAME: f"{device.name} Power Consumption",
+                        ATTR_ENTITY_ID: f"{device.ain}_power_consumption",
+                        ATTR_UNIT_OF_MEASUREMENT: POWER_WATT,
+                        ATTR_DEVICE_CLASS: DEVICE_CLASS_POWER,
+                        ATTR_STATE_CLASS: STATE_CLASS_MEASUREMENT,
+                    },
+                    coordinator,
+                    ain,
+                )
+            )
+            entities.append(
+                FritzBoxEnergySensor(
+                    {
+                        ATTR_NAME: f"{device.name} Total Energy",
+                        ATTR_ENTITY_ID: f"{device.ain}_total_energy",
+                        ATTR_UNIT_OF_MEASUREMENT: ENERGY_KILO_WATT_HOUR,
+                        ATTR_DEVICE_CLASS: DEVICE_CLASS_ENERGY,
+                        ATTR_STATE_CLASS: None,
+                    },
+                    coordinator,
+                    ain,
+                )
+            )
+
     async_add_entities(entities)
 
 
 class FritzBoxBatterySensor(FritzBoxEntity, SensorEntity):
-    """The entity class for FRITZ!SmartHome sensors."""
+    """The entity class for FRITZ!SmartHome battery sensors."""
 
     @property
     def state(self) -> int | None:
         """Return the state of the sensor."""
         return self.device.battery_level  # type: ignore [no-any-return]
+
+
+class FritzBoxPowerSensor(FritzBoxEntity, SensorEntity):
+    """The entity class for FRITZ!SmartHome power consumption sensors."""
+
+    @property
+    def state(self) -> float | None:
+        """Return the state of the sensor."""
+        return self.device.power / 1000  # type: ignore [no-any-return]
+
+
+class FritzBoxEnergySensor(FritzBoxEntity, SensorEntity):
+    """The entity class for FRITZ!SmartHome total energy sensors."""
+
+    @property
+    def state(self) -> float | None:
+        """Return the state of the sensor."""
+        return (self.device.energy or 0.0) / 1000
 
 
 class FritzBoxTempSensor(FritzBoxEntity, SensorEntity):

--- a/homeassistant/components/fritzbox/sensor.py
+++ b/homeassistant/components/fritzbox/sensor.py
@@ -1,6 +1,8 @@
 """Support for AVM FRITZ!SmartHome temperature sensor only devices."""
 from __future__ import annotations
 
+from datetime import datetime
+
 from homeassistant.components.sensor import (
     ATTR_STATE_CLASS,
     STATE_CLASS_MEASUREMENT,
@@ -23,6 +25,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.dt import utc_from_timestamp
 
 from . import FritzBoxEntity
 from .const import (
@@ -128,6 +131,12 @@ class FritzBoxEnergySensor(FritzBoxEntity, SensorEntity):
     def state(self) -> float | None:
         """Return the state of the sensor."""
         return (self.device.energy or 0.0) / 1000
+
+    @property
+    def last_reset(self) -> datetime:
+        """Return the time when the sensor was last reset, if any."""
+        # device does not provide timestamp of initialization
+        return utc_from_timestamp(0)
 
 
 class FritzBoxTempSensor(FritzBoxEntity, SensorEntity):

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -12,7 +12,6 @@ from homeassistant.const import (
     ATTR_NAME,
     ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
-    ENERGY_KILO_WATT_HOUR,
     TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
@@ -23,14 +22,10 @@ from .const import (
     ATTR_STATE_DEVICE_LOCKED,
     ATTR_STATE_LOCKED,
     ATTR_TEMPERATURE_UNIT,
-    ATTR_TOTAL_CONSUMPTION,
-    ATTR_TOTAL_CONSUMPTION_UNIT,
     CONF_COORDINATOR,
     DOMAIN as FRITZBOX_DOMAIN,
 )
 from .model import SwitchExtraAttributes
-
-ATTR_TOTAL_CONSUMPTION_UNIT_VALUE = ENERGY_KILO_WATT_HOUR
 
 
 async def async_setup_entry(
@@ -92,11 +87,6 @@ class FritzboxSwitch(FritzBoxEntity, SwitchEntity):
             ATTR_STATE_LOCKED: self.device.lock,
         }
 
-        if self.device.has_powermeter:
-            attrs[
-                ATTR_TOTAL_CONSUMPTION
-            ] = f"{((self.device.energy or 0.0) / 1000):.3f}"
-            attrs[ATTR_TOTAL_CONSUMPTION_UNIT] = ATTR_TOTAL_CONSUMPTION_UNIT_VALUE
         if self.device.has_temperature_sensor:
             attrs[ATTR_TEMPERATURE] = str(
                 self.hass.config.units.temperature(
@@ -105,8 +95,3 @@ class FritzboxSwitch(FritzBoxEntity, SwitchEntity):
             )
             attrs[ATTR_TEMPERATURE_UNIT] = self.hass.config.units.temperature_unit
         return attrs
-
-    @property
-    def current_power_w(self) -> float:
-        """Return the current power usage in W."""
-        return self.device.power / 1000  # type: ignore [no-any-return]

--- a/homeassistant/components/fritzbox/switch.py
+++ b/homeassistant/components/fritzbox/switch.py
@@ -10,9 +10,7 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
     ATTR_NAME,
-    ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
-    TEMP_CELSIUS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -21,7 +19,6 @@ from . import FritzBoxEntity
 from .const import (
     ATTR_STATE_DEVICE_LOCKED,
     ATTR_STATE_LOCKED,
-    ATTR_TEMPERATURE_UNIT,
     CONF_COORDINATOR,
     DOMAIN as FRITZBOX_DOMAIN,
 )
@@ -86,12 +83,4 @@ class FritzboxSwitch(FritzBoxEntity, SwitchEntity):
             ATTR_STATE_DEVICE_LOCKED: self.device.device_lock,
             ATTR_STATE_LOCKED: self.device.lock,
         }
-
-        if self.device.has_temperature_sensor:
-            attrs[ATTR_TEMPERATURE] = str(
-                self.hass.config.units.temperature(
-                    self.device.temperature, TEMP_CELSIUS
-                )
-            )
-            attrs[ATTR_TEMPERATURE_UNIT] = self.hass.config.units.temperature_unit
         return attrs

--- a/tests/components/fritzbox/__init__.py
+++ b/tests/components/fritzbox/__init__.py
@@ -55,6 +55,7 @@ class FritzDeviceBinarySensorMock(FritzDeviceBaseMock):
     battery_level = 23
     fw_version = "1.2.3"
     has_alarm = True
+    has_powermeter = False
     has_switch = False
     has_temperature_sensor = False
     has_thermostat = False
@@ -73,6 +74,7 @@ class FritzDeviceClimateMock(FritzDeviceBaseMock):
     eco_temperature = 16.0
     fw_version = "1.2.3"
     has_alarm = False
+    has_powermeter = False
     has_switch = False
     has_temperature_sensor = False
     has_thermostat = True
@@ -91,6 +93,7 @@ class FritzDeviceSensorMock(FritzDeviceBaseMock):
     device_lock = "fake_locked_device"
     fw_version = "1.2.3"
     has_alarm = False
+    has_powermeter = False
     has_switch = False
     has_temperature_sensor = True
     has_thermostat = False
@@ -107,6 +110,7 @@ class FritzDeviceSwitchMock(FritzDeviceBaseMock):
     energy = 1234
     fw_version = "1.2.3"
     has_alarm = False
+    has_powermeter = True
     has_switch = True
     has_temperature_sensor = True
     has_thermostat = False

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -8,8 +8,6 @@ from homeassistant.components.fritzbox.const import (
     ATTR_STATE_DEVICE_LOCKED,
     ATTR_STATE_LOCKED,
     ATTR_TEMPERATURE_UNIT,
-    ATTR_TOTAL_CONSUMPTION,
-    ATTR_TOTAL_CONSUMPTION_UNIT,
     DOMAIN as FB_DOMAIN,
 )
 from homeassistant.components.sensor import (
@@ -17,7 +15,7 @@ from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
     STATE_CLASS_MEASUREMENT,
 )
-from homeassistant.components.switch import ATTR_CURRENT_POWER_W, DOMAIN
+from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
@@ -25,6 +23,7 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
     ENERGY_KILO_WATT_HOUR,
+    POWER_WATT,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_ON,
@@ -51,14 +50,11 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     state = hass.states.get(ENTITY_ID)
     assert state
     assert state.state == STATE_ON
-    assert state.attributes[ATTR_CURRENT_POWER_W] == 5.678
     assert state.attributes[ATTR_FRIENDLY_NAME] == CONF_FAKE_NAME
     assert state.attributes[ATTR_STATE_DEVICE_LOCKED] == "fake_locked_device"
     assert state.attributes[ATTR_STATE_LOCKED] == "fake_locked"
     assert state.attributes[ATTR_TEMPERATURE] == "1.23"
     assert state.attributes[ATTR_TEMPERATURE_UNIT] == TEMP_CELSIUS
-    assert state.attributes[ATTR_TOTAL_CONSUMPTION] == "1.234"
-    assert state.attributes[ATTR_TOTAL_CONSUMPTION_UNIT] == ENERGY_KILO_WATT_HOUR
     assert ATTR_STATE_CLASS not in state.attributes
 
     state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_temperature")
@@ -69,6 +65,20 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_STATE_LOCKED] == "fake_locked"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == TEMP_CELSIUS
     assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_MEASUREMENT
+
+    state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_power_consumption")
+    assert state
+    assert state.state == "5.678"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Power Consumption"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == POWER_WATT
+    assert state.attributes[ATTR_STATE_CLASS] == STATE_CLASS_MEASUREMENT
+
+    state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_total_energy")
+    assert state
+    assert state.state == "1.234"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Total Energy"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_KILO_WATT_HOUR
+    assert ATTR_STATE_CLASS not in state.attributes
 
 
 async def test_turn_on(hass: HomeAssistant, fritz: Mock):

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -11,6 +11,7 @@ from homeassistant.components.fritzbox.const import (
     DOMAIN as FB_DOMAIN,
 )
 from homeassistant.components.sensor import (
+    ATTR_LAST_RESET,
     ATTR_STATE_CLASS,
     DOMAIN as SENSOR_DOMAIN,
     STATE_CLASS_MEASUREMENT,
@@ -76,6 +77,7 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_total_energy")
     assert state
     assert state.state == "1.234"
+    assert state.attributes[ATTR_LAST_RESET] == "1970-01-01T00:00:00+00:00"
     assert state.attributes[ATTR_FRIENDLY_NAME] == f"{CONF_FAKE_NAME} Total Energy"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == ENERGY_KILO_WATT_HOUR
     assert ATTR_STATE_CLASS not in state.attributes

--- a/tests/components/fritzbox/test_switch.py
+++ b/tests/components/fritzbox/test_switch.py
@@ -7,7 +7,6 @@ from requests.exceptions import HTTPError
 from homeassistant.components.fritzbox.const import (
     ATTR_STATE_DEVICE_LOCKED,
     ATTR_STATE_LOCKED,
-    ATTR_TEMPERATURE_UNIT,
     DOMAIN as FB_DOMAIN,
 )
 from homeassistant.components.sensor import (
@@ -20,7 +19,6 @@ from homeassistant.components.switch import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_FRIENDLY_NAME,
-    ATTR_TEMPERATURE,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_DEVICES,
     ENERGY_KILO_WATT_HOUR,
@@ -54,8 +52,6 @@ async def test_setup(hass: HomeAssistant, fritz: Mock):
     assert state.attributes[ATTR_FRIENDLY_NAME] == CONF_FAKE_NAME
     assert state.attributes[ATTR_STATE_DEVICE_LOCKED] == "fake_locked_device"
     assert state.attributes[ATTR_STATE_LOCKED] == "fake_locked"
-    assert state.attributes[ATTR_TEMPERATURE] == "1.23"
-    assert state.attributes[ATTR_TEMPERATURE_UNIT] == TEMP_CELSIUS
     assert ATTR_STATE_CLASS not in state.attributes
 
     state = hass.states.get(f"{SENSOR_DOMAIN}.{CONF_FAKE_NAME}_temperature")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The property `current_power_w` and extra attributes `total_consumption` and `temperature` of switch entities were moved into own sensors.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As discussed in home-assistant/architecture#579 the `current_power_w` properties of the switch entity is removed and migrated to a sensor. Same is done for extra attribute `total_consumption` of switch entities, to be more consistent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes  #53313
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#18398

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
