### PR TITLE
Fix deadlock at shutdown with python 3.9

### DIFF
--- a/homeassistant/runner.py
+++ b/homeassistant/runner.py
@@ -73,16 +73,6 @@ class HassEventLoopPolicy(asyncio.DefaultEventLoopPolicy):  # type: ignore[valid
         loop.set_default_executor = warn_use(  # type: ignore
             loop.set_default_executor, "sets default executor on the event loop"
         )
-
-        # Shut down executor when we shut down loop
-        orig_close = loop.close
-
-        def close() -> None:
-            executor.logged_shutdown()
-            orig_close()
-
-        loop.close = close  # type: ignore
-
         return loop
 
 

--- a/homeassistant/util/executor.py
+++ b/homeassistant/util/executor.py
@@ -62,7 +62,7 @@ def join_or_interrupt_threads(
 class InterruptibleThreadPoolExecutor(ThreadPoolExecutor):
     """A ThreadPoolExecutor instance that will not deadlock on shutdown."""
 
-    def logged_shutdown(self) -> None:
+    def shutdown(self, *args, **kwargs) -> None:  # type: ignore
         """Shutdown backport from cpython 3.9 with interrupt support added."""
         with self._shutdown_lock:  # type: ignore[attr-defined]
             self._shutdown = True

--- a/tests/util/test_executor.py
+++ b/tests/util/test_executor.py
@@ -24,7 +24,7 @@ async def test_executor_shutdown_can_interrupt_threads(caplog):
     for _ in range(100):
         sleep_futures.append(iexecutor.submit(_loop_sleep_in_executor))
 
-    iexecutor.logged_shutdown()
+    iexecutor.shutdown()
 
     for future in sleep_futures:
         with pytest.raises((concurrent.futures.CancelledError, SystemExit)):
@@ -45,13 +45,13 @@ async def test_executor_shutdown_only_logs_max_attempts(caplog):
     iexecutor.submit(_loop_sleep_in_executor)
 
     with patch.object(executor, "EXECUTOR_SHUTDOWN_TIMEOUT", 0.3):
-        iexecutor.logged_shutdown()
+        iexecutor.shutdown()
 
     assert "time.sleep(0.2)" in caplog.text
     assert (
         caplog.text.count("is still running at shutdown") == executor.MAX_LOG_ATTEMPTS
     )
-    iexecutor.logged_shutdown()
+    iexecutor.shutdown()
 
 
 async def test_executor_shutdown_does_not_log_shutdown_on_first_attempt(caplog):
@@ -65,7 +65,7 @@ async def test_executor_shutdown_does_not_log_shutdown_on_first_attempt(caplog):
     for _ in range(5):
         iexecutor.submit(_do_nothing)
 
-    iexecutor.logged_shutdown()
+    iexecutor.shutdown()
 
     assert "is still running at shutdown" not in caplog.text
 
@@ -83,9 +83,9 @@ async def test_overall_timeout_reached(caplog):
 
     start = time.monotonic()
     with patch.object(executor, "EXECUTOR_SHUTDOWN_TIMEOUT", 0.5):
-        iexecutor.logged_shutdown()
+        iexecutor.shutdown()
     finish = time.monotonic()
 
     assert finish - start < 1
 
-    iexecutor.logged_shutdown()
+    iexecutor.shutdown()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`logged_shutdown` happened and then the `shutdown` (which blocks or worse deadlocks) happened when we call `close` on the loop, but it wasn't noticeable until python 3.9 made a change where thread pool executor threads are no longer daemonic in https://github.com/python/cpython/pull/19149 which means we deadlock at shutdown if a background process is still running if it won't die on its own.

Noticed while troubleshooting nmap in https://github.com/home-assistant/core/issues/52565#issuecomment-875179313

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
