### PR TITLE
Improve config entry title for GIOS integration

### DIFF
--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -49,7 +49,7 @@ class GiosFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     await gios.async_update()
 
                 return self.async_create_entry(
-                    title=f"{gios.station_name} ({user_input[CONF_STATION_ID]})",
+                    title=gios.station_name,
                     data=user_input,
                 )
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):

--- a/homeassistant/components/gios/config_flow.py
+++ b/homeassistant/components/gios/config_flow.py
@@ -49,7 +49,7 @@ class GiosFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
                     await gios.async_update()
 
                 return self.async_create_entry(
-                    title=user_input[CONF_STATION_ID],
+                    title=f"{gios.station_name} ({user_input[CONF_STATION_ID]})",
                     data=user_input,
                 )
             except (ApiError, ClientConnectorError, asyncio.TimeoutError):

--- a/tests/components/gios/test_config_flow.py
+++ b/tests/components/gios/test_config_flow.py
@@ -99,7 +99,7 @@ async def test_create_entry(hass):
         result = await flow.async_step_user(user_input=CONFIG)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == CONFIG[CONF_STATION_ID]
+        assert result["title"] == f"Test Name 1 ({CONFIG[CONF_STATION_ID]})"
         assert result["data"][CONF_STATION_ID] == CONFIG[CONF_STATION_ID]
 
         assert flow.context["unique_id"] == "123"

--- a/tests/components/gios/test_config_flow.py
+++ b/tests/components/gios/test_config_flow.py
@@ -99,7 +99,7 @@ async def test_create_entry(hass):
         result = await flow.async_step_user(user_input=CONFIG)
 
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == f"Test Name 1 ({CONFIG[CONF_STATION_ID]})"
+        assert result["title"] == "Test Name 1"
         assert result["data"][CONF_STATION_ID] == CONFIG[CONF_STATION_ID]
 
         assert flow.context["unique_id"] == "123"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR changes config entry title from `station id` to `station name`.

![image](https://user-images.githubusercontent.com/478555/124593744-4bce4200-de5f-11eb-99d7-d777c193e692.png)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
