### PR TITLE
Add tests for LCN switch platform

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -581,7 +581,6 @@ omit =
     homeassistant/components/lcn/scene.py
     homeassistant/components/lcn/sensor.py
     homeassistant/components/lcn/services.py
-    homeassistant/components/lcn/switch.py
     homeassistant/components/lg_netcast/media_player.py
     homeassistant/components/lg_soundbar/media_player.py
     homeassistant/components/life360/*

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -8,21 +8,9 @@ import pypck.module
 from pypck.module import GroupConnection, ModuleConnection
 import pytest
 
-from homeassistant.components.lcn.const import (
-    CONF_DIM_MODE,
-    CONF_SK_NUM_TRIES,
-    CONNECTION,
-    DOMAIN,
-)
+from homeassistant.components.lcn.const import DOMAIN
 from homeassistant.components.lcn.helpers import generate_unique_id
-from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_IP_ADDRESS,
-    CONF_PASSWORD,
-    CONF_PORT,
-    CONF_USERNAME,
-)
+from homeassistant.const import CONF_HOST
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -125,29 +113,6 @@ async def init_integration(hass, entry):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         yield lcn_connection
-
-
-async def setup_platform(hass, entry, platform):
-    """Set up the LCN platform."""
-    hass.config.components.add(entry.domain)
-    entry.state = ConfigEntryState.LOADED
-    settings = {
-        "SK_NUMN_TRIES": entry.data[CONF_SK_NUM_TRIES],
-        "DIM_MODE": pypck.lcn_defs.OutputPortDimMode[entry.data[CONF_DIM_MODE]],
-    }
-    lcn_connection = MockPchkConnectionManager(
-        entry.data[CONF_IP_ADDRESS],
-        entry.data[CONF_PORT],
-        entry.data[CONF_USERNAME],
-        entry.data[CONF_PASSWORD],
-        settings=settings,
-        connection_id=entry.title,
-    )
-
-    hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN].setdefault(entry.entry_id, {CONNECTION: lcn_connection})
-    await hass.config_entries.async_forward_entry_setup(entry, platform)
-    await hass.async_block_till_done()
 
 
 async def setup_component(hass):

--- a/tests/components/lcn/conftest.py
+++ b/tests/components/lcn/conftest.py
@@ -8,9 +8,21 @@ import pypck.module
 from pypck.module import GroupConnection, ModuleConnection
 import pytest
 
-from homeassistant.components.lcn.const import DOMAIN
+from homeassistant.components.lcn.const import (
+    CONF_DIM_MODE,
+    CONF_SK_NUM_TRIES,
+    CONNECTION,
+    DOMAIN,
+)
 from homeassistant.components.lcn.helpers import generate_unique_id
-from homeassistant.const import CONF_HOST
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_USERNAME,
+)
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
@@ -113,6 +125,29 @@ async def init_integration(hass, entry):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
         yield lcn_connection
+
+
+async def setup_platform(hass, entry, platform):
+    """Set up the LCN platform."""
+    hass.config.components.add(entry.domain)
+    entry.state = ConfigEntryState.LOADED
+    settings = {
+        "SK_NUMN_TRIES": entry.data[CONF_SK_NUM_TRIES],
+        "DIM_MODE": pypck.lcn_defs.OutputPortDimMode[entry.data[CONF_DIM_MODE]],
+    }
+    lcn_connection = MockPchkConnectionManager(
+        entry.data[CONF_IP_ADDRESS],
+        entry.data[CONF_PORT],
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        settings=settings,
+        connection_id=entry.title,
+    )
+
+    hass.data.setdefault(DOMAIN, {})
+    hass.data[DOMAIN].setdefault(entry.entry_id, {CONNECTION: lcn_connection})
+    await hass.config_entries.async_forward_entry_setup(entry, platform)
+    await hass.async_block_till_done()
 
 
 async def setup_component(hass):

--- a/tests/components/lcn/fixtures/config.json
+++ b/tests/components/lcn/fixtures/config.json
@@ -27,6 +27,21 @@
         "output": "output1"
       },
       {
+        "name": "Switch_Output2",
+        "address": "s0.m7",
+        "output": "output2"
+      },
+      {
+        "name": "Switch_Relay1",
+        "address": "s0.m7",
+        "output": "relay1"
+      },
+      {
+        "name": "Switch_Relay2",
+        "address": "s0.m7",
+        "output": "relay2"
+      },
+      {
         "name": "Switch_Group5",
         "address": "s0.g5",
         "output": "relay1"

--- a/tests/components/lcn/fixtures/config_entry_pchk.json
+++ b/tests/components/lcn/fixtures/config_entry_pchk.json
@@ -33,6 +33,33 @@
       }
     },
     {
+      "address": [0, 7, false],
+      "name": "Switch_Output2",
+      "resource": "output2",
+      "domain": "switch",
+      "domain_data": {
+        "output": "OUTPUT2"
+      }
+    },
+    {
+      "address": [0, 7, false],
+      "name": "Switch_Relay1",
+      "resource": "relay1",
+      "domain": "switch",
+      "domain_data": {
+        "output": "RELAY1"
+      }
+    },
+    {
+      "address": [0, 7, false],
+      "name": "Switch_Relay2",
+      "resource": "relay2",
+      "domain": "switch",
+      "domain_data": {
+        "output": "RELAY2"
+      }
+    },
+    {
       "address": [0, 5, true],
       "name": "Switch_Group5",
       "resource": "relay1",

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -250,5 +250,5 @@ async def test_pushed_relay_status_change(hass, entry, lcn_connection):
 
 async def test_unload_config_entry(hass, entry, lcn_connection):
     """Test the switch is removed when the config entry is unloaded."""
-    await hass.config_entries.async_forward_entry_unload(entry, DOMAIN_SWITCH)
+    await hass.config_entries.async_unload(entry.entry_id)
     assert hass.states.get("switch.switch_output1").state == STATE_UNAVAILABLE

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -34,6 +34,16 @@ async def test_setup_lcn_switch(activate_status_request_handler, hass, entry):
     activate_status_request_handler.assert_has_awaits(calls, any_order=True)
     assert activate_status_request_handler.await_count == 4
 
+    for entity_id in (
+        "switch.switch_output1",
+        "switch.switch_output2",
+        "switch.switch_relay1",
+        "switch.switch_relay2",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_OFF
+
 
 async def test_entity_attributes(hass, entry):
     """Test the attributes of an entity."""
@@ -71,8 +81,7 @@ async def test_output_turn_on(dim_output, hass, entry):
     dim_output.assert_awaited_with(0, 100, 0)
 
     state = hass.states.get("switch.switch_output1")
-    assert state is not None
-    assert state.state != STATE_ON
+    assert state.state == STATE_OFF
 
     # command success
     dim_output.reset_mock(return_value=True)
@@ -88,7 +97,6 @@ async def test_output_turn_on(dim_output, hass, entry):
     dim_output.assert_awaited_with(0, 100, 0)
 
     state = hass.states.get("switch.switch_output1")
-    assert state is not None
     assert state.state == STATE_ON
 
 
@@ -113,8 +121,7 @@ async def test_output_turn_off(dim_output, hass, entry):
     dim_output.assert_awaited_with(0, 0, 0)
 
     state = hass.states.get("switch.switch_output1")
-    assert state is not None
-    assert state.state != STATE_OFF
+    assert state.state == STATE_ON
 
     # command success
     dim_output.reset_mock(return_value=True)
@@ -130,7 +137,6 @@ async def test_output_turn_off(dim_output, hass, entry):
     dim_output.assert_awaited_with(0, 0, 0)
 
     state = hass.states.get("switch.switch_output1")
-    assert state is not None
     assert state.state == STATE_OFF
 
 
@@ -155,8 +161,7 @@ async def test_relay_turn_on(control_relays, hass, entry):
     control_relays.assert_awaited_with(states)
 
     state = hass.states.get("switch.switch_relay1")
-    assert state is not None
-    assert state.state != STATE_ON
+    assert state.state == STATE_OFF
 
     # command success
     control_relays.reset_mock(return_value=True)
@@ -172,7 +177,6 @@ async def test_relay_turn_on(control_relays, hass, entry):
     control_relays.assert_awaited_with(states)
 
     state = hass.states.get("switch.switch_relay1")
-    assert state is not None
     assert state.state == STATE_ON
 
 
@@ -200,8 +204,7 @@ async def test_relay_turn_off(control_relays, hass, entry):
     control_relays.assert_awaited_with(states)
 
     state = hass.states.get("switch.switch_relay1")
-    assert state is not None
-    assert state.state != STATE_OFF
+    assert state.state == STATE_ON
 
     # command success
     control_relays.reset_mock(return_value=True)
@@ -217,7 +220,6 @@ async def test_relay_turn_off(control_relays, hass, entry):
     control_relays.assert_awaited_with(states)
 
     state = hass.states.get("switch.switch_relay1")
-    assert state is not None
     assert state.state == STATE_OFF
 
 
@@ -228,21 +230,19 @@ async def test_pushed_output_status_change(hass, entry):
     address = LcnAddr(0, 7, False)
 
     # push status "on"
-    input = ModStatusOutput(address, 0, 100)
-    await device_connection.async_process_input(input)
+    inp = ModStatusOutput(address, 0, 100)
+    await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.switch_output1")
-    assert state is not None
     assert state.state == STATE_ON
 
     # push status "off"
-    input = ModStatusOutput(address, 0, 0)
-    await device_connection.async_process_input(input)
+    inp = ModStatusOutput(address, 0, 0)
+    await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.switch_output1")
-    assert state is not None
     assert state.state == STATE_OFF
 
 
@@ -255,22 +255,20 @@ async def test_pushed_relay_status_change(hass, entry):
 
     # push status "on"
     states[0] = True
-    input = ModStatusRelays(address, states)
-    await device_connection.async_process_input(input)
+    inp = ModStatusRelays(address, states)
+    await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.switch_relay1")
-    assert state is not None
     assert state.state == STATE_ON
 
     # push status "off"
     states[0] = False
-    input = ModStatusRelays(address, states)
-    await device_connection.async_process_input(input)
+    inp = ModStatusRelays(address, states)
+    await device_connection.async_process_input(inp)
     await hass.async_block_till_done()
 
     state = hass.states.get("switch.switch_relay1")
-    assert state is not None
     assert state.state == STATE_OFF
 
 

--- a/tests/components/lcn/test_switch.py
+++ b/tests/components/lcn/test_switch.py
@@ -1,0 +1,281 @@
+"""Test for the LCN switch platform."""
+from unittest.mock import call, patch
+
+from pypck.inputs import ModStatusOutput, ModStatusRelays
+from pypck.lcn_addr import LcnAddr
+from pypck.lcn_defs import OutputPort, RelayPort, RelayStateModifier
+
+from homeassistant.components.lcn.helpers import get_device_connection
+from homeassistant.components.switch import DOMAIN as DOMAIN_SWITCH
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+
+from .conftest import MockModuleConnection, setup_platform
+
+
+@patch.object(MockModuleConnection, "activate_status_request_handler")
+async def test_setup_lcn_switch(activate_status_request_handler, hass, entry):
+    """Test the setup of switch."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+    device_connection = get_device_connection(hass, (0, 7, False), entry)
+    assert device_connection
+    calls = [
+        call(OutputPort.OUTPUT1),
+        call(OutputPort.OUTPUT2),
+        call(RelayPort.RELAY1),
+        call(RelayPort.RELAY2),
+    ]
+    activate_status_request_handler.assert_has_awaits(calls, any_order=True)
+    assert activate_status_request_handler.await_count == 4
+
+
+async def test_entity_attributes(hass, entry):
+    """Test the attributes of an entity."""
+    entity_registry = await hass.helpers.entity_registry.async_get_registry()
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+
+    entity_output = entity_registry.async_get("switch.switch_output1")
+
+    assert entity_output
+    assert entity_output.unique_id == f"{entry.entry_id}-m000007-output1"
+    assert entity_output.original_name == "Switch_Output1"
+
+    entity_relay = entity_registry.async_get("switch.switch_relay1")
+
+    assert entity_relay
+    assert entity_relay.unique_id == f"{entry.entry_id}-m000007-relay1"
+    assert entity_relay.original_name == "Switch_Relay1"
+
+
+@patch.object(MockModuleConnection, "dim_output")
+async def test_output_turn_on(dim_output, hass, entry):
+    """Test the output switch turns on."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+
+    # command failed
+    dim_output.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.switch_output1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    dim_output.assert_awaited_with(0, 100, 0)
+
+    state = hass.states.get("switch.switch_output1")
+    assert state is not None
+    assert state.state != STATE_ON
+
+    # command success
+    dim_output.reset_mock(return_value=True)
+    dim_output.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.switch_output1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    dim_output.assert_awaited_with(0, 100, 0)
+
+    state = hass.states.get("switch.switch_output1")
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+@patch.object(MockModuleConnection, "dim_output")
+async def test_output_turn_off(dim_output, hass, entry):
+    """Test the output switch turns off."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+
+    state = hass.states.get("switch.switch_output1")
+    state.state = STATE_ON
+
+    # command failed
+    dim_output.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.switch_output1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    dim_output.assert_awaited_with(0, 0, 0)
+
+    state = hass.states.get("switch.switch_output1")
+    assert state is not None
+    assert state.state != STATE_OFF
+
+    # command success
+    dim_output.reset_mock(return_value=True)
+    dim_output.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.switch_output1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    dim_output.assert_awaited_with(0, 0, 0)
+
+    state = hass.states.get("switch.switch_output1")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+@patch.object(MockModuleConnection, "control_relays")
+async def test_relay_turn_on(control_relays, hass, entry):
+    """Test the relay switch turns on."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+
+    states = [RelayStateModifier.NOCHANGE] * 8
+    states[0] = RelayStateModifier.ON
+
+    # command failed
+    control_relays.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.switch_relay1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_relays.assert_awaited_with(states)
+
+    state = hass.states.get("switch.switch_relay1")
+    assert state is not None
+    assert state.state != STATE_ON
+
+    # command success
+    control_relays.reset_mock(return_value=True)
+    control_relays.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.switch_relay1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_relays.assert_awaited_with(states)
+
+    state = hass.states.get("switch.switch_relay1")
+    assert state is not None
+    assert state.state == STATE_ON
+
+
+@patch.object(MockModuleConnection, "control_relays")
+async def test_relay_turn_off(control_relays, hass, entry):
+    """Test the relay switch turns off."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+
+    states = [RelayStateModifier.NOCHANGE] * 8
+    states[0] = RelayStateModifier.OFF
+
+    state = hass.states.get("switch.switch_relay1")
+    state.state = STATE_ON
+
+    # command failed
+    control_relays.return_value = False
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.switch_relay1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_relays.assert_awaited_with(states)
+
+    state = hass.states.get("switch.switch_relay1")
+    assert state is not None
+    assert state.state != STATE_OFF
+
+    # command success
+    control_relays.reset_mock(return_value=True)
+    control_relays.return_value = True
+
+    await hass.services.async_call(
+        DOMAIN_SWITCH,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.switch_relay1"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    control_relays.assert_awaited_with(states)
+
+    state = hass.states.get("switch.switch_relay1")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_pushed_output_status_change(hass, entry):
+    """Test the output switch changes its state on status received."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+    device_connection = get_device_connection(hass, (0, 7, False), entry)
+    address = LcnAddr(0, 7, False)
+
+    # push status "on"
+    input = ModStatusOutput(address, 0, 100)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.switch_output1")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    # push status "off"
+    input = ModStatusOutput(address, 0, 0)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.switch_output1")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_pushed_relay_status_change(hass, entry):
+    """Test the relay switch changes its state on status received."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+    device_connection = get_device_connection(hass, (0, 7, False), entry)
+    address = LcnAddr(0, 7, False)
+    states = [False] * 8
+
+    # push status "on"
+    states[0] = True
+    input = ModStatusRelays(address, states)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.switch_relay1")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    # push status "off"
+    states[0] = False
+    input = ModStatusRelays(address, states)
+    await device_connection.async_process_input(input)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.switch_relay1")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_unload_config_entry(hass, entry):
+    """Test the switch is removed when the config entry is unloaded."""
+    await setup_platform(hass, entry, DOMAIN_SWITCH)
+    await hass.config_entries.async_forward_entry_unload(entry, DOMAIN_SWITCH)
+    assert hass.states.get("switch.switch_output1").state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add tests for LCN switch platform.
There are two types of switch entities which have to be tested. One acts on a mains switch (`output`) and one on a relay (`relay`).
Tests are written for switch platform setup, unloading, turn on/off and state changes due to status messages received.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
