### PR TITLE
Refactor the logic for peeking into the start of the stream

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -316,6 +316,7 @@ def stream_worker(
                                 _LOGGER.warning(
                                     "ADTS AAC detected - disabling audio stream"
                                 )
+                                dts_validator = TimestampValidator()
                                 container_packets = filter(
                                     dts_validator.is_valid,
                                     container.demux(video_stream),

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -316,7 +316,6 @@ def stream_worker(
                                 _LOGGER.warning(
                                     "ADTS AAC detected - disabling audio stream"
                                 )
-                                dts_validator = TimestampValidator()
                                 container_packets = filter(
                                     dts_validator.is_valid,
                                     container.demux(video_stream),

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -2,11 +2,11 @@
 from __future__ import annotations
 
 from collections import deque
-from collections.abc import Iterator, Mapping
+from collections.abc import Generator, Iterator, Mapping
 from io import BytesIO
 import logging
 from threading import Event
-from typing import Any, Callable, Generator, cast
+from typing import Any, Callable, cast
 
 import av
 
@@ -208,7 +208,7 @@ class PeekIterator(Iterator):
     peek() and rewind() methods that buffer consumed items from the iterator.
     """
 
-    def __init__(self, iterator: Iterator[av.Packet]):
+    def __init__(self, iterator: Iterator[av.Packet]) -> None:
         """Initialize PeekIterator."""
         self._iterator = iterator
         self._cursor: av.Packet = None
@@ -338,7 +338,7 @@ def stream_worker(
         filter(dts_validator.is_valid, container.demux((video_stream, audio_stream)))
     )
 
-    def is_video(packet: av.Packetiterator) -> Any:
+    def is_video(packet: av.Packet) -> Any:
         """Return true if the packet is for the video stream."""
         return packet.stream == video_stream
 

--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -205,13 +205,12 @@ class PeekIterator(Iterator):
     """An Iterator that may allow multiple passes.
 
     This may be consumed like a normal Iterator, however also supports a
-    peek() and rewind() methods that buffer consumed items from the iterator.
+    peek() method that buffers consumed items from the iterator.
     """
 
     def __init__(self, iterator: Iterator[av.Packet]) -> None:
         """Initialize PeekIterator."""
         self._iterator = iterator
-        self._cursor: av.Packet = None
         self._buffer: deque[av.Packet] = deque()
 
     def __iter__(self) -> Iterator:
@@ -221,10 +220,8 @@ class PeekIterator(Iterator):
     def __next__(self) -> av.Packet:
         """Return and consume the next item available."""
         if self._buffer:
-            self._cursor = self._buffer.popleft()
-        else:
-            self._cursor = next(self._iterator)
-        return self._cursor
+            return self._buffer.popleft()
+        return next(self._iterator)
 
     def peek(self) -> Generator[av.Packet, None, None]:
         """Return items without consuming from the iterator."""

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -606,10 +606,10 @@ async def test_update_stream_source(hass):
         nonlocal last_stream_source
         if not isinstance(stream_source, io.BytesIO):
             last_stream_source = stream_source
-        # Let test know the thread is running
-        worker_open.set()
-        # Block worker thread until test wakes up
-        worker_wake.wait()
+            # Let test know the thread is running
+            worker_open.set()
+            # Block worker thread until test wakes up
+            worker_wake.wait()
         return py_av.open(stream_source, args, kwargs)
 
     with patch("av.open", new=blocking_open), patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is a refactoring change, meant to add some abstractions to make it easier to follow the purpose of what the stream worker is doing.

The primary change is to introduce a `PeekIterator` which supports buffering consumed packets so that it can be restarted, making multiple passes to simplify the flow. This allows separation of the audio stream validation from the video start dts adjustment logic into separate functions.

Also fixes a race in `test_update_stream_source` by reducing  when the test thread is woken up to the intended cases only.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [X] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
