### PR TITLE
Report average of position and tilt_position for cover groups

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -47,6 +47,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType
 
 from . import GroupEntity
+from .util import attribute_equal, reduce_attribute
 
 KEY_OPEN_CLOSE = "open_close"
 KEY_STOP = "stop"
@@ -265,41 +266,25 @@ class CoverGroup(GroupEntity, CoverEntity):
                 self._attr_is_opening = True
                 break
 
-        self._attr_current_cover_position = None
-        if self._covers[KEY_POSITION]:
-            position: int | None = -1
-            self._attr_current_cover_position = 0 if self.is_closed else 100
-            for entity_id in self._covers[KEY_POSITION]:
-                state = self.hass.states.get(entity_id)
-                if state is None:
-                    continue
-                pos = state.attributes.get(ATTR_CURRENT_POSITION)
-                if position == -1:
-                    position = pos
-                elif position != pos:
-                    self._attr_assumed_state = True
-                    break
-            else:
-                if position != -1:
-                    self._attr_current_cover_position = position
+        position_covers = self._covers[KEY_POSITION]
+        all_position_states = [self.hass.states.get(x) for x in position_covers]
+        position_states: list[State] = list(filter(None, all_position_states))
+        self._attr_current_cover_position = reduce_attribute(
+            position_states, ATTR_CURRENT_POSITION
+        )
+        self._attr_assumed_state |= not attribute_equal(
+            position_states, ATTR_CURRENT_POSITION
+        )
 
-        self._attr_current_cover_tilt_position = None
-        if self._tilts[KEY_POSITION]:
-            position = -1
-            self._attr_current_cover_tilt_position = 100
-            for entity_id in self._tilts[KEY_POSITION]:
-                state = self.hass.states.get(entity_id)
-                if state is None:
-                    continue
-                pos = state.attributes.get(ATTR_CURRENT_TILT_POSITION)
-                if position == -1:
-                    position = pos
-                elif position != pos:
-                    self._attr_assumed_state = True
-                    break
-            else:
-                if position != -1:
-                    self._attr_current_cover_tilt_position = position
+        tilt_covers = self._tilts[KEY_POSITION]
+        all_tilt_states = [self.hass.states.get(x) for x in tilt_covers]
+        tilt_states: list[State] = list(filter(None, all_tilt_states))
+        self._attr_current_cover_tilt_position = reduce_attribute(
+            tilt_states, ATTR_CURRENT_TILT_POSITION
+        )
+        self._attr_assumed_state |= not attribute_equal(
+            tilt_states, ATTR_CURRENT_TILT_POSITION
+        )
 
         supported_features = 0
         supported_features |= (

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -258,13 +258,13 @@ class CoverGroup(GroupEntity, CoverEntity):
                 continue
             if state.state == STATE_OPEN:
                 self._attr_is_closed = False
-                break
+                continue
             if state.state == STATE_CLOSING:
                 self._attr_is_closing = True
-                break
+                continue
             if state.state == STATE_OPENING:
                 self._attr_is_opening = True
-                break
+                continue
 
         position_covers = self._covers[KEY_POSITION]
         all_position_states = [self.hass.states.get(x) for x in position_covers]

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -2,9 +2,8 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Iterator
 import itertools
-from typing import Any, Callable, Set, cast
+from typing import Any, Set, cast
 
 import voluptuous as vol
 
@@ -49,6 +48,7 @@ from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.typing import ConfigType
 
 from . import GroupEntity
+from .util import find_state_attributes, mean_tuple, reduce_attribute
 
 DEFAULT_NAME = "Light Group"
 
@@ -187,36 +187,36 @@ class LightGroup(GroupEntity, light.LightEntity):
 
         self._attr_is_on = len(on_states) > 0
         self._attr_available = any(state.state != STATE_UNAVAILABLE for state in states)
-        self._attr_brightness = _reduce_attribute(on_states, ATTR_BRIGHTNESS)
+        self._attr_brightness = reduce_attribute(on_states, ATTR_BRIGHTNESS)
 
-        self._attr_hs_color = _reduce_attribute(
-            on_states, ATTR_HS_COLOR, reduce=_mean_tuple
+        self._attr_hs_color = reduce_attribute(
+            on_states, ATTR_HS_COLOR, reduce=mean_tuple
         )
-        self._attr_rgb_color = _reduce_attribute(
-            on_states, ATTR_RGB_COLOR, reduce=_mean_tuple
+        self._attr_rgb_color = reduce_attribute(
+            on_states, ATTR_RGB_COLOR, reduce=mean_tuple
         )
-        self._attr_rgbw_color = _reduce_attribute(
-            on_states, ATTR_RGBW_COLOR, reduce=_mean_tuple
+        self._attr_rgbw_color = reduce_attribute(
+            on_states, ATTR_RGBW_COLOR, reduce=mean_tuple
         )
-        self._attr_rgbww_color = _reduce_attribute(
-            on_states, ATTR_RGBWW_COLOR, reduce=_mean_tuple
+        self._attr_rgbww_color = reduce_attribute(
+            on_states, ATTR_RGBWW_COLOR, reduce=mean_tuple
         )
-        self._attr_xy_color = _reduce_attribute(
-            on_states, ATTR_XY_COLOR, reduce=_mean_tuple
+        self._attr_xy_color = reduce_attribute(
+            on_states, ATTR_XY_COLOR, reduce=mean_tuple
         )
 
-        self._white_value = _reduce_attribute(on_states, ATTR_WHITE_VALUE)
+        self._white_value = reduce_attribute(on_states, ATTR_WHITE_VALUE)
 
-        self._attr_color_temp = _reduce_attribute(on_states, ATTR_COLOR_TEMP)
-        self._attr_min_mireds = _reduce_attribute(
+        self._attr_color_temp = reduce_attribute(on_states, ATTR_COLOR_TEMP)
+        self._attr_min_mireds = reduce_attribute(
             states, ATTR_MIN_MIREDS, default=154, reduce=min
         )
-        self._attr_max_mireds = _reduce_attribute(
+        self._attr_max_mireds = reduce_attribute(
             states, ATTR_MAX_MIREDS, default=500, reduce=max
         )
 
         self._attr_effect_list = None
-        all_effect_lists = list(_find_state_attributes(states, ATTR_EFFECT_LIST))
+        all_effect_lists = list(find_state_attributes(states, ATTR_EFFECT_LIST))
         if all_effect_lists:
             # Merge all effects from all effect_lists with a union merge.
             self._attr_effect_list = list(set().union(*all_effect_lists))
@@ -226,14 +226,14 @@ class LightGroup(GroupEntity, light.LightEntity):
                 self._attr_effect_list.insert(0, "None")
 
         self._attr_effect = None
-        all_effects = list(_find_state_attributes(on_states, ATTR_EFFECT))
+        all_effects = list(find_state_attributes(on_states, ATTR_EFFECT))
         if all_effects:
             # Report the most common effect.
             effects_count = Counter(itertools.chain(all_effects))
             self._attr_effect = effects_count.most_common(1)[0][0]
 
         self._attr_color_mode = None
-        all_color_modes = list(_find_state_attributes(on_states, ATTR_COLOR_MODE))
+        all_color_modes = list(find_state_attributes(on_states, ATTR_COLOR_MODE))
         if all_color_modes:
             # Report the most common color mode, select brightness and onoff last
             color_mode_count = Counter(itertools.chain(all_color_modes))
@@ -245,7 +245,7 @@ class LightGroup(GroupEntity, light.LightEntity):
 
         self._attr_supported_color_modes = None
         all_supported_color_modes = list(
-            _find_state_attributes(states, ATTR_SUPPORTED_COLOR_MODES)
+            find_state_attributes(states, ATTR_SUPPORTED_COLOR_MODES)
         )
         if all_supported_color_modes:
             # Merge all color modes.
@@ -254,49 +254,10 @@ class LightGroup(GroupEntity, light.LightEntity):
             )
 
         self._attr_supported_features = 0
-        for support in _find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
+        for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
             # Merge supported features by emulating support for every feature
             # we find.
             self._attr_supported_features |= support
         # Bitwise-and the supported features with the GroupedLight's features
         # so that we don't break in the future when a new feature is added.
         self._attr_supported_features &= SUPPORT_GROUP_LIGHT
-
-
-def _find_state_attributes(states: list[State], key: str) -> Iterator[Any]:
-    """Find attributes with matching key from states."""
-    for state in states:
-        value = state.attributes.get(key)
-        if value is not None:
-            yield value
-
-
-def _mean_int(*args: Any) -> int:
-    """Return the mean of the supplied values."""
-    return int(sum(args) / len(args))
-
-
-def _mean_tuple(*args: Any) -> tuple[float | Any, ...]:
-    """Return the mean values along the columns of the supplied values."""
-    return tuple(sum(x) / len(x) for x in zip(*args))
-
-
-def _reduce_attribute(
-    states: list[State],
-    key: str,
-    default: Any | None = None,
-    reduce: Callable[..., Any] = _mean_int,
-) -> Any:
-    """Find the first attribute matching key from states.
-
-    If none are found, return default.
-    """
-    attrs = list(_find_state_attributes(states, key))
-
-    if not attrs:
-        return default
-
-    if len(attrs) == 1:
-        return attrs[0]
-
-    return reduce(*attrs)

--- a/homeassistant/components/group/util.py
+++ b/homeassistant/components/group/util.py
@@ -1,8 +1,9 @@
 """Utility functions to combine state attributes from multiple entities."""
 from __future__ import annotations
 
+from collections.abc import Iterator
 from itertools import groupby
-from typing import Any, Callable, Iterator
+from typing import Any, Callable
 
 from homeassistant.core import State
 
@@ -31,8 +32,8 @@ def attribute_equal(states: list[State], key: str) -> bool:
     Note: Returns True if no matching attribute is found.
     """
     attrs = find_state_attributes(states, key)
-    g = groupby(attrs)
-    return True if next(g, True) and not next(g, False) else False
+    grp = groupby(attrs)
+    return bool(next(grp, True) and not next(grp, False))
 
 
 def reduce_attribute(

--- a/homeassistant/components/group/util.py
+++ b/homeassistant/components/group/util.py
@@ -1,0 +1,56 @@
+"""Utility functions to combine state attributes from multiple entities."""
+from __future__ import annotations
+
+from itertools import groupby
+from typing import Any, Callable, Iterator
+
+from homeassistant.core import State
+
+
+def find_state_attributes(states: list[State], key: str) -> Iterator[Any]:
+    """Find attributes with matching key from states."""
+    for state in states:
+        value = state.attributes.get(key)
+        if value is not None:
+            yield value
+
+
+def mean_int(*args: Any) -> int:
+    """Return the mean of the supplied values."""
+    return int(sum(args) / len(args))
+
+
+def mean_tuple(*args: Any) -> tuple[float | Any, ...]:
+    """Return the mean values along the columns of the supplied values."""
+    return tuple(sum(x) / len(x) for x in zip(*args))
+
+
+def attribute_equal(states: list[State], key: str) -> bool:
+    """Return True if all attributes found matching key from states are equal.
+
+    Note: Returns True if no matching attribute is found.
+    """
+    attrs = find_state_attributes(states, key)
+    g = groupby(attrs)
+    return True if next(g, True) and not next(g, False) else False
+
+
+def reduce_attribute(
+    states: list[State],
+    key: str,
+    default: Any | None = None,
+    reduce: Callable[..., Any] = mean_int,
+) -> Any:
+    """Find the first attribute matching key from states.
+
+    If none are found, return default.
+    """
+    attrs = list(find_state_attributes(states, key))
+
+    if not attrs:
+        return default
+
+    if len(attrs) == 1:
+        return attrs[0]
+
+    return reduce(*attrs)

--- a/tests/components/group/test_cover.py
+++ b/tests/components/group/test_cover.py
@@ -174,7 +174,7 @@ async def test_attributes(hass, setup_comp):
     assert state.state == STATE_OPEN
     assert state.attributes[ATTR_ASSUMED_STATE] is True
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 244
-    assert state.attributes[ATTR_CURRENT_POSITION] == 100
+    assert state.attributes[ATTR_CURRENT_POSITION] == 85  # (70 + 100) / 2
     assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 60
 
     hass.states.async_remove(DEMO_COVER)
@@ -201,7 +201,7 @@ async def test_attributes(hass, setup_comp):
     assert state.attributes[ATTR_ASSUMED_STATE] is True
     assert state.attributes[ATTR_SUPPORTED_FEATURES] == 128
     assert ATTR_CURRENT_POSITION not in state.attributes
-    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 100
+    assert state.attributes[ATTR_CURRENT_TILT_POSITION] == 80  # (60 + 100) / 2
 
     hass.states.async_remove(DEMO_COVER_TILT)
     hass.states.async_set(DEMO_TILT, STATE_CLOSED)
@@ -360,7 +360,7 @@ async def test_stop_covers(hass, setup_comp):
 
     state = hass.states.get(COVER_GROUP)
     assert state.state == STATE_OPEN
-    assert state.attributes[ATTR_CURRENT_POSITION] == 100
+    assert state.attributes[ATTR_CURRENT_POSITION] == 50  # (20 + 80) / 2
 
     assert hass.states.get(DEMO_COVER).state == STATE_OPEN
     assert hass.states.get(DEMO_COVER_POS).attributes[ATTR_CURRENT_POSITION] == 20


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Report the average of of group members' `current_position` and `current_tilt_position` for cover groups

Move prioritization of state of the group to base class, which means:
- If at least one group member is opening, the group's state will be `opening`
- Otherwise, if at least one group member is closing, the group's state will be `closing`
- Otherwise, if at least one group member is open, the group's state will be `open`
- Otherwise, the group's state will be `closed`

The old behavior would:
- For `current_position`
  - If all covers have same `current_position` report that
  - Report position as 100 if at least one cover in state `open`
  - Report position as 0 otherwise
- For `current_tilt_position`
  - If all covers have same `current_tilt_position` report that
  - Report position as 100 otherwise
- For `state`
  -  The state would reflect the state of the first member of a cover group

Also:
 - Move some helpers which combine state attributes from multiple entities to `homeassistant.components.group.util`

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: https://github.com/home-assistant/core/issues/44554

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] The code has been formatted using Black (`black --fast homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [ ] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
