### PR TITLE
Use iso-formatted times in MetOffice weather forecast

### DIFF
--- a/homeassistant/components/metoffice/sensor.py
+++ b/homeassistant/components/metoffice/sensor.py
@@ -196,7 +196,7 @@ class MetOfficeCurrentSensor(CoordinatorEntity, SensorEntity):
         """Return the state attributes of the device."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            ATTR_LAST_UPDATE: self.coordinator.data.now.date,
+            ATTR_LAST_UPDATE: self.coordinator.data.now.date.isoformat(),
             ATTR_SENSOR_ID: self._type,
             ATTR_SITE_ID: self.coordinator.data.site.id,
             ATTR_SITE_NAME: self.coordinator.data.site.name,

--- a/homeassistant/components/metoffice/sensor.py
+++ b/homeassistant/components/metoffice/sensor.py
@@ -196,7 +196,7 @@ class MetOfficeCurrentSensor(CoordinatorEntity, SensorEntity):
         """Return the state attributes of the device."""
         return {
             ATTR_ATTRIBUTION: ATTRIBUTION,
-            ATTR_LAST_UPDATE: self.coordinator.data.now.date.isoformat(),
+            ATTR_LAST_UPDATE: self.coordinator.data.now.date,
             ATTR_SENSOR_ID: self._type,
             ATTR_SITE_ID: self.coordinator.data.site.id,
             ATTR_SITE_NAME: self.coordinator.data.site.name,

--- a/homeassistant/components/metoffice/weather.py
+++ b/homeassistant/components/metoffice/weather.py
@@ -47,7 +47,7 @@ async def async_setup_entry(
 
 def _build_forecast_data(timestep):
     data = {}
-    data[ATTR_FORECAST_TIME] = timestep.date
+    data[ATTR_FORECAST_TIME] = timestep.date.isoformat()
     if timestep.weather:
         data[ATTR_FORECAST_CONDITION] = _get_weather_condition(timestep.weather.value)
     if timestep.precipitation:

--- a/tests/components/metoffice/const.py
+++ b/tests/components/metoffice/const.py
@@ -2,8 +2,7 @@
 
 from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME
 
-DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S%z"
-TEST_DATETIME_STRING = "2020-04-25 12:00:00+0000"
+TEST_DATETIME_STRING = "2020-04-25T12:00:00+00:00"
 
 TEST_API_KEY = "test-metoffice-api-key"
 

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -6,7 +6,6 @@ from homeassistant.components.metoffice.const import ATTRIBUTION, DOMAIN
 
 from . import NewDateTime
 from .const import (
-    DATETIME_FORMAT,
     KINGSLYNN_SENSOR_RESULTS,
     METOFFICE_CONFIG_KINGSLYNN,
     METOFFICE_CONFIG_WAVERTREE,
@@ -54,13 +53,10 @@ async def test_one_sensor_site_running(hass, requests_mock, legacy_patchable_tim
     for running_id in running_sensor_ids:
         sensor = hass.states.get(running_id)
         sensor_id = sensor.attributes.get("sensor_id")
-        sensor_name, sensor_value = WAVERTREE_SENSOR_RESULTS[sensor_id]
+        _, sensor_value = WAVERTREE_SENSOR_RESULTS[sensor_id]
 
         assert sensor.state == sensor_value
-        assert (
-            sensor.attributes.get("last_update").strftime(DATETIME_FORMAT)
-            == TEST_DATETIME_STRING
-        )
+        assert sensor.attributes.get("last_update") == TEST_DATETIME_STRING
         assert sensor.attributes.get("site_id") == "354107"
         assert sensor.attributes.get("site_name") == TEST_SITE_NAME_WAVERTREE
         assert sensor.attributes.get("attribution") == ATTRIBUTION
@@ -115,24 +111,18 @@ async def test_two_sensor_sites_running(hass, requests_mock, legacy_patchable_ti
         sensor = hass.states.get(running_id)
         sensor_id = sensor.attributes.get("sensor_id")
         if sensor.attributes.get("site_id") == "354107":
-            sensor_name, sensor_value = WAVERTREE_SENSOR_RESULTS[sensor_id]
+            _, sensor_value = WAVERTREE_SENSOR_RESULTS[sensor_id]
             assert sensor.state == sensor_value
-            assert (
-                sensor.attributes.get("last_update").strftime(DATETIME_FORMAT)
-                == TEST_DATETIME_STRING
-            )
+            assert sensor.attributes.get("last_update") == TEST_DATETIME_STRING
             assert sensor.attributes.get("sensor_id") == sensor_id
             assert sensor.attributes.get("site_id") == "354107"
             assert sensor.attributes.get("site_name") == TEST_SITE_NAME_WAVERTREE
             assert sensor.attributes.get("attribution") == ATTRIBUTION
 
         else:
-            sensor_name, sensor_value = KINGSLYNN_SENSOR_RESULTS[sensor_id]
+            _, sensor_value = KINGSLYNN_SENSOR_RESULTS[sensor_id]
             assert sensor.state == sensor_value
-            assert (
-                sensor.attributes.get("last_update").strftime(DATETIME_FORMAT)
-                == TEST_DATETIME_STRING
-            )
+            assert sensor.attributes.get("last_update") == TEST_DATETIME_STRING
             assert sensor.attributes.get("sensor_id") == sensor_id
             assert sensor.attributes.get("site_id") == "322380"
             assert sensor.attributes.get("site_name") == TEST_SITE_NAME_KINGSLYNN

--- a/tests/components/metoffice/test_sensor.py
+++ b/tests/components/metoffice/test_sensor.py
@@ -56,7 +56,7 @@ async def test_one_sensor_site_running(hass, requests_mock, legacy_patchable_tim
         _, sensor_value = WAVERTREE_SENSOR_RESULTS[sensor_id]
 
         assert sensor.state == sensor_value
-        assert sensor.attributes.get("last_update") == TEST_DATETIME_STRING
+        assert sensor.attributes.get("last_update").isoformat() == TEST_DATETIME_STRING
         assert sensor.attributes.get("site_id") == "354107"
         assert sensor.attributes.get("site_name") == TEST_SITE_NAME_WAVERTREE
         assert sensor.attributes.get("attribution") == ATTRIBUTION
@@ -113,7 +113,9 @@ async def test_two_sensor_sites_running(hass, requests_mock, legacy_patchable_ti
         if sensor.attributes.get("site_id") == "354107":
             _, sensor_value = WAVERTREE_SENSOR_RESULTS[sensor_id]
             assert sensor.state == sensor_value
-            assert sensor.attributes.get("last_update") == TEST_DATETIME_STRING
+            assert (
+                sensor.attributes.get("last_update").isoformat() == TEST_DATETIME_STRING
+            )
             assert sensor.attributes.get("sensor_id") == sensor_id
             assert sensor.attributes.get("site_id") == "354107"
             assert sensor.attributes.get("site_name") == TEST_SITE_NAME_WAVERTREE
@@ -122,7 +124,9 @@ async def test_two_sensor_sites_running(hass, requests_mock, legacy_patchable_ti
         else:
             _, sensor_value = KINGSLYNN_SENSOR_RESULTS[sensor_id]
             assert sensor.state == sensor_value
-            assert sensor.attributes.get("last_update") == TEST_DATETIME_STRING
+            assert (
+                sensor.attributes.get("last_update").isoformat() == TEST_DATETIME_STRING
+            )
             assert sensor.attributes.get("sensor_id") == sensor_id
             assert sensor.attributes.get("site_id") == "322380"
             assert sensor.attributes.get("site_name") == TEST_SITE_NAME_KINGSLYNN

--- a/tests/components/metoffice/test_weather.py
+++ b/tests/components/metoffice/test_weather.py
@@ -9,7 +9,6 @@ from homeassistant.util import utcnow
 
 from . import NewDateTime
 from .const import (
-    DATETIME_FORMAT,
     METOFFICE_CONFIG_KINGSLYNN,
     METOFFICE_CONFIG_WAVERTREE,
     WAVERTREE_SENSOR_RESULTS,
@@ -74,11 +73,11 @@ async def test_site_cannot_update(hass, requests_mock, legacy_patchable_time):
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    entity = hass.states.get("weather.met_office_wavertree_3_hourly")
-    assert entity
+    weather = hass.states.get("weather.met_office_wavertree_3_hourly")
+    assert weather
 
-    entity = hass.states.get("weather.met_office_wavertree_daily")
-    assert entity
+    weather = hass.states.get("weather.met_office_wavertree_daily")
+    assert weather
 
     requests_mock.get("/public/data/val/wxfcs/all/json/354107?res=3hourly", text="")
     requests_mock.get("/public/data/val/wxfcs/all/json/354107?res=daily", text="")
@@ -87,11 +86,11 @@ async def test_site_cannot_update(hass, requests_mock, legacy_patchable_time):
     async_fire_time_changed(hass, future_time)
     await hass.async_block_till_done()
 
-    entity = hass.states.get("weather.met_office_wavertree_3_hourly")
-    assert entity.state == STATE_UNAVAILABLE
+    weather = hass.states.get("weather.met_office_wavertree_3_hourly")
+    assert weather.state == STATE_UNAVAILABLE
 
-    entity = hass.states.get("weather.met_office_wavertree_daily")
-    assert entity.state == STATE_UNAVAILABLE
+    weather = hass.states.get("weather.met_office_wavertree_daily")
+    assert weather.state == STATE_UNAVAILABLE
 
 
 @patch(
@@ -126,50 +125,49 @@ async def test_one_weather_site_running(hass, requests_mock, legacy_patchable_ti
     await hass.async_block_till_done()
 
     # Wavertree 3-hourly weather platform expected results
-    entity = hass.states.get("weather.met_office_wavertree_3_hourly")
-    assert entity
+    weather = hass.states.get("weather.met_office_wavertree_3_hourly")
+    assert weather
 
-    assert entity.state == "sunny"
-    assert entity.attributes.get("temperature") == 17
-    assert entity.attributes.get("wind_speed") == 9
-    assert entity.attributes.get("wind_bearing") == "SSE"
-    assert entity.attributes.get("visibility") == "Good - 10-20"
-    assert entity.attributes.get("humidity") == 50
+    assert weather.state == "sunny"
+    assert weather.attributes.get("temperature") == 17
+    assert weather.attributes.get("wind_speed") == 9
+    assert weather.attributes.get("wind_bearing") == "SSE"
+    assert weather.attributes.get("visibility") == "Good - 10-20"
+    assert weather.attributes.get("humidity") == 50
 
     # Forecasts added - just pick out 1 entry to check
-    assert len(entity.attributes.get("forecast")) == 35
+    assert len(weather.attributes.get("forecast")) == 35
 
     assert (
-        entity.attributes.get("forecast")[26]["datetime"].strftime(DATETIME_FORMAT)
-        == "2020-04-28 21:00:00+0000"
+        weather.attributes.get("forecast")[26]["datetime"]
+        == "2020-04-28T21:00:00+00:00"
     )
-    assert entity.attributes.get("forecast")[26]["condition"] == "cloudy"
-    assert entity.attributes.get("forecast")[26]["temperature"] == 10
-    assert entity.attributes.get("forecast")[26]["wind_speed"] == 4
-    assert entity.attributes.get("forecast")[26]["wind_bearing"] == "NNE"
+    assert weather.attributes.get("forecast")[26]["condition"] == "cloudy"
+    assert weather.attributes.get("forecast")[26]["temperature"] == 10
+    assert weather.attributes.get("forecast")[26]["wind_speed"] == 4
+    assert weather.attributes.get("forecast")[26]["wind_bearing"] == "NNE"
 
     # Wavertree daily weather platform expected results
-    entity = hass.states.get("weather.met_office_wavertree_daily")
-    assert entity
+    weather = hass.states.get("weather.met_office_wavertree_daily")
+    assert weather
 
-    assert entity.state == "sunny"
-    assert entity.attributes.get("temperature") == 19
-    assert entity.attributes.get("wind_speed") == 9
-    assert entity.attributes.get("wind_bearing") == "SSE"
-    assert entity.attributes.get("visibility") == "Good - 10-20"
-    assert entity.attributes.get("humidity") == 50
+    assert weather.state == "sunny"
+    assert weather.attributes.get("temperature") == 19
+    assert weather.attributes.get("wind_speed") == 9
+    assert weather.attributes.get("wind_bearing") == "SSE"
+    assert weather.attributes.get("visibility") == "Good - 10-20"
+    assert weather.attributes.get("humidity") == 50
 
     # Also has Forecasts added - again, just pick out 1 entry to check
-    assert len(entity.attributes.get("forecast")) == 8
+    assert len(weather.attributes.get("forecast")) == 8
 
     assert (
-        entity.attributes.get("forecast")[7]["datetime"].strftime(DATETIME_FORMAT)
-        == "2020-04-29 12:00:00+0000"
+        weather.attributes.get("forecast")[7]["datetime"] == "2020-04-29T12:00:00+00:00"
     )
-    assert entity.attributes.get("forecast")[7]["condition"] == "rainy"
-    assert entity.attributes.get("forecast")[7]["temperature"] == 13
-    assert entity.attributes.get("forecast")[7]["wind_speed"] == 13
-    assert entity.attributes.get("forecast")[7]["wind_bearing"] == "SE"
+    assert weather.attributes.get("forecast")[7]["condition"] == "rainy"
+    assert weather.attributes.get("forecast")[7]["temperature"] == 13
+    assert weather.attributes.get("forecast")[7]["wind_speed"] == 13
+    assert weather.attributes.get("forecast")[7]["wind_bearing"] == "SE"
 
 
 @patch(
@@ -216,93 +214,91 @@ async def test_two_weather_sites_running(hass, requests_mock, legacy_patchable_t
     await hass.async_block_till_done()
 
     # Wavertree 3-hourly weather platform expected results
-    entity = hass.states.get("weather.met_office_wavertree_3_hourly")
-    assert entity
+    weather = hass.states.get("weather.met_office_wavertree_3_hourly")
+    assert weather
 
-    assert entity.state == "sunny"
-    assert entity.attributes.get("temperature") == 17
-    assert entity.attributes.get("wind_speed") == 9
-    assert entity.attributes.get("wind_bearing") == "SSE"
-    assert entity.attributes.get("visibility") == "Good - 10-20"
-    assert entity.attributes.get("humidity") == 50
+    assert weather.state == "sunny"
+    assert weather.attributes.get("temperature") == 17
+    assert weather.attributes.get("wind_speed") == 9
+    assert weather.attributes.get("wind_bearing") == "SSE"
+    assert weather.attributes.get("visibility") == "Good - 10-20"
+    assert weather.attributes.get("humidity") == 50
 
     # Forecasts added - just pick out 1 entry to check
-    assert len(entity.attributes.get("forecast")) == 35
+    assert len(weather.attributes.get("forecast")) == 35
 
     assert (
-        entity.attributes.get("forecast")[18]["datetime"].strftime(DATETIME_FORMAT)
-        == "2020-04-27 21:00:00+0000"
+        weather.attributes.get("forecast")[18]["datetime"]
+        == "2020-04-27T21:00:00+00:00"
     )
-    assert entity.attributes.get("forecast")[18]["condition"] == "sunny"
-    assert entity.attributes.get("forecast")[18]["temperature"] == 9
-    assert entity.attributes.get("forecast")[18]["wind_speed"] == 4
-    assert entity.attributes.get("forecast")[18]["wind_bearing"] == "NW"
+    assert weather.attributes.get("forecast")[18]["condition"] == "sunny"
+    assert weather.attributes.get("forecast")[18]["temperature"] == 9
+    assert weather.attributes.get("forecast")[18]["wind_speed"] == 4
+    assert weather.attributes.get("forecast")[18]["wind_bearing"] == "NW"
 
     # Wavertree daily weather platform expected results
-    entity = hass.states.get("weather.met_office_wavertree_daily")
-    assert entity
+    weather = hass.states.get("weather.met_office_wavertree_daily")
+    assert weather
 
-    assert entity.state == "sunny"
-    assert entity.attributes.get("temperature") == 19
-    assert entity.attributes.get("wind_speed") == 9
-    assert entity.attributes.get("wind_bearing") == "SSE"
-    assert entity.attributes.get("visibility") == "Good - 10-20"
-    assert entity.attributes.get("humidity") == 50
+    assert weather.state == "sunny"
+    assert weather.attributes.get("temperature") == 19
+    assert weather.attributes.get("wind_speed") == 9
+    assert weather.attributes.get("wind_bearing") == "SSE"
+    assert weather.attributes.get("visibility") == "Good - 10-20"
+    assert weather.attributes.get("humidity") == 50
 
     # Also has Forecasts added - again, just pick out 1 entry to check
-    assert len(entity.attributes.get("forecast")) == 8
+    assert len(weather.attributes.get("forecast")) == 8
 
     assert (
-        entity.attributes.get("forecast")[7]["datetime"].strftime(DATETIME_FORMAT)
-        == "2020-04-29 12:00:00+0000"
+        weather.attributes.get("forecast")[7]["datetime"] == "2020-04-29T12:00:00+00:00"
     )
-    assert entity.attributes.get("forecast")[7]["condition"] == "rainy"
-    assert entity.attributes.get("forecast")[7]["temperature"] == 13
-    assert entity.attributes.get("forecast")[7]["wind_speed"] == 13
-    assert entity.attributes.get("forecast")[7]["wind_bearing"] == "SE"
+    assert weather.attributes.get("forecast")[7]["condition"] == "rainy"
+    assert weather.attributes.get("forecast")[7]["temperature"] == 13
+    assert weather.attributes.get("forecast")[7]["wind_speed"] == 13
+    assert weather.attributes.get("forecast")[7]["wind_bearing"] == "SE"
 
     # King's Lynn 3-hourly weather platform expected results
-    entity = hass.states.get("weather.met_office_king_s_lynn_3_hourly")
-    assert entity
+    weather = hass.states.get("weather.met_office_king_s_lynn_3_hourly")
+    assert weather
 
-    assert entity.state == "sunny"
-    assert entity.attributes.get("temperature") == 14
-    assert entity.attributes.get("wind_speed") == 2
-    assert entity.attributes.get("wind_bearing") == "E"
-    assert entity.attributes.get("visibility") == "Very Good - 20-40"
-    assert entity.attributes.get("humidity") == 60
+    assert weather.state == "sunny"
+    assert weather.attributes.get("temperature") == 14
+    assert weather.attributes.get("wind_speed") == 2
+    assert weather.attributes.get("wind_bearing") == "E"
+    assert weather.attributes.get("visibility") == "Very Good - 20-40"
+    assert weather.attributes.get("humidity") == 60
 
     # Also has Forecast added - just pick out 1 entry to check
-    assert len(entity.attributes.get("forecast")) == 35
+    assert len(weather.attributes.get("forecast")) == 35
 
     assert (
-        entity.attributes.get("forecast")[18]["datetime"].strftime(DATETIME_FORMAT)
-        == "2020-04-27 21:00:00+0000"
+        weather.attributes.get("forecast")[18]["datetime"]
+        == "2020-04-27T21:00:00+00:00"
     )
-    assert entity.attributes.get("forecast")[18]["condition"] == "cloudy"
-    assert entity.attributes.get("forecast")[18]["temperature"] == 10
-    assert entity.attributes.get("forecast")[18]["wind_speed"] == 7
-    assert entity.attributes.get("forecast")[18]["wind_bearing"] == "SE"
+    assert weather.attributes.get("forecast")[18]["condition"] == "cloudy"
+    assert weather.attributes.get("forecast")[18]["temperature"] == 10
+    assert weather.attributes.get("forecast")[18]["wind_speed"] == 7
+    assert weather.attributes.get("forecast")[18]["wind_bearing"] == "SE"
 
     # King's Lynn daily weather platform expected results
-    entity = hass.states.get("weather.met_office_king_s_lynn_daily")
-    assert entity
+    weather = hass.states.get("weather.met_office_king_s_lynn_daily")
+    assert weather
 
-    assert entity.state == "cloudy"
-    assert entity.attributes.get("temperature") == 9
-    assert entity.attributes.get("wind_speed") == 4
-    assert entity.attributes.get("wind_bearing") == "ESE"
-    assert entity.attributes.get("visibility") == "Very Good - 20-40"
-    assert entity.attributes.get("humidity") == 75
+    assert weather.state == "cloudy"
+    assert weather.attributes.get("temperature") == 9
+    assert weather.attributes.get("wind_speed") == 4
+    assert weather.attributes.get("wind_bearing") == "ESE"
+    assert weather.attributes.get("visibility") == "Very Good - 20-40"
+    assert weather.attributes.get("humidity") == 75
 
     # All should have Forecast added - again, just picking out 1 entry to check
-    assert len(entity.attributes.get("forecast")) == 8
+    assert len(weather.attributes.get("forecast")) == 8
 
     assert (
-        entity.attributes.get("forecast")[5]["datetime"].strftime(DATETIME_FORMAT)
-        == "2020-04-28 12:00:00+0000"
+        weather.attributes.get("forecast")[5]["datetime"] == "2020-04-28T12:00:00+00:00"
     )
-    assert entity.attributes.get("forecast")[5]["condition"] == "cloudy"
-    assert entity.attributes.get("forecast")[5]["temperature"] == 11
-    assert entity.attributes.get("forecast")[5]["wind_speed"] == 7
-    assert entity.attributes.get("forecast")[5]["wind_bearing"] == "ESE"
+    assert weather.attributes.get("forecast")[5]["condition"] == "cloudy"
+    assert weather.attributes.get("forecast")[5]["temperature"] == 11
+    assert weather.attributes.get("forecast")[5]["wind_speed"] == 7
+    assert weather.attributes.get("forecast")[5]["wind_bearing"] == "ESE"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently this integration exposes `datetime` objects in forecast as opposed as formatted strings. While generally it works fine, it seems to break, for instance, when you use forecast in template weather entity. This PR changes it to ISO-formatted string.

Also implementing variable naming suggestions in tests proposed by @MartinHjelmare in https://github.com/home-assistant/core/pull/50876

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [x] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
