### PR TITLE
Ensure Jewish Calendar returns an iso formatted timestamp

### DIFF
--- a/homeassistant/components/jewish_calendar/sensor.py
+++ b/homeassistant/components/jewish_calendar/sensor.py
@@ -1,4 +1,5 @@
 """Platform to retrieve Jewish calendar information for Home Assistant."""
+from datetime import datetime
 import logging
 
 import hdate
@@ -51,6 +52,8 @@ class JewishCalendarSensor(SensorEntity):
     @property
     def state(self):
         """Return the state of the sensor."""
+        if isinstance(self._state, datetime):
+            return self._state.isoformat()
         return self._state
 
     async def async_update(self):
@@ -133,7 +136,9 @@ class JewishCalendarTimeSensor(JewishCalendarSensor):
     @property
     def state(self):
         """Return the state of the sensor."""
-        return dt_util.as_utc(self._state) if self._state is not None else None
+        if self._state is None:
+            return None
+        return dt_util.as_utc(self._state).isoformat()
 
     @property
     def extra_state_attributes(self):

--- a/tests/components/jewish_calendar/test_sensor.py
+++ b/tests/components/jewish_calendar/test_sensor.py
@@ -188,13 +188,13 @@ async def test_jewish_calendar_sensor(
         await hass.async_block_till_done()
 
     result = (
-        dt_util.as_utc(result.replace(tzinfo=time_zone))
+        dt_util.as_utc(result.replace(tzinfo=time_zone)).isoformat()
         if isinstance(result, dt)
         else result
     )
 
     sensor_object = hass.states.get(f"sensor.test_{sensor}")
-    assert sensor_object.state == str(result)
+    assert sensor_object.state == result
 
     if sensor == "holiday":
         assert sensor_object.attributes.get("id") == "rosh_hashana_i"
@@ -544,7 +544,7 @@ async def test_shabbat_times_sensor(
         sensor_type = sensor_type.replace(f"{language}_", "")
 
         result_value = (
-            dt_util.as_utc(result_value)
+            dt_util.as_utc(result_value).isoformat()
             if isinstance(result_value, dt)
             else result_value
         )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

The Jewish Calendar integration returned a datetime format that wasn't properly formatted according to ISO standards. This has been adjusted. If you rely on manually parsing of dates that are returned from this integration, you might need to adjust your templates to incorporate this change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR ensures the Jewish Calendar integration returns its states as ISO formatted datetime strings.
Previously is relied on stringifying from Python, which does not return an ISO format and can cause issues with our frontend.

Discovered while working on #52671

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Black (`black --fast homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] Untested files have been added to `.coveragerc`.

The integration reached or maintains the following [Integration Quality Scale][quality-scale]:
<!--
  The Integration Quality Scale scores an integration on the code quality
  and user experience. Each level of the quality scale consists of a list
  of requirements. We highly recommend getting your integration scored!
-->

- [x] No score or internal
- [ ] 🥈 Silver
- [ ] 🥇 Gold
- [ ] 🏆 Platinum

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
[quality-scale]: https://developers.home-assistant.io/docs/en/next/integration_quality_scale_index.html
[docs-repository]: https://github.com/home-assistant/home-assistant.io
