### PR TITLE
Ignore unused keys from Sonos device properties callback

### DIFF
--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -410,7 +410,9 @@ class SonosSpeaker:
             battery_dict = dict(x.split(":") for x in more_info.split(","))
             for unused in UNUSED_DEVICE_KEYS:
                 battery_dict.pop(unused, None)
-            if battery_dict and "BattChg" not in battery_dict:
+            if not battery_dict:
+                return
+            if "BattChg" not in battery_dict:
                 _LOGGER.debug(
                     "Unknown device properties update for %s (%s), please report an issue: '%s'",
                     self.zone_name,

--- a/homeassistant/components/sonos/speaker.py
+++ b/homeassistant/components/sonos/speaker.py
@@ -71,6 +71,7 @@ SUBSCRIPTION_SERVICES = [
     "zoneGroupTopology",
 ]
 UNAVAILABLE_VALUES = {"", "NOT_IMPLEMENTED", None}
+UNUSED_DEVICE_KEYS = ["SPID", "TargetRoomName"]
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -407,7 +408,9 @@ class SonosSpeaker:
         """Update device properties from an event."""
         if more_info := event.variables.get("more_info"):
             battery_dict = dict(x.split(":") for x in more_info.split(","))
-            if "BattChg" not in battery_dict:
+            for unused in UNUSED_DEVICE_KEYS:
+                battery_dict.pop(unused, None)
+            if battery_dict and "BattChg" not in battery_dict:
                 _LOGGER.debug(
                     "Unknown device properties update for %s (%s), please report an issue: '%s'",
                     self.zone_name,

--- a/tests/components/sonos/test_sensor.py
+++ b/tests/components/sonos/test_sensor.py
@@ -103,3 +103,23 @@ async def test_device_payload_without_battery(
     await hass.async_block_till_done()
 
     assert bad_payload in caplog.text
+
+
+async def test_device_payload_without_battery_and_ignored_keys(
+    hass, config_entry, config, soco, battery_event, caplog
+):
+    """Test device properties event update without battery info and ignored keys."""
+    soco.get_battery_info.return_value = None
+
+    await setup_platform(hass, config_entry, config)
+
+    subscription = soco.deviceProperties.subscribe.return_value
+    sub_callback = subscription.callback
+
+    ignored_payload = "SPID:InCeiling,TargetRoomName:Bouncy House"
+    battery_event.variables["more_info"] = ignored_payload
+
+    sub_callback(battery_event)
+    await hass.async_block_till_done()
+
+    assert ignored_payload not in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
As seen in #52036 there are known but unused keys provided in the subscription callback used for battery state reporting. This avoids printing a debug message for them.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
