### PR TITLE
Allow removing workday holidays by name

### DIFF
--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -109,15 +109,16 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                 removed = obj_holidays.pop(date)
                 _LOGGER.debug("Removed %s", date)
             else:
-                # remove holiday by name
-                _LOGGER.debug("Treating '%s' as named holiday", date)
-                removed = obj_holidays.pop_named(date)
-                for holiday in removed:
-                    _LOGGER.debug("Removed %s by name '%s'", holiday, date)
+                try:
+                    # remove holiday by name
+                    _LOGGER.debug("Treating '%s' as named holiday", date)
+                    removed = obj_holidays.pop_named(date)
+                    for holiday in removed:
+                        _LOGGER.debug("Removed %s by name '%s'", holiday, date)
+                except KeyError as unmatched:
+                    _LOGGER.debug("No holiday found matching %s", unmatched)
     except TypeError:
         _LOGGER.debug("No holidays to remove or invalid holidays")
-    except KeyError as unmatched:
-        _LOGGER.debug("No holiday found matching %s", unmatched)
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for date, name in sorted(obj_holidays.items()):

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -106,12 +106,18 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
             # is this formatted as a date?
             if dt.parse_date(date):
                 # remove holiday by date
-                obj_holidays.pop(date)
+                removed = obj_holidays.pop(date)
+                _LOGGER.debug("Removed %s", date)
             else:
                 # remove holiday by name
-                obj_holidays.pop_named(date)
+                _LOGGER.debug("Treating '%s' as named holiday", date)
+                removed = obj_holidays.pop_named(date)
+                for holiday in removed:
+                    _LOGGER.debug("Removed %s by name '%s'", holiday, date)
     except TypeError:
         _LOGGER.debug("No holidays to remove or invalid holidays")
+    except KeyError as unmatched:
+        _LOGGER.debug("No holiday found matching %s", unmatched)
 
     _LOGGER.debug("Found the following holidays for your configuration:")
     for date, name in sorted(obj_holidays.items()):

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -103,7 +103,13 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # Remove holidays
     try:
         for date in remove_holidays:
-            obj_holidays.pop(date)
+            # is this formatted as a date?
+            if dt.parse_date(date):
+                # remove holiday by date
+                obj_holidays.pop(date)
+            else:
+                # remove holiday by name
+                obj_holidays.pop_named(date)
     except TypeError:
         _LOGGER.debug("No holidays to remove or invalid holidays")
 

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -116,7 +116,7 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
                     for holiday in removed:
                         _LOGGER.debug("Removed %s by name '%s'", holiday, date)
                 except KeyError as unmatched:
-                    _LOGGER.debug("No holiday found matching %s", unmatched)
+                    _LOGGER.warning("No holiday found matching %s", unmatched)
     except TypeError:
         _LOGGER.debug("No holidays to remove or invalid holidays")
 

--- a/homeassistant/components/workday/binary_sensor.py
+++ b/homeassistant/components/workday/binary_sensor.py
@@ -103,20 +103,20 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     # Remove holidays
     try:
         for date in remove_holidays:
-            # is this formatted as a date?
-            if dt.parse_date(date):
-                # remove holiday by date
-                removed = obj_holidays.pop(date)
-                _LOGGER.debug("Removed %s", date)
-            else:
-                try:
+            try:
+                # is this formatted as a date?
+                if dt.parse_date(date):
+                    # remove holiday by date
+                    removed = obj_holidays.pop(date)
+                    _LOGGER.debug("Removed %s", date)
+                else:
                     # remove holiday by name
                     _LOGGER.debug("Treating '%s' as named holiday", date)
                     removed = obj_holidays.pop_named(date)
                     for holiday in removed:
                         _LOGGER.debug("Removed %s by name '%s'", holiday, date)
-                except KeyError as unmatched:
-                    _LOGGER.warning("No holiday found matching %s", unmatched)
+            except KeyError as unmatched:
+                _LOGGER.warning("No holiday found matching %s", unmatched)
     except TypeError:
         _LOGGER.debug("No holidays to remove or invalid holidays")
 

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -91,7 +91,7 @@ class TestWorkdaySetup:
                 "country": "US",
                 "workdays": ["mon", "tue", "wed", "thu", "fri"],
                 "excludes": ["sat", "sun", "holiday"],
-                "remove_holidays": ["Christmas", "Thanksgiving", "Not a Holiday"],
+                "remove_holidays": ["Not a Holiday", "Christmas", "Thanksgiving"],
             }
         }
 

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -91,7 +91,7 @@ class TestWorkdaySetup:
                 "country": "US",
                 "workdays": ["mon", "tue", "wed", "thu", "fri"],
                 "excludes": ["sat", "sun", "holiday"],
-                "remove_holidays": ["Christmas", "Thanksgiving"],
+                "remove_holidays": ["Christmas", "Thanksgiving", "Not a Holiday"],
             }
         }
 

--- a/tests/components/workday/test_binary_sensor.py
+++ b/tests/components/workday/test_binary_sensor.py
@@ -85,6 +85,16 @@ class TestWorkdaySetup:
             }
         }
 
+        self.config_remove_named_holidays = {
+            "binary_sensor": {
+                "platform": "workday",
+                "country": "US",
+                "workdays": ["mon", "tue", "wed", "thu", "fri"],
+                "excludes": ["sat", "sun", "holiday"],
+                "remove_holidays": ["Christmas", "Thanksgiving"],
+            }
+        }
+
         self.config_tomorrow = {
             "binary_sensor": {"platform": "workday", "country": "DE", "days_offset": 1}
         }
@@ -315,6 +325,20 @@ class TestWorkdaySetup:
         """Test if removed holidays are reported correctly."""
         with assert_setup_component(1, "binary_sensor"):
             setup_component(self.hass, "binary_sensor", self.config_remove_holidays)
+
+        self.hass.start()
+
+        entity = self.hass.states.get("binary_sensor.workday_sensor")
+        assert entity.state == "on"
+
+    # Freeze time to test Fri, but remove holiday by name - Christmas
+    @patch(FUNCTION_PATH, return_value=date(2020, 12, 25))
+    def test_config_remove_named_holidays_xmas(self, mock_date):
+        """Test if removed by name holidays are reported correctly."""
+        with assert_setup_component(1, "binary_sensor"):
+            setup_component(
+                self.hass, "binary_sensor", self.config_remove_named_holidays
+            )
 
         self.hass.start()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The workday integration loads region-specific holidays.  Some of these holidays may not be days off from work, and it is tedious to remove each of these holidays by date, year after year.  The Python module [holidays](https://pypi.org/project/holidays/) supports removal by partial string match, this PR exposes that functionality to the integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/18423
- See feature request: [Workday sensor needs holiday exclusions list](https://community.home-assistant.io/t/workday-sensor-needs-holiday-exclusions-list/147830/8)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
