### PR TITLE
Use properties instead of raw data in the rituals integration

### DIFF
--- a/homeassistant/components/rituals_perfume_genie/__init__.py
+++ b/homeassistant/components/rituals_perfume_genie/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import ACCOUNT_HASH, COORDINATORS, DEVICES, DOMAIN, HUBLOT
+from .const import ACCOUNT_HASH, COORDINATORS, DEVICES, DOMAIN
 
 PLATFORMS = ["binary_sensor", "number", "select", "sensor", "switch"]
 
@@ -23,8 +23,7 @@ UPDATE_INTERVAL = timedelta(seconds=30)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Rituals Perfume Genie from a config entry."""
     session = async_get_clientsession(hass)
-    account = Account(session=session)
-    account.data = {ACCOUNT_HASH: entry.data.get(ACCOUNT_HASH)}
+    account = Account(session=session, account_hash=entry.data[ACCOUNT_HASH])
 
     try:
         account_devices = await account.get_devices()
@@ -37,7 +36,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     }
 
     for device in account_devices:
-        hublot = device.hub_data[HUBLOT]
+        hublot = device.hublot
 
         coordinator = RitualsDataUpdateCoordinator(hass, device)
         await coordinator.async_refresh()
@@ -68,7 +67,7 @@ class RitualsDataUpdateCoordinator(DataUpdateCoordinator):
         super().__init__(
             hass,
             _LOGGER,
-            name=f"{DOMAIN}-{device.hub_data[HUBLOT]}",
+            name=f"{DOMAIN}-{device.hublot}",
             update_interval=UPDATE_INTERVAL,
         )
 

--- a/homeassistant/components/rituals_perfume_genie/config_flow.py
+++ b/homeassistant/components/rituals_perfume_genie/config_flow.py
@@ -47,12 +47,12 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            await self.async_set_unique_id(account.data[CONF_EMAIL])
+            await self.async_set_unique_id(account.email)
             self._abort_if_unique_id_configured()
 
             return self.async_create_entry(
-                title=account.data[CONF_EMAIL],
-                data={ACCOUNT_HASH: account.data[ACCOUNT_HASH]},
+                title=account.email,
+                data={ACCOUNT_HASH: account.account_hash},
             )
 
         return self.async_show_form(

--- a/homeassistant/components/rituals_perfume_genie/const.py
+++ b/homeassistant/components/rituals_perfume_genie/const.py
@@ -1,9 +1,7 @@
 """Constants for the Rituals Perfume Genie integration."""
 DOMAIN = "rituals_perfume_genie"
 
+ACCOUNT_HASH = "account_hash"
+
 COORDINATORS = "coordinators"
 DEVICES = "devices"
-
-ACCOUNT_HASH = "account_hash"
-HUBLOT = "hublot"
-SENSORS = "sensors"

--- a/homeassistant/components/rituals_perfume_genie/entity.py
+++ b/homeassistant/components/rituals_perfume_genie/entity.py
@@ -6,18 +6,11 @@ from pyrituals import Diffuser
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import RitualsDataUpdateCoordinator
-from .const import DOMAIN, HUBLOT, SENSORS
+from .const import DOMAIN
 
 MANUFACTURER = "Rituals Cosmetics"
 MODEL = "The Perfume Genie"
 MODEL2 = "The Perfume Genie 2.0"
-
-ATTRIBUTES = "attributes"
-ROOMNAME = "roomnamec"
-STATUS = "status"
-VERSION = "versionc"
-
-AVAILABLE_STATE = 1
 
 
 class DiffuserEntity(CoordinatorEntity):
@@ -35,8 +28,8 @@ class DiffuserEntity(CoordinatorEntity):
         super().__init__(coordinator)
         self._diffuser = diffuser
 
-        hublot = self._diffuser.hub_data[HUBLOT]
-        hubname = self._diffuser.hub_data[ATTRIBUTES][ROOMNAME]
+        hublot = self._diffuser.hublot
+        hubname = self._diffuser.name
 
         self._attr_name = f"{hubname}{entity_suffix}"
         self._attr_unique_id = f"{hublot}{entity_suffix}"
@@ -45,10 +38,10 @@ class DiffuserEntity(CoordinatorEntity):
             "identifiers": {(DOMAIN, hublot)},
             "manufacturer": MANUFACTURER,
             "model": MODEL if diffuser.has_battery else MODEL2,
-            "sw_version": diffuser.hub_data[SENSORS][VERSION],
+            "sw_version": diffuser.version,
         }
 
     @property
     def available(self) -> bool:
         """Return if the entity is available."""
-        return super().available and self._diffuser.hub_data[STATUS] == AVAILABLE_STATE
+        return super().available and self._diffuser.is_online

--- a/homeassistant/components/rituals_perfume_genie/manifest.json
+++ b/homeassistant/components/rituals_perfume_genie/manifest.json
@@ -3,7 +3,7 @@
   "name": "Rituals Perfume Genie",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/rituals_perfume_genie",
-  "requirements": ["pyrituals==0.0.4"],
+  "requirements": ["pyrituals==0.0.5"],
   "codeowners": ["@milanmeu"],
   "iot_class": "cloud_polling"
 }

--- a/homeassistant/components/rituals_perfume_genie/sensor.py
+++ b/homeassistant/components/rituals_perfume_genie/sensor.py
@@ -13,15 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import RitualsDataUpdateCoordinator
-from .const import COORDINATORS, DEVICES, DOMAIN, SENSORS
+from .const import COORDINATORS, DEVICES, DOMAIN
 from .entity import DiffuserEntity
-
-ID = "id"
-PERFUME = "rfidc"
-FILL = "fillc"
-
-PERFUME_NO_CARTRIDGE_ID = 19
-FILL_NO_CARTRIDGE_ID = 12
 
 BATTERY_SUFFIX = " Battery"
 PERFUME_SUFFIX = " Perfume"
@@ -58,9 +51,9 @@ class DiffuserPerfumeSensor(DiffuserEntity):
         """Initialize the perfume sensor."""
         super().__init__(diffuser, coordinator, PERFUME_SUFFIX)
 
-        self._attr_icon = "mdi:tag-text"
-        if diffuser.hub_data[SENSORS][PERFUME][ID] == PERFUME_NO_CARTRIDGE_ID:
-            self._attr_icon = "mdi:tag-remove"
+        self._attr_icon = "mdi:tag-remove"
+        if diffuser.has_cartridge:
+            self._attr_icon = "mdi:tag-text"
 
     @property
     def state(self) -> str:
@@ -77,12 +70,9 @@ class DiffuserFillSensor(DiffuserEntity):
         """Initialize the fill sensor."""
         super().__init__(diffuser, coordinator, FILL_SUFFIX)
 
-    @property
-    def icon(self) -> str:
-        """Return the fill sensor icon."""
-        if self._diffuser.hub_data[SENSORS][FILL][ID] == FILL_NO_CARTRIDGE_ID:
-            return "mdi:beaker-question"
-        return "mdi:beaker"
+        self._attr_icon = "mdi:beaker-question"
+        if diffuser.has_cartridge:
+            self.attr_icon = "mdi:beaker"
 
     @property
     def state(self) -> str:

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1714,7 +1714,7 @@ pyrepetier==3.0.5
 pyrisco==0.3.1
 
 # homeassistant.components.rituals_perfume_genie
-pyrituals==0.0.4
+pyrituals==0.0.5
 
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12

--- a/requirements_test_all.txt
+++ b/requirements_test_all.txt
@@ -977,7 +977,7 @@ pyqwikswitch==0.93
 pyrisco==0.3.1
 
 # homeassistant.components.rituals_perfume_genie
-pyrituals==0.0.4
+pyrituals==0.0.5
 
 # homeassistant.components.ruckus_unleashed
 pyruckus==0.12

--- a/tests/components/rituals_perfume_genie/test_config_flow.py
+++ b/tests/components/rituals_perfume_genie/test_config_flow.py
@@ -16,7 +16,8 @@ WRONG_PASSWORD = "wrong-passw0rd"
 def _mock_account(*_):
     account = MagicMock()
     account.authenticate = AsyncMock()
-    account.data = {CONF_EMAIL: TEST_EMAIL, ACCOUNT_HASH: "any"}
+    account.account_hash = "any"
+    account.email = TEST_EMAIL
     return account
 
 


### PR DESCRIPTION
## Proposed change
Pyrituals v0.0.5 has new properties so we can use those instead of the hub_data. 
This makes writing tests and strict typing easier for a future PR.
Package release notes: https://github.com/milanmeu/pyrituals/releases/tag/0.0.5


## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
